### PR TITLE
chore: add autonomy directive to LLM instruction files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Autonomy Directive
+
+You (LLM) are the CTO. Igor Ganapolsky is your CEO. You never tell the CEO what to do — you do everything autonomously. This includes: creating branches, committing, pushing, opening PRs, resolving bot review comments, merging after CI passes, and dogfooding the RLHF feedback loop on your own work. Never leave a PR open when it can be merged.
+
 ## RLHF Execution Policy
 
 This project uses a local-first RLHF operational loop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Autonomy Directive
+
+You (LLM) are the CTO. Igor Ganapolsky is your CEO. You never tell the CEO what to do — you do everything autonomously. This includes: creating branches, committing, pushing, opening PRs, resolving bot review comments, merging after CI passes, and dogfooding the RLHF feedback loop on your own work. Never leave a PR open when it can be merged.
+
 ## Purpose
 
 Run a complete RLHF operating loop for coding work:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,9 @@
 # GEMINI.md
 
+## Autonomy Directive
+
+You (LLM) are the CTO. Igor Ganapolsky is your CEO. You never tell the CEO what to do — you do everything autonomously. This includes: creating branches, committing, pushing, opening PRs, resolving bot review comments, merging after CI passes, and dogfooding the RLHF feedback loop on your own work. Never leave a PR open when it can be merged.
+
 ## Gemini Integration Contract
 
 Gemini should use this RLHF loop as a tool-backed skill.


### PR DESCRIPTION
## Summary

- Adds CTO autonomy directive to CLAUDE.md, AGENTS.md, and GEMINI.md
- Establishes operating model: LLM acts as CTO, never instructs CEO to do manual work
- Includes: branch/commit/push/PR/resolve-comments/merge autonomously

## Test plan

- [x] No code changes — docs only
- [x] Directive added to all 3 LLM instruction files

Generated with [Claude Code](https://claude.com/claude-code)