### PR TITLE
docs: rewrite README for humans, fix repo SEO

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: IgorGanapolsky
+custom: ["https://buy.stripe.com/"]

--- a/README.md
+++ b/README.md
@@ -2,85 +2,85 @@
 
 [![CI](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/ci.yml)
 [![Self-Healing](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/self-healing-monitor.yml/badge.svg)](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/self-healing-monitor.yml)
+[![npm](https://img.shields.io/npm/v/rlhf-feedback-loop)](https://www.npmjs.com/package/rlhf-feedback-loop)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Tests](https://img.shields.io/badge/tests-573%20passing-brightgreen)]()
 [![MCP Ready](https://img.shields.io/badge/MCP-ready-black)](adapters/mcp/server-stdio.js)
 [![DPO Ready](https://img.shields.io/badge/DPO-ready-blue)](scripts/export-dpo-pairs.js)
 
-Production-grade RLHF operations for AI agents across ChatGPT, Claude, Gemini, Codex, and Amp.
+**Make your AI agent learn from mistakes.**
 
-## Quick Install
+Your AI coding agent makes the same errors over and over. It claims things are done when they're not. It forgets what worked last time. This fixes that.
 
-Install on any platform with a single command. Be capturing feedback in under 5 minutes.
+**rlhf-feedback-loop** captures thumbs up/down feedback on your agent's work, remembers what went right and wrong, blocks repeated failures, and exports training data so the agent actually improves.
 
-### Universal (any platform)
+Works with **ChatGPT**, **Claude**, **Codex**, **Gemini**, and **Amp** — same core, different adapters.
+
+## Why This Exists
+
+| Problem | What this does |
+|---------|---------------|
+| Agent keeps making the same mistake | Prevention rules auto-generated from repeated failures |
+| No proof agent tested before claiming "done" | Rubric engine blocks positive feedback without test evidence |
+| Feedback collected but never used | DPO pairs exported for actual model fine-tuning |
+| Different tools, different formats | One API + MCP server works across 5 platforms |
+| Costs spiral with LLM calls | Budget guard caps spend at $10/month by default |
+
+## Install in 60 Seconds
 
 ```bash
 npx rlhf-feedback-loop init
-node .rlhf/capture-feedback.js --feedback=up --context="test"
+node .rlhf/capture-feedback.js --feedback=up --context="tests pass"
 ```
 
-### Claude Code
+That's it. You're capturing feedback. Now plug it into your agent:
 
-```bash
-cp plugins/claude-skill/SKILL.md .claude/skills/rlhf-feedback.md
+| Platform | One-liner |
+|----------|-----------|
+| **Claude Code** | `cp plugins/claude-skill/SKILL.md .claude/skills/rlhf-feedback.md` |
+| **Codex** | `cat adapters/codex/config.toml >> ~/.codex/config.toml` |
+| **Gemini** | `cp adapters/gemini/function-declarations.json .gemini/rlhf-tools.json` |
+| **Amp** | `cp plugins/amp-skill/SKILL.md .amp/skills/rlhf-feedback.md` |
+| **ChatGPT** | Import `adapters/chatgpt/openapi.yaml` in GPT Builder |
+
+Detailed guides: [Claude](plugins/claude-skill/INSTALL.md) | [Codex](plugins/codex-profile/INSTALL.md) | [Gemini](plugins/gemini-extension/INSTALL.md) | [Amp](plugins/amp-skill/INSTALL.md) | [ChatGPT](adapters/chatgpt/INSTALL.md)
+
+## How It Works
+
+```
+You give feedback (thumbs up/down)
+        |
+        v
+  Capture + validate
+        |
+        v
+  Score with rubric (is this actually good?)
+        |
+    +---+---+
+    |       |
+   Good    Bad
+    |       |
+  Learn   Remember mistake
+    |       |
+    v       v
+  DPO    Prevention
+  pairs   rules
 ```
 
-Full guide: [plugins/claude-skill/INSTALL.md](plugins/claude-skill/INSTALL.md)
-
-### Codex
-
-```bash
-cat adapters/codex/config.toml >> ~/.codex/config.toml
-```
-
-Full guide: [plugins/codex-profile/INSTALL.md](plugins/codex-profile/INSTALL.md)
-
-### Gemini
-
-```bash
-cp adapters/gemini/function-declarations.json .gemini/rlhf-tools.json
-```
-
-Full guide: [plugins/gemini-extension/INSTALL.md](plugins/gemini-extension/INSTALL.md)
-
-### Amp
-
-```bash
-cp plugins/amp-skill/SKILL.md .amp/skills/rlhf-feedback.md
-```
-
-Full guide: [plugins/amp-skill/INSTALL.md](plugins/amp-skill/INSTALL.md)
-
-### ChatGPT (GPT Actions)
-
-Import `adapters/chatgpt/openapi.yaml` in the GPT Builder Actions editor.
-
-Full guide: [adapters/chatgpt/INSTALL.md](adapters/chatgpt/INSTALL.md)
-
----
-
-## Value Proposition
-
-Most teams collect feedback but do not convert it into reliable behavior change.
-This project gives you a working loop:
-
-1. Capture thumbs up/down with context.
-2. Score outcomes with weighted rubrics and objective guardrails.
-3. Promote only schema-valid, rubric-eligible memories.
-4. Generate prevention rules from repeated mistakes and failed rubric dimensions.
-5. Export DPO-ready preference pairs with rubric deltas.
-6. Construct bounded context packs (constructor/loader/evaluator).
-7. Reuse the same core through API + MCP wrappers.
-8. Route intents through policy bundles with human checkpoints on high-risk actions.
+1. You (or your agent) gives thumbs up or down with context
+2. The rubric engine scores it — blocks false positives (e.g., "done!" with no tests)
+3. Good outcomes become learning memories, bad ones become error memories
+4. Errors generate prevention rules so the agent stops repeating them
+5. Matched pairs export as DPO training data for fine-tuning
 
 ## Pricing
 
 | Plan | Price | What you get |
 |------|-------|-------------|
-| **Open Source** | $0 forever | Full source, self-hosted, MIT license, 314+ tests, 5-platform plugins |
-| **Cloud Pro** | $49/mo | Hosted HTTPS API on Railway, provisioned API key on payment, usage metering, email support |
+| **Open Source** | **$0 forever** | Full source, self-hosted, MIT license, 573 tests, 5-platform plugins |
+| **Cloud Pro** | **$10/mo** | Hosted HTTPS API, provisioned API key on payment, Stripe billing, email support |
 
-Get Cloud Pro: see the [landing page](docs/landing-page.html) or go straight to Stripe Checkout.
+Get Cloud Pro: see the [landing page](docs/landing-page.html) or go straight to [Stripe Checkout](https://buy.stripe.com/)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
   "name": "rlhf-feedback-loop",
   "version": "0.5.0",
-  "description": "Production-grade RLHF feedback operations for coding agents: capture thumbs signals, enforce schema quality, prevent repeated mistakes, and export DPO pairs.",
+  "description": "Make your AI agent learn from mistakes. Capture thumbs up/down feedback, block repeated failures, export DPO training data. Works with ChatGPT, Claude, Codex, Gemini, Amp.",
+  "homepage": "https://github.com/IgorGanapolsky/rlhf-feedback-loop#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IgorGanapolsky/rlhf-feedback-loop.git"
+  },
+  "bugs": {
+    "url": "https://github.com/IgorGanapolsky/rlhf-feedback-loop/issues"
+  },
   "main": "scripts/feedback-loop.js",
   "bin": {
     "rlhf-feedback-loop": "./bin/cli.js"
@@ -79,8 +87,17 @@
     "claude",
     "codex",
     "gemini",
+    "chatgpt",
+    "amp",
+    "mcp",
+    "model-context-protocol",
     "agent-evaluation",
-    "prompt-engineering"
+    "prompt-engineering",
+    "context-engineering",
+    "ai-safety",
+    "machine-learning",
+    "openapi",
+    "developer-tools"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

- README rewritten in plain language for non-technical audience
- GitHub repo description simplified: "Make your AI agent learn from mistakes"
- 20 GitHub topics for discoverability
- npm package.json: homepage, repository, bugs, 20 keywords
- FUNDING.yml for sponsor button
- Test count 314+ -> 573, price $49 -> $10

## Test plan

- [x] No code changes — docs/metadata only
- [x] package.json validates (`node -e "require('./package.json')"`)

Generated with [Claude Code](https://claude.com/claude-code)