### PR TITLE
feat: fuzzy normalize for feedback signals

### DIFF
--- a/.claude/scripts/feedback/capture-feedback.js
+++ b/.claude/scripts/feedback/capture-feedback.js
@@ -24,10 +24,33 @@ function parseArgs(argv) {
   return args;
 }
 
+function levenshtein(a, b) {
+  const m = a.length, n = b.length;
+  const dp = Array.from({ length: m + 1 }, (_, i) => {
+    const row = new Array(n + 1);
+    row[0] = i;
+    return row;
+  });
+  for (let j = 1; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + (a[i - 1] !== b[j - 1] ? 1 : 0)
+      );
+  return dp[m][n];
+}
+
 function normalize(feedback) {
-  const raw = String(feedback || '').toLowerCase();
-  if (['up', 'thumbs_up', 'thumbsup', 'positive'].includes(raw)) return 'up';
-  if (['down', 'thumbs_down', 'thumbsdown', 'negative'].includes(raw)) return 'down';
+  const raw = String(feedback || '').toLowerCase().replace(/[^a-z]/g, '');
+  const UP_VARIANTS = ['up', 'thumbsup', 'thumbs_up', 'positive', 'thumbup', 'thumbsu'];
+  const DOWN_VARIANTS = ['down', 'thumbsdown', 'thumbs_down', 'negative', 'thumbdown'];
+  if (UP_VARIANTS.includes(raw)) return 'up';
+  if (DOWN_VARIANTS.includes(raw)) return 'down';
+  // Fuzzy match: accept if edit distance <= 2 from any known variant
+  for (const v of UP_VARIANTS) if (levenshtein(raw, v) <= 2) return 'up';
+  for (const v of DOWN_VARIANTS) if (levenshtein(raw, v) <= 2) return 'down';
   return feedback;
 }
 
@@ -52,8 +75,8 @@ function main() {
   }
 
   const feedback = normalize(args.feedback);
-  if (!feedback) {
-    console.error('Missing --feedback=up|down');
+  if (!feedback || (feedback !== 'up' && feedback !== 'down')) {
+    console.error('Missing or unrecognized --feedback=up|down');
     process.exit(1);
   }
 

--- a/tests/feedback-normalize.test.js
+++ b/tests/feedback-normalize.test.js
@@ -1,0 +1,77 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const SCRIPT = path.join(__dirname, '..', '.claude', 'scripts', 'feedback', 'capture-feedback.js');
+
+function run(feedbackValue) {
+  return spawnSync('node', [SCRIPT, `--feedback=${feedbackValue}`, '--context=fuzzy-test'], {
+    encoding: 'utf-8',
+    timeout: 10000,
+    cwd: path.join(__dirname, '..'),
+  });
+}
+
+// Exit 0 = promoted, exit 2 = captured but not promoted (rubric gate).
+// Exit 1 = normalize failed (unrecognized input).
+// We test normalize by asserting status !== 1.
+
+// Exact matches
+test('normalize: "up" accepted', () => {
+  assert.notEqual(run('up').status, 1);
+});
+
+test('normalize: "down" accepted', () => {
+  assert.notEqual(run('down').status, 1);
+});
+
+test('normalize: "thumbsup" accepted', () => {
+  assert.notEqual(run('thumbsup').status, 1);
+});
+
+test('normalize: "thumbsdown" accepted', () => {
+  assert.notEqual(run('thumbsdown').status, 1);
+});
+
+test('normalize: "positive" -> up', () => {
+  assert.notEqual(run('positive').status, 1);
+});
+
+test('normalize: "negative" -> down', () => {
+  assert.notEqual(run('negative').status, 1);
+});
+
+// Misspell variants — fuzzy match (edit distance <= 2)
+test('normalize: "thubs up" -> up (missing h)', () => {
+  assert.notEqual(run('thubs up').status, 1);
+});
+
+test('normalize: "thumbs u" -> up (missing p)', () => {
+  assert.notEqual(run('thumbs u').status, 1);
+});
+
+test('normalize: "thumb down" -> down (missing s)', () => {
+  assert.notEqual(run('thumb down').status, 1);
+});
+
+test('normalize: "thumps up" -> up (p instead of b)', () => {
+  assert.notEqual(run('thumps up').status, 1);
+});
+
+test('normalize: "thumbs dwon" -> down (transposed wo)', () => {
+  assert.notEqual(run('thumbs dwon').status, 1);
+});
+
+test('normalize: "thumbs donw" -> down (transposed nw)', () => {
+  assert.notEqual(run('thumbs donw').status, 1);
+});
+
+// Garbage input should fail (exit 1)
+test('normalize: "banana" rejected', () => {
+  assert.equal(run('banana').status, 1);
+});
+
+test('normalize: "xyz" rejected', () => {
+  assert.equal(run('xyz').status, 1);
+});


### PR DESCRIPTION
## Summary
- Feedback capture now accepts misspelled variants: "thubs up", "thumbs u", "thumb down", "thumps up", "thumbs dwon", etc.
- Uses Levenshtein distance (edit distance <= 2) with zero new dependencies
- Unrecognized garbage input now properly rejected (exit 1)
- 14 new tests covering exact matches, fuzzy matches, and rejection

## Test plan
- [x] `node --test tests/feedback-normalize.test.js` — 14/14 pass
- [x] `npm test` — full suite 0 failures
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)