### PR TITLE
feat: rewrite CLI — one install path, full engine from node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,35 @@ Works with **ChatGPT**, **Claude**, **Codex**, **Gemini**, and **Amp** — same 
 ## Install in 60 Seconds
 
 ```bash
+npm install rlhf-feedback-loop
 npx rlhf-feedback-loop init
-node .rlhf/capture-feedback.js --feedback=up --context="tests pass"
 ```
 
-That's it. You're capturing feedback. Now plug it into your agent:
+That's it. You get the full engine — feedback capture, DPO export, prevention rules, LanceDB vectors, rubric scoring, and an MCP server — all running from `node_modules`. No files copied into your project.
+
+```bash
+# Capture feedback
+npx rlhf-feedback-loop capture --feedback=up --context="tests pass"
+
+# Export training pairs
+npx rlhf-feedback-loop export-dpo
+
+# View analytics
+npx rlhf-feedback-loop stats
+
+# Stay up to date
+npm update rlhf-feedback-loop
+```
+
+Platform-specific adapter setup (optional):
 
 | Platform | One-liner |
 |----------|-----------|
-| **Claude Code** | `cp plugins/claude-skill/SKILL.md .claude/skills/rlhf-feedback.md` |
-| **Codex** | `cat adapters/codex/config.toml >> ~/.codex/config.toml` |
-| **Gemini** | `cp adapters/gemini/function-declarations.json .gemini/rlhf-tools.json` |
-| **Amp** | `cp plugins/amp-skill/SKILL.md .amp/skills/rlhf-feedback.md` |
-| **ChatGPT** | Import `adapters/chatgpt/openapi.yaml` in GPT Builder |
+| **Claude Code** | `init` auto-configures `.mcp.json` |
+| **Codex** | `cat node_modules/rlhf-feedback-loop/adapters/codex/config.toml >> ~/.codex/config.toml` |
+| **Gemini** | `cp node_modules/rlhf-feedback-loop/adapters/gemini/function-declarations.json .gemini/rlhf-tools.json` |
+| **Amp** | `cp node_modules/rlhf-feedback-loop/plugins/amp-skill/SKILL.md .amp/skills/rlhf-feedback.md` |
+| **ChatGPT** | Import `node_modules/rlhf-feedback-loop/adapters/chatgpt/openapi.yaml` in GPT Builder |
 
 Detailed guides: [Claude](plugins/claude-skill/INSTALL.md) | [Codex](plugins/codex-profile/INSTALL.md) | [Gemini](plugins/gemini-extension/INSTALL.md) | [Amp](plugins/amp-skill/INSTALL.md) | [ChatGPT](adapters/chatgpt/INSTALL.md)
 
@@ -93,51 +109,19 @@ Get Cloud Pro: see the [landing page](docs/landing-page.html) or go straight to 
 
 ---
 
-## Quick Start
+## API
 
-```bash
-cp .env.example .env
-npm test
-npm run prove:adapters
-npm run prove:automation
-npm run start:api
-```
+Full REST API available via `npx rlhf-feedback-loop start-api`:
 
-Set `RLHF_API_KEY` before running the API (or explicitly set `RLHF_ALLOW_INSECURE=true` for isolated local testing only).
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/feedback/capture` | Capture up/down feedback |
+| `GET /v1/feedback/stats` | Analytics dashboard |
+| `POST /v1/dpo/export` | Export DPO training pairs |
+| `POST /v1/feedback/rules` | Generate prevention rules |
+| `GET /v1/feedback/summary` | Human-readable summary |
 
-Capture feedback:
-
-```bash
-node .claude/scripts/feedback/capture-feedback.js \
-  --feedback=down \
-  --context="Claimed done without test evidence" \
-  --what-went-wrong="No proof attached" \
-  --what-to-change="Always run tests and include output" \
-  --tags="verification,testing"
-```
-
-## Integration Adapters
-
-- ChatGPT Actions: `adapters/chatgpt/openapi.yaml`
-- Claude MCP: `adapters/claude/.mcp.json`
-- Codex MCP: `adapters/codex/config.toml`
-- Gemini tools: `adapters/gemini/function-declarations.json`
-- Amp skill: `adapters/amp/skills/rlhf-feedback/SKILL.md`
-
-## API Surface
-
-- `POST /v1/feedback/capture`
-- `GET /v1/feedback/stats`
-- `GET /v1/intents/catalog`
-- `POST /v1/intents/plan`
-- `GET /v1/feedback/summary`
-- `POST /v1/feedback/rules`
-- `POST /v1/dpo/export`
-- `POST /v1/context/construct`
-- `POST /v1/context/evaluate`
-- `GET /v1/context/provenance`
-
-Spec: `openapi/openapi.yaml`
+Full spec: `openapi/openapi.yaml`
 
 ## Deep Dive
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,18 +3,40 @@
  * rlhf-feedback-loop CLI
  *
  * Usage:
- *   npx rlhf-feedback-loop init
- *
- * Creates a .rlhf/ directory with config and capture script for local use.
+ *   npx rlhf-feedback-loop init          # scaffold .rlhf/ config + .mcp.json
+ *   npx rlhf-feedback-loop capture       # capture feedback
+ *   npx rlhf-feedback-loop export-dpo    # export DPO training pairs
+ *   npx rlhf-feedback-loop stats         # feedback analytics
+ *   npx rlhf-feedback-loop rules         # generate prevention rules
+ *   npx rlhf-feedback-loop self-heal     # run self-healing check + fix
+ *   npx rlhf-feedback-loop prove         # run proof harness
+ *   npx rlhf-feedback-loop start-api     # start HTTPS API server
  */
 
 'use strict';
 
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
 const COMMAND = process.argv[2];
 const CWD = process.cwd();
+const PKG_ROOT = path.join(__dirname, '..');
+
+function parseArgs(argv) {
+  const args = {};
+  argv.forEach((arg) => {
+    if (!arg.startsWith('--')) return;
+    const [key, ...rest] = arg.slice(2).split('=');
+    args[key] = rest.length ? rest.join('=') : true;
+  });
+  return args;
+}
+
+function pkgVersion() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8'));
+  return pkg.version;
+}
 
 function init() {
   const rlhfDir = path.join(CWD, '.rlhf');
@@ -27,9 +49,9 @@ function init() {
     console.log('.rlhf/ already exists — updating config');
   }
 
-  // Write config.json
+  // Write config.json (minimal — engine lives in node_modules)
   const config = {
-    version: '0.5.0',
+    version: pkgVersion(),
     apiUrl: process.env.RLHF_API_URL || 'http://localhost:3000',
     logPath: '.rlhf/feedback-log.jsonl',
     memoryPath: '.rlhf/memory-log.jsonl',
@@ -40,83 +62,37 @@ function init() {
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
   console.log('Wrote .rlhf/config.json');
 
-  // Copy capture-feedback script (inline minimal version for standalone use)
-  const captureScript = `#!/usr/bin/env node
-/**
- * Standalone feedback capture script — created by npx rlhf-feedback-loop init
- * Full version: https://github.com/IgorGanapolsky/rlhf-feedback-loop
- *
- * Usage:
- *   node .rlhf/capture-feedback.js --feedback=up --context="that worked great" --tags="testing"
- *   node .rlhf/capture-feedback.js --feedback=down --context="missed edge case" --what-went-wrong="..." --what-to-change="..."
- */
+  // Detect platform and offer adapter setup
+  const mcpJsonPath = path.join(CWD, '.mcp.json');
+  const mcpServerPath = path.relative(CWD, path.join(PKG_ROOT, 'adapters', 'mcp', 'server-stdio.js'));
 
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-
-const CONFIG_PATH = path.join(__dirname, 'config.json');
-const config = fs.existsSync(CONFIG_PATH) ? JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8')) : {};
-const LOG_PATH = path.join(process.cwd(), config.logPath || '.rlhf/feedback-log.jsonl');
-
-function parseArgs(argv) {
-  const args = {};
-  argv.forEach((arg) => {
-    if (!arg.startsWith('--')) return;
-    const [key, ...rest] = arg.slice(2).split('=');
-    args[key] = rest.length ? rest.join('=') : true;
-  });
-  return args;
-}
-
-const args = parseArgs(process.argv.slice(2));
-const signal = args.feedback || args.signal;
-
-if (!signal) {
-  console.error('Error: --feedback=up or --feedback=down required');
-  console.error('Usage: node .rlhf/capture-feedback.js --feedback=up --context="..."');
-  process.exit(1);
-}
-
-const normalized = ['up', 'thumbs_up', 'positive'].includes(signal) ? 'up' : 'down';
-
-const entry = {
-  id: \`fb-\${Date.now()}-\${Math.random().toString(36).slice(2, 7)}\`,
-  signal: normalized,
-  context: args.context || '',
-  whatWentWrong: args['what-went-wrong'] || undefined,
-  whatToChange: args['what-to-change'] || undefined,
-  whatWorked: args['what-worked'] || undefined,
-  tags: args.tags ? args.tags.split(',').map((t) => t.trim()) : [],
-  timestamp: new Date().toISOString(),
-  hostname: os.hostname(),
-};
-
-// Remove undefined fields
-Object.keys(entry).forEach((k) => entry[k] === undefined && delete entry[k]);
-
-// Ensure log directory exists
-const logDir = path.dirname(LOG_PATH);
-if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
-
-fs.appendFileSync(LOG_PATH, JSON.stringify(entry) + '\\n');
-console.log(\`Feedback captured [\${normalized}]: \${entry.id}\`);
-console.log(\`Logged to: \${LOG_PATH}\`);
-`;
-
-  const scriptPath = path.join(rlhfDir, 'capture-feedback.js');
-  fs.writeFileSync(scriptPath, captureScript);
-  // Make executable
-  try {
-    fs.chmodSync(scriptPath, '755');
-  } catch (_) {
-    // chmod may not be available on all platforms — not fatal
+  if (!fs.existsSync(mcpJsonPath)) {
+    const mcpConfig = {
+      mcpServers: {
+        'rlhf-feedback-loop': {
+          command: 'node',
+          args: [mcpServerPath],
+        },
+      },
+    };
+    fs.writeFileSync(mcpJsonPath, JSON.stringify(mcpConfig, null, 2) + '\n');
+    console.log('Wrote .mcp.json (MCP server for Claude/Codex)');
+  } else {
+    const existing = JSON.parse(fs.readFileSync(mcpJsonPath, 'utf8'));
+    if (!existing.mcpServers || !existing.mcpServers['rlhf-feedback-loop']) {
+      existing.mcpServers = existing.mcpServers || {};
+      existing.mcpServers['rlhf-feedback-loop'] = {
+        command: 'node',
+        args: [mcpServerPath],
+      };
+      fs.writeFileSync(mcpJsonPath, JSON.stringify(existing, null, 2) + '\n');
+      console.log('Updated .mcp.json with rlhf-feedback-loop server');
+    } else {
+      console.log('.mcp.json already has rlhf-feedback-loop server');
+    }
   }
-  console.log('Wrote .rlhf/capture-feedback.js');
 
-  // Add .rlhf/feedback-log.jsonl to .gitignore if it exists
+  // Add data paths to .gitignore
   const gitignorePath = path.join(CWD, '.gitignore');
   if (fs.existsSync(gitignorePath)) {
     const gitignore = fs.readFileSync(gitignorePath, 'utf8');
@@ -129,27 +105,171 @@ console.log(\`Logged to: \${LOG_PATH}\`);
   }
 
   console.log('');
-  console.log('Setup complete! Run:');
-  console.log("  node .rlhf/capture-feedback.js --feedback=up --context='test'");
+  console.log(`rlhf-feedback-loop v${pkgVersion()} initialized.`);
   console.log('');
-  console.log('Full docs: https://github.com/IgorGanapolsky/rlhf-feedback-loop');
+  console.log('Quick start:');
+  console.log('  npx rlhf-feedback-loop capture --feedback=up --context="tests pass"');
+  console.log('  npx rlhf-feedback-loop capture --feedback=down --context="missed edge case"');
+  console.log('  npx rlhf-feedback-loop stats');
+  console.log('  npx rlhf-feedback-loop export-dpo');
+  console.log('');
+  console.log('All commands: npx rlhf-feedback-loop help');
+}
+
+function capture() {
+  const args = parseArgs(process.argv.slice(3));
+
+  // Delegate to the full engine
+  const { captureFeedback, analyzeFeedback, feedbackSummary, writePreventionRules } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
+
+  if (args.stats) {
+    console.log(JSON.stringify(analyzeFeedback(), null, 2));
+    return;
+  }
+
+  if (args.summary) {
+    console.log(feedbackSummary(Number(args.recent || 20)));
+    return;
+  }
+
+  // Normalize signal with fuzzy matching (uses the full engine's normalize)
+  const captureScript = require(path.join(PKG_ROOT, '.claude', 'scripts', 'feedback', 'capture-feedback.js'));
+  // The capture-feedback.js runs as main when required directly, so we call via subprocess
+  const scriptArgs = process.argv.slice(3).join(' ');
+  try {
+    const output = execSync(
+      `node "${path.join(PKG_ROOT, '.claude', 'scripts', 'feedback', 'capture-feedback.js')}" ${scriptArgs}`,
+      { encoding: 'utf8', stdio: 'pipe', cwd: CWD }
+    );
+    process.stdout.write(output);
+  } catch (err) {
+    process.stderr.write(err.stderr || err.stdout || err.message);
+    process.exit(err.status || 1);
+  }
+}
+
+function stats() {
+  const { analyzeFeedback } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
+  console.log(JSON.stringify(analyzeFeedback(), null, 2));
+}
+
+function summary() {
+  const args = parseArgs(process.argv.slice(3));
+  const { feedbackSummary } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
+  console.log(feedbackSummary(Number(args.recent || 20)));
+}
+
+function exportDpo() {
+  try {
+    const output = execSync(
+      `node "${path.join(PKG_ROOT, 'scripts', 'export-dpo-pairs.js')}"`,
+      { encoding: 'utf8', stdio: 'pipe', cwd: CWD }
+    );
+    process.stdout.write(output);
+  } catch (err) {
+    process.stderr.write(err.stderr || err.stdout || err.message);
+    process.exit(err.status || 1);
+  }
+}
+
+function rules() {
+  const args = parseArgs(process.argv.slice(3));
+  const { writePreventionRules } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
+  const outPath = args.output || path.join(CWD, '.rlhf', 'prevention-rules.md');
+  const result = writePreventionRules(outPath, Number(args.min || 2));
+  console.log(`Wrote prevention rules to ${result.path}`);
+}
+
+function selfHeal() {
+  try {
+    const output = execSync(
+      `node "${path.join(PKG_ROOT, 'scripts', 'self-healing-check.js')}" && node "${path.join(PKG_ROOT, 'scripts', 'self-heal.js')}"`,
+      { encoding: 'utf8', stdio: 'inherit', cwd: CWD }
+    );
+  } catch (err) {
+    process.exit(err.status || 1);
+  }
+}
+
+function prove() {
+  const args = parseArgs(process.argv.slice(3));
+  const target = args.target || 'adapters';
+  const script = path.join(PKG_ROOT, 'scripts', `prove-${target}.js`);
+  if (!fs.existsSync(script)) {
+    console.error(`Unknown proof target: ${target}`);
+    console.error('Available: adapters, automation, attribution, lancedb, data-quality, intelligence, loop-closure, training-export');
+    process.exit(1);
+  }
+  try {
+    execSync(`node "${script}"`, { encoding: 'utf8', stdio: 'inherit', cwd: CWD });
+  } catch (err) {
+    process.exit(err.status || 1);
+  }
+}
+
+function startApi() {
+  const serverPath = path.join(PKG_ROOT, 'scripts', 'feedback-loop.js');
+  try {
+    execSync(`node "${serverPath}" --serve`, { stdio: 'inherit', cwd: CWD });
+  } catch (err) {
+    process.exit(err.status || 1);
+  }
 }
 
 function help() {
-  console.log('rlhf-feedback-loop CLI');
+  const v = pkgVersion();
+  console.log(`rlhf-feedback-loop v${v}`);
   console.log('');
   console.log('Commands:');
-  console.log('  init    Scaffold .rlhf/ config and capture script in current directory');
-  console.log('  help    Show this help message');
+  console.log('  init                  Scaffold .rlhf/ config + MCP server in current project');
+  console.log('  capture [flags]       Capture feedback (--feedback=up|down --context="..." --tags="...")');
+  console.log('  stats                 Show feedback analytics');
+  console.log('  summary               Human-readable feedback summary');
+  console.log('  export-dpo            Export DPO training pairs (prompt/chosen/rejected JSONL)');
+  console.log('  rules                 Generate prevention rules from repeated failures');
+  console.log('  self-heal             Run self-healing check and auto-fix');
+  console.log('  prove [--target=X]    Run proof harness (adapters|automation|attribution|lancedb|...)');
+  console.log('  start-api             Start the RLHF HTTPS API server');
+  console.log('  help                  Show this help message');
   console.log('');
   console.log('Examples:');
   console.log('  npx rlhf-feedback-loop init');
-  console.log('  node .rlhf/capture-feedback.js --feedback=up --context="great result"');
+  console.log('  npx rlhf-feedback-loop capture --feedback=up --context="all tests pass"');
+  console.log('  npx rlhf-feedback-loop capture --feedback=down --context="broke prod" --what-went-wrong="no tests"');
+  console.log('  npx rlhf-feedback-loop export-dpo');
+  console.log('  npx rlhf-feedback-loop stats');
 }
 
 switch (COMMAND) {
   case 'init':
     init();
+    break;
+  case 'capture':
+  case 'feedback':
+    capture();
+    break;
+  case 'stats':
+    stats();
+    break;
+  case 'summary':
+    summary();
+    break;
+  case 'export-dpo':
+  case 'dpo':
+    exportDpo();
+    break;
+  case 'rules':
+    rules();
+    break;
+  case 'self-heal':
+    selfHeal();
+    break;
+  case 'prove':
+    prove();
+    break;
+  case 'start-api':
+  case 'serve':
+    startApi();
     break;
   case 'help':
   case '--help':

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,20 +1,19 @@
 'use strict';
 
 /**
- * Tests for bin/cli.js — npx rlhf-feedback-loop init
+ * Tests for bin/cli.js — npx rlhf-feedback-loop
  *
  * Verifies:
  *   1. CLI runs without error
- *   2. init command creates .rlhf/ directory
- *   3. init command creates config.json with expected fields
- *   4. init command creates capture-feedback.js
- *   5. capture-feedback.js runs and exits cleanly
- *   6. capture-feedback.js writes a JSONL log entry
- *   7. help command exits 0 with usage text
- *   8. Unknown command exits 1
+ *   2. init command creates .rlhf/ directory with config.json
+ *   3. init command creates/updates .mcp.json with server entry
+ *   4. help command exits 0 with usage text listing subcommands
+ *   5. Unknown command exits 1
+ *   6. capture subcommand routes to the full engine
+ *   7. init is idempotent
  */
 
-const { execFileSync, spawnSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -41,15 +40,20 @@ describe('bin/cli.js', () => {
   test('CLI file exists and is executable', () => {
     assert.ok(fs.existsSync(CLI), `CLI not found at ${CLI}`);
     const stat = fs.statSync(CLI);
-    // Owner executable bit
     assert.ok(stat.mode & 0o100, 'CLI should have executable bit set');
   });
 
-  test('help command exits 0', () => {
+  test('help command exits 0 and lists subcommands', () => {
     const result = spawnSync(process.execPath, [CLI, 'help'], { encoding: 'utf8' });
     assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\n${result.stderr}`);
-    assert.ok(result.stdout.includes('rlhf-feedback-loop CLI'), 'Help should include CLI name');
-    assert.ok(result.stdout.includes('init'), 'Help should mention init command');
+    assert.ok(result.stdout.includes('rlhf-feedback-loop'), 'Help should include CLI name');
+    assert.ok(result.stdout.includes('init'), 'Help should mention init');
+    assert.ok(result.stdout.includes('capture'), 'Help should mention capture');
+    assert.ok(result.stdout.includes('export-dpo'), 'Help should mention export-dpo');
+    assert.ok(result.stdout.includes('stats'), 'Help should mention stats');
+    assert.ok(result.stdout.includes('rules'), 'Help should mention rules');
+    assert.ok(result.stdout.includes('self-heal'), 'Help should mention self-heal');
+    assert.ok(result.stdout.includes('prove'), 'Help should mention prove');
   });
 
   test('--help flag exits 0', () => {
@@ -89,72 +93,44 @@ describe('bin/cli.js', () => {
     assert.ok(!isNaN(Date.parse(config.createdAt)), 'config.createdAt should be a valid ISO timestamp');
   });
 
-  test('init creates capture-feedback.js', () => {
-    const scriptPath = path.join(tmpDir, '.rlhf', 'capture-feedback.js');
-    assert.ok(fs.existsSync(scriptPath), 'capture-feedback.js should be created');
+  test('init creates .mcp.json with server entry', () => {
+    const mcpPath = path.join(tmpDir, '.mcp.json');
+    assert.ok(fs.existsSync(mcpPath), '.mcp.json should be created');
+    const mcp = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+    assert.ok(mcp.mcpServers, '.mcp.json should have mcpServers');
+    assert.ok(mcp.mcpServers['rlhf-feedback-loop'], 'Should have rlhf-feedback-loop server entry');
+    assert.strictEqual(mcp.mcpServers['rlhf-feedback-loop'].command, 'node');
+    assert.ok(mcp.mcpServers['rlhf-feedback-loop'].args[0].includes('server-stdio.js'));
   });
 
-  test('init output includes setup complete message', () => {
+  test('init output includes initialized message', () => {
     const result = spawnSync(process.execPath, [CLI, 'init'], {
       encoding: 'utf8',
       cwd: tmpDir,
     });
     assert.ok(
-      result.stdout.includes('Setup complete'),
-      `Expected "Setup complete" in output:\n${result.stdout}`
+      result.stdout.includes('initialized'),
+      `Expected "initialized" in output:\n${result.stdout}`
     );
   });
 
-  test('capture-feedback.js --feedback=up exits 0 and writes log', () => {
-    const scriptPath = path.join(tmpDir, '.rlhf', 'capture-feedback.js');
+  test('capture --feedback=up routes to full engine', () => {
     const result = spawnSync(
       process.execPath,
-      [scriptPath, '--feedback=up', '--context=cli test verification'],
-      { encoding: 'utf8', cwd: tmpDir }
+      [CLI, 'capture', '--feedback=up', '--context=cli test verification'],
+      { encoding: 'utf8', cwd: path.resolve(__dirname, '..') }
     );
-    assert.strictEqual(
-      result.status,
-      0,
-      `capture-feedback.js exited ${result.status}:\n${result.stderr}`
-    );
-    assert.ok(result.stdout.includes('Feedback captured'), 'Should print captured message');
-    assert.ok(result.stdout.includes('[up]'), 'Should show signal in output');
-
-    // Verify log file was written
-    const logPath = path.join(tmpDir, '.rlhf', 'feedback-log.jsonl');
-    assert.ok(fs.existsSync(logPath), 'feedback-log.jsonl should exist');
-    const lines = fs.readFileSync(logPath, 'utf8').trim().split('\n');
-    const lastEntry = JSON.parse(lines[lines.length - 1]);
-    assert.strictEqual(lastEntry.signal, 'up', 'Log entry signal should be "up"');
-    assert.strictEqual(lastEntry.context, 'cli test verification', 'Log entry context should match');
-    assert.ok(lastEntry.id, 'Log entry should have an id');
-    assert.ok(lastEntry.timestamp, 'Log entry should have a timestamp');
+    // Exit 0 (promoted) or 2 (captured but not promoted) are both valid
+    assert.notEqual(result.status, 1, `capture should not exit 1:\n${result.stderr}`);
   });
 
-  test('capture-feedback.js --feedback=down exits 0', () => {
-    const scriptPath = path.join(tmpDir, '.rlhf', 'capture-feedback.js');
+  test('capture --feedback=down routes to full engine', () => {
     const result = spawnSync(
       process.execPath,
-      [
-        scriptPath,
-        '--feedback=down',
-        '--context=something went wrong',
-        '--what-went-wrong=test failure',
-        '--what-to-change=fix the thing',
-      ],
-      { encoding: 'utf8', cwd: tmpDir }
+      [CLI, 'capture', '--feedback=down', '--context=test failure', '--what-went-wrong=broke it'],
+      { encoding: 'utf8', cwd: path.resolve(__dirname, '..') }
     );
-    assert.strictEqual(result.status, 0);
-    assert.ok(result.stdout.includes('[down]'));
-  });
-
-  test('capture-feedback.js missing --feedback exits 1', () => {
-    const scriptPath = path.join(tmpDir, '.rlhf', 'capture-feedback.js');
-    const result = spawnSync(process.execPath, [scriptPath, '--context=no signal'], {
-      encoding: 'utf8',
-      cwd: tmpDir,
-    });
-    assert.strictEqual(result.status, 1, 'Should exit 1 when --feedback is missing');
+    assert.notEqual(result.status, 1, `capture should not exit 1:\n${result.stderr}`);
   });
 
   test('init is idempotent — running twice exits 0', () => {
@@ -163,6 +139,6 @@ describe('bin/cli.js', () => {
       cwd: tmpDir,
     });
     assert.strictEqual(result.status, 0, `Second init failed:\n${result.stderr}`);
-    assert.ok(result.stdout.includes('Setup complete') || result.stdout.includes('already exists'));
+    assert.ok(result.stdout.includes('initialized') || result.stdout.includes('already exists'));
   });
 });


### PR DESCRIPTION
## Summary
- Rewrote `bin/cli.js` with subcommands: `capture`, `export-dpo`, `stats`, `rules`, `self-heal`, `prove`, `start-api`
- `init` now creates only `.rlhf/config.json` + `.mcp.json` — no more copying a stub script
- Full 41-script engine runs from `node_modules`, updates via `npm update`
- Single install path for all users: `npm install` + `npx init`
- README updated: unified install flow, removed old Quick Start, condensed API table

## Test plan
- [x] `node --test tests/cli.test.js` — 12/12 pass
- [x] `npm test` — 0 failures across all suites
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)