### PR TITLE
feat: live Stripe checkout + Cloud Run API deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Everything is stored locally in your project as plain JSONL files — fully tran
 | **Open Source** | **$0 forever** | Full source, self-hosted, MIT license, 573 tests, 5-platform plugins |
 | **Cloud Pro** | **$10/mo** | Hosted HTTPS API, provisioned API key on payment, Stripe billing, email support |
 
-Get Cloud Pro: see the [landing page](docs/landing-page.html) or go straight to [Stripe Checkout](https://buy.stripe.com/)
+Get Cloud Pro: see the [landing page](docs/landing-page.html) or go straight to [Stripe Checkout](https://buy.stripe.com/bJe14neyU4r4f0leOD3sI02)
 
 ---
 

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -517,7 +517,7 @@
           <li>Email support</li>
         </ul>
         <!-- Replace STRIPE_CHECKOUT_URL with your actual Stripe Checkout link -->
-        <a href="https://buy.stripe.com/STRIPE_CHECKOUT_URL" class="btn-checkout" id="checkout-btn">
+        <a href="https://buy.stripe.com/bJe14neyU4r4f0leOD3sI02" class="btn-checkout" id="checkout-btn">
           Get Started — $49/mo
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Wired real Stripe payment link (created from STRIPE_PRICE_ID)
- Replaced placeholder URLs in README and landing page
- Deployed RLHF API to Google Cloud Run (us-central1)
- Health check: https://rlhf-feedback-loop-710216278770.us-central1.run.app/health

## Test plan
- [x] Stripe payment link returns HTTP 200
- [x] Cloud Run health endpoint returns `{"status":"ok","version":"0.5.0"}`
- [x] `npm test` — 0 failures
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)