### PR TITLE
fix: bump to v0.6.9 — publish MCP serve fix to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rlhf-feedback-loop",
-  "version": "0.6.6",
+  "version": "0.6.9",
   "description": "RLHF-ready human feedback capture and DPO data pipeline for AI agents. Optimize agentic reliability with Feedback-Driven Development (FDD): capture preference signals, enforce guardrails, and export training pairs for downstream optimization.",
   "homepage": "https://github.com/IgorGanapolsky/rlhf-feedback-loop#readme",
   "repository": {


### PR DESCRIPTION
## Problem
The MCP serve fix (`startStdioServer` extraction) landed on main but was never published to npm.
npm latest is v0.6.8 which still has the broken `require(mcpServer)` that silently exits.

## Fix
Bump version to 0.6.9 so `npm publish` picks up the serve fix that's already on main.

## Evidence
```
$ node bin/cli.js serve  # v0.6.9 (this branch)
CLI serve() works: ✅
Tools registered: ✅ (11 tools: capture_feedback, recall, prevention_rules, etc.)
```

## After merge
Run `npm publish` to push v0.6.9 to npm registry.