### PR TITLE
feat: PreToolUse contextual bandit hook for Claude Code

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -6,3 +6,8 @@
 - `claude/.mcp.json`: example Claude Code MCP config.
 - `codex/config.toml`: example Codex MCP profile section.
 - `amp/skills/rlhf-feedback/SKILL.md`: Amp skill template.
+
+# Hooks
+
+- `../hooks/claude-code/pretool-inject.js`: PreToolUse contextual bandit hook for Claude Code.
+- `../hooks/claude-code/install.js`: auto-installs the hook into `~/.claude/settings.local.json`.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -428,6 +428,7 @@ function help() {
   console.log('  pro                   Upgrade to Cloud Pro ($10/mo)');
   console.log('  prove [--target=X]    Run proof harness (adapters|automation|attribution|lancedb|...)');
   console.log('  start-api             Start the RLHF HTTPS API server');
+  console.log('  install-hooks         Install Claude Code PreToolUse hook for contextual bandit injection');
   console.log('  help                  Show this help message');
   console.log('');
   console.log('Examples:');
@@ -475,6 +476,9 @@ switch (COMMAND) {
     break;
   case 'start-api':
     startApi();
+    break;
+  case 'install-hooks':
+    require('../hooks/claude-code/install').install();
     break;
   case 'help':
   case '--help':

--- a/hooks/claude-code/install.js
+++ b/hooks/claude-code/install.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Install Claude Code hooks for rlhf-feedback-loop.
+ *
+ * Adds PreToolUse hook to ~/.claude/settings.local.json so that
+ * pretool-inject.js runs before every tool call.
+ *
+ * Usage:
+ *   node hooks/claude-code/install.js
+ *   npx rlhf-feedback-loop install-hooks   (via CLI)
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const HOME = process.env.HOME || process.env.USERPROFILE || '';
+const SETTINGS_PATH = path.join(HOME, '.claude', 'settings.local.json');
+
+const HOOK_ENTRY = {
+  matcher: '*',
+  hooks: [
+    {
+      type: 'command',
+      command: 'node node_modules/rlhf-feedback-loop/hooks/claude-code/pretool-inject.js',
+    },
+  ],
+};
+
+function install() {
+  let settings = {};
+
+  if (fs.existsSync(SETTINGS_PATH)) {
+    try {
+      settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+    } catch (_) {
+      console.error('Warning: could not parse existing settings.local.json, creating new one');
+      settings = {};
+    }
+  } else {
+    const dir = path.dirname(SETTINGS_PATH);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  }
+
+  settings.hooks = settings.hooks || {};
+  settings.hooks.PreToolUse = settings.hooks.PreToolUse || [];
+
+  // Check if already installed
+  const existing = settings.hooks.PreToolUse.some(
+    (entry) =>
+      entry.hooks &&
+      entry.hooks.some((h) => h.command && h.command.includes('pretool-inject.js')),
+  );
+
+  if (existing) {
+    console.log('PreToolUse hook already installed in ' + SETTINGS_PATH);
+    return false;
+  }
+
+  settings.hooks.PreToolUse.push(HOOK_ENTRY);
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + '\n');
+  console.log('Installed PreToolUse hook in ' + SETTINGS_PATH);
+  return true;
+}
+
+module.exports = { install, HOOK_ENTRY, SETTINGS_PATH };
+
+if (require.main === module) {
+  install();
+}

--- a/hooks/claude-code/pretool-inject.js
+++ b/hooks/claude-code/pretool-inject.js
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse Hook — Contextual Bandit Injection
+ *
+ * Intercepts Claude Code tool calls and injects targeted warnings for
+ * tool+context combinations with low Thompson Sampling reliability scores.
+ *
+ * How it works:
+ *   1. Claude Code fires a PreToolUse hook before each tool call
+ *   2. This script derives a compound context key (e.g. "Bash:git_push")
+ *   3. Looks up the key in the Thompson model to get reliability (mu)
+ *   4. If mu < threshold: injects a warning via additionalContext
+ *   5. If mu >= threshold: allows silently (no overhead)
+ *
+ * Install:
+ *   npx rlhf-feedback-loop install-hooks
+ *
+ * Or manually add to ~/.claude/settings.local.json:
+ *   {
+ *     "hooks": {
+ *       "PreToolUse": [{
+ *         "matcher": "*",
+ *         "hooks": [{
+ *           "type": "command",
+ *           "command": "node node_modules/rlhf-feedback-loop/hooks/claude-code/pretool-inject.js"
+ *         }]
+ *       }]
+ *     }
+ *   }
+ *
+ * Performance budget: <50ms (no network, no model loading — just JSON lookups)
+ *
+ * References:
+ *   - Contextual Bandits for LLM Routing (arxiv:2510.07429)
+ *   - Neural Thompson Sampling (arxiv:2010.00827)
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const WEAK_ARM_THRESHOLD = parseFloat(process.env.RLHF_WEAK_THRESHOLD || '0.6');
+const MAX_CONTEXT_LEN = 200;
+
+// Model path: project-local first, then global fallback
+const PROJECT_MODEL = path.join(process.cwd(), '.rlhf', 'thompson-model.json');
+const GLOBAL_MODEL = path.join(
+  process.env.HOME || process.env.USERPROFILE || '',
+  '.rlhf',
+  'thompson-model.json',
+);
+
+// ---------------------------------------------------------------------------
+// Context Key Derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a compound context key from a tool call.
+ *
+ * Splits flat tool categories into fine-grained keys so that e.g.
+ * "git push" failures don't penalize "npm test" reliability.
+ *
+ * @param {string} toolName - The tool being called (Bash, Edit, Read, etc.)
+ * @param {Object} toolInput - The tool's input parameters
+ * @returns {string} Compound key like "Bash:git_push" or "Edit:test"
+ */
+function deriveContextKey(toolName, toolInput) {
+  const name = (toolName || '').toLowerCase();
+
+  if (name === 'bash') {
+    return 'Bash:' + deriveBashKey(toolInput);
+  }
+  if (name === 'edit' || name === 'write') {
+    return name.charAt(0).toUpperCase() + name.slice(1) + ':' + deriveFileKey(toolInput);
+  }
+  if (name === 'read') {
+    return 'Read:' + deriveReadKey(toolInput);
+  }
+  if (name === 'glob' || name === 'grep') {
+    return name.charAt(0).toUpperCase() + name.slice(1) + ':' + deriveSearchKey(toolInput);
+  }
+
+  return 'tool:' + name;
+}
+
+function deriveBashKey(input) {
+  const cmd = (input.command || input.cmd || '').trim();
+  if (/^git\s+push/i.test(cmd)) return 'git_push';
+  if (/^git\s+commit/i.test(cmd)) return 'git_commit';
+  if (/^git\s+reset/i.test(cmd)) return 'git_reset';
+  if (/^git\s+/i.test(cmd)) return 'git_other';
+  if (/^npm\s+test/i.test(cmd)) return 'npm_test';
+  if (/^npm\s+run/i.test(cmd)) return 'npm_run';
+  if (/^npm\s+install/i.test(cmd)) return 'npm_install';
+  if (/^(rm|del)\s/i.test(cmd)) return 'destructive';
+  if (/^curl\s/i.test(cmd)) return 'network';
+  if (/\|\s*(grep|awk|sed)\s/i.test(cmd)) return 'pipe';
+  return 'general';
+}
+
+function deriveFileKey(input) {
+  const filePath = (input.file_path || input.path || '').toLowerCase();
+  if (/\.(test|spec)\.[jt]sx?$/.test(filePath) || /__tests__/.test(filePath)) return 'test';
+  if (/\.env/.test(filePath)) return 'config';
+  if (/package\.json/.test(filePath)) return 'deps';
+  if (/\.(yml|yaml)$/.test(filePath) || /\.github/.test(filePath)) return 'ci';
+  if (/\.md$/.test(filePath)) return 'docs';
+  return 'source';
+}
+
+function deriveReadKey(input) {
+  const filePath = (input.file_path || input.path || '').toLowerCase();
+  if (/\.env/.test(filePath)) return 'config';
+  if (/\.(test|spec)\.[jt]sx?$/.test(filePath)) return 'test';
+  if (/package\.json/.test(filePath) || /node_modules/.test(filePath)) return 'deps';
+  return 'source';
+}
+
+function deriveSearchKey(input) {
+  const pattern = (input.pattern || input.query || '').toLowerCase();
+  if (/\*\.tsx?$/.test(pattern)) return 'typescript';
+  if (/\*\.test\./.test(pattern)) return 'test';
+  return 'general';
+}
+
+// ---------------------------------------------------------------------------
+// Model Lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the Thompson model from disk. Returns null if not found.
+ * Checks project-local path first, then global fallback.
+ */
+function loadModel() {
+  for (const modelPath of [PROJECT_MODEL, GLOBAL_MODEL]) {
+    try {
+      if (fs.existsSync(modelPath)) {
+        return JSON.parse(fs.readFileSync(modelPath, 'utf8'));
+      }
+    } catch (_) {
+      // Corrupted model — skip
+    }
+  }
+  return null;
+}
+
+/**
+ * Get the reliability (mu = alpha / (alpha + beta)) for a context key.
+ * Falls back to the parent tool key, then to 0.5 (uninformative prior).
+ */
+function getReliability(model, contextKey) {
+  if (!model || !model.categories) return 0.5;
+
+  // Exact match
+  const cat = model.categories[contextKey];
+  if (cat) {
+    const total = (cat.alpha || 1) + (cat.beta || 1);
+    return (cat.alpha || 1) / total;
+  }
+
+  // Fallback: parent key (e.g. "Bash:git_push" → "Bash")
+  const parent = contextKey.split(':')[0].toLowerCase();
+  const parentCat = model.categories[parent] || model.categories['tool:' + parent];
+  if (parentCat) {
+    const total = (parentCat.alpha || 1) + (parentCat.beta || 1);
+    return (parentCat.alpha || 1) / total;
+  }
+
+  return 0.5;
+}
+
+// ---------------------------------------------------------------------------
+// Warning Lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a targeted warning message for a weak context key.
+ * Uses prevention rules if available, otherwise a generic caution.
+ */
+function buildWarning(contextKey, mu) {
+  const parts = [`CAUTION [${contextKey}]: reliability=${mu.toFixed(3)} (below ${WEAK_ARM_THRESHOLD}).`];
+
+  // Load prevention rules for additional context
+  for (const rulesPath of [
+    path.join(process.cwd(), '.rlhf', 'prevention-rules.md'),
+    path.join(process.env.HOME || '', '.rlhf', 'prevention-rules.md'),
+  ]) {
+    try {
+      if (fs.existsSync(rulesPath)) {
+        const rules = fs.readFileSync(rulesPath, 'utf8');
+        // Extract rules relevant to this context key
+        const keyParts = contextKey.toLowerCase().split(':');
+        const relevant = rules
+          .split('\n')
+          .filter((line) => keyParts.some((k) => line.toLowerCase().includes(k)))
+          .slice(0, 3)
+          .join(' ');
+        if (relevant.length > 10) {
+          parts.push('Past issues: ' + relevant.slice(0, MAX_CONTEXT_LEN - parts[0].length));
+        }
+        break;
+      }
+    } catch (_) {}
+  }
+
+  return parts.join(' ').slice(0, MAX_CONTEXT_LEN);
+}
+
+// ---------------------------------------------------------------------------
+// Main Hook Handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a PreToolUse hook event from stdin.
+ * Outputs JSON with optional additionalContext for weak arms.
+ */
+function main() {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { input += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const event = JSON.parse(input);
+      const toolName = event.tool_name || '';
+      const toolInput = event.tool_input || {};
+
+      const contextKey = deriveContextKey(toolName, toolInput);
+      const model = loadModel();
+      const mu = getReliability(model, contextKey);
+
+      if (mu < WEAK_ARM_THRESHOLD) {
+        const warning = buildWarning(contextKey, mu);
+        const result = { additionalContext: warning };
+        process.stdout.write(JSON.stringify(result));
+      }
+      // Strong arm → output nothing (allow silently)
+    } catch (_) {
+      // Parse error or unexpected input → allow silently
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Exports (for testing) + CLI entry
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  deriveContextKey,
+  loadModel,
+  getReliability,
+  buildWarning,
+  WEAK_ARM_THRESHOLD,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/tests/pretool-inject.test.js
+++ b/tests/pretool-inject.test.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+'use strict';
+
+const {
+  deriveContextKey,
+  getReliability,
+  buildWarning,
+  WEAK_ARM_THRESHOLD,
+} = require('../hooks/claude-code/pretool-inject');
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, name) {
+  if (condition) {
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } else {
+    failed++;
+    console.log(`  ❌ ${name}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// deriveContextKey
+// ---------------------------------------------------------------------------
+
+console.log('\nderiveContextKey:');
+
+assert(
+  deriveContextKey('Bash', { command: 'git push origin main' }) === 'Bash:git_push',
+  'git push → Bash:git_push',
+);
+
+assert(
+  deriveContextKey('Bash', { command: 'git commit -m "test"' }) === 'Bash:git_commit',
+  'git commit → Bash:git_commit',
+);
+
+assert(
+  deriveContextKey('Bash', { command: 'npm test' }) === 'Bash:npm_test',
+  'npm test → Bash:npm_test',
+);
+
+assert(
+  deriveContextKey('Bash', { command: 'npm run lint' }) === 'Bash:npm_run',
+  'npm run → Bash:npm_run',
+);
+
+assert(
+  deriveContextKey('Bash', { command: 'rm -rf /tmp/old' }) === 'Bash:destructive',
+  'rm → Bash:destructive',
+);
+
+assert(
+  deriveContextKey('Bash', { command: 'curl https://api.example.com' }) === 'Bash:network',
+  'curl → Bash:network',
+);
+
+assert(
+  deriveContextKey('Bash', { command: 'ls -la' }) === 'Bash:general',
+  'ls → Bash:general',
+);
+
+assert(
+  deriveContextKey('Edit', { file_path: 'src/utils/__tests__/helper.test.ts' }) === 'Edit:test',
+  'edit test file → Edit:test',
+);
+
+assert(
+  deriveContextKey('Edit', { file_path: '.env.local' }) === 'Edit:config',
+  'edit .env → Edit:config',
+);
+
+assert(
+  deriveContextKey('Edit', { file_path: 'src/App.tsx' }) === 'Edit:source',
+  'edit source → Edit:source',
+);
+
+assert(
+  deriveContextKey('Read', { file_path: '.env' }) === 'Read:config',
+  'read .env → Read:config',
+);
+
+assert(
+  deriveContextKey('Read', { file_path: 'package.json' }) === 'Read:deps',
+  'read package.json → Read:deps',
+);
+
+assert(
+  deriveContextKey('Glob', { pattern: '**/*.tsx' }) === 'Glob:typescript',
+  'glob tsx → Glob:typescript',
+);
+
+assert(
+  deriveContextKey('Glob', { pattern: '**/*.test.ts' }) === 'Glob:test',
+  'glob test → Glob:test',
+);
+
+assert(
+  deriveContextKey('WebSearch', {}) === 'tool:websearch',
+  'unknown tool → tool:websearch',
+);
+
+// ---------------------------------------------------------------------------
+// getReliability
+// ---------------------------------------------------------------------------
+
+console.log('\ngetReliability:');
+
+const mockModel = {
+  categories: {
+    'Bash:git_push': { alpha: 3, beta: 7 },
+    'Bash:npm_test': { alpha: 9, beta: 1 },
+    bash: { alpha: 6, beta: 4 },
+    'tool:bash': { alpha: 6, beta: 4 },
+  },
+};
+
+assert(
+  Math.abs(getReliability(mockModel, 'Bash:git_push') - 0.3) < 0.01,
+  'exact match: git_push reliability=0.3',
+);
+
+assert(
+  Math.abs(getReliability(mockModel, 'Bash:npm_test') - 0.9) < 0.01,
+  'exact match: npm_test reliability=0.9',
+);
+
+assert(
+  Math.abs(getReliability(mockModel, 'Bash:unknown_cmd') - 0.6) < 0.01,
+  'fallback to parent: Bash reliability=0.6',
+);
+
+assert(
+  Math.abs(getReliability(mockModel, 'Edit:source') - 0.5) < 0.01,
+  'no match → uninformative prior 0.5',
+);
+
+assert(
+  Math.abs(getReliability(null, 'Bash:git_push') - 0.5) < 0.01,
+  'null model → 0.5',
+);
+
+// ---------------------------------------------------------------------------
+// buildWarning
+// ---------------------------------------------------------------------------
+
+console.log('\nbuildWarning:');
+
+const warning = buildWarning('Bash:git_push', 0.3);
+assert(warning.includes('CAUTION'), 'warning includes CAUTION');
+assert(warning.includes('Bash:git_push'), 'warning includes context key');
+assert(warning.includes('0.300'), 'warning includes mu value');
+assert(warning.length <= 200, 'warning respects MAX_CONTEXT_LEN');
+
+// ---------------------------------------------------------------------------
+// Threshold
+// ---------------------------------------------------------------------------
+
+console.log('\nthreshold:');
+
+assert(WEAK_ARM_THRESHOLD === 0.6, 'default threshold is 0.6');
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log(`\n${'═'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed, ${passed + failed} total`);
+console.log(`${'═'.repeat(50)}\n`);
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Adds a Claude Code PreToolUse hook that intercepts tool calls and injects targeted warnings for weak Thompson Sampling arms. Compound context keys (Bash:git_push, Edit:test) enable fine-grained reliability tracking. 25 tests, zero regressions.