### PR TITLE
chore: tighten CI install hygiene and remove unused Stripe dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'npm'
 
       - name: Install deps
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/self-healing-auto-fix.yml
+++ b/.github/workflows/self-healing-auto-fix.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'npm'
 
       - name: Install deps
-        run: npm install
+        run: npm ci
 
       - name: Run self-heal
         run: node scripts/self-heal.js --reason=scheduled-auto-fix > self_heal_report.json || true

--- a/.github/workflows/self-healing-monitor.yml
+++ b/.github/workflows/self-healing-monitor.yml
@@ -32,7 +32,7 @@ jobs:
           cache: 'npm'
 
       - name: Install deps
-        run: npm install
+        run: npm ci
 
       - name: Run health checks
         run: node scripts/self-healing-check.js --json --no-fail > health_report.json
@@ -145,7 +145,7 @@ jobs:
           cache: 'npm'
 
       - name: Install deps
-        run: npm install
+        run: npm ci
 
       - name: Run self-heal
         run: node scripts/self-heal.js --reason=scheduled-health-check > self_heal_report.json || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "rlhf-feedback-loop",
-  "version": "0.6.6",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rlhf-feedback-loop",
-      "version": "0.6.6",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@lancedb/lancedb": "^0.26.2",
-        "apache-arrow": "^18.1.0",
-        "stripe": "^20.4.1"
+        "apache-arrow": "^18.1.0"
       },
       "bin": {
         "rlhf-feedback-loop": "bin/cli.js"
@@ -1356,23 +1355,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/stripe": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
-      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/node": ">=16"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -117,8 +117,7 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "@lancedb/lancedb": "^0.26.2",
-    "apache-arrow": "^18.1.0",
-    "stripe": "^20.4.1"
+    "apache-arrow": "^18.1.0"
   },
   "mcpName": "io.github.IgorGanapolsky/rlhf-feedback-loop"
 }

--- a/scripts/code-reasoning.js
+++ b/scripts/code-reasoning.js
@@ -305,4 +305,4 @@ module.exports = {
   aggregateTraces,
   DEFAULT_CONFIDENCE_THRESHOLD,
 };
-// test coverage: 573 tests
+// Tests cover this module through the node:test suite; avoid hardcoding counts here.


### PR DESCRIPTION
## Summary
- switch CI and self-healing workflows from `npm install` to deterministic `npm ci`
- remove the unused `stripe` dependency and normalize the lockfile package version
- replace a stale hardcoded test-count comment with a non-lying module note

## Verification
- `npm test`
- `node scripts/self-healing-check.js --json --no-fail`

## Audit Notes
- `main` CI before this PR: https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/runs/22861752642
- Coverage remains untracked at the repo level; this PR does not invent a percentage.
