### PR TITLE
test: isolate proof outputs from tracked artifacts

### DIFF
--- a/scripts/prove-data-quality.js
+++ b/scripts/prove-data-quality.js
@@ -18,13 +18,21 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const PROOF_DIR = path.join(__dirname, '..', 'proof');
-const REPORT_JSON = path.join(PROOF_DIR, 'data-quality-report.json');
-const REPORT_MD = path.join(PROOF_DIR, 'data-quality-report.md');
+const ROOT = path.join(__dirname, '..');
+
+function resolveProofPaths() {
+  const proofDir = process.env.RLHF_PROOF_DIR || path.join(ROOT, 'proof');
+  return {
+    proofDir,
+    reportJson: path.join(proofDir, 'data-quality-report.json'),
+    reportMd: path.join(proofDir, 'data-quality-report.md'),
+  };
+}
 
 function run() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rlhf-qual-proof-'));
   const results = { passed: 0, failed: 0, requirements: {} };
+  const { proofDir, reportJson, reportMd } = resolveProofPaths();
 
   const checks = [
     {
@@ -132,7 +140,7 @@ function run() {
       desc: 'test:quality (node --test tests/validate-feedback.test.js) passes with 0 failures',
       fn: () => {
         const out = execSync('node --test tests/validate-feedback.test.js', {
-          cwd: path.join(__dirname, '..'),
+          cwd: ROOT,
           env: { ...process.env, RLHF_FEEDBACK_DIR: tmpDir },
           encoding: 'utf8',
           stdio: 'pipe',
@@ -173,7 +181,7 @@ function run() {
   delete process.env.RLHF_FEEDBACK_DIR;
 
   // Write proof artifacts
-  fs.mkdirSync(PROOF_DIR, { recursive: true });
+  fs.mkdirSync(proofDir, { recursive: true });
 
   const report = {
     phase: '07-data-quality',
@@ -184,7 +192,7 @@ function run() {
     requirements: results.requirements,
   };
 
-  fs.writeFileSync(REPORT_JSON, JSON.stringify(report, null, 2) + '\n');
+  fs.writeFileSync(reportJson, JSON.stringify(report, null, 2) + '\n');
 
   const md = [
     '# Phase 7: Data Quality — Proof Report',
@@ -208,10 +216,10 @@ function run() {
     '',
   ].join('\n');
 
-  fs.writeFileSync(REPORT_MD, md);
+  fs.writeFileSync(reportMd, md);
 
   console.log(`\nPhase 7 proof: ${results.passed} passed, ${results.failed} failed`);
-  console.log(`Report: ${REPORT_JSON}`);
+  console.log(`Report: ${reportJson}`);
 
   if (results.failed > 0) process.exit(1);
 }

--- a/scripts/prove-intelligence.js
+++ b/scripts/prove-intelligence.js
@@ -15,7 +15,9 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 const ROOT = path.join(__dirname, '..');
-const PROOF_DIR = path.join(ROOT, 'proof');
+function getProofDir() {
+  return process.env.RLHF_PROOF_DIR || path.join(ROOT, 'proof');
+}
 
 function ensureDir(d) {
   if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
@@ -185,9 +187,10 @@ async function main() {
     overallPassed: allPassed,
   };
 
-  ensureDir(PROOF_DIR);
-  const jsonPath = path.join(PROOF_DIR, 'intelligence-report.json');
-  const mdPath = path.join(PROOF_DIR, 'intelligence-report.md');
+  const proofDir = getProofDir();
+  ensureDir(proofDir);
+  const jsonPath = path.join(proofDir, 'intelligence-report.json');
+  const mdPath = path.join(proofDir, 'intelligence-report.md');
 
   fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
 

--- a/scripts/prove-loop-closure.js
+++ b/scripts/prove-loop-closure.js
@@ -18,13 +18,21 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const PROOF_DIR = path.join(__dirname, '..', 'proof');
-const REPORT_JSON = path.join(PROOF_DIR, 'loop-closure-report.json');
-const REPORT_MD = path.join(PROOF_DIR, 'loop-closure-report.md');
+const ROOT = path.join(__dirname, '..');
+
+function resolveProofPaths() {
+  const proofDir = process.env.RLHF_PROOF_DIR || path.join(ROOT, 'proof');
+  return {
+    proofDir,
+    reportJson: path.join(proofDir, 'loop-closure-report.json'),
+    reportMd: path.join(proofDir, 'loop-closure-report.md'),
+  };
+}
 
 function run() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rlhf-loop-proof-'));
   const results = { passed: 0, failed: 0, requirements: {} };
+  const { proofDir, reportJson, reportMd } = resolveProofPaths();
 
   const checks = [
     {
@@ -168,7 +176,7 @@ function run() {
       desc: 'test:loop-closure (node --test tests/loop-closure.test.js) passes with 0 failures',
       fn: () => {
         const out = execSync('node --test tests/loop-closure.test.js', {
-          cwd: path.join(__dirname, '..'),
+          cwd: ROOT,
           env: { ...process.env, RLHF_FEEDBACK_DIR: tmpDir },
           encoding: 'utf8',
           stdio: 'pipe',
@@ -207,7 +215,7 @@ function run() {
   } catch {}
 
   // Write proof artifacts
-  fs.mkdirSync(PROOF_DIR, { recursive: true });
+  fs.mkdirSync(proofDir, { recursive: true });
 
   const report = {
     phase: '08-loop-closure',
@@ -218,7 +226,7 @@ function run() {
     requirements: results.requirements,
   };
 
-  fs.writeFileSync(REPORT_JSON, JSON.stringify(report, null, 2) + '\n');
+  fs.writeFileSync(reportJson, JSON.stringify(report, null, 2) + '\n');
 
   const md = [
     '# Phase 8: Loop Closure — Proof Report',
@@ -244,10 +252,10 @@ function run() {
     '',
   ].join('\n');
 
-  fs.writeFileSync(REPORT_MD, md);
+  fs.writeFileSync(reportMd, md);
 
   console.log(`\nPhase 8 proof: ${results.passed} passed, ${results.failed} failed`);
-  console.log(`Report: ${REPORT_JSON}`);
+  console.log(`Report: ${reportJson}`);
 
   if (results.failed > 0) process.exit(1);
 }

--- a/scripts/prove-training-export.js
+++ b/scripts/prove-training-export.js
@@ -15,7 +15,9 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 const ROOT = path.join(__dirname, '..');
-const PROOF_DIR = path.join(ROOT, 'proof');
+function getProofDir() {
+  return process.env.RLHF_PROOF_DIR || path.join(ROOT, 'proof');
+}
 
 function ensureDir(d) {
   if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
@@ -251,9 +253,10 @@ async function main() {
     overallPassed: allPassed,
   };
 
-  ensureDir(PROOF_DIR);
-  const jsonPath = path.join(PROOF_DIR, 'training-export-report.json');
-  const mdPath = path.join(PROOF_DIR, 'training-export-report.md');
+  const proofDir = getProofDir();
+  ensureDir(proofDir);
+  const jsonPath = path.join(proofDir, 'training-export-report.json');
+  const mdPath = path.join(proofDir, 'training-export-report.md');
 
   fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
 

--- a/tests/prove-data-quality.test.js
+++ b/tests/prove-data-quality.test.js
@@ -1,13 +1,18 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 test('data-quality proof script exits 0', () => {
+  const tmpProofDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prove-data-quality-'));
   const result = spawnSync('node', ['scripts/prove-data-quality.js'], {
     cwd: path.join(__dirname, '..'),
+    env: { ...process.env, RLHF_PROOF_DIR: tmpProofDir },
     encoding: 'utf-8',
     timeout: 120000,
   });
+  fs.rmSync(tmpProofDir, { recursive: true, force: true });
   assert.equal(result.status, 0, `proof failed: ${(result.stderr || '').slice(-500)}`);
 });

--- a/tests/prove-intelligence.test.js
+++ b/tests/prove-intelligence.test.js
@@ -1,13 +1,18 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 test('intelligence proof script exits 0', () => {
+  const tmpProofDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prove-intelligence-'));
   const result = spawnSync('node', ['scripts/prove-intelligence.js'], {
     cwd: path.join(__dirname, '..'),
+    env: { ...process.env, RLHF_PROOF_DIR: tmpProofDir },
     encoding: 'utf-8',
     timeout: 120000,
   });
+  fs.rmSync(tmpProofDir, { recursive: true, force: true });
   assert.equal(result.status, 0, `proof failed: ${(result.stderr || '').slice(-500)}`);
 });

--- a/tests/prove-loop-closure.test.js
+++ b/tests/prove-loop-closure.test.js
@@ -1,13 +1,18 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 test('loop-closure proof script exits 0', () => {
+  const tmpProofDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prove-loop-closure-'));
   const result = spawnSync('node', ['scripts/prove-loop-closure.js'], {
     cwd: path.join(__dirname, '..'),
+    env: { ...process.env, RLHF_PROOF_DIR: tmpProofDir },
     encoding: 'utf-8',
     timeout: 120000,
   });
+  fs.rmSync(tmpProofDir, { recursive: true, force: true });
   assert.equal(result.status, 0, `proof failed: ${(result.stderr || '').slice(-500)}`);
 });

--- a/tests/prove-training-export.test.js
+++ b/tests/prove-training-export.test.js
@@ -1,13 +1,18 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 test('training-export proof script exits 0', () => {
+  const tmpProofDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prove-training-export-'));
   const result = spawnSync('node', ['scripts/prove-training-export.js'], {
     cwd: path.join(__dirname, '..'),
+    env: { ...process.env, RLHF_PROOF_DIR: tmpProofDir },
     encoding: 'utf-8',
     timeout: 120000,
   });
+  fs.rmSync(tmpProofDir, { recursive: true, force: true });
   assert.equal(result.status, 0, `proof failed: ${(result.stderr || '').slice(-500)}`);
 });


### PR DESCRIPTION
## Summary
- let four proof scripts honor `RLHF_PROOF_DIR` instead of always writing into tracked `proof/`
- run the matching proof tests against temp output directories
- reduce local verification churn in dedicated worktrees

## Verification
- `node --test tests/prove-data-quality.test.js tests/prove-intelligence.test.js tests/prove-loop-closure.test.js tests/prove-training-export.test.js`
- `npm run test:proof`

## Audit Notes
- This addresses a real hygiene gap found during the audit: proof verification was mutating tracked artifacts during local runs.
