### PR TITLE
docs: refresh audit verification evidence

### DIFF
--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -257,9 +257,9 @@ Observed results:
 
 - `npm test`: pass.
 - `npm run test:coverage`: pass with Node test runner coverage summary:
-  - line coverage: `81.57%`
-  - branch coverage: `67.00%`
-  - function coverage: `83.65%`
+  - line coverage: `81.61%`
+  - branch coverage: `67.06%`
+  - function coverage: `83.76%`
 - `npm run prove:adapters`: pass with `21 passed`, `0 failed`.
 - `npm run prove:automation`: pass with `14 passed`, `0 failed`.
 - `self-healing-check`: `Overall: HEALTHY` with `4/4` healthy checks.

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -176,7 +176,7 @@ MIT
 
 ## Test Count
 
-560+ passing Node test assertions in the current coverage runner, plus inline script test phases in CI. No placeholder results.
+570 passing Node test assertions in the current coverage runner, plus inline script test phases in CI. No placeholder results.
 
 ```bash
 npm test

--- a/proof/attribution-report.json
+++ b/proof/attribution-report.json
@@ -1,10 +1,10 @@
 {
   "phase": "06-feedback-attribution",
-  "generated": "2026-03-06T23:02:45.865Z",
+  "generated": "2026-03-09T16:07:32.192Z",
   "requirements": {
     "ATTR-01": {
       "status": "pass",
-      "evidence": "recordAction('Bash', git push --force) returned ok=true, intent=git-risk. action-log.jsonl written to /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-attr01-PzZRrK. action_id=act_1772838165866_72a355e8, risk_score=8. attributeFeedback('negative', ...) returned ok=true, attributedCount=1. feedback-attributions.jsonl written. attribution_id=att_1772838165867_8f90bc9a, signal=negative. Module: scripts/feedback-attribution.js. Pure offline JSONL-based attribution."
+      "evidence": "recordAction('Bash', git push --force) returned ok=true, intent=git-risk. action-log.jsonl written to /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-attr01-bmbVNA. action_id=act_1773072452194_72a355e8, risk_score=8. attributeFeedback('negative', ...) returned ok=true, attributedCount=1. feedback-attributions.jsonl written. attribution_id=att_1773072452195_8f90bc9a, signal=negative. Module: scripts/feedback-attribution.js. Pure offline JSONL-based attribution."
     },
     "ATTR-02": {
       "status": "pass",

--- a/proof/attribution-report.md
+++ b/proof/attribution-report.md
@@ -1,6 +1,6 @@
 # Feedback Attribution — Proof Report
 
-Generated: 2026-03-06T23:02:45.865Z
+Generated: 2026-03-09T16:07:32.192Z
 Phase: 06-feedback-attribution
 
 **Passed: 2 | Failed: 1**
@@ -9,7 +9,7 @@ Phase: 06-feedback-attribution
 
 | Requirement | Status | Evidence |
 |-------------|--------|----------|
-| ATTR-01 | PASS | recordAction('Bash', git push --force) returned ok=true, intent=git-risk. action-log.jsonl written to /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-attr01-PzZRrK. action_id=act_1772838165866_72a355e8, risk_score=8. attributeFeedback('negative', ...) returned ok=true, attributedCount=1. feedback-attributions.jsonl written. attribution_id=att_1772838165867_8f90bc9a, signal=negative. Module: scripts/feedback-attribution.js. Pure offline JSONL-based attribution. |
+| ATTR-01 | PASS | recordAction('Bash', git push --force) returned ok=true, intent=git-risk. action-log.jsonl written to /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-attr01-bmbVNA. action_id=act_1773072452194_72a355e8, risk_score=8. attributeFeedback('negative', ...) returned ok=true, attributedCount=1. feedback-attributions.jsonl written. attribution_id=att_1773072452195_8f90bc9a, signal=negative. Module: scripts/feedback-attribution.js. Pure offline JSONL-based attribution. |
 | ATTR-02 | PASS | buildHybridState() detected 1 recurring pattern(s). Top pattern count=3 (>= 3 → critical). evaluatePretoolFromState('Bash', 'git push force main') → mode=block. evaluatePretoolFromState('Read', 'some-unrelated-file.md') → mode=allow. block + allow paths verified. No false positive for unrelated Read tool. Module: scripts/hybrid-feedback-context.js. hasTwoKeywordHits enforces no-false-positive invariant. |
 | ATTR-03 | FAIL | node --test attribution files: pass=0, fail=0. Expected >= 1 passing and 0 failures. Only 0 tests passing (need >= 1). |
 
@@ -17,7 +17,7 @@ Phase: 06-feedback-attribution
 
 ### ATTR-01 — PASS
 
-recordAction('Bash', git push --force) returned ok=true, intent=git-risk. action-log.jsonl written to /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-attr01-PzZRrK. action_id=act_1772838165866_72a355e8, risk_score=8. attributeFeedback('negative', ...) returned ok=true, attributedCount=1. feedback-attributions.jsonl written. attribution_id=att_1772838165867_8f90bc9a, signal=negative. Module: scripts/feedback-attribution.js. Pure offline JSONL-based attribution.
+recordAction('Bash', git push --force) returned ok=true, intent=git-risk. action-log.jsonl written to /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-attr01-bmbVNA. action_id=act_1773072452194_72a355e8, risk_score=8. attributeFeedback('negative', ...) returned ok=true, attributedCount=1. feedback-attributions.jsonl written. attribution_id=att_1773072452195_8f90bc9a, signal=negative. Module: scripts/feedback-attribution.js. Pure offline JSONL-based attribution.
 
 ### ATTR-02 — PASS
 

--- a/proof/automation/report.json
+++ b/proof/automation/report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-09T16:02:13.023Z",
+  "generatedAt": "2026-03-09T16:07:40.022Z",
   "checks": [
     {
       "name": "feedback.capture.rubric_pass",
@@ -130,7 +130,7 @@
       "name": "code_reasoning.dpo_traces",
       "passed": true,
       "details": {
-        "traceId": "trace-ff80fc604931",
+        "traceId": "trace-4c7c297e282b",
         "confidence": 1,
         "aggregateConfidence": 1
       }
@@ -162,8 +162,8 @@
   },
   "proofTraces": [
     {
-      "traceId": "trace-85cef5c291e4",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-a18ec625e326",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "feedback.capture.rubric_pass",
       "steps": [
@@ -191,8 +191,8 @@
       }
     },
     {
-      "traceId": "trace-a00fc20caeee",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-dbf33c319eef",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "feedback.capture.rubric_block",
       "steps": [
@@ -220,8 +220,8 @@
       }
     },
     {
-      "traceId": "trace-1b0f11c9c8db",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-16f2b9349eb7",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "feedback.capture.negative_with_rubric",
       "steps": [
@@ -249,8 +249,8 @@
       }
     },
     {
-      "traceId": "trace-6070bb3c0057",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-7ed01af5cbc1",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "analytics.rubric_tracking",
       "steps": [
@@ -272,8 +272,8 @@
       }
     },
     {
-      "traceId": "trace-0aa5e487b8ee",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-f5bf88f8bc97",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "prevention_rules.rubric_dimensions",
       "steps": [
@@ -295,8 +295,8 @@
       }
     },
     {
-      "traceId": "trace-37f42d89b568",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-80c017f3b784",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "dpo_export.rubric_metadata",
       "steps": [
@@ -318,8 +318,8 @@
       }
     },
     {
-      "traceId": "trace-10b30b7576a1",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-7927d674752c",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "api.rubric_gate",
       "steps": [
@@ -347,8 +347,8 @@
       }
     },
     {
-      "traceId": "trace-f872ea44d84f",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-174ba4d0fcd7",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "mcp.rubric_gate",
       "steps": [
@@ -376,8 +376,8 @@
       }
     },
     {
-      "traceId": "trace-0ee0a942ab4c",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-0c0f63d98666",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "intent.checkpoint_enforcement",
       "steps": [
@@ -399,8 +399,8 @@
       }
     },
     {
-      "traceId": "trace-da1151e73e7d",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-92b4a5c9f0d6",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "context.evaluate.rubric",
       "steps": [
@@ -422,8 +422,8 @@
       }
     },
     {
-      "traceId": "trace-9d68d6f41840",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-19c148268b5a",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "context.semantic_cache.hit",
       "steps": [
@@ -445,8 +445,8 @@
       }
     },
     {
-      "traceId": "trace-c51ee28591fd",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-1ba6926fb1d7",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "self_healing.helpers",
       "steps": [
@@ -468,15 +468,15 @@
       }
     },
     {
-      "traceId": "trace-624756b98a6d",
-      "timestamp": "2026-03-09T16:02:13.757Z",
+      "traceId": "trace-68b51ab9cc2a",
+      "timestamp": "2026-03-09T16:07:40.658Z",
       "type": "proof-gate",
       "subject": "code_reasoning.dpo_traces",
       "steps": [
         {
           "location": "check:code_reasoning.dpo_traces",
           "claim": "Proof check \"code_reasoning.dpo_traces\" passes",
-          "evidence": "Passed with details: {\"traceId\":\"trace-ff80fc604931\",\"confidence\":1,\"aggregateConfidence\":1}",
+          "evidence": "Passed with details: {\"traceId\":\"trace-4c7c297e282b\",\"confidence\":1,\"aggregateConfidence\":1}",
           "verdict": "verified"
         }
       ],

--- a/proof/automation/report.md
+++ b/proof/automation/report.md
@@ -1,6 +1,6 @@
 # Automation Proof
 
-Generated: 2026-03-09T16:02:13.023Z
+Generated: 2026-03-09T16:07:40.022Z
 
 Passed: 14
 Failed: 0

--- a/proof/automation/self-heal-run.json
+++ b/proof/automation/self-heal-run.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-03-09T16:02:00.780Z",
+  "timestamp": "2026-03-09T16:07:27.786Z",
   "reason": "manual",
   "plan": [
     "feedback:rules"
@@ -13,7 +13,7 @@
         "script": "feedback:rules",
         "status": "success",
         "exitCode": 0,
-        "durationMs": 256,
+        "durationMs": 207,
         "error": null,
         "outputTail": "> rlhf-feedback-loop@0.6.10 feedback:rules\n> node .claude/scripts/feedback/capture-feedback.js --rules\n\nWrote prevention rules to /Users/ganapolsky_i/workspace/git/igor/_worktrees/rlhf-tech-debt/.claude/memory/feedback/prevention-rules.md",
         "changedFiles": []
@@ -25,35 +25,16 @@
     ".claude/context-engine/quality-log.json",
     ".rlhf/feedback-log.jsonl",
     ".rlhf/feedback-summary.json",
-    ".well-known/mcp/server-card.json",
-    "CLAUDE.md",
-    "docs/VERIFICATION_EVIDENCE.md",
-    "docs/landing-page.html",
-    "docs/mcp-hub-submission.md",
-    "package-lock.json",
-    "package.json",
     "proof/attribution-report.json",
     "proof/attribution-report.md",
+    "proof/automation/report.json",
+    "proof/automation/report.md",
     "proof/automation/self-heal-run.json",
     "proof/automation/self-healing-health.json",
-    "proof/baseline-test-count.md",
-    "proof/contract-audit-report.md",
-    "proof/data-quality-report.json",
-    "proof/data-quality-report.md",
-    "proof/intelligence-report.json",
-    "proof/intelligence-report.md",
+    "proof/compatibility/report.json",
+    "proof/compatibility/report.md",
     "proof/lancedb-report.json",
-    "proof/lancedb-report.md",
-    "proof/loop-closure-report.json",
-    "proof/loop-closure-report.md",
-    "proof/training-export-report.json",
-    "proof/training-export-report.md",
-    "proof/v2-milestone-report.json",
-    "proof/v2-milestone-report.md",
-    "proof/v3-milestone-report.json",
-    "proof/v3-milestone-report.md",
-    "scripts/code-reasoning.js",
-    "server.json"
+    "proof/lancedb-report.md"
   ],
   "changedFiles": [],
   "changed": false,
@@ -71,15 +52,15 @@
   },
   "traces": [
     {
-      "traceId": "trace-5774f59f9645",
-      "timestamp": "2026-03-09T16:02:00.779Z",
+      "traceId": "trace-721cfaa183a8",
+      "timestamp": "2026-03-09T16:07:27.785Z",
       "type": "self-heal",
       "subject": "feedback:rules",
       "steps": [
         {
           "location": "npm run feedback:rules",
           "claim": "Fix script \"feedback:rules\" executes without error",
-          "evidence": "Exit code 0, completed in 256ms",
+          "evidence": "Exit code 0, completed in 207ms",
           "verdict": "verified"
         },
         {

--- a/proof/automation/self-healing-health.json
+++ b/proof/automation/self-healing-health.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-03-09T16:02:00.370Z",
-  "durationMs": 13472,
+  "generatedAt": "2026-03-09T16:07:27.472Z",
+  "durationMs": 13247,
   "overall_status": "healthy",
   "summary": {
     "total": 4,
@@ -13,7 +13,7 @@
       "command": "npm run budget:status",
       "status": "healthy",
       "exitCode": 0,
-      "durationMs": 256,
+      "durationMs": 208,
       "error": null,
       "outputTail": "> rlhf-feedback-loop@0.6.10 budget:status\n> node scripts/budget-guard.js --status\n\n{\n  \"month\": \"2026-03\",\n  \"totalUsd\": 0,\n  \"budgetUsd\": 10,\n  \"remainingUsd\": 10\n}"
     },
@@ -22,16 +22,16 @@
       "command": "npm test",
       "status": "healthy",
       "exitCode": 0,
-      "durationMs": 11600,
+      "durationMs": 11560,
       "error": null,
-      "outputTail": "(1.051416ms)\n  ✔ POST /v1/billing/webhook handles customer.subscription.deleted (2.037625ms)\n  ✔ POST /v1/billing/provision without customerId returns 400 (0.424084ms)\n  ✔ invalid Bearer key returns 401 on protected route (0.529375ms)\n  ✔ usage metering increments after authenticated API call (2.58825ms)\n  ✔ GET /v1/analytics/funnel returns counts and conversion rates (0.445917ms)\n✔ API server — /v1/billing/* routes (26.284875ms)\n▶ API server — admin provision boundary\n  ✔ admin static token can call POST /v1/billing/provision (1.067458ms)\n  ✔ billing key is forbidden from POST /v1/billing/provision (0.806ms)\n✔ API server — admin provision boundary (3.458791ms)\nℹ tests 34\nℹ suites 10\nℹ pass 34\nℹ fail 0\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 136.612833\n\n> rlhf-feedback-loop@0.6.10 test:cli\n> node --test tests/cli.test.js\n\n▶ bin/cli.js\n  ✔ CLI file exists and is executable (0.462583ms)\n  ✔ help command exits 0 and lists subcommands (61.564625ms)\n  ✔ --help flag exits 0 (64.841167ms)\n  ✔ no-arg invocation exits 0 with help (60.81925ms)\n  ✔ unknown command exits 1 (61.809625ms)\n  ✔ init creates .rlhf/ directory (127.850334ms)\n  ✔ init creates config.json with required fields (0.231167ms)\n  ✔ init emits acquisition funnel event correlated by installId (116.934625ms)\n  ✔ init creates .mcp.json with server entry (0.227083ms)\n  ✔ init output includes initialized message and platform detection (110.484667ms)\n  ✔ capture --feedback=up routes to full engine (56.83425ms)\n  ✔ capture --feedback=down routes to full engine (62.630791ms)\n  ✔ serve responds to initialize over Content-Length framed transport (66.405375ms)\n  ✔ serve responds to initialize over newline-delimited JSON transport (63.558958ms)\n  ✔ serve returns ndjson error envelope for malformed ndjson input (65.347458ms)\n  ✔ init is idempotent — running twice exits 0 (126.335084ms)\n✔ bin/cli.js (1048.889583ms)\nℹ tests 16\nℹ suites 1\nℹ pass 16\nℹ fail 0\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 1132.718958"
+      "outputTail": "d (1.125375ms)\n  ✔ POST /v1/billing/webhook handles customer.subscription.deleted (1.605542ms)\n  ✔ POST /v1/billing/provision without customerId returns 400 (0.412459ms)\n  ✔ invalid Bearer key returns 401 on protected route (0.6475ms)\n  ✔ usage metering increments after authenticated API call (3.021167ms)\n  ✔ GET /v1/analytics/funnel returns counts and conversion rates (0.491916ms)\n✔ API server — /v1/billing/* routes (26.657625ms)\n▶ API server — admin provision boundary\n  ✔ admin static token can call POST /v1/billing/provision (1.112375ms)\n  ✔ billing key is forbidden from POST /v1/billing/provision (0.783458ms)\n✔ API server — admin provision boundary (3.280834ms)\nℹ tests 34\nℹ suites 10\nℹ pass 34\nℹ fail 0\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 134.464208\n\n> rlhf-feedback-loop@0.6.10 test:cli\n> node --test tests/cli.test.js\n\n▶ bin/cli.js\n  ✔ CLI file exists and is executable (0.50025ms)\n  ✔ help command exits 0 and lists subcommands (62.628417ms)\n  ✔ --help flag exits 0 (63.610833ms)\n  ✔ no-arg invocation exits 0 with help (63.3185ms)\n  ✔ unknown command exits 1 (60.491459ms)\n  ✔ init creates .rlhf/ directory (126.110667ms)\n  ✔ init creates config.json with required fields (0.308375ms)\n  ✔ init emits acquisition funnel event correlated by installId (109.821375ms)\n  ✔ init creates .mcp.json with server entry (0.23525ms)\n  ✔ init output includes initialized message and platform detection (111.585584ms)\n  ✔ capture --feedback=up routes to full engine (61.553167ms)\n  ✔ capture --feedback=down routes to full engine (65.015542ms)\n  ✔ serve responds to initialize over Content-Length framed transport (63.472375ms)\n  ✔ serve responds to initialize over newline-delimited JSON transport (65.656875ms)\n  ✔ serve returns ndjson error envelope for malformed ndjson input (65.741416ms)\n  ✔ init is idempotent — running twice exits 0 (121.265667ms)\n✔ bin/cli.js (1043.833625ms)\nℹ tests 16\nℹ suites 1\nℹ pass 16\nℹ fail 0\nℹ cancelled 0\nℹ skipped 0\nℹ todo 0\nℹ duration_ms 1125.3925"
     },
     {
       "name": "prove_adapters",
       "command": "npm run prove:adapters",
       "status": "healthy",
       "exitCode": 0,
-      "durationMs": 586,
+      "durationMs": 577,
       "error": null,
       "outputTail": "> rlhf-feedback-loop@0.6.10 prove:adapters\n> node scripts/prove-adapters.js\n\n{\n  \"passed\": 21,\n  \"failed\": 0\n}\n\ndtype not specified for \"model\". Using the default dtype (fp32) for this device (cpu)."
     },
@@ -40,7 +40,7 @@
       "command": "npm run prove:automation",
       "status": "healthy",
       "exitCode": 0,
-      "durationMs": 1028,
+      "durationMs": 901,
       "error": null,
       "outputTail": "> rlhf-feedback-loop@0.6.10 prove:automation\n> node scripts/prove-automation.js\n\n{\n  \"passed\": 14,\n  \"failed\": 0\n}\n\ndtype not specified for \"model\". Using the default dtype (fp32) for this device (cpu).\ndtype not specified for \"model\". Using the default dtype (fp32) for this device (cpu)."
     }

--- a/proof/compatibility/report.json
+++ b/proof/compatibility/report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-09T16:02:12.435Z",
+  "generatedAt": "2026-03-09T16:07:39.445Z",
   "checks": [
     {
       "name": "api.healthz",
@@ -49,7 +49,7 @@
       "name": "api.context.construct",
       "passed": true,
       "details": {
-        "packId": "pack_1773072132569_5v2vkw",
+        "packId": "pack_1773072459583_sa040d",
         "items": 5
       }
     },

--- a/proof/compatibility/report.md
+++ b/proof/compatibility/report.md
@@ -1,6 +1,6 @@
 # Adapter Compatibility Proof
 
-Generated: 2026-03-09T16:02:12.435Z
+Generated: 2026-03-09T16:07:39.445Z
 
 Passed: 21
 Failed: 0

--- a/proof/lancedb-report.json
+++ b/proof/lancedb-report.json
@@ -1,10 +1,10 @@
 {
   "phase": "04-lancedb-vector-storage",
-  "generated": "2026-03-06T23:02:47.508Z",
+  "generated": "2026-03-09T16:07:33.949Z",
   "requirements": {
     "VEC-01": {
       "status": "pass",
-      "evidence": "lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-UOjM7X/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories."
+      "evidence": "lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-EhN4XL/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories."
     },
     "VEC-02": {
       "status": "pass",

--- a/proof/lancedb-report.md
+++ b/proof/lancedb-report.md
@@ -1,6 +1,6 @@
 # LanceDB Vector Storage Proof Report
 
-Generated: 2026-03-06T23:02:47.508Z
+Generated: 2026-03-09T16:07:33.949Z
 Phase: 04-lancedb-vector-storage
 
 **Passed: 4 | Failed: 1 | Warned: 0**
@@ -9,7 +9,7 @@ Phase: 04-lancedb-vector-storage
 
 | Requirement | Status | Evidence |
 |-------------|--------|----------|
-| VEC-01 | PASS | lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-UOjM7X/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories. |
+| VEC-01 | PASS | lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-EhN4XL/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories. |
 | VEC-02 | PASS | scripts/vector-store.js uses dynamic import() at line 16: `_lancedb = await import('@lancedb/lancedb');`; line 23: `const { pipeline } = await import('@huggingface/transformers');`. Total dynamic import() calls: 2. This is the only CJS-compatible approach for ESM-only @lancedb/lancedb and @huggingface/transformers. |
 | VEC-03 | PASS | package.json: apache-arrow="^18.1.0" (base: 18.1.0), @lancedb/lancedb="^0.26.2". LanceDB 0.26.2 peer dep is apache-arrow >=15.0.0 <=18.1.0. Arrow 19+ breaks binary compat. Pin confirmed safe: 18.1.0 <= 18.1.0 ceiling. |
 | VEC-04 | PASS | searchSimilar() returned 2 result(s). proof-vec01 present: true. proof-vec04-b present: true. API: searchSimilar(queryText, limit=10) returns vector-ranked rows from rlhf_memories table. Note: stub embed (RLHF_VECTOR_STUB_EMBED=true) returns identical 384-dim unit vectors — ranking is insertion-order with stub, cosine similarity with real ONNX model. |
@@ -19,7 +19,7 @@ Phase: 04-lancedb-vector-storage
 
 ### VEC-01 — PASS
 
-lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-UOjM7X/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories.
+lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-EhN4XL/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories.
 
 ### VEC-02 — PASS
 


### PR DESCRIPTION
## Summary
- refresh proof artifacts after the post-merge audit rerun
- sync `docs/VERIFICATION_EVIDENCE.md` to the actual current coverage numbers
- tighten the MCP submission test-count wording to match the latest coverage run

## Verification
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `node scripts/self-healing-check.js --json > proof/automation/self-healing-health.json`
- `node scripts/self-heal.js --reason=manual > proof/automation/self-heal-run.json`
