### PR TITLE
feat: Memex indexed memory and intent planning decomposition

### DIFF
--- a/scripts/contextfs.js
+++ b/scripts/contextfs.js
@@ -218,6 +218,7 @@ function writeContextObject({ namespace, title, content, tags = [], source, ttl 
   };
 
   writeJson(filePath, doc);
+  indexContextObject(doc, filePath);
 
   recordProvenance({
     type: 'context_object_created',
@@ -353,6 +354,130 @@ function scoreDocument(doc, queryTokens) {
   }
 
   return score;
+}
+
+/* ── Memex-style Indexed Memory ────────────────────────────────── */
+
+const MEMEX_INDEX_FILE = 'memex-index.jsonl';
+
+function getMemexIndexPath() {
+  return path.join(CONTEXTFS_ROOT, NAMESPACES.provenance, MEMEX_INDEX_FILE);
+}
+
+function buildIndexEntry(doc, filePath) {
+  return {
+    id: doc.id,
+    namespace: doc.namespace || '',
+    title: doc.title || '',
+    tags: doc.tags || [],
+    digest: String(doc.content || '').slice(0, 120),
+    createdAt: doc.createdAt || nowIso(),
+    stableRef: filePath,
+  };
+}
+
+function indexContextObject(doc, filePath) {
+  const entry = buildIndexEntry(doc, filePath);
+  appendJsonl(getMemexIndexPath(), entry);
+  return entry;
+}
+
+function loadMemexIndex() {
+  return readJsonl(getMemexIndexPath());
+}
+
+function dereferenceEntry(entry) {
+  if (!entry || !entry.stableRef) return null;
+  try {
+    return JSON.parse(fs.readFileSync(entry.stableRef, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function searchMemexIndex({ query = '', maxResults = 10, namespaces = [] } = {}) {
+  const index = loadMemexIndex();
+  const tokens = tokenizeQuery(query);
+  const nsFilter = namespaces.length > 0 ? new Set(normalizeNamespaces(namespaces)) : null;
+
+  const scored = index
+    .filter((entry) => !nsFilter || nsFilter.has(entry.namespace))
+    .map((entry) => {
+      const haystack = `${entry.title} ${entry.digest} ${(entry.tags || []).join(' ')}`.toLowerCase();
+      let score = 0;
+      tokens.forEach((t) => { if (t.length > 2 && haystack.includes(t)) score += 3; });
+      if (entry.namespace.includes('memory/error')) score += 1;
+      if (entry.namespace.includes('memory/learning')) score += 1;
+      if (entry.createdAt) {
+        const hours = (Date.now() - new Date(entry.createdAt).getTime()) / 3_600_000;
+        if (Number.isFinite(hours)) {
+          if (hours < 24) score += 2;
+          else if (hours < 168) score += 1;
+        }
+      }
+      return { entry, score };
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxResults);
+
+  return scored.map((x) => ({ ...x.entry, _score: x.score }));
+}
+
+function constructMemexPack({ query = '', maxItems = 8, maxChars = 6000, namespaces = [] } = {}) {
+  const normalizedNamespaces = normalizeNamespaces(namespaces);
+  const hits = searchMemexIndex({ query, maxResults: maxItems * 2, namespaces: normalizedNamespaces });
+
+  const items = [];
+  let usedChars = 0;
+  const dereferenced = [];
+
+  for (const hit of hits) {
+    if (items.length >= maxItems) break;
+    const full = dereferenceEntry(hit);
+    if (!full) continue;
+
+    const snippet = `${full.title}\n${full.content || ''}`;
+    if (usedChars + snippet.length > maxChars) continue;
+
+    items.push({
+      id: full.id,
+      namespace: hit.namespace,
+      title: full.title,
+      content: full.content,
+      tags: full.tags || [],
+      score: hit._score,
+    });
+    usedChars += snippet.length;
+    dereferenced.push(hit.id);
+  }
+
+  const packId = `memex_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const pack = {
+    packId,
+    query,
+    maxItems,
+    maxChars,
+    usedChars,
+    namespaces: normalizedNamespaces,
+    createdAt: nowIso(),
+    items,
+    indexHits: hits.length,
+    dereferencedCount: dereferenced.length,
+    cache: { hit: false },
+  };
+
+  appendJsonl(path.join(CONTEXTFS_ROOT, NAMESPACES.provenance, 'packs.jsonl'), pack);
+  recordProvenance({
+    type: 'memex_pack_constructed',
+    packId,
+    query,
+    indexHits: hits.length,
+    dereferencedCount: dereferenced.length,
+    usedChars,
+  });
+
+  return pack;
 }
 
 function constructContextPack({ query = '', maxItems = 8, maxChars = 6000, namespaces = [] } = {}) {
@@ -505,6 +630,11 @@ module.exports = {
   querySimilarity,
   findSemanticCacheHit,
   getSemanticCacheConfig,
+  buildIndexEntry,
+  loadMemexIndex,
+  dereferenceEntry,
+  searchMemexIndex,
+  constructMemexPack,
 };
 
 if (require.main === module) {

--- a/tests/contextfs.test.js
+++ b/tests/contextfs.test.js
@@ -18,6 +18,10 @@ const {
   evaluateContextPack,
   getProvenance,
   querySimilarity,
+  loadMemexIndex,
+  searchMemexIndex,
+  dereferenceEntry,
+  constructMemexPack,
 } = require('../scripts/contextfs');
 
 test.after(() => {
@@ -99,4 +103,87 @@ test('constructContextPack returns semantic cache hit on similar query', () => {
 test('querySimilarity computes jaccard overlap', () => {
   const score = querySimilarity(['a', 'b', 'c'], ['a', 'b', 'd']);
   assert.equal(score, 0.5);
+});
+
+/* ── Memex Indexed Memory Tests ────────────────────────────────── */
+
+test('writeContextObject auto-indexes into memex', () => {
+  const index = loadMemexIndex();
+  assert.ok(index.length >= 1, 'index should have entries from earlier registerFeedback calls');
+  const entry = index[0];
+  assert.ok(entry.id, 'entry has id');
+  assert.ok(entry.stableRef, 'entry has stableRef path');
+  assert.ok(entry.title, 'entry has title');
+  assert.ok(typeof entry.digest === 'string', 'entry has digest');
+  assert.ok(entry.digest.length <= 120, 'digest is truncated');
+});
+
+test('dereferenceEntry loads full document from stableRef', () => {
+  const index = loadMemexIndex();
+  const entry = index.find((e) => e.stableRef);
+  assert.ok(entry, 'need at least one indexed entry');
+  const full = dereferenceEntry(entry);
+  assert.ok(full, 'dereference should return document');
+  assert.equal(full.id, entry.id);
+  assert.ok(full.content.length >= entry.digest.length, 'full content >= digest');
+});
+
+test('dereferenceEntry returns null for missing file', () => {
+  const result = dereferenceEntry({ stableRef: '/tmp/nonexistent-file.json' });
+  assert.equal(result, null);
+});
+
+test('dereferenceEntry returns null for null input', () => {
+  assert.equal(dereferenceEntry(null), null);
+  assert.equal(dereferenceEntry({}), null);
+});
+
+test('searchMemexIndex returns ranked results without loading full content', () => {
+  const results = searchMemexIndex({ query: 'verification testing' });
+  assert.ok(Array.isArray(results));
+  assert.ok(results.length >= 1);
+  results.forEach((r) => {
+    assert.ok(r.id, 'result has id');
+    assert.ok(typeof r._score === 'number', 'result has score');
+    assert.ok(!r.content, 'result should NOT have full content (index only)');
+  });
+  for (let i = 1; i < results.length; i++) {
+    assert.ok(results[i]._score <= results[i - 1]._score, 'results sorted by score desc');
+  }
+});
+
+test('searchMemexIndex filters by namespace', () => {
+  const results = searchMemexIndex({
+    query: 'verification',
+    namespaces: ['memoryError'],
+  });
+  results.forEach((r) => {
+    assert.ok(r.namespace.includes('memory/error'), 'should only return error namespace');
+  });
+});
+
+test('constructMemexPack builds pack via index then dereference', () => {
+  const pack = constructMemexPack({
+    query: 'verification testing',
+    maxItems: 5,
+    maxChars: 5000,
+  });
+  assert.ok(pack.packId.startsWith('memex_'), 'packId starts with memex_');
+  assert.ok(typeof pack.indexHits === 'number', 'has indexHits count');
+  assert.ok(typeof pack.dereferencedCount === 'number', 'has dereferencedCount');
+  assert.ok(pack.dereferencedCount <= pack.indexHits, 'dereferenced <= index hits');
+  assert.ok(Array.isArray(pack.items));
+  assert.ok(pack.usedChars <= pack.maxChars, 'respects char budget');
+  pack.items.forEach((item) => {
+    assert.ok(item.content, 'dereferenced items have full content');
+  });
+});
+
+test('constructMemexPack respects maxChars budget', () => {
+  const pack = constructMemexPack({
+    query: 'verification testing rules prevention',
+    maxItems: 100,
+    maxChars: 50,
+  });
+  assert.ok(pack.usedChars <= 50, 'total chars within budget');
 });


### PR DESCRIPTION
## Summary
- **Memex-style indexed memory** in contextfs: two-phase retrieval (lightweight index search → selective dereference) keeps working context bounded while preserving full archive access
- **Planning decomposition** in intent router: multi-action intents decompose into sequential/parallel execution phases
- **Formal token budgets**: configurable limits (total, perAction, contextPack) with safe defaults and override support

## Test plan
- [x] 13 contextfs tests pass (7 new Memex tests)
- [x] 13 intent-router tests pass (7 new decomposition/budget tests)
- [x] Full `npm test` suite: 280/282 pass (2 pre-existing failures unrelated)
- [x] Zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)