### PR TITLE
feat: reposition GTM docs around one workflow wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,37 @@
 [![Marketplace Ready](https://img.shields.io/badge/Anthropic_Marketplace-Ready-blue)](docs/ANTHROPIC_MARKETPLACE_STRATEGY.md)
 [![GEO Optimized](https://img.shields.io/badge/GEO-optimized-orange)](docs/geo-strategy-for-ai-agents.md)
 
-Feedback-Driven Development (FDD) for AI agents. The open-source RLHF Feedback Loop captures preference signals, steers behavior via Thompson Sampling, generates prevention rules, and exports KTO/DPO training pairs for downstream fine-tuning. Cloud Pro adds the hosted layer teams actually pay for: shared memory, provisioned API keys, funnel evidence, and team-safe workflow runs.
+Stop one AI workflow from repeating the same mistakes.
 
-The best first paid wedge is not "agent infra" by itself. It is one workflow with a clear business outcome, such as lead-to-meeting, onboarding, or internal ops automation. This repo is the reliability layer behind that workflow.
+RLHF Feedback Loop is the open-source Agentic Feedback Studio and Veto Layer for teams shipping AI workflows with real business stakes. Start with one workflow like lead-to-meeting, onboarding, or internal ops automation. Capture operator feedback, turn repeated failures into prevention rules, and prove the workflow is getting safer over time.
+
+The open-source core gives one operator local feedback capture, context packs, Thompson Sampling, and KTO/DPO export. Cloud Pro is the hosted layer teams pay for when they need shared memory, provisioned API keys, funnel evidence, and proof-ready workflow runs.
+
+## North Star
+
+One team running one proof-backed workflow every week with shared memory, hosted guardrails, and clear evidence that the workflow is improving.
+
+That is the wedge. Not generic "agent infrastructure." Not another prompt library. One workflow outcome that a buyer can justify.
+
+## Who Buys And Who Uses
+
+- Buyer: head of ops, head of growth, platform lead, or consultancy owner funding a workflow rollout.
+- User: the operator running lead intake, research, drafting, approval, onboarding, or internal ops steps.
+- Champion: the engineer or platform owner wiring the Veto Layer, policy checks, and verification evidence into the workflow.
 
 ## Why someone would pay
 
-- They want hosted API keys instead of self-hosting the feedback and guardrail store.
+- They want to make one workflow deployable, auditable, and improvable over time.
+- They need hosted API keys instead of self-hosting the feedback and guardrail store.
 - They need shared memory and prevention rules across operators, repos, or agents.
 - They need proof-ready runs and funnel evidence instead of local-only logs.
+
+## Install To Value
+
+1. Install the MCP server or package.
+2. Instrument one workflow with feedback capture and context packs.
+3. Turn repeated failures into prevention rules instead of repeated incidents.
+4. Review proof-ready runs and verification evidence to decide whether the workflow is ready for team-wide rollout.
 
 ## Quick Start
 
@@ -57,7 +79,7 @@ The OSS package stays free. Cloud Pro remains a low-friction founding offer whil
 | Team sharing | Manual | Built-in |
 | Onboarding | Self-serve | Checkout + provisioned API key |
 
-[Landing Page](https://rlhf-feedback-loop-710216278770.us-central1.run.app) | [Get Cloud Pro ($10/mo)](https://buy.stripe.com/bJe14neyU4r4f0leOD3sI02) | [Verification Evidence](docs/VERIFICATION_EVIDENCE.md)
+[Landing Page](https://rlhf-feedback-loop-710216278770.us-central1.run.app) | [30-Day GTM Plan](docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md) | [Get Cloud Pro ($10/mo)](https://buy.stripe.com/bJe14neyU4r4f0leOD3sI02) | [Verification Evidence](docs/VERIFICATION_EVIDENCE.md)
 
 ## Agent Runner Contract
 
@@ -87,6 +109,13 @@ The most credible first paid workflow is a lead-to-meeting system:
 - audit trail and prevention rules
 
 Cloud Pro sits underneath that workflow as the hosted memory, guardrail, and evidence layer.
+
+## What The Buyer Gets
+
+- One workflow with shared memory instead of scattered local learnings.
+- A Veto Layer that turns repeated operator complaints into prevention rules.
+- Proof-ready runs, audit trails, and machine-readable evidence for rollout decisions.
+- A compounding data asset through KTO/DPO export once the workflow is producing useful feedback.
 
 ## Architecture
 

--- a/docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md
+++ b/docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md
@@ -1,0 +1,172 @@
+# 30-Day GTM Plan | Go-To-Market Revenue Wedge (March 2026)
+
+## Decision
+
+Sell one workflow outcome, not horizontal agent infrastructure.
+
+The product story is strongest when Cloud Pro is presented as the hosted reliability layer behind one workflow with business stakes. The first wedge is a lead-to-meeting workflow. Onboarding and internal ops automation use the same operating model, but they should stay secondary until the wedge is converting.
+
+Proof anchors for public claims:
+
+- [Verification Evidence](VERIFICATION_EVIDENCE.md)
+- [Compatibility proof](../proof/compatibility/report.json)
+- [Automation proof](../proof/automation/report.json)
+
+## North Star
+
+Weekly active proof-backed workflow runs.
+
+This is the metric that matters:
+
+- a real workflow owner
+- a real workflow running weekly
+- shared memory and hosted guardrails enabled
+- proof artifacts reviewed by an operator or buyer
+
+Traffic, stars, and installs are upstream indicators. They are not the business North Star.
+
+## Why This Wedge
+
+Lead-to-meeting is specific enough to sell and broad enough to prove the product story:
+
+- intake, enrichment, drafting, approval, and CRM sync are already familiar steps
+- human review is normal, which makes a Veto Layer easy to justify
+- failures are visible and painful, which makes prevention rules credible
+- proof-ready runs and funnel evidence map to a buyer outcome instead of abstract model quality
+
+## Buyer, User, Champion
+
+| Role | What they care about | What they need from us |
+| --- | --- | --- |
+| Buyer | safer rollout, accountability, measurable outcome | one workflow they can justify |
+| User | less drift, fewer repeated mistakes, clearer next step | shared memory, better microcopy, reliable approvals |
+| Champion | policy, proof, integration, runtime consistency | MCP/API install path, context packs, evidence |
+
+## Core Message
+
+Use this sentence family everywhere:
+
+`One workflow. Shared memory. Hosted guardrails. Proof-ready runs.`
+
+Supporting message:
+
+- We make one AI workflow safe enough to ship team-wide.
+- We turn operator feedback into prevention rules and proof.
+- We do not ask buyers to fund a generic agent platform on day one.
+
+## What Stays Secondary
+
+Do not lead with these unless the audience is explicitly technical:
+
+- KTO/DPO export
+- Thompson Sampling
+- semantic cache policy tuning
+- context engineering internals
+
+These matter, but they are the compounding engine behind the workflow, not the sales headline.
+
+## Offer Stack
+
+### OSS Core
+
+- best for one operator or one builder
+- local feedback capture
+- local context packs
+- prevention rules
+- DPO/KTO export
+
+### Cloud Pro
+
+- best for one team running one workflow
+- hosted API keys
+- shared memory and shared prevention rules
+- proof-ready workflow runs
+- policy and checkpoint controls
+
+### Workflow Install Workshop
+
+- best for buyers who want speed and low risk
+- one workflow scoped in advance
+- hands-on setup with buyer and operator present
+- explicit proof path before broader rollout
+
+## 30-Day Plan
+
+### Week 1: Sharpen The Surfaces
+
+- make the landing page, README, and pitch value-led
+- make the workflow wedge explicit
+- make the North Star explicit
+- keep `SoftwareApplication` and `FAQPage` schema accurate
+- link every public-facing surface back to `VERIFICATION_EVIDENCE.md`
+
+### Week 2: Publish High-Density Proof Content
+
+- comparison page: local-only workflow vs shared proof-backed workflow
+- FAQ blocks answering buyer questions directly
+- one proof-led teardown of the lead-to-meeting wedge
+- one install-to-value guide: install -> instrument -> capture feedback -> prove improvement
+
+### Week 3: Run Distribution As A Craft
+
+- founder-led outreach to companies already investing in AI workflow operations
+- target intent signals: hiring, funding, workflow tooling changes, public AI automation efforts
+- post in developer and AI workflow communities where technical promotion is accepted
+- treat AI search as a channel: structured markdown, tables, FAQs, machine-readable evidence
+
+### Week 4: Convert Through Workshops
+
+- run hands-on workflow workshops instead of generic webinars
+- require one workflow owner, one buyer, and one measurable pain
+- use a skinny funnel and disqualify weak fits early
+- convert strong conversations into design-partner pilots or Cloud Pro installs
+
+## Distribution Channels
+
+### AI Search And Search Engines
+
+- public docs with high-density semantic chunks
+- FAQ blocks and comparison tables
+- `SoftwareApplication` and `FAQPage` schema
+- direct links to proof artifacts and `VERIFICATION_EVIDENCE.md`
+
+### Founder-Led Outbound
+
+- intent-based lists, not broad cold blasting
+- mention the workflow outcome first
+- offer a workflow install session, not a generic demo
+
+### Communities
+
+- target technical communities where workflow reliability is already a live pain
+- publish mechanism-based copywriting, not vague claims
+- show how the Veto Layer changes behavior over time
+
+## Qualification Rules
+
+Do not spend cycles on accounts that lack:
+
+- one named workflow owner
+- one workflow with repeated failures or human review pain
+- one buyer willing to fund rollout if proof is strong
+
+## Metrics That Support The North Star
+
+- number of teams running one proof-backed workflow weekly
+- number of workflows with shared memory and prevention rules enabled
+- number of workshop installs that become active pilots
+- OSS to Cloud Pro conversion for teams with a live workflow
+- reduction in repeated workflow failures after V2V capture and prevention rules
+
+## Guardrails
+
+- never claim ROI that has not been observed
+- never lead with architecture when the buyer needs an outcome
+- never widen from one workflow to platform language before the wedge converts
+- never publish public-facing claims without linking proof or evidence
+
+## North Star Narrative
+
+The company wins when a buyer can say:
+
+`We rolled out one AI workflow, it stopped repeating the same mistakes, and we can prove it.`

--- a/docs/PACKAGING_AND_SALES_PLAN.md
+++ b/docs/PACKAGING_AND_SALES_PLAN.md
@@ -1,5 +1,17 @@
 # Packaging and Sales Plan
 
+## North Star
+
+Weekly active proof-backed workflow runs.
+
+This is the metric that matters most. Stars, visits, and installs matter only if they lead to teams running one monitored workflow with shared memory, guardrails, and evidence.
+
+## Best First Offer
+
+- OSS core for one operator proving a workflow locally.
+- Cloud Pro for one team running one workflow with shared memory and proof-ready runs.
+- Workflow install workshop for buyers who want help wiring lead-to-meeting, onboarding, or internal ops automation into a production process.
+
 ## Product Tiers
 
 ### Tier 1: Open Source Core (Free)
@@ -13,17 +25,16 @@
 ### Tier 2: Cloud Pro (Founding price: $10/mo)
 
 - Hosted API endpoint
-- Team workspaces
-- Managed analytics dashboard
-- Webhooks for CI/incident tooling
-- Intent routing control plane (policy bundles + checkpoint approvals)
-- Semantic cache analytics + cache policy tuning
-- Autonomous GitOps controls (self-healing + PR auto-merge policy)
+- Provisioned API keys and hosted onboarding
+- Shared memory and prevention rules across operators
+- Proof-ready runs with auditable workflow evidence
+- Intent routing and checkpoint surfaces for policy-aware workflows
+- Context pack construction and provenance endpoints for bounded retrieval
 
 Pricing note:
 
 - Keep the current live Stripe price at `$10/mo` while Cloud Pro is still proving conversion.
-- Revisit repricing after the hosted analytics dashboard and team workspace workflows are generally available.
+- Revisit repricing after the hosted workflow layer shows retained usage and stronger buyer pull.
 
 ### Tier 3: Enterprise (Pricing: custom quote)
 
@@ -32,46 +43,60 @@ Pricing note:
 - Data residency options
 - Dedicated support + onboarding
 
-## Distribution Channels
+## Buyer And User Split
 
-1. ChatGPT: Custom GPT + GPT Actions (OpenAPI import).
-2. Claude: MCP server via `.mcp.json`.
-3. Codex: MCP server via `config.toml`.
-4. Gemini: function declarations + API integration.
-5. Amp: skill template and policy instructions.
+- Buyer: head of ops, head of growth, platform lead, or consultancy owner funding the rollout.
+- User: the operator running the workflow.
+- Champion: the engineer or platform owner wiring the Veto Layer and proof path.
+
+## Distribution Channels By Intent
+
+1. AI coding agent teams: Claude, Codex, Gemini, ChatGPT, Amp, and custom runners.
+2. RevOps and growth teams automating lead-to-meeting with human approvals.
+3. Platform teams standardizing one policy and memory layer across multiple runtimes.
+4. Consultancies installing AI workflows for clients that demand proof and auditability.
 
 ## Ideal Customer Profile
 
-1. Teams running multiple AI coding agents with repeated regression patterns.
-2. Engineering organizations that need auditable feedback-to-behavior loops.
-3. Platform teams standardizing one RLHF policy layer across ChatGPT, Claude, Codex, Gemini, and Amp.
+1. Teams with one workflow owner and one workflow pain severe enough to justify change.
+2. Organizations that need auditable feedback-to-behavior loops before broader rollout.
+3. Buyers who care more about deployability and proof than about adding another feature list.
 
 ## Buyer Outcome Statement
 
-1. Reduce repeated failure patterns by enforcing prevention rules from real feedback.
-2. Prove adapter/runtime compatibility with reproducible, machine-readable evidence artifacts.
+1. Make one workflow deployable, auditable, and improvable over time.
+2. Reduce repeated workflow regressions by enforcing prevention rules from real operator feedback.
+3. Prove workflow behavior with reproducible, machine-readable evidence artifacts.
 
 ## Discovery Plan
 
-1. Keywords and topics optimized in GitHub About.
-2. README conversion flow: pain -> value -> demo -> proof.
-3. Technical credibility: CI badge + verification report.
-4. Multi-runtime support called out as a differentiator.
-5. Cost story: semantic cache + budget guard + optional model gateway routing.
+1. Keywords and topics optimized in GitHub About and public docs.
+2. README conversion flow: pain -> workflow outcome -> proof -> install path.
+3. Technical credibility: CI badge, verification report, and proof artifacts.
+4. Structured content for AI search: comparison tables, FAQ blocks, SoftwareApplication and FAQPage schema.
+5. Value-led landing-page microcopy that makes the outcome obvious before architecture language appears.
 
 ## Sales Motion
 
-1. Land: OSS adoption by individual builders.
-2. Expand: team features in hosted control plane.
-3. Close enterprise: security, compliance, support SLA.
+1. Land: OSS adoption by one operator proving a workflow locally.
+2. Expand: Cloud Pro for shared memory, hosted keys, proof-ready runs, and team rollout.
+3. Accelerate: workshop/install offer for buyers who want fast implementation with minimal risk.
+4. Close enterprise: security, compliance, support SLA, and governance requirements.
 
-## KPI Targets
+## Outbound And Workshop Motion
 
-1. Visitor to star conversion.
-2. Star to issue/discussion conversion.
-3. OSS user to paid workspace conversion.
-4. Reduction in repeated failure rate from baseline.
-5. LLM spend saved via semantic cache hit-rate.
+1. Use intent-based outreach around job posts, funding events, and companies publicly investing in AI workflow operations.
+2. Run hands-on workflow workshops instead of generic webinars.
+3. Use a skinny funnel: disqualify teams without one owned workflow, one buyer, and one measurable pain.
+4. Keep founder-led outreach and manual installs until the wedge is consistently converting.
+
+## Metrics That Support The North Star
+
+1. Number of teams running one monitored workflow weekly.
+2. Number of proof-backed workflow runs reviewed by operators or buyers.
+3. OSS user to Cloud Pro conversion for teams running a real workflow.
+4. Workshop-to-pilot conversion rate.
+5. Reduction in repeated workflow failure patterns after prevention rules are enabled.
 
 ## Proof Links
 

--- a/docs/PITCH.md
+++ b/docs/PITCH.md
@@ -1,29 +1,45 @@
 # One-Line Pitch
 
-The enterprise-grade **Agentic Feedback Studio** that turns user vibes into verifiable context and stops AI agents from repeating mistakes.
+Make one AI workflow safe enough to ship team-wide.
 
 # Positioning
 
-The Studio is the operational layer between raw LLM output and production reliability. We provide a **Context Engineering Studio** that move beyond simple prompts to high-density semantic environments.
+RLHF Feedback Loop is the hosted reliability layer behind one workflow with business value. It is not another horizontal agent platform. It gives teams shared memory, guardrails, and proof-ready runs so a workflow can be deployed, audited, and improved over time.
 
-- **Primary Goal:** Transform "Vibe Coding" into "Context Engineering" through the **Veto Layer**.
-- **Secondary Goal:** Generate **RLHF-ready datasets** to permanently align custom models with human preference.
+- **Primary Goal:** Turn "vibe coding" into a controlled rollout through the **Veto Layer**.
+- **Secondary Goal:** Convert real operator feedback into prevention rules, Thompson Sampling signals, and RLHF-ready datasets such as KTO/DPO pairs.
+
+# Buyer Promise
+
+We make one AI workflow measurable enough to justify and safe enough to roll out.
+
+- Ship a lead-to-meeting, onboarding, or internal ops workflow without relying on one operator's laptop.
+- Turn operator complaints into reusable prevention rules instead of repeated incidents.
+- Prove what happened through audit trails, context provenance, and verification evidence.
+
+# Buyer, User, Champion
+
+- **Buyer:** head of ops, head of growth, platform lead, or consultancy owner.
+- **User:** the operator running the workflow day to day.
+- **Champion:** the engineer or platform owner wiring Cloud Pro, the Agentic Feedback Studio, and the Veto Layer into the workflow.
 
 # High-Signal Features
 
-- **Vibe-to-Verification (V2V):** Capture thumbs up/down and convert them into repo-level rules.
-- **Zero-Config Plug-and-Play:** Drop into any repo; auto-discovers project context or falls back to global store.
-- **ShieldCortex Context Packs:** Dynamic semantic assembly of project knowledge for agent boot-up.
-- **Agentic Guardrails (The Veto Layer):** Repeated failures trigger non-bypassable `CLAUDE.md` / `AGENTS.md` rules.
+- **Vibe-to-Verification (V2V):** Capture thumbs up/down and convert them into workflow-level rules.
+- **ShieldCortex Context Packs:** Dynamic semantic assembly of project knowledge for agent boot-up and bounded retrieval.
+- **Agentic Guardrails (The Veto Layer):** Repeated failures trigger non-bypassable `CLAUDE.md` / `AGENTS.md` rules and shared prevention policies.
+- **Proof-Ready Runs:** Machine-readable evidence, audit trails, and hosted workflow artifacts for rollout decisions.
 
-# Buyer Value
+# Best First Wedge
 
-- Reduce repeated failures from AI agents in production workflows.
-- Increase trust via explicit and auditable feedback handling.
-- Shorten time from customer complaint to model improvement.
+Start with one workflow, not a platform migration.
+
+- Best first offer: lead-to-meeting with intake, enrichment, drafting, approvals, CRM sync, and auditability.
+- Same operating model: onboarding and internal ops automation.
+- Technical engine stays the same: feedback capture, context engineering, Thompson Sampling, and DPO export.
 
 # ICP (Ideal Customer Profile)
 
-- AI-first product teams shipping copilots/agents.
-- Platform teams standardizing agent behavior across runtimes (Claude, GPT, Gemini).
-- Consultancies integrating LLM workflows for enterprise clients.
+- AI-first product teams shipping copilots or agentic workflows with real business owners.
+- Platform teams standardizing behavior across Claude, GPT, Codex, Gemini, and custom runners.
+- Consultancies installing AI workflows for clients who need proof, policy, and auditability.


### PR DESCRIPTION
## Summary
- shift README and pitch from feature-led language to one workflow outcome
- clarify North Star plus buyer, user, and champion roles
- add a concrete 30-day GTM plan the landing page can link to safely

## Verification
- `npm ci`
- `npm test`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`

## Known issue
- `npm run test:coverage` still fails on the untouched `origin/main` ADK coverage tests (`tests/adk-consolidator.test.js` and `tests/spike-and-sink.test.js`). This docs slice does not modify those files.