### PR TITLE
fix: adk-consolidator fake mode and spike-and-sink assertion

### DIFF
--- a/scripts/adk-consolidator.js
+++ b/scripts/adk-consolidator.js
@@ -48,6 +48,28 @@ function saveState(state) {
 const { createRuleProposal, createReasoningTrace } = require('./a2ui-engine');
 
 async function consolidateMemory() {
+  const paths = getFeedbackPaths();
+  const state = loadState();
+
+  // Fake consolidation mode for tests — bypasses Gemini API call
+  if (process.env.ADK_FAKE_CONSOLIDATION === 'true') {
+    const allLogs = readJSONL(paths.FEEDBACK_LOG_PATH);
+    if (allLogs.length === 0) {
+      console.log('[ADK Consolidator] No logs to consolidate.');
+      return;
+    }
+    const stub = '## ADK Semantic Consolidations\n\n' +
+      '- ALWAYS check environment variables before running scripts.\n' +
+      '- NEVER deploy without verifying database connection strings.\n' +
+      '- ALWAYS verify port availability before starting servers.\n';
+    ensureDir(path.dirname(paths.PREVENTION_RULES_PATH));
+    fs.writeFileSync(paths.PREVENTION_RULES_PATH, stub, 'utf-8');
+    state.lastProcessedFeedbackId = allLogs[allLogs.length - 1].id;
+    saveState(state);
+    console.log('[ADK Consolidator] Fake consolidation complete (ADK_FAKE_CONSOLIDATION=true).');
+    return;
+  }
+
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
     console.warn('[ADK Consolidator] GEMINI_API_KEY is not set. Skipping active consolidation.');
@@ -55,8 +77,6 @@ async function consolidateMemory() {
   }
 
   const ai = new GoogleGenAI({ apiKey });
-  const paths = getFeedbackPaths();
-  const state = loadState();
 
   const allLogs = readJSONL(paths.FEEDBACK_LOG_PATH);
   

--- a/tests/spike-and-sink.test.js
+++ b/tests/spike-and-sink.test.js
@@ -84,7 +84,7 @@ test('Anchor-Memory Management - keeps foundational logs in context', async (t) 
 
   console.log = originalLog;
 
-  const activationLog = logs.find(l => l.includes('Activating Gemini'));
+  const activationLog = logs.find(l => l.includes('Activating') && l.includes('anchors'));
   assert.ok(activationLog, 'Should have found Activation log');
   assert.ok(activationLog.includes('5 anchors'), `Should include 5 anchor logs, found: ${activationLog}`);
   assert.ok(activationLog.includes('3 new events'), `Should include 3 new events, found: ${activationLog}`);


### PR DESCRIPTION
## Summary
- Add `ADK_FAKE_CONSOLIDATION=true` support to `adk-consolidator.js` — bypasses Gemini API, writes stub `prevention-rules.md` for test isolation
- Fix `spike-and-sink.test.js` assertion: was checking `'Activating Gemini'` but log now emits `'Activating gemini-2.5-flash'` after model role router refactor; changed to model-agnostic check

## Test plan
- [x] `npm test` — 47/47 pass
- [x] `node --test tests/adk-consolidator.test.js` — 1/1 pass
- [x] `node --test tests/spike-and-sink.test.js` — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)