### PR TITLE
fix: harden mcp launcher generation and proof cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@ node_modules/
 !.claude/memory/feedback/.gitkeep
 # Billing key store — contains provisioned API keys, never commit
 .claude/memory/feedback/api-keys.json
+.rlhf/adk-state.json
+.rlhf/adk-test-run/
+.rlhf/a2ui_proposal_*.json
+.rlhf/reminder-state.json
+.rlhf/reminder_*.json
 .npmrc

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Add the MCP server directly in your client config:
 
 | Platform | Command |
 |----------|---------|
-| **Claude** | `claude mcp add rlhf -- npx -y rlhf-feedback-loop serve` |
-| **Codex** | `codex mcp add rlhf -- npx -y rlhf-feedback-loop serve` |
-| **Gemini** | `gemini mcp add rlhf "npx -y rlhf-feedback-loop serve"` |
-| **Amp** | `amp mcp add rlhf -- npx -y rlhf-feedback-loop serve` |
-| **Cursor** | `cursor mcp add rlhf -- npx -y rlhf-feedback-loop serve` |
+| **Claude** | `claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
+| **Codex** | `codex mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
+| **Gemini** | `gemini mcp add rlhf "npx -y rlhf-feedback-loop@0.6.11 serve"` |
+| **Amp** | `amp mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
+| **Cursor** | `cursor mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
 
 Optional auto-installer:
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,6 +3,6 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx -y rlhf-feedback-loop serve`.
-- `codex/config.toml`: example Codex MCP profile section using the same portable launcher.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx -y rlhf-feedback-loop@0.6.11 serve`.
+- `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/rlhf-feedback/SKILL.md`: Amp skill template.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop", "serve"]
+      "args": ["-y", "rlhf-feedback-loop@0.6.11", "serve"]
     }
   }
 }

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -1,4 +1,4 @@
 # Codex MCP profile (copy into ~/.codex/config.toml or merge section)
 [mcp_servers.rlhf]
 command = "npx"
-args = ["-y", "rlhf-feedback-loop", "serve"]
+args = ["-y", "rlhf-feedback-loop@0.6.11", "serve"]

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,22 +42,43 @@ const HOME = process.env.HOME || process.env.USERPROFILE || '';
 const MCP_SERVER_NAME = 'rlhf';
 const LEGACY_MCP_SERVER_NAMES = ['rlhf', 'rlhf-feedback-loop', 'rlhf_feedback_loop'];
 const PORTABLE_MCP_COMMAND = 'npx';
-const PORTABLE_MCP_ARGS = ['-y', 'rlhf-feedback-loop', 'serve'];
+const LOCAL_MCP_COMMAND = 'node';
+
+function portableMcpArgs() {
+  return ['-y', `rlhf-feedback-loop@${pkgVersion()}`, 'serve'];
+}
+
+function localServerEntryPath() {
+  return path.join(PKG_ROOT, 'adapters', 'mcp', 'server-stdio.js');
+}
+
+function shouldUseLocalServerEntry() {
+  return fs.existsSync(path.join(PKG_ROOT, '.git'));
+}
 
 function portableMcpEntry() {
   return {
     command: PORTABLE_MCP_COMMAND,
-    args: [...PORTABLE_MCP_ARGS],
+    args: portableMcpArgs(),
   };
 }
 
-function isPortableMcpEntry(entry) {
+function localMcpEntry() {
+  return {
+    command: LOCAL_MCP_COMMAND,
+    args: [localServerEntryPath()],
+  };
+}
+
+function mcpEntriesMatch(entry, expectedEntry) {
   return Boolean(
     entry &&
-    entry.command === PORTABLE_MCP_COMMAND &&
+    expectedEntry &&
+    entry.command === expectedEntry.command &&
     Array.isArray(entry.args) &&
-    entry.args.length === PORTABLE_MCP_ARGS.length &&
-    entry.args.every((arg, index) => arg === PORTABLE_MCP_ARGS[index])
+    Array.isArray(expectedEntry.args) &&
+    entry.args.length === expectedEntry.args.length &&
+    entry.args.every((arg, index) => arg === expectedEntry.args[index])
   );
 }
 
@@ -65,8 +86,17 @@ function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function formatTomlStringArray(values) {
+  return `[${values.map((value) => JSON.stringify(value)).join(', ')}]`;
+}
+
+function canonicalMcpEntry() {
+  return shouldUseLocalServerEntry() ? localMcpEntry() : portableMcpEntry();
+}
+
 function mcpSectionBlock(name = MCP_SERVER_NAME) {
-  return `[mcp_servers.${name}]\ncommand = "${PORTABLE_MCP_COMMAND}"\nargs = ["${PORTABLE_MCP_ARGS.join('", "')}"]\n`;
+  const entry = canonicalMcpEntry();
+  return `[mcp_servers.${name}]\ncommand = "${entry.command}"\nargs = ${formatTomlStringArray(entry.args)}\n`;
 }
 
 function upsertCodexServerConfig(content) {
@@ -121,7 +151,7 @@ function upsertCodexServerConfig(content) {
 }
 
 function mergeMcpJson(filePath, label) {
-  const canonicalEntry = portableMcpEntry();
+  const canonicalEntry = canonicalMcpEntry();
   if (!fs.existsSync(filePath)) {
     const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
@@ -134,7 +164,7 @@ function mergeMcpJson(filePath, label) {
 
   let changed = false;
   const currentEntry = existing.mcpServers[MCP_SERVER_NAME];
-  if (!isPortableMcpEntry(currentEntry)) {
+  if (!mcpEntriesMatch(currentEntry, canonicalEntry)) {
     existing.mcpServers[MCP_SERVER_NAME] = canonicalEntry;
     changed = true;
   }
@@ -192,9 +222,10 @@ function setupGemini() {
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
     settings.mcpServers = settings.mcpServers || {};
     let changed = false;
+    const canonicalEntry = canonicalMcpEntry();
 
-    if (!isPortableMcpEntry(settings.mcpServers[MCP_SERVER_NAME])) {
-      settings.mcpServers[MCP_SERVER_NAME] = portableMcpEntry();
+    if (!mcpEntriesMatch(settings.mcpServers[MCP_SERVER_NAME], canonicalEntry)) {
+      settings.mcpServers[MCP_SERVER_NAME] = canonicalEntry;
       changed = true;
     }
 

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -30,12 +30,12 @@ This avoids platform-specific rewrite cost and keeps the product under a `$10/mo
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y rlhf-feedback-loop serve`
+- Transport: local stdio MCP server launched via `npx -y rlhf-feedback-loop@0.6.11 serve`
 
 ## Codex (MCP)
 
 - Merge section from `adapters/codex/config.toml`
-- Transport: local stdio MCP server launched via `npx -y rlhf-feedback-loop serve`
+- Transport: local stdio MCP server launched via `npx -y rlhf-feedback-loop@0.6.11 serve`
 
 ## Gemini (Function Calling)
 

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1,5 +1,50 @@
 # Verification Evidence (March 9, 2026)
 
+## March 10, 2026: MCP launcher hardening and proof-cleanup reliability
+
+Commands:
+
+```bash
+npm ci
+node --test tests/adapters.test.js tests/install-mcp.test.js tests/cli.test.js
+node --test tests/prove-adapters.test.js tests/prove-lancedb.test.js
+npm test
+npm run prove:adapters
+npm run prove:automation
+node scripts/prove-lancedb.js
+npm run self-heal:check
+npm run test:coverage
+```
+
+Observed result:
+
+- `npm ci` completed successfully with `0 vulnerabilities`.
+- Targeted launcher verification passed: `39` tests passed, `0` failed across `tests/adapters.test.js`, `tests/install-mcp.test.js`, and `tests/cli.test.js`.
+- Targeted proof cleanup verification passed: `39` tests passed, `0` failed across `tests/prove-adapters.test.js` and `tests/prove-lancedb.test.js`.
+- `npm test` passed end-to-end after hardening MCP launcher generation and retry-based cleanup in the proof scripts.
+- `npm run prove:adapters`: `24 passed`, `0 failed`.
+- `npm run prove:automation`: `14 passed`, `0 failed`.
+- `node scripts/prove-lancedb.js`: `5 passed`, `0 failed`, `0 warned`.
+- `npm run self-heal:check`: `HEALTHY` with `4/4` checks healthy.
+- `npm run test:coverage` passed with overall coverage at `83.16%` lines, `69.30%` branches, and `86.86%` functions (`719` passed, `0` failed, `1` skipped).
+
+Evidence artifacts:
+
+- `proof/compatibility/report.json`
+- `proof/compatibility/report.md`
+- `proof/automation/report.json`
+- `proof/automation/report.md`
+- `proof/lancedb-report.json`
+- `proof/lancedb-report.md`
+
+Requirements verified:
+
+- Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y rlhf-feedback-loop@0.6.11 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
+- Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
+- Transient `.rlhf` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
+
 ## March 10, 2026: Value-led GTM surfaces and hermetic ADK coverage
 
 Commands:

--- a/docs/marketing/devto-article.md
+++ b/docs/marketing/devto-article.md
@@ -59,19 +59,19 @@ Pick your platform:
 
 ```bash
 # Claude
-claude mcp add rlhf -- npx -y rlhf-feedback-loop serve
+claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
 
 # Codex
-codex mcp add rlhf -- npx -y rlhf-feedback-loop serve
+codex mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
 
 # Gemini
-gemini mcp add rlhf "npx -y rlhf-feedback-loop serve"
+gemini mcp add rlhf "npx -y rlhf-feedback-loop@0.6.11 serve"
 
 # Amp
-amp mcp add rlhf -- npx -y rlhf-feedback-loop serve
+amp mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
 
 # Cursor
-cursor mcp add rlhf -- npx -y rlhf-feedback-loop serve
+cursor mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
 ```
 
 Run once per project. The MCP server starts automatically on each session after that.

--- a/docs/marketing/show-hn.md
+++ b/docs/marketing/show-hn.md
@@ -7,7 +7,7 @@ rlhf-feedback-loop is an MCP server that captures thumbs-up/down feedback during
 **One-line install (Claude Code):**
 
 ```
-claude mcp add rlhf -- npx -y rlhf-feedback-loop serve
+claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
 ```
 
 **What it actually does:**

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Cloud Pro host
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add rlhf -- npx -y rlhf-feedback-loop serve
+claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop", "serve"],
+      "args": ["-y", "rlhf-feedback-loop@0.6.11", "serve"],
       "env": {
         "RLHF_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop", "serve"],
+      "args": ["-y", "rlhf-feedback-loop@0.6.11", "serve"],
       "env": {
         "RLHF_BASE_URL": "https://rlhf-feedback-loop-710216278770.us-central1.run.app",
         "RLHF_API_KEY": "rlhf_YOUR_KEY_HERE"
@@ -123,7 +123,7 @@ Verification evidence: https://github.com/IgorGanapolsky/rlhf-feedback-loop/blob
 
 ## Transport
 
-- **stdio** (primary): `npx -y rlhf-feedback-loop serve` — portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y rlhf-feedback-loop@0.6.11 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---

--- a/proof/automation/report.json
+++ b/proof/automation/report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-10T16:45:06.661Z",
+  "generatedAt": "2026-03-10T17:00:51.209Z",
   "checks": [
     {
       "name": "feedback.capture.rubric_pass",
@@ -131,7 +131,7 @@
       "name": "code_reasoning.dpo_traces",
       "passed": true,
       "details": {
-        "traceId": "trace-47930daf70e5",
+        "traceId": "trace-f993fd20a0a6",
         "confidence": 1,
         "aggregateConfidence": 1
       }
@@ -164,8 +164,8 @@
   },
   "proofTraces": [
     {
-      "traceId": "trace-d72e1849efaf",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-8f256fd286c9",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "feedback.capture.rubric_pass",
       "steps": [
@@ -197,8 +197,8 @@
       }
     },
     {
-      "traceId": "trace-c64611994db6",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-a7d7d1d542cc",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "feedback.capture.rubric_block",
       "steps": [
@@ -230,8 +230,8 @@
       }
     },
     {
-      "traceId": "trace-b545be1648a4",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-2929e04d2c19",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "feedback.capture.negative_with_rubric",
       "steps": [
@@ -263,8 +263,8 @@
       }
     },
     {
-      "traceId": "trace-f1a533f28b91",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-96c0d051ec0b",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "analytics.rubric_tracking",
       "steps": [
@@ -288,8 +288,8 @@
       }
     },
     {
-      "traceId": "trace-1fa7fb017485",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-7969ef485d56",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "prevention_rules.rubric_dimensions",
       "steps": [
@@ -313,8 +313,8 @@
       }
     },
     {
-      "traceId": "trace-99c6a7dd2883",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-a147a945ec82",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "dpo_export.rubric_metadata",
       "steps": [
@@ -338,8 +338,8 @@
       }
     },
     {
-      "traceId": "trace-ae047c93885b",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-376369a94704",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "api.rubric_gate",
       "steps": [
@@ -371,8 +371,8 @@
       }
     },
     {
-      "traceId": "trace-45bec99ca007",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-794e0129c6c4",
+      "timestamp": "2026-03-10T17:00:54.413Z",
       "type": "proof-gate",
       "subject": "mcp.rubric_gate",
       "steps": [
@@ -404,8 +404,8 @@
       }
     },
     {
-      "traceId": "trace-30ca63fdec6d",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-013ef326a06c",
+      "timestamp": "2026-03-10T17:00:54.414Z",
       "type": "proof-gate",
       "subject": "intent.checkpoint_enforcement",
       "steps": [
@@ -429,8 +429,8 @@
       }
     },
     {
-      "traceId": "trace-cca01dd42aae",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-b2eb94d79c82",
+      "timestamp": "2026-03-10T17:00:54.414Z",
       "type": "proof-gate",
       "subject": "context.evaluate.rubric",
       "steps": [
@@ -454,8 +454,8 @@
       }
     },
     {
-      "traceId": "trace-9a2fb2d16a27",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-011dd34e7c32",
+      "timestamp": "2026-03-10T17:00:54.414Z",
       "type": "proof-gate",
       "subject": "context.semantic_cache.hit",
       "steps": [
@@ -479,8 +479,8 @@
       }
     },
     {
-      "traceId": "trace-8a44c0e4f3c0",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-17017d49bb51",
+      "timestamp": "2026-03-10T17:00:54.414Z",
       "type": "proof-gate",
       "subject": "self_healing.helpers",
       "steps": [
@@ -504,15 +504,15 @@
       }
     },
     {
-      "traceId": "trace-048586a418e1",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-6b1c9d3beced",
+      "timestamp": "2026-03-10T17:00:54.414Z",
       "type": "proof-gate",
       "subject": "code_reasoning.dpo_traces",
       "steps": [
         {
           "location": "check:code_reasoning.dpo_traces",
           "claim": "Proof check \"code_reasoning.dpo_traces\" passes",
-          "evidence": "Passed with details: {\"traceId\":\"trace-47930daf70e5\",\"confidence\":1,\"aggregateConfidence\":1}",
+          "evidence": "Passed with details: {\"traceId\":\"trace-f993fd20a0a6\",\"confidence\":1,\"aggregateConfidence\":1}",
           "verdict": "verified"
         }
       ],

--- a/proof/automation/report.md
+++ b/proof/automation/report.md
@@ -1,6 +1,6 @@
 # Automation Proof
 
-Generated: 2026-03-10T16:45:06.661Z
+Generated: 2026-03-10T17:00:51.209Z
 
 Passed: 14
 Failed: 0

--- a/proof/compatibility/report.json
+++ b/proof/compatibility/report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-10T16:45:05.987Z",
+  "generatedAt": "2026-03-10T17:00:48.921Z",
   "checks": [
     {
       "name": "api.healthz",
@@ -57,7 +57,7 @@
       "name": "api.context.construct",
       "passed": true,
       "details": {
-        "packId": "pack_1773161106215_scok79",
+        "packId": "pack_1773162049420_53o82m",
         "items": 5
       }
     },

--- a/proof/compatibility/report.md
+++ b/proof/compatibility/report.md
@@ -1,6 +1,6 @@
 # Adapter Compatibility Proof
 
-Generated: 2026-03-10T16:45:05.987Z
+Generated: 2026-03-10T17:00:48.921Z
 
 Passed: 24
 Failed: 0

--- a/proof/lancedb-report.json
+++ b/proof/lancedb-report.json
@@ -1,14 +1,14 @@
 {
   "phase": "04-lancedb-vector-storage",
-  "generated": "2026-03-09T16:07:33.949Z",
+  "generated": "2026-03-10T16:58:21.895Z",
   "requirements": {
     "VEC-01": {
       "status": "pass",
-      "evidence": "lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-EhN4XL/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories."
+      "evidence": "lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-9wvWex/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories."
     },
     "VEC-02": {
       "status": "pass",
-      "evidence": "scripts/vector-store.js uses dynamic import() at line 16: `_lancedb = await import('@lancedb/lancedb');`; line 23: `const { pipeline } = await import('@huggingface/transformers');`. Total dynamic import() calls: 2. This is the only CJS-compatible approach for ESM-only @lancedb/lancedb and @huggingface/transformers."
+      "evidence": "scripts/vector-store.js uses dynamic import() at line 26: `_lancedb = _lancedbLoader ? await _lancedbLoader() : await import('@lancedb/lancedb');`; line 61: `const pipeline = _pipelineLoader || (await import('@huggingface/transformers')).pipeline;`. Total dynamic import() calls: 2. This is the only CJS-compatible approach for ESM-only @lancedb/lancedb and @huggingface/transformers."
     },
     "VEC-03": {
       "status": "pass",
@@ -19,13 +19,13 @@
       "evidence": "searchSimilar() returned 2 result(s). proof-vec01 present: true. proof-vec04-b present: true. API: searchSimilar(queryText, limit=10) returns vector-ranked rows from rlhf_memories table. Note: stub embed (RLHF_VECTOR_STUB_EMBED=true) returns identical 384-dim unit vectors — ranking is insertion-order with stub, cosine similarity with real ONNX model."
     },
     "VEC-05": {
-      "status": "fail",
-      "evidence": "node --test tests/vector-store.test.js: pass=0, fail=0. Expected >= 4 passing tests, got 0."
+      "status": "pass",
+      "evidence": "node --test tests/vector-store.test.js: pass=6, fail=0. Delta from Phase 3 baseline (89 tests): +6 vector-store tests. Meets VEC-05 requirement: >= 4 new tests above Phase 3 baseline. Test file: tests/vector-store.test.js (4 it() blocks using node:test describe/it pattern). Proof report: proof/lancedb-report.md (this file)."
     }
   },
   "summary": {
-    "passed": 4,
-    "failed": 1,
+    "passed": 5,
+    "failed": 0,
     "warned": 0
   }
 }

--- a/proof/lancedb-report.md
+++ b/proof/lancedb-report.md
@@ -1,29 +1,29 @@
 # LanceDB Vector Storage Proof Report
 
-Generated: 2026-03-09T16:07:33.949Z
+Generated: 2026-03-10T16:58:21.895Z
 Phase: 04-lancedb-vector-storage
 
-**Passed: 4 | Failed: 1 | Warned: 0**
+**Passed: 5 | Failed: 0 | Warned: 0**
 
 ## Requirements
 
 | Requirement | Status | Evidence |
 |-------------|--------|----------|
-| VEC-01 | PASS | lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-EhN4XL/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories. |
-| VEC-02 | PASS | scripts/vector-store.js uses dynamic import() at line 16: `_lancedb = await import('@lancedb/lancedb');`; line 23: `const { pipeline } = await import('@huggingface/transformers');`. Total dynamic import() calls: 2. This is the only CJS-compatible approach for ESM-only @lancedb/lancedb and @huggingface/transformers. |
+| VEC-01 | PASS | lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-9wvWex/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories. |
+| VEC-02 | PASS | scripts/vector-store.js uses dynamic import() at line 26: `_lancedb = _lancedbLoader ? await _lancedbLoader() : await import('@lancedb/lancedb');`; line 61: `const pipeline = _pipelineLoader \|\| (await import('@huggingface/transformers')).pipeline;`. Total dynamic import() calls: 2. This is the only CJS-compatible approach for ESM-only @lancedb/lancedb and @huggingface/transformers. |
 | VEC-03 | PASS | package.json: apache-arrow="^18.1.0" (base: 18.1.0), @lancedb/lancedb="^0.26.2". LanceDB 0.26.2 peer dep is apache-arrow >=15.0.0 <=18.1.0. Arrow 19+ breaks binary compat. Pin confirmed safe: 18.1.0 <= 18.1.0 ceiling. |
 | VEC-04 | PASS | searchSimilar() returned 2 result(s). proof-vec01 present: true. proof-vec04-b present: true. API: searchSimilar(queryText, limit=10) returns vector-ranked rows from rlhf_memories table. Note: stub embed (RLHF_VECTOR_STUB_EMBED=true) returns identical 384-dim unit vectors — ranking is insertion-order with stub, cosine similarity with real ONNX model. |
-| VEC-05 | FAIL | node --test tests/vector-store.test.js: pass=0, fail=0. Expected >= 4 passing tests, got 0. |
+| VEC-05 | PASS | node --test tests/vector-store.test.js: pass=6, fail=0. Delta from Phase 3 baseline (89 tests): +6 vector-store tests. Meets VEC-05 requirement: >= 4 new tests above Phase 3 baseline. Test file: tests/vector-store.test.js (4 it() blocks using node:test describe/it pattern). Proof report: proof/lancedb-report.md (this file). |
 
 ## Requirement Details
 
 ### VEC-01 — PASS
 
-lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-EhN4XL/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories.
+lancedb dir created at /var/folders/yw/2qhx3yzj0psf87rdxh8lqlmm0000gp/T/prove-lancedb-9wvWex/lancedb. upsertFeedback() resolved, searchSimilar() returned 1 result(s) including proof-vec01. Table name: rlhf_memories.
 
 ### VEC-02 — PASS
 
-scripts/vector-store.js uses dynamic import() at line 16: `_lancedb = await import('@lancedb/lancedb');`; line 23: `const { pipeline } = await import('@huggingface/transformers');`. Total dynamic import() calls: 2. This is the only CJS-compatible approach for ESM-only @lancedb/lancedb and @huggingface/transformers.
+scripts/vector-store.js uses dynamic import() at line 26: `_lancedb = _lancedbLoader ? await _lancedbLoader() : await import('@lancedb/lancedb');`; line 61: `const pipeline = _pipelineLoader || (await import('@huggingface/transformers')).pipeline;`. Total dynamic import() calls: 2. This is the only CJS-compatible approach for ESM-only @lancedb/lancedb and @huggingface/transformers.
 
 ### VEC-03 — PASS
 
@@ -33,9 +33,9 @@ package.json: apache-arrow="^18.1.0" (base: 18.1.0), @lancedb/lancedb="^0.26.2".
 
 searchSimilar() returned 2 result(s). proof-vec01 present: true. proof-vec04-b present: true. API: searchSimilar(queryText, limit=10) returns vector-ranked rows from rlhf_memories table. Note: stub embed (RLHF_VECTOR_STUB_EMBED=true) returns identical 384-dim unit vectors — ranking is insertion-order with stub, cosine similarity with real ONNX model.
 
-### VEC-05 — FAIL
+### VEC-05 — PASS
 
-node --test tests/vector-store.test.js: pass=0, fail=0. Expected >= 4 passing tests, got 0.
+node --test tests/vector-store.test.js: pass=6, fail=0. Delta from Phase 3 baseline (89 tests): +6 vector-store tests. Meets VEC-05 requirement: >= 4 new tests above Phase 3 baseline. Test file: tests/vector-store.test.js (4 it() blocks using node:test describe/it pattern). Proof report: proof/lancedb-report.md (this file).
 
 ## Test Count Delta
 

--- a/scripts/install-mcp.js
+++ b/scripts/install-mcp.js
@@ -16,10 +16,32 @@ const fs = require('fs');
 const path = require('path');
 
 const MCP_SERVER_KEY = 'rlhf';
-const MCP_SERVER_CONFIG = {
-  command: 'npx',
-  args: ['-y', 'rlhf-feedback-loop', 'serve'],
-};
+const PKG_ROOT = path.join(__dirname, '..');
+const PKG_VERSION = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, 'package.json'), 'utf8')).version;
+
+function portableMcpConfig() {
+  return {
+    command: 'npx',
+    args: ['-y', `rlhf-feedback-loop@${PKG_VERSION}`, 'serve'],
+  };
+}
+
+function localMcpConfig() {
+  return {
+    command: 'node',
+    args: [path.join(PKG_ROOT, 'adapters', 'mcp', 'server-stdio.js')],
+  };
+}
+
+function shouldUseLocalMcpConfig() {
+  return fs.existsSync(path.join(PKG_ROOT, '.git'));
+}
+
+function resolveMcpServerConfig() {
+  return shouldUseLocalMcpConfig() ? localMcpConfig() : portableMcpConfig();
+}
+
+const MCP_SERVER_CONFIG = resolveMcpServerConfig();
 
 function parseFlags(argv) {
   const flags = {};
@@ -58,11 +80,21 @@ function backupFile(filePath) {
   return backupPath;
 }
 
+function serverConfigMatches(entry) {
+  return Boolean(
+    entry &&
+    entry.command === MCP_SERVER_CONFIG.command &&
+    Array.isArray(entry.args) &&
+    entry.args.length === MCP_SERVER_CONFIG.args.length &&
+    entry.args.every((arg, index) => arg === MCP_SERVER_CONFIG.args[index])
+  );
+}
+
 function isAlreadyInstalled(settings) {
   return !!(
     settings &&
     settings.mcpServers &&
-    settings.mcpServers[MCP_SERVER_KEY]
+    serverConfigMatches(settings.mcpServers[MCP_SERVER_KEY])
   );
 }
 

--- a/scripts/prove-adapters.js
+++ b/scripts/prove-adapters.js
@@ -362,7 +362,7 @@ async function runProof(options = {}) {
         check(Boolean(response.result && response.result.serverInfo), 'cli serve bad HOME initialize missing serverInfo');
         addResult('mcp.cli.serve.bad_home.initialize', true, { server: response.result.serverInfo.name });
       } finally {
-        fs.rmSync(isolatedDir, { recursive: true, force: true });
+        fs.rmSync(isolatedDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     }
 
@@ -522,7 +522,7 @@ async function runProof(options = {}) {
     addResult('fatal', false, { error: err.message });
   } finally {
     await new Promise((resolve) => server.close(resolve));
-    fs.rmSync(tmpFeedbackDir, { recursive: true, force: true });
+    fs.rmSync(tmpFeedbackDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     if (previousFeedbackDir === undefined) delete process.env.RLHF_FEEDBACK_DIR;
     else process.env.RLHF_FEEDBACK_DIR = previousFeedbackDir;
     if (previousApiKey === undefined) delete process.env.RLHF_API_KEY;

--- a/scripts/prove-lancedb.js
+++ b/scripts/prove-lancedb.js
@@ -228,7 +228,7 @@ async function runProof(options = {}) {
   } finally {
     // Clean up tmp dir
     try {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     } catch (_) {
       // ignore cleanup errors
     }

--- a/tests/adapters.test.js
+++ b/tests/adapters.test.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const root = path.join(__dirname, '..');
+const packageVersion = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8')).version;
 
 test('adapter files exist', () => {
   const files = [
@@ -35,7 +36,7 @@ test('claude .mcp.json is valid JSON with mcpServers key', () => {
   assert.equal(typeof payload.mcpServers, 'object');
   assert.deepEqual(payload.mcpServers.rlhf, {
     command: 'npx',
-    args: ['-y', 'rlhf-feedback-loop', 'serve'],
+    args: ['-y', `rlhf-feedback-loop@${packageVersion}`, 'serve'],
   });
 });
 
@@ -44,7 +45,11 @@ test('codex config.toml contains mcp_servers section', () => {
   const content = fs.readFileSync(filePath, 'utf-8');
   assert.match(content, /\[mcp_servers\.rlhf\]/, 'config.toml must contain canonical rlhf section');
   assert.match(content, /command = "npx"/, 'config.toml must use portable npx launcher');
-  assert.match(content, /args = \["-y", "rlhf-feedback-loop", "serve"\]/, 'config.toml must launch the package serve entrypoint');
+  assert.match(
+    content,
+    new RegExp(`args = \\["-y", "rlhf-feedback-loop@${packageVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}", "serve"\\]`),
+    'config.toml must launch the version-pinned package serve entrypoint'
+  );
 });
 
 test('amp SKILL.md contains capture-feedback reference', () => {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -21,6 +21,7 @@ const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 
 const CLI = path.resolve(__dirname, '../bin/cli.js');
+const MCP_SERVER_PATH = path.resolve(__dirname, '../adapters/mcp/server-stdio.js');
 const savedFunnelPath = process.env._TEST_FUNNEL_LEDGER_PATH;
 const savedHome = process.env.HOME;
 const savedUserProfile = process.env.USERPROFILE;
@@ -490,11 +491,11 @@ describe('bin/cli.js', () => {
     const mcp = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
     assert.ok(mcp.mcpServers, '.mcp.json should have mcpServers');
     assert.ok(mcp.mcpServers.rlhf, 'Should have canonical rlhf server entry');
-    assert.strictEqual(mcp.mcpServers.rlhf.command, 'npx');
-    assert.deepEqual(mcp.mcpServers.rlhf.args, ['-y', 'rlhf-feedback-loop', 'serve']);
+    assert.strictEqual(mcp.mcpServers.rlhf.command, 'node');
+    assert.deepEqual(mcp.mcpServers.rlhf.args, [MCP_SERVER_PATH]);
   });
 
-  test('init writes portable codex MCP launcher when Codex home exists', () => {
+  test('init writes local direct codex MCP launcher when running from source checkout', () => {
     const isolatedDir = makeTmpDir();
     const isolatedHome = makeTmpDir();
     const codexHome = path.join(isolatedHome, '.codex');
@@ -515,9 +516,8 @@ describe('bin/cli.js', () => {
     const configPath = path.join(codexHome, 'config.toml');
     const content = fs.readFileSync(configPath, 'utf8');
     assert.match(content, /\[mcp_servers\.rlhf\]/);
-    assert.match(content, /command = "npx"/);
-    assert.match(content, /args = \["-y", "rlhf-feedback-loop", "serve"\]/);
-    assert.doesNotMatch(content, /server-stdio\.js/);
+    assert.match(content, /command = "node"/);
+    assert.match(content, new RegExp(`args = \\["${MCP_SERVER_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"\\]`));
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(isolatedHome, { recursive: true, force: true });

--- a/tests/install-mcp.test.js
+++ b/tests/install-mcp.test.js
@@ -44,16 +44,14 @@ describe('install-mcp', () => {
   test('buildMcpConfig generates correct MCP config JSON', () => {
     const config = buildMcpConfig();
     assert.deepStrictEqual(config, {
-      rlhf: {
-        command: 'npx',
-        args: ['-y', 'rlhf-feedback-loop', 'serve'],
-      },
+      rlhf: MCP_SERVER_CONFIG,
     });
   });
 
-  test('MCP_SERVER_CONFIG has expected shape', () => {
-    assert.equal(MCP_SERVER_CONFIG.command, 'npx');
-    assert.deepStrictEqual(MCP_SERVER_CONFIG.args, ['-y', 'rlhf-feedback-loop', 'serve']);
+  test('MCP_SERVER_CONFIG prefers local direct server path in source checkouts', () => {
+    assert.equal(MCP_SERVER_CONFIG.command, 'node');
+    assert.equal(MCP_SERVER_CONFIG.args.length, 1);
+    assert.match(MCP_SERVER_CONFIG.args[0], /adapters[\\/]mcp[\\/]server-stdio\.js$/);
   });
 
   test('parseFlags detects --project flag', () => {
@@ -118,6 +116,34 @@ describe('install-mcp', () => {
       const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
       const serverKeys = Object.keys(settings.mcpServers);
       assert.equal(serverKeys.filter((k) => k === MCP_SERVER_KEY).length, 1);
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(isolatedDir, { recursive: true, force: true });
+    }
+  });
+
+  test('replaces a stale existing server entry with the resolved config', () => {
+    const isolatedDir = makeTmpDir();
+    const settingsDir = path.join(isolatedDir, '.claude');
+    const settingsPath = path.join(settingsDir, 'settings.json');
+
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      mcpServers: {
+        [MCP_SERVER_KEY]: {
+          command: 'npx',
+          args: ['-y', 'rlhf-feedback-loop', 'serve'],
+        },
+      },
+    }, null, 2) + '\n');
+
+    const origHome = process.env.HOME;
+    process.env.HOME = isolatedDir;
+    try {
+      const result = installMcp({});
+      assert.equal(result.installed, true);
+      const updated = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      assert.deepStrictEqual(updated.mcpServers[MCP_SERVER_KEY], MCP_SERVER_CONFIG);
     } finally {
       process.env.HOME = origHome;
       fs.rmSync(isolatedDir, { recursive: true, force: true });

--- a/tests/prove-adapters.test.js
+++ b/tests/prove-adapters.test.js
@@ -113,6 +113,6 @@ test('adapter proof: default profile has more tools than locked', () => {
 
 test('adapter proof: cleanup', () => {
   try {
-    fs.rmSync(tmpProofDir, { recursive: true, force: true });
+    fs.rmSync(tmpProofDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   } catch (err) {}
 });

--- a/tests/prove-lancedb.test.js
+++ b/tests/prove-lancedb.test.js
@@ -13,7 +13,7 @@ test('lancedb proof core requirements pass (VEC-01 through VEC-04)', () => {
         const r = await runProof({ proofDir: tmp });
         process.stderr.write('PROOF_JSON:' + JSON.stringify({ passed: r.summary.passed, reqs: Object.fromEntries(Object.entries(r.requirements).map(([k,v]) => [k, v.status])) }) + '\\n');
       } finally {
-        fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       }
     })();
   `], {


### PR DESCRIPTION
## Summary
- generate canonical local MCP entries from source checkouts by launching `node adapters/mcp/server-stdio.js`
- pin portable launcher examples/config to `npx -y rlhf-feedback-loop@0.6.11 serve` and upgrade stale configs on reinstall
- harden adapter/LanceDB proof cleanup with retry-capable recursive removal and ignore transient `.rlhf` runtime files

## Verification
- `npm ci`
- `node --test tests/adapters.test.js tests/install-mcp.test.js tests/cli.test.js`
- `node --test tests/prove-adapters.test.js tests/prove-lancedb.test.js`
- `npm test`
- `npm run prove:adapters`
- `npm run prove:automation`
- `node scripts/prove-lancedb.js`
- `npm run self-heal:check`
- `npm run test:coverage`

## Evidence
- `docs/VERIFICATION_EVIDENCE.md`
- `proof/compatibility/report.json`
- `proof/automation/report.json`
- `proof/lancedb-report.json`
