### PR TITLE
fix: harden proof verification under coverage

### DIFF
--- a/proof/automation/report.json
+++ b/proof/automation/report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-10T16:45:06.661Z",
+  "generatedAt": "2026-03-10T17:10:38.937Z",
   "checks": [
     {
       "name": "feedback.capture.rubric_pass",
@@ -131,7 +131,7 @@
       "name": "code_reasoning.dpo_traces",
       "passed": true,
       "details": {
-        "traceId": "trace-47930daf70e5",
+        "traceId": "trace-ed7841f75ca3",
         "confidence": 1,
         "aggregateConfidence": 1
       }
@@ -164,8 +164,8 @@
   },
   "proofTraces": [
     {
-      "traceId": "trace-d72e1849efaf",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-cadf633e49a5",
+      "timestamp": "2026-03-10T17:10:39.680Z",
       "type": "proof-gate",
       "subject": "feedback.capture.rubric_pass",
       "steps": [
@@ -197,8 +197,8 @@
       }
     },
     {
-      "traceId": "trace-c64611994db6",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-42e3dd18af5b",
+      "timestamp": "2026-03-10T17:10:39.680Z",
       "type": "proof-gate",
       "subject": "feedback.capture.rubric_block",
       "steps": [
@@ -230,8 +230,8 @@
       }
     },
     {
-      "traceId": "trace-b545be1648a4",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-3403a7933e87",
+      "timestamp": "2026-03-10T17:10:39.680Z",
       "type": "proof-gate",
       "subject": "feedback.capture.negative_with_rubric",
       "steps": [
@@ -263,8 +263,8 @@
       }
     },
     {
-      "traceId": "trace-f1a533f28b91",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-cfc010f438fc",
+      "timestamp": "2026-03-10T17:10:39.680Z",
       "type": "proof-gate",
       "subject": "analytics.rubric_tracking",
       "steps": [
@@ -288,8 +288,8 @@
       }
     },
     {
-      "traceId": "trace-1fa7fb017485",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-197a4b5bd5e4",
+      "timestamp": "2026-03-10T17:10:39.680Z",
       "type": "proof-gate",
       "subject": "prevention_rules.rubric_dimensions",
       "steps": [
@@ -313,8 +313,8 @@
       }
     },
     {
-      "traceId": "trace-99c6a7dd2883",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-45d08b0df1c0",
+      "timestamp": "2026-03-10T17:10:39.680Z",
       "type": "proof-gate",
       "subject": "dpo_export.rubric_metadata",
       "steps": [
@@ -338,8 +338,8 @@
       }
     },
     {
-      "traceId": "trace-ae047c93885b",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-f9d5fdb52b2d",
+      "timestamp": "2026-03-10T17:10:39.681Z",
       "type": "proof-gate",
       "subject": "api.rubric_gate",
       "steps": [
@@ -371,8 +371,8 @@
       }
     },
     {
-      "traceId": "trace-45bec99ca007",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-6dc231d0ff71",
+      "timestamp": "2026-03-10T17:10:39.681Z",
       "type": "proof-gate",
       "subject": "mcp.rubric_gate",
       "steps": [
@@ -404,8 +404,8 @@
       }
     },
     {
-      "traceId": "trace-30ca63fdec6d",
-      "timestamp": "2026-03-10T16:45:07.308Z",
+      "traceId": "trace-2d62b9d83093",
+      "timestamp": "2026-03-10T17:10:39.681Z",
       "type": "proof-gate",
       "subject": "intent.checkpoint_enforcement",
       "steps": [
@@ -429,8 +429,8 @@
       }
     },
     {
-      "traceId": "trace-cca01dd42aae",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-24ae40e3dfed",
+      "timestamp": "2026-03-10T17:10:39.681Z",
       "type": "proof-gate",
       "subject": "context.evaluate.rubric",
       "steps": [
@@ -454,8 +454,8 @@
       }
     },
     {
-      "traceId": "trace-9a2fb2d16a27",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-d0745dd0f95c",
+      "timestamp": "2026-03-10T17:10:39.681Z",
       "type": "proof-gate",
       "subject": "context.semantic_cache.hit",
       "steps": [
@@ -479,8 +479,8 @@
       }
     },
     {
-      "traceId": "trace-8a44c0e4f3c0",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-d9081b29787c",
+      "timestamp": "2026-03-10T17:10:39.681Z",
       "type": "proof-gate",
       "subject": "self_healing.helpers",
       "steps": [
@@ -504,15 +504,15 @@
       }
     },
     {
-      "traceId": "trace-048586a418e1",
-      "timestamp": "2026-03-10T16:45:07.309Z",
+      "traceId": "trace-e8853f0f29fc",
+      "timestamp": "2026-03-10T17:10:39.681Z",
       "type": "proof-gate",
       "subject": "code_reasoning.dpo_traces",
       "steps": [
         {
           "location": "check:code_reasoning.dpo_traces",
           "claim": "Proof check \"code_reasoning.dpo_traces\" passes",
-          "evidence": "Passed with details: {\"traceId\":\"trace-47930daf70e5\",\"confidence\":1,\"aggregateConfidence\":1}",
+          "evidence": "Passed with details: {\"traceId\":\"trace-ed7841f75ca3\",\"confidence\":1,\"aggregateConfidence\":1}",
           "verdict": "verified"
         }
       ],

--- a/proof/automation/report.md
+++ b/proof/automation/report.md
@@ -1,6 +1,6 @@
 # Automation Proof
 
-Generated: 2026-03-10T16:45:06.661Z
+Generated: 2026-03-10T17:10:38.937Z
 
 Passed: 14
 Failed: 0

--- a/proof/compatibility/report.json
+++ b/proof/compatibility/report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-10T16:45:05.987Z",
+  "generatedAt": "2026-03-10T17:10:38.086Z",
   "checks": [
     {
       "name": "api.healthz",
@@ -57,7 +57,7 @@
       "name": "api.context.construct",
       "passed": true,
       "details": {
-        "packId": "pack_1773161106215_scok79",
+        "packId": "pack_1773162638441_ietgvw",
         "items": 5
       }
     },

--- a/proof/compatibility/report.md
+++ b/proof/compatibility/report.md
@@ -1,6 +1,6 @@
 # Adapter Compatibility Proof
 
-Generated: 2026-03-10T16:45:05.987Z
+Generated: 2026-03-10T17:10:38.086Z
 
 Passed: 24
 Failed: 0

--- a/scripts/feedback-loop.js
+++ b/scripts/feedback-loop.js
@@ -33,6 +33,7 @@ const DOMAIN_CATEGORIES = [
 ];
 
 const HOME = process.env.HOME || process.env.USERPROFILE || '';
+const pendingBackgroundSideEffects = new Set();
 
 function getFeedbackPaths() {
   if (process.env.RLHF_FEEDBACK_DIR) {
@@ -113,6 +114,34 @@ function ensureDir(dirPath) {
 function appendJSONL(filePath, record) {
   ensureDir(path.dirname(filePath));
   fs.appendFileSync(filePath, `${JSON.stringify(record)}\n`);
+}
+
+function trackBackgroundSideEffect(taskPromise) {
+  if (!taskPromise || typeof taskPromise.then !== 'function') {
+    return null;
+  }
+
+  let tracked;
+  tracked = Promise.resolve(taskPromise)
+    .catch(() => {
+      // Non-critical side effects should never fail the primary feedback write.
+    })
+    .finally(() => {
+      pendingBackgroundSideEffects.delete(tracked);
+    });
+
+  pendingBackgroundSideEffects.add(tracked);
+  return tracked;
+}
+
+async function waitForBackgroundSideEffects() {
+  while (pendingBackgroundSideEffects.size > 0) {
+    await Promise.allSettled([...pendingBackgroundSideEffects]);
+  }
+}
+
+function getPendingBackgroundSideEffectCount() {
+  return pendingBackgroundSideEffects.size;
 }
 
 function readJSONL(filePath) {
@@ -555,10 +584,8 @@ function captureFeedback(params) {
 
   // Vector storage side-effect (non-blocking — primary write already succeeded)
   const vectorStore = getVectorStoreModule();
-  if (vectorStore) {
-    vectorStore.upsertFeedback(feedbackEvent).catch(() => {
-      // Non-critical; primary feedback log is the source of truth
-    });
+  if (vectorStore && typeof vectorStore.upsertFeedback === 'function') {
+    trackBackgroundSideEffect(vectorStore.upsertFeedback(feedbackEvent));
   }
 
   // RLAIF self-audit side-effect (non-blocking — 4th enrichment layer)
@@ -964,6 +991,8 @@ module.exports = {
   inferDomain,
   inferOutcome,
   enrichFeedbackContext,
+  waitForBackgroundSideEffects,
+  getPendingBackgroundSideEffectCount,
   get FEEDBACK_LOG_PATH() {
     return getFeedbackPaths().FEEDBACK_LOG_PATH;
   },

--- a/scripts/prove-adapters.js
+++ b/scripts/prove-adapters.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { spawn } = require('child_process');
+const { waitForBackgroundSideEffects } = require('./feedback-loop');
 const { startServer } = require('../src/api/server');
 const { handleRequest } = require('../adapters/mcp/server-stdio');
 const { validateSubagentProfiles, listSubagentProfiles } = require('./subagent-profiles');
@@ -33,6 +34,24 @@ function parseLeadingJson(text) {
   const boundary = raw.indexOf(marker);
   const jsonSegment = boundary === -1 ? raw : raw.slice(0, boundary);
   return JSON.parse(jsonSegment.trim());
+}
+
+async function fetchWithRetry(url, options, { retries = 5, delayMs = 100 } = {}) {
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fetch(url, options);
+    } catch (err) {
+      lastError = err;
+      if (attempt === retries) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs * (attempt + 1)));
+    }
+  }
+
+  throw lastError;
 }
 
 async function proveMcpStdioTransport({
@@ -173,11 +192,14 @@ async function runProof(options = {}) {
   }
 
   const { server, port } = await startServer({ port: proofPort });
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let currentCheck = 'bootstrap';
 
   try {
     // API checks
     {
-      const res = await fetch(`http://localhost:${port}/healthz`, {
+      currentCheck = 'api.healthz';
+      const res = await fetchWithRetry(`${baseUrl}/healthz`, {
         headers: { Authorization: 'Bearer proof-key' },
       });
       check(res.status === 200, `health expected 200, got ${res.status}`);
@@ -185,13 +207,15 @@ async function runProof(options = {}) {
     }
 
     {
-      const res = await fetch(`http://localhost:${port}/v1/feedback/stats`);
+      currentCheck = 'api.auth.required';
+      const res = await fetchWithRetry(`${baseUrl}/v1/feedback/stats`);
       check(res.status === 401, `stats unauthorized expected 401, got ${res.status}`);
       addResult('api.auth.required', true, { status: res.status });
     }
 
     {
-      const res = await fetch(`http://localhost:${port}/v1/intents/catalog?mcpProfile=locked`, {
+      currentCheck = 'api.intents.catalog';
+      const res = await fetchWithRetry(`${baseUrl}/v1/intents/catalog?mcpProfile=locked`, {
         headers: { Authorization: 'Bearer proof-key' },
       });
       check(res.status === 200, `intents catalog expected 200, got ${res.status}`);
@@ -201,7 +225,8 @@ async function runProof(options = {}) {
     }
 
     {
-      const res = await fetch(`http://localhost:${port}/v1/intents/plan`, {
+      currentCheck = 'api.intents.plan';
+      const res = await fetchWithRetry(`${baseUrl}/v1/intents/plan`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer proof-key',
@@ -220,7 +245,8 @@ async function runProof(options = {}) {
     }
 
     {
-      const res = await fetch(`http://localhost:${port}/v1/feedback/capture`, {
+      currentCheck = 'api.capture_feedback';
+      const res = await fetchWithRetry(`${baseUrl}/v1/feedback/capture`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer proof-key',
@@ -240,7 +266,8 @@ async function runProof(options = {}) {
     }
 
     {
-      const res = await fetch(`http://localhost:${port}/v1/feedback/capture`, {
+      currentCheck = 'api.capture_feedback.clarification';
+      const res = await fetchWithRetry(`${baseUrl}/v1/feedback/capture`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer proof-key',
@@ -260,7 +287,8 @@ async function runProof(options = {}) {
     }
 
     {
-      const res = await fetch(`http://localhost:${port}/v1/feedback/capture`, {
+      currentCheck = 'api.capture_feedback.rubric_gate';
+      const res = await fetchWithRetry(`${baseUrl}/v1/feedback/capture`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer proof-key',
@@ -285,7 +313,8 @@ async function runProof(options = {}) {
     }
 
     {
-      const construct = await fetch(`http://localhost:${port}/v1/context/construct`, {
+      currentCheck = 'api.context.construct';
+      const construct = await fetchWithRetry(`${baseUrl}/v1/context/construct`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer proof-key',
@@ -298,7 +327,8 @@ async function runProof(options = {}) {
       check(Boolean(pack.packId), 'context packId missing');
       addResult('api.context.construct', true, { packId: pack.packId, items: pack.items.length });
 
-      const evaluate = await fetch(`http://localhost:${port}/v1/context/evaluate`, {
+      currentCheck = 'api.context.evaluate';
+      const evaluate = await fetchWithRetry(`${baseUrl}/v1/context/evaluate`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer proof-key',
@@ -519,10 +549,15 @@ async function runProof(options = {}) {
       });
     }
   } catch (err) {
-    addResult('fatal', false, { error: err.message });
+    addResult('fatal', false, {
+      check: currentCheck,
+      error: err.message,
+      cause: err.cause && err.cause.message ? err.cause.message : null,
+    });
   } finally {
     await new Promise((resolve) => server.close(resolve));
-    fs.rmSync(tmpFeedbackDir, { recursive: true, force: true });
+    await waitForBackgroundSideEffects();
+    fs.rmSync(tmpFeedbackDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     if (previousFeedbackDir === undefined) delete process.env.RLHF_FEEDBACK_DIR;
     else process.env.RLHF_FEEDBACK_DIR = previousFeedbackDir;
     if (previousApiKey === undefined) delete process.env.RLHF_API_KEY;

--- a/scripts/prove-automation.js
+++ b/scripts/prove-automation.js
@@ -8,6 +8,7 @@ const {
   buildPreventionRules,
   getFeedbackPaths,
   readJSONL,
+  waitForBackgroundSideEffects,
 } = require('./feedback-loop');
 const { exportDpoFromMemories } = require('./export-dpo-pairs');
 const { planIntent } = require('./intent-router');
@@ -27,6 +28,24 @@ function ensureDir(dirPath) {
 
 function check(condition, message) {
   if (!condition) throw new Error(message);
+}
+
+async function fetchWithRetry(url, options, { retries = 5, delayMs = 100 } = {}) {
+  let lastError = null;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fetch(url, options);
+    } catch (err) {
+      lastError = err;
+      if (attempt === retries) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs * (attempt + 1)));
+    }
+  }
+
+  throw lastError;
 }
 
 async function runAutomationProof(options = {}) {
@@ -54,6 +73,8 @@ async function runAutomationProof(options = {}) {
   }
 
   const { server, port } = await startServer({ port: proofPort });
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let currentCheck = 'bootstrap';
   try {
     // 1) Positive with valid rubric -> accepted
     {
@@ -159,7 +180,8 @@ async function runAutomationProof(options = {}) {
 
     // 7) API rubric gate returns 422
     {
-      const res = await fetch(`http://localhost:${port}/v1/feedback/capture`, {
+      currentCheck = 'api.rubric_gate';
+      const res = await fetchWithRetry(`${baseUrl}/v1/feedback/capture`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer automation-proof-key',
@@ -185,6 +207,7 @@ async function runAutomationProof(options = {}) {
 
     // 8) MCP rubric gate returns accepted=false
     {
+      currentCheck = 'mcp.rubric_gate';
       const call = await handleRequest({
         jsonrpc: '2.0',
         id: 91,
@@ -210,6 +233,7 @@ async function runAutomationProof(options = {}) {
 
     // 9) intent checkpoints still enforced
     {
+      currentCheck = 'intent.checkpoint_enforcement';
       const planBlocked = planIntent({
         intentId: 'publish_dpo_training_data',
         mcpProfile: 'default',
@@ -231,7 +255,8 @@ async function runAutomationProof(options = {}) {
 
     // 10) context evaluate stores rubric evaluation
     {
-      const construct = await fetch(`http://localhost:${port}/v1/context/construct`, {
+      currentCheck = 'context.evaluate.construct';
+      const construct = await fetchWithRetry(`${baseUrl}/v1/context/construct`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer automation-proof-key',
@@ -242,7 +267,8 @@ async function runAutomationProof(options = {}) {
       check(construct.status === 200, `context construct expected 200, got ${construct.status}`);
       const pack = await construct.json();
 
-      const evaluate = await fetch(`http://localhost:${port}/v1/context/evaluate`, {
+      currentCheck = 'context.evaluate.rubric';
+      const evaluate = await fetchWithRetry(`${baseUrl}/v1/context/evaluate`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer automation-proof-key',
@@ -267,8 +293,9 @@ async function runAutomationProof(options = {}) {
 
     // 11) semantic cache hit on equivalent query
     {
+      currentCheck = 'context.semantic_cache.hit.first';
       fs.rmSync(path.join(CONTEXTFS_ROOT, NAMESPACES.provenance, 'semantic-cache.jsonl'), { force: true });
-      const first = await fetch(`http://localhost:${port}/v1/context/construct`, {
+      const first = await fetchWithRetry(`${baseUrl}/v1/context/construct`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer automation-proof-key',
@@ -279,7 +306,8 @@ async function runAutomationProof(options = {}) {
       check(first.status === 200, `first context construct expected 200, got ${first.status}`);
       const firstPack = await first.json();
 
-      const second = await fetch(`http://localhost:${port}/v1/context/construct`, {
+      currentCheck = 'context.semantic_cache.hit.second';
+      const second = await fetchWithRetry(`${baseUrl}/v1/context/construct`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer automation-proof-key',
@@ -355,10 +383,15 @@ async function runAutomationProof(options = {}) {
       });
     }
   } catch (err) {
-    addResult('fatal', false, { error: err.message });
+    addResult('fatal', false, {
+      check: currentCheck,
+      error: err.message,
+      cause: err.cause && err.cause.message ? err.cause.message : null,
+    });
   } finally {
     await new Promise((resolve) => server.close(resolve));
-    fs.rmSync(tmpFeedbackDir, { recursive: true, force: true });
+    await waitForBackgroundSideEffects();
+    fs.rmSync(tmpFeedbackDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
 
   if (writeArtifacts) {

--- a/tests/feedback-loop.test.js
+++ b/tests/feedback-loop.test.js
@@ -12,11 +12,13 @@ const {
   analyzeFeedback,
   buildPreventionRules,
   feedbackSummary,
+  getPendingBackgroundSideEffectCount,
   readJSONL,
   getFeedbackPaths,
   inferDomain,
   inferOutcome,
   enrichFeedbackContext,
+  waitForBackgroundSideEffects,
 } = require('../scripts/feedback-loop');
 
 function makeTmpDir() {
@@ -254,4 +256,41 @@ test('analyzeFeedback: includes boosted risk summary after sequence training row
 
   const summary = feedbackSummary();
   assert.ok(summary.includes('Boosted risk'), `expected boosted risk line in summary, got: ${summary}`);
+});
+
+test('captureFeedback: waitForBackgroundSideEffects drains deferred vector writes', async (t) => {
+  const tmpDir = makeTmpDir();
+  process.env.RLHF_FEEDBACK_DIR = tmpDir;
+  await waitForBackgroundSideEffects();
+
+  const vectorStore = require('../scripts/vector-store');
+  const originalUpsertFeedback = vectorStore.upsertFeedback;
+  let flushed = false;
+
+  vectorStore.upsertFeedback = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    flushed = true;
+  };
+
+  t.after(() => {
+    vectorStore.upsertFeedback = originalUpsertFeedback;
+    delete process.env.RLHF_FEEDBACK_DIR;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch {}
+  });
+
+  const result = captureFeedback({
+    signal: 'up',
+    context: 'Deferred vector side-effect proof',
+    whatWorked: 'background task tracking',
+    tags: ['verification'],
+  });
+
+  assert.equal(result.accepted, true);
+  assert.equal(flushed, false);
+  assert.equal(getPendingBackgroundSideEffectCount(), 1);
+
+  await waitForBackgroundSideEffects();
+
+  assert.equal(flushed, true);
+  assert.equal(getPendingBackgroundSideEffectCount(), 0);
 });

--- a/tests/prove-adapters.test.js
+++ b/tests/prove-adapters.test.js
@@ -8,15 +8,21 @@ const { runProof } = require('../scripts/prove-adapters');
 let report;
 let tmpProofDir;
 
+function getCheck(name) {
+  assert.ok(report, 'proof report missing');
+  const fatal = report.checks.find((check) => check.name === 'fatal');
+  assert.equal(fatal, undefined, fatal ? `proof fatal: ${JSON.stringify(fatal.details)}` : 'proof fatal check present');
+  const found = report.checks.find((check) => check.name === name);
+  assert.ok(
+    found,
+    `check "${name}" not found in report; available: ${report.checks.map((check) => check.name).join(', ')}`,
+  );
+  return found;
+}
+
 test('adapter proof harness setup', async () => {
   tmpProofDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rlhf-proof-test-'));
-  try {
-    report = await runProof({ proofDir: tmpProofDir, port: 0 });
-  } catch (err) {
-    if (err.code !== 'ENOTEMPTY') throw err;
-    // Fallback if ENOTEMPTY breaks the promise rejection
-    report = { summary: { passed: 0, failed: 1 }, checks: [] };
-  }
+  report = await runProof({ proofDir: tmpProofDir, port: 0 });
 });
 
 test('adapter proof: zero failures', () => {
@@ -65,49 +71,49 @@ const requiredChecks = [
 
 for (const checkName of requiredChecks) {
   test(`adapter proof: individual check "${checkName}" passes`, () => {
-    const found = report.checks.find((c) => c.name === checkName);
-    assert.ok(found, `check "${checkName}" not found in report`);
+    const found = getCheck(checkName);
     assert.equal(found.passed, true, `check "${checkName}" failed: ${JSON.stringify(found.details)}`);
   });
 }
 
 test('adapter proof: no unexpected failing checks', () => {
+  assert.ok(report.checks.length > 0, 'proof report should include checks');
   const failed = report.checks.filter((c) => !c.passed);
   assert.equal(failed.length, 0, `unexpected failures: ${failed.map((c) => c.name).join(', ')}`);
 });
 
 test('adapter proof: API healthz returns status 200', () => {
-  const check = report.checks.find((c) => c.name === 'api.healthz');
+  const check = getCheck('api.healthz');
   assert.equal(check.details.status, 200);
 });
 
 test('adapter proof: auth required returns 401', () => {
-  const check = report.checks.find((c) => c.name === 'api.auth.required');
+  const check = getCheck('api.auth.required');
   assert.equal(check.details.status, 401);
 });
 
 test('adapter proof: rubric gate returns accepted=false', () => {
-  const check = report.checks.find((c) => c.name === 'api.capture_feedback.rubric_gate');
+  const check = getCheck('api.capture_feedback.rubric_gate');
   assert.equal(check.details.accepted, false);
 });
 
 test('adapter proof: vague API feedback requires clarification', () => {
-  const check = report.checks.find((c) => c.name === 'api.capture_feedback.clarification');
+  const check = getCheck('api.capture_feedback.clarification');
   assert.equal(check.details.status, 'clarification_required');
 });
 
 test('adapter proof: vague MCP feedback requires clarification', () => {
-  const check = report.checks.find((c) => c.name === 'mcp.tools.call.capture_feedback.clarification');
+  const check = getCheck('mcp.tools.call.capture_feedback.clarification');
   assert.equal(check.details.status, 'clarification_required');
 });
 
 test('adapter proof: gemini has >= 3 tools', () => {
-  const check = report.checks.find((c) => c.name === 'adapter.gemini.declarations');
+  const check = getCheck('adapter.gemini.declarations');
   assert.ok(check.details.tools >= 3);
 });
 
 test('adapter proof: default profile has more tools than locked', () => {
-  const check = report.checks.find((c) => c.name === 'mcp.policy.profile_differentiation');
+  const check = getCheck('mcp.policy.profile_differentiation');
   assert.ok(check.details.defaultTools > check.details.lockedTools);
 });
 

--- a/tests/prove-automation.test.js
+++ b/tests/prove-automation.test.js
@@ -8,6 +8,18 @@ const { runAutomationProof } = require('../scripts/prove-automation');
 let report;
 let tmpProofDir;
 
+function getCheck(name) {
+  assert.ok(report, 'automation proof report missing');
+  const fatal = report.checks.find((check) => check.name === 'fatal');
+  assert.equal(fatal, undefined, fatal ? `automation proof fatal: ${JSON.stringify(fatal.details)}` : 'automation fatal check present');
+  const found = report.checks.find((check) => check.name === name);
+  assert.ok(
+    found,
+    `check "${name}" not found in report; available: ${report.checks.map((check) => check.name).join(', ')}`,
+  );
+  return found;
+}
+
 test('automation proof harness setup', async () => {
   tmpProofDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rlhf-automation-proof-test-'));
   report = await runAutomationProof({ proofDir: tmpProofDir, port: 0 });
@@ -49,80 +61,80 @@ const requiredChecks = [
 
 for (const checkName of requiredChecks) {
   test(`automation proof: individual check "${checkName}" passes`, () => {
-    const found = report.checks.find((c) => c.name === checkName);
-    assert.ok(found, `check "${checkName}" not found in report`);
+    const found = getCheck(checkName);
     assert.equal(found.passed, true, `check "${checkName}" failed: ${JSON.stringify(found.details)}`);
   });
 }
 
 test('automation proof: no unexpected failing checks', () => {
+  assert.ok(report.checks.length > 0, 'automation proof report should include checks');
   const failed = report.checks.filter((c) => !c.passed);
   assert.equal(failed.length, 0, `unexpected failures: ${failed.map((c) => c.name).join(', ')}`);
 });
 
 test('automation proof: rubric pass has weighted score', () => {
-  const check = report.checks.find((c) => c.name === 'feedback.capture.rubric_pass');
+  const check = getCheck('feedback.capture.rubric_pass');
   assert.ok(typeof check.details.weightedScore === 'number');
   assert.ok(check.details.weightedScore > 0);
 });
 
 test('automation proof: rubric block has rejection reason', () => {
-  const check = report.checks.find((c) => c.name === 'feedback.capture.rubric_block');
+  const check = getCheck('feedback.capture.rubric_block');
   assert.equal(check.details.accepted, false);
   assert.ok(check.details.reason);
 });
 
 test('automation proof: negative with rubric has failure tags', () => {
-  const check = report.checks.find((c) => c.name === 'feedback.capture.negative_with_rubric');
+  const check = getCheck('feedback.capture.negative_with_rubric');
   assert.ok(Array.isArray(check.details.tags));
   assert.ok(check.details.tags.some((t) => t.startsWith('rubric-')));
 });
 
 test('automation proof: analytics tracks rubric samples >= 3', () => {
-  const check = report.checks.find((c) => c.name === 'analytics.rubric_tracking');
+  const check = getCheck('analytics.rubric_tracking');
   assert.ok(check.details.samples >= 3);
 });
 
 test('automation proof: DPO rubric metadata present', () => {
-  const check = report.checks.find((c) => c.name === 'dpo_export.rubric_metadata');
+  const check = getCheck('dpo_export.rubric_metadata');
   assert.ok(check.details);
 });
 
 test('automation proof: API rubric gate returns 422', () => {
-  const check = report.checks.find((c) => c.name === 'api.rubric_gate');
+  const check = getCheck('api.rubric_gate');
   assert.equal(check.details.status, 422);
 });
 
 test('automation proof: MCP rubric gate rejects', () => {
-  const check = report.checks.find((c) => c.name === 'mcp.rubric_gate');
+  const check = getCheck('mcp.rubric_gate');
   assert.equal(check.details.accepted, false);
 });
 
 test('automation proof: intent checkpoint enforced', () => {
-  const check = report.checks.find((c) => c.name === 'intent.checkpoint_enforcement');
+  const check = getCheck('intent.checkpoint_enforcement');
   assert.equal(check.details.blocked, 'checkpoint_required');
   assert.equal(check.details.approved, 'ready');
 });
 
 test('automation proof: semantic cache hit on equivalent query', () => {
-  const check = report.checks.find((c) => c.name === 'context.semantic_cache.hit');
+  const check = getCheck('context.semantic_cache.hit');
   assert.equal(check.details.firstHit, false);
   assert.equal(check.details.secondHit, true);
 });
 
 test('automation proof: self-healing includes reasoning traces', () => {
-  const check = report.checks.find((c) => c.name === 'self_healing.helpers');
+  const check = getCheck('self_healing.helpers');
   assert.ok(check.details.reasoning, 'should include reasoning aggregate');
   assert.ok(check.details.reasoning.allPassed, 'all traces should pass');
 });
 
 test('automation proof: code reasoning DPO traces have confidence', () => {
-  const check = report.checks.find((c) => c.name === 'code_reasoning.dpo_traces');
+  const check = getCheck('code_reasoning.dpo_traces');
   assert.ok(check.details);
 });
 
 test('automation proof: code reasoning proof gate passes', () => {
-  const check = report.checks.find((c) => c.name === 'code_reasoning.proof_gate');
+  const check = getCheck('code_reasoning.proof_gate');
   assert.ok(check.details.allPassed, 'all proof traces should pass');
   assert.ok(check.details.averageConfidence > 0);
 });


### PR DESCRIPTION
## Summary
- drain deferred RLHF background side effects before proof temp-dir cleanup so coverage/CI runs do not hit `ENOTEMPTY`
- harden proof HTTP calls to use `127.0.0.1` with retry-on-network-error and richer fatal context for coverage runs
- improve proof tests so fatal failures surface directly instead of cascading into misleading missing-check assertions
- refresh tracked machine-readable proof reports after the clean verification run

## Root Cause
`main` failed on merge commit `0e3eaf7c1649eaf9fb340913503a4e6a8df8fa6a` in CI run `22913864611` because `tests/prove-adapters.test.js` masked two proof-runner issues:
1. deferred vector-store writes could race temp-dir cleanup and trigger `ENOTEMPTY`
2. under full coverage instrumentation, proof HTTP fetches could fail transiently on loopback startup and collapse into a generic fatal

## Verification
- `npm ci`
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`

## Evidence
- `npm test`: pass
- `npm run test:coverage`: pass, `83.16%` lines / `69.24%` branches / `86.89%` functions
- `npm run prove:adapters`: `{ "passed": 24, "failed": 0 }`
- `npm run prove:automation`: `{ "passed": 14, "failed": 0 }`
- `npm run self-heal:check`: `Overall: HEALTHY`, `4/4 healthy`
- Verification evidence doc: `docs/VERIFICATION_EVIDENCE.md`
- Machine-readable reports:
  - `proof/compatibility/report.json`
  - `proof/automation/report.json`

## Prior failing run
- https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/runs/22913864611
