### PR TITLE
feat: JSONL file watcher, status dashboard, serve+watch integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MCP Memory Gateway | Hosted Guardrails and Context Hub for AI Agents
+# MCP Memory Gateway
 
 [![CI](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/ci.yml)
 [![Self-Healing](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/self-healing-monitor.yml/badge.svg)](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/self-healing-monitor.yml)
@@ -6,134 +6,148 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.18.0-brightgreen)](package.json)
 
-**The Universal Context & Memory Layer for Model Context Protocol (MCP) Agents.**
+**Local-first memory and feedback pipeline for AI agents.** Captures thumbs-up/down signals, promotes reusable memories, generates prevention rules from repeated failures, and exports KTO/DPO pairs for fine-tuning.
 
-As the AI ecosystem standardizes on MCP, agents need a centralized, "Always-On" brain to store context, consolidate failures, and enforce architectural guardrails across sessions. 
+Works with any MCP-compatible agent: Claude, Codex, Gemini, Amp, Cursor.
 
-This repository provides a production-ready, local-first **MCP Memory Gateway** that bridges the gap between raw LLM inference and long-term agentic reliability. Turn repeated AI failures into strict prevention rules, track token consumption, and share reasoning graphs across your entire team.
+## What It Does
 
-The open-source core gives one operator local feedback capture, context packs, and "Always-On" ADK memory consolidation. **Cloud Pro** is the hosted layer teams pay for when they need a shared context hub, remote observability, and a live web dashboard.
+```
+thumbs up/down → validate → promote to memory → vector index → prevention rules → DPO export
+```
 
-## North Star
-
-One unified MCP gateway powering every agent in your team, ensuring they never make the same mistake twice while maintaining absolute context security.
-
-That is the wedge. Not generic "agent infrastructure." Not another prompt library. One workflow outcome that a buyer can justify.
-
-## Who Buys And Who Uses
-
-- Buyer: head of ops, head of growth, platform lead, or consultancy owner funding a workflow rollout.
-- User: the operator running lead intake, research, drafting, approval, onboarding, or internal ops steps.
-- Champion: the engineer or platform owner wiring the Veto Layer, policy checks, and verification evidence into the workflow.
-
-## Why someone would pay
-
-- They want to make one workflow deployable, auditable, and improvable over time.
-- They need hosted API keys instead of self-hosting the feedback and guardrail store.
-- They need shared memory and prevention rules across operators, repos, or agents.
-- They need proof-ready runs and funnel evidence instead of local-only logs.
-
-## Install To Value
-
-1. Install the MCP server or package.
-2. Instrument one workflow with feedback capture and context packs.
-3. Turn repeated failures into prevention rules instead of repeated incidents.
-4. Review proof-ready runs and verification evidence to decide whether the workflow is ready for team-wide rollout.
+1. **Capture** — `capture_feedback` MCP tool accepts signals with context
+2. **Validate** — Rubric engine gates promotion (vague feedback is rejected with clarification prompts)
+3. **Remember** — Promoted memories stored in JSONL + LanceDB vectors
+4. **Prevent** — Repeated failures auto-generate prevention rules
+5. **Export** — KTO/DPO pairs for downstream fine-tuning
+6. **Bridge** — JSONL file watcher auto-ingests signals from external sources (Amp plugins, hooks, scripts)
 
 ## Quick Start
 
-Add the MCP server directly in your client config:
-
-| Platform | Command |
-|----------|---------|
-| **Claude** | `claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
-| **Codex** | `codex mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
-| **Gemini** | `gemini mcp add rlhf "npx -y rlhf-feedback-loop@0.6.11 serve"` |
-| **Amp** | `amp mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
-| **Cursor** | `cursor mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve` |
-
-Optional auto-installer:
-
 ```bash
-npx add-mcp rlhf-feedback-loop
+# Add to any MCP-compatible agent
+claude mcp add rlhf -- npx -y rlhf-feedback-loop serve
+codex mcp add rlhf -- npx -y rlhf-feedback-loop serve
+amp mcp add rlhf -- npx -y rlhf-feedback-loop serve
+gemini mcp add rlhf "npx -y rlhf-feedback-loop serve"
+
+# Or auto-detect all installed platforms
+npx rlhf-feedback-loop init
 ```
 
-### As npm package
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `capture_feedback` | Accept up/down signal + context, validate, promote to memory |
+| `recall` | Vector-search past feedback and prevention rules for current task |
+| `feedback_stats` | Approval rate, per-skill/tag breakdown, trend analysis |
+| `feedback_summary` | Human-readable recent feedback summary |
+| `prevention_rules` | Generate prevention rules from repeated mistakes |
+| `export_dpo_pairs` | Build DPO preference pairs from promoted memories |
+| `construct_context_pack` | Bounded context pack from contextfs |
+| `evaluate_context_pack` | Record context pack outcome (closes learning loop) |
+| `list_intents` | Available action plan templates |
+| `plan_intent` | Generate execution plan with policy checkpoints |
+| `context_provenance` | Audit trail of context decisions |
+
+## CLI
 
 ```bash
-npm install rlhf-feedback-loop
+npx rlhf-feedback-loop init              # Scaffold .rlhf/ + configure MCP
+npx rlhf-feedback-loop serve             # Start MCP server (stdio) + watcher
+npx rlhf-feedback-loop status            # Learning curve dashboard
+npx rlhf-feedback-loop watch             # Watch .rlhf/ for external signals
+npx rlhf-feedback-loop watch --once      # Process pending signals and exit
+npx rlhf-feedback-loop capture           # Capture feedback via CLI
+npx rlhf-feedback-loop stats             # Analytics + Revenue-at-Risk
+npx rlhf-feedback-loop rules             # Generate prevention rules
+npx rlhf-feedback-loop export-dpo        # Export DPO training pairs
+npx rlhf-feedback-loop risk              # Train/query boosted risk scorer
+npx rlhf-feedback-loop self-heal         # Run self-healing diagnostics
 ```
 
-The MCP is intentionally strict: a bare `thumbs up` or `thumbs down` is logged as a signal, but reusable memory promotion requires one sentence explaining why. If feedback is vague, the server asks for clarification instead of pretending it learned something.
+## JSONL File Watcher
 
-## OSS vs Cloud Pro
+The `serve` command automatically starts a background watcher that monitors `feedback-log.jsonl` for entries written by external sources (Amp plugins, shell hooks, CI scripts). These entries are routed through the full `captureFeedback()` pipeline — validation, memory promotion, vector indexing, and DPO eligibility.
 
-The OSS package stays free. Cloud Pro remains a low-friction founding offer while the hosted workflow layer proves onboarding and retention.
+```bash
+# Standalone watcher
+npx rlhf-feedback-loop watch --source amp-plugin-bridge
 
-| | OSS core | Cloud Pro |
-|---|---|---|
-| Price | `$0` | `$10/mo` |
-| Feedback capture | Local MCP server | Hosted HTTPS API |
-| Storage | Your machine | Managed cloud |
-| KTO/DPO export | CLI command | API endpoint |
-| Team sharing | Manual | Built-in |
-| Onboarding | Self-serve | Checkout + provisioned API key |
+# Process pending entries once and exit
+npx rlhf-feedback-loop watch --once
+```
 
-[Landing Page](https://rlhf-feedback-loop-710216278770.us-central1.run.app) | [30-Day GTM Plan](docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md) | [Get Cloud Pro ($10/mo)](https://buy.stripe.com/bJe14neyU4r4f0leOD3sI02) | [Verification Evidence](docs/VERIFICATION_EVIDENCE.md)
+External sources write entries with a `source` field:
+```json
+{"signal":"positive","context":"Agent fixed bug on first try","source":"amp-plugin-bridge","tags":["amp-ui-bridge"]}
+```
+
+The watcher tracks its position via `.rlhf/.watcher-offset` for crash-safe, idempotent processing.
+
+## Learning Curve Dashboard
+
+```bash
+npx rlhf-feedback-loop status
+```
+
+```
+╔══════════════════════════════════════╗
+║     RLHF Learning Curve Dashboard   ║
+╠══════════════════════════════════════╣
+║ Total signals:    148                ║
+║ Positive:          45  (30%)         ║
+║ Negative:         103  (70%)         ║
+║ Recent (last 20):  20%               ║
+║ Trend:            📉 declining       ║
+║ Memories:          17                ║
+║ Prevention rules:   9                ║
+╠══════════════════════════════════════╣
+║ Top failure domains:                 ║
+║   execution-gap     4                ║
+║   asked-not-doing   2                ║
+║   speed             2                ║
+╠══════════════════════════════════════╣
+║ Learning curve (approval % by window)║
+║   [1-10]   10% ██                    ║
+║   [11-20]  20% ████                  ║
+║   [21-30]  35% ███████               ║
+║   [31-40]  30% ██████                ║
+╚══════════════════════════════════════╝
+```
+
+## Architecture
+
+Five-phase pipeline: **Capture** → **Validate** → **Remember** → **Prevent** → **Export**
+
+```
+Agent (Claude/Codex/Amp/Gemini)
+  │
+  ├── MCP tool call ──→ captureFeedback()
+  ├── REST API ────────→ captureFeedback()
+  ├── CLI ─────────────→ captureFeedback()
+  └── External write ──→ JSONL ──→ Watcher ──→ captureFeedback()
+                                        │
+                                        ▼
+                              ┌─────────────────┐
+                              │  Full Pipeline   │
+                              │  • Schema valid  │
+                              │  • Rubric gate   │
+                              │  • Memory promo  │
+                              │  • Vector index  │
+                              │  • Risk scoring  │
+                              │  • RLAIF audit   │
+                              │  • DPO eligible  │
+                              └─────────────────┘
+```
 
 ## Agent Runner Contract
-
-This repo now ships a Symphony-compatible, repo-owned agent-runner contract:
 
 - [WORKFLOW.md](WORKFLOW.md): scope, proof-of-work, hard stops, and done criteria for isolated agent runs
 - [.github/ISSUE_TEMPLATE/ready-for-agent.yml](.github/ISSUE_TEMPLATE/ready-for-agent.yml): bounded intake template for "Ready for Agent" tickets
 - [.github/pull_request_template.md](.github/pull_request_template.md): proof-first handoff format for PRs
-
-Validate the contract locally with:
-
-```bash
-node scripts/validate-workflow-contract.js
-node scripts/prove-workflow-contract.js
-```
-
-## Best First Use Case
-
-The most credible first paid workflow is a lead-to-meeting system:
-
-- inbound or CSV lead intake
-- enrichment
-- account research
-- draft generation
-- approval step
-- CRM sync
-- audit trail and prevention rules
-
-Cloud Pro sits underneath that workflow as the hosted memory, guardrail, and evidence layer.
-
-## What The Buyer Gets
-
-- One workflow with shared memory instead of scattered local learnings.
-- A Veto Layer that turns repeated operator complaints into prevention rules.
-- Proof-ready runs, audit trails, and machine-readable evidence for rollout decisions.
-- A compounding data asset through KTO/DPO export once the workflow is producing useful feedback.
-
-## Architecture
-
-![RLHF Feedback Loop Architecture](docs/diagrams/rlhf-architecture-pb.png)
-
-Five-phase pipeline: **Capture** human signals → **Validate** with rubric engine → **Learn** via LanceDB vector memory → **Prevent** repeated mistakes → **Export** KTO/DPO pairs for fine-tuning.
-
-![Plugin Topology](docs/diagrams/plugin-topology-pb.png)
-
-Three-tier stack: external integrations (Claude, Codex, Gemini, ChatGPT via MCP/OpenAPI) → plugin orchestration (schema validation, Bayesian scoring, DPO export) → data persistence (JSONL, LanceDB vectors, ShieldCortex context packs).
-
-## Deep Dive
-
-- [GTM Revenue Wedge](docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md)
-- [Pricing Research](docs/PRICING_RESEARCH_2026-03-09.md)
-- [Verification Evidence](docs/VERIFICATION_EVIDENCE.md)
-- [API Reference](openapi/openapi.yaml)
-- [Context Engine](docs/CONTEXTFS.md)
 
 ## License
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -592,11 +592,39 @@ function prove() {
   }
 }
 
+function watchCmd() {
+  const args = parseArgs(process.argv.slice(3));
+  const { watch, once } = require(path.join(PKG_ROOT, 'scripts', 'jsonl-watcher'));
+  const sourceFilter = args.source || undefined;
+  if (args.once) {
+    once(sourceFilter);
+  } else {
+    watch(sourceFilter);
+  }
+}
+
+function status() {
+  const statusDashboard = require(path.join(PKG_ROOT, 'scripts', 'status-dashboard'));
+  const { getFeedbackPaths } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
+  const { FEEDBACK_DIR } = getFeedbackPaths();
+  const data = statusDashboard.generateStatus(FEEDBACK_DIR);
+  // printDashboard writes directly to stdout when run as main;
+  // for CLI we call the same renderer
+  statusDashboard.printDashboard
+    ? statusDashboard.printDashboard(data)
+    : console.log(JSON.stringify(data, null, 2));
+}
+
 function serve() {
   // Start MCP server over stdio
   const mcpServer = path.join(PKG_ROOT, 'adapters', 'mcp', 'server-stdio.js');
   const { startStdioServer } = require(mcpServer);
   startStdioServer();
+  // Start watcher as a background daemon alongside MCP server
+  try {
+    const { watch } = require(path.join(PKG_ROOT, 'scripts', 'jsonl-watcher'));
+    watch();
+  } catch (_) { /* watcher is non-critical */ }
 }
 
 function install() {
@@ -650,6 +678,8 @@ function help() {
   console.log('  self-heal             Run self-healing check and auto-fix');
   console.log('  pro                   Upgrade to Cloud Pro ($10/mo)');
   console.log('  prove [--target=X]    Run proof harness (adapters|automation|attribution|lancedb|local-intelligence|...)');
+  console.log('  watch [flags]           Watch .rlhf/ for external signals and ingest through pipeline (--once, --source=X)');
+  console.log('  status                  Show learning curve dashboard — approval trend + failure domains');
   console.log('  start-api             Start the RLHF HTTPS API server');
   console.log('  help                  Show this help message');
   console.log('');
@@ -706,6 +736,12 @@ switch (COMMAND) {
     break;
   case 'prove':
     prove();
+    break;
+  case 'watch':
+    watchCmd();
+    break;
+  case 'status':
+    status();
     break;
   case 'start-api':
     startApi();

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "type": "commonjs",
   "scripts": {
-    "test": "npm run test:schema && npm run test:loop && npm run test:dpo && npm run test:kto && npm run test:api && npm run test:proof && npm run test:e2e && npm run test:rlaif && npm run test:attribution && npm run test:quality && npm run test:intelligence && npm run test:training-export && npm run test:deployment && npm run test:workflow && npm run test:billing && npm run test:cli",
+    "test": "npm run test:schema && npm run test:loop && npm run test:dpo && npm run test:kto && npm run test:api && npm run test:proof && npm run test:e2e && npm run test:rlaif && npm run test:attribution && npm run test:quality && npm run test:intelligence && npm run test:training-export && npm run test:deployment && npm run test:workflow && npm run test:billing && npm run test:cli && npm run test:watcher",
     "test:e2e": "node --test tests/e2e-pipeline.test.js",
     "test:schema": "node scripts/feedback-schema.js --test",
     "test:loop": "node scripts/feedback-loop.js --test",
@@ -87,7 +87,10 @@
     "ml:risk": "node scripts/risk-scorer.js",
     "adk:consolidate": "node scripts/adk-consolidator.js",
     "adk:watch": "node scripts/adk-consolidator.js --watch",
-    "pr:manage": "node scripts/pr-manager.js"
+    "pr:manage": "node scripts/pr-manager.js",
+    "watch": "node scripts/jsonl-watcher.js",
+    "status": "node scripts/status-dashboard.js",
+    "test:watcher": "node --test tests/jsonl-watcher.test.js"
   },
   "keywords": [
     "rlhf",

--- a/scripts/jsonl-watcher.js
+++ b/scripts/jsonl-watcher.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * JSONL File Watcher
+ *
+ * Watches feedback-log.jsonl for new entries written by external sources
+ * (e.g., Amp plugin bridge) and routes them through captureFeedback()
+ * for full pipeline processing: memory promotion, vector indexing,
+ * sequence tracking, and DPO export eligibility.
+ *
+ * Usage:
+ *   node scripts/jsonl-watcher.js                    # watch mode
+ *   node scripts/jsonl-watcher.js --once             # process pending, exit
+ *   node scripts/jsonl-watcher.js --source amp-plugin-bridge  # filter by source
+ *
+ * The watcher tracks its position via .rlhf/.watcher-offset to avoid
+ * reprocessing entries on restart.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { captureFeedback, getFeedbackPaths } = require('./feedback-loop');
+
+const POLL_INTERVAL_MS = 2000;
+const WATCHER_SOURCE_TAG = 'watcher-ingested';
+
+// Use stderr for logging so stdout stays clean for MCP JSON-RPC when co-hosted
+const log = (...args) => process.stderr.write(`${args.join(' ')}\n`);
+
+function getOffsetPath(feedbackDir) {
+  return path.join(feedbackDir, '.watcher-offset');
+}
+
+function readOffset(feedbackDir) {
+  const offsetPath = getOffsetPath(feedbackDir);
+  try {
+    return parseInt(fs.readFileSync(offsetPath, 'utf-8').trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeOffset(feedbackDir, offset) {
+  fs.writeFileSync(getOffsetPath(feedbackDir), String(offset) + '\n');
+}
+
+function parseEntry(line) {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+function shouldIngest(entry, sourceFilter) {
+  // Only ingest entries from external sources (not from captureFeedback itself)
+  if (!entry || !entry.source) return false;
+  if (sourceFilter && entry.source !== sourceFilter) return false;
+  // Skip entries already ingested by the watcher
+  if (entry.tags && entry.tags.includes(WATCHER_SOURCE_TAG)) return false;
+  return true;
+}
+
+function ingestEntry(entry) {
+  const signal = entry.signal === 'positive' ? 'up' : entry.signal === 'negative' ? 'down' : entry.signal;
+
+  const result = captureFeedback({
+    signal,
+    context: entry.context || '',
+    whatWentWrong: entry.whatWentWrong || undefined,
+    whatToChange: entry.whatToChange || undefined,
+    whatWorked: entry.whatWorked || undefined,
+    tags: [...(entry.tags || []), WATCHER_SOURCE_TAG, `bridged-from:${entry.source}`],
+    skill: entry.skill || undefined,
+  });
+
+  return result;
+}
+
+function processNewEntries(feedbackDir, feedbackLogPath, sourceFilter) {
+  if (!fs.existsSync(feedbackLogPath)) return { processed: 0, promoted: 0 };
+
+  const content = fs.readFileSync(feedbackLogPath, 'utf-8');
+  const lines = content.split('\n').filter(Boolean);
+  const offset = readOffset(feedbackDir);
+
+  if (offset >= lines.length) return { processed: 0, promoted: 0 };
+
+  const newLines = lines.slice(offset);
+  let processed = 0;
+  let promoted = 0;
+
+  for (const line of newLines) {
+    const entry = parseEntry(line);
+    if (shouldIngest(entry, sourceFilter)) {
+      const result = ingestEntry(entry);
+      processed++;
+      if (result && result.accepted) promoted++;
+    }
+  }
+
+  writeOffset(feedbackDir, lines.length);
+  return { processed, promoted };
+}
+
+function watch(sourceFilter) {
+  const { FEEDBACK_DIR, FEEDBACK_LOG_PATH } = getFeedbackPaths();
+
+  // Initialize offset to current end of file to avoid reprocessing history
+  if (!fs.existsSync(getOffsetPath(FEEDBACK_DIR))) {
+    if (fs.existsSync(FEEDBACK_LOG_PATH)) {
+      const lines = fs.readFileSync(FEEDBACK_LOG_PATH, 'utf-8').split('\n').filter(Boolean);
+      writeOffset(FEEDBACK_DIR, lines.length);
+    } else {
+      writeOffset(FEEDBACK_DIR, 0);
+    }
+    log(`[jsonl-watcher] Initialized offset at current end of file`);
+  }
+
+  log(`[jsonl-watcher] Watching ${FEEDBACK_LOG_PATH}`);
+  if (sourceFilter) log(`[jsonl-watcher] Filtering source: ${sourceFilter}`);
+
+  setInterval(() => {
+    const result = processNewEntries(FEEDBACK_DIR, FEEDBACK_LOG_PATH, sourceFilter);
+    if (result.processed > 0) {
+      log(`[jsonl-watcher] Ingested ${result.processed} entries (${result.promoted} promoted)`);
+    }
+  }, POLL_INTERVAL_MS);
+}
+
+function once(sourceFilter) {
+  const { FEEDBACK_DIR, FEEDBACK_LOG_PATH } = getFeedbackPaths();
+  const result = processNewEntries(FEEDBACK_DIR, FEEDBACK_LOG_PATH, sourceFilter);
+  log(`[jsonl-watcher] Processed ${result.processed} entries (${result.promoted} promoted)`);
+  return result;
+}
+
+// CLI
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const isOnce = args.includes('--once');
+  const sourceIdx = args.indexOf('--source');
+  const sourceFilter = sourceIdx >= 0 ? args[sourceIdx + 1] : undefined;
+
+  if (isOnce) {
+    once(sourceFilter);
+  } else {
+    watch(sourceFilter);
+  }
+}
+
+module.exports = { processNewEntries, ingestEntry, shouldIngest, watch, once };

--- a/scripts/status-dashboard.js
+++ b/scripts/status-dashboard.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Status Dashboard
+ *
+ * CLI dashboard that reads feedback data and outputs a learning curve summary.
+ *
+ * Usage:
+ *   node scripts/status-dashboard.js
+ *
+ * Exports:
+ *   generateStatus(feedbackDir) — returns status object with approval rates,
+ *   trends, failure domains, memory count, prevention rule count, and learning curve.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { getFeedbackPaths, readJSONL } = require('./feedback-loop');
+
+function generateStatus(feedbackDir) {
+  const feedbackLogPath = path.join(feedbackDir, 'feedback-log.jsonl');
+  const memoryLogPath = path.join(feedbackDir, 'memory-log.jsonl');
+  const preventionRulesPath = path.join(feedbackDir, 'prevention-rules.md');
+
+  const entries = readJSONL(feedbackLogPath);
+  const totalSignals = entries.length;
+  const positive = entries.filter((e) => e.signal === 'positive').length;
+  const negative = entries.filter((e) => e.signal === 'negative').length;
+  const approvalRate = totalSignals > 0 ? Math.round((positive / totalSignals) * 100) : 0;
+
+  // Recent approval rate (last 20)
+  const recentWindow = 20;
+  const recent = entries.slice(-recentWindow);
+  const recentPositive = recent.filter((e) => e.signal === 'positive').length;
+  const recentApprovalRate = recent.length > 0 ? Math.round((recentPositive / recent.length) * 100) : 0;
+
+  // Trend
+  let trend = 'stable';
+  if (totalSignals >= recentWindow) {
+    const diff = recentApprovalRate - approvalRate;
+    if (diff > 5) trend = 'improving';
+    else if (diff < -5) trend = 'declining';
+  }
+
+  // Top failure domains
+  const domainCounts = {};
+  entries
+    .filter((e) => e.signal === 'negative')
+    .forEach((e) => {
+      const domain = (e.richContext && e.richContext.domain) || inferDomainFromTags(e.tags);
+      domainCounts[domain] = (domainCounts[domain] || 0) + 1;
+    });
+  const topFailureDomains = Object.entries(domainCounts)
+    .map(([domain, count]) => ({ domain, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // Memory count
+  const memoryEntries = readJSONL(memoryLogPath);
+  const memoryCount = memoryEntries.length;
+
+  // Prevention rule count
+  let preventionRuleCount = 0;
+  if (fs.existsSync(preventionRulesPath)) {
+    const rulesContent = fs.readFileSync(preventionRulesPath, 'utf-8');
+    const ruleHeaders = rulesContent.match(/^## /gm);
+    preventionRuleCount = ruleHeaders ? ruleHeaders.length : 0;
+  }
+
+  // Learning curve — sliding windows of 10
+  const learningCurve = [];
+  const windowSize = 10;
+  for (let i = 0; i + windowSize <= entries.length; i++) {
+    const window = entries.slice(i, i + windowSize);
+    const windowPositive = window.filter((e) => e.signal === 'positive').length;
+    const windowRate = Math.round((windowPositive / windowSize) * 100);
+    learningCurve.push({ window: i, approvalRate: windowRate });
+  }
+
+  return {
+    totalSignals,
+    positive,
+    negative,
+    approvalRate,
+    recentApprovalRate,
+    trend,
+    topFailureDomains,
+    memoryCount,
+    preventionRuleCount,
+    learningCurve,
+  };
+}
+
+function inferDomainFromTags(tags) {
+  if (!Array.isArray(tags) || tags.length === 0) return 'general';
+  const tagSet = new Set(tags.map((t) => t.toLowerCase()));
+  if (tagSet.has('testing') || tagSet.has('test')) return 'testing';
+  if (tagSet.has('security')) return 'security';
+  if (tagSet.has('performance') || tagSet.has('perf')) return 'performance';
+  if (tagSet.has('ui') || tagSet.has('component')) return 'ui-components';
+  if (tagSet.has('api') || tagSet.has('endpoint')) return 'api-integration';
+  if (tagSet.has('git') || tagSet.has('commit')) return 'git-workflow';
+  if (tagSet.has('doc') || tagSet.has('readme')) return 'documentation';
+  if (tagSet.has('debug') || tagSet.has('debugging')) return 'debugging';
+  if (tagSet.has('arch') || tagSet.has('architecture')) return 'architecture';
+  if (tagSet.has('data') || tagSet.has('schema')) return 'data-modeling';
+  return 'general';
+}
+
+function printDashboard(status) {
+  console.log('╔══════════════════════════════════════════╗');
+  console.log('║        RLHF Learning Status Dashboard    ║');
+  console.log('╠══════════════════════════════════════════╣');
+  console.log(`║  Total Signals:     ${String(status.totalSignals).padStart(6)}              ║`);
+  console.log(`║  Positive:          ${String(status.positive).padStart(6)}              ║`);
+  console.log(`║  Negative:          ${String(status.negative).padStart(6)}              ║`);
+  console.log(`║  Approval Rate:     ${String(status.approvalRate + '%').padStart(6)}              ║`);
+  console.log(`║  Recent (last 20):  ${String(status.recentApprovalRate + '%').padStart(6)}              ║`);
+  console.log(`║  Trend:             ${status.trend.padStart(6)}              ║`);
+  console.log(`║  Memories:          ${String(status.memoryCount).padStart(6)}              ║`);
+  console.log(`║  Prevention Rules:  ${String(status.preventionRuleCount).padStart(6)}              ║`);
+  console.log('╠══════════════════════════════════════════╣');
+
+  if (status.topFailureDomains.length > 0) {
+    console.log('║  Top Failure Domains:                    ║');
+    status.topFailureDomains.slice(0, 5).forEach((d) => {
+      const line = `    ${d.domain}: ${d.count}`;
+      console.log(`║  ${line.padEnd(38)}║`);
+    });
+  } else {
+    console.log('║  No failure domains recorded             ║');
+  }
+
+  console.log('╠══════════════════════════════════════════╣');
+  console.log('║  Learning Curve:                         ║');
+  if (status.learningCurve.length > 0) {
+    const step = Math.max(1, Math.floor(status.learningCurve.length / 5));
+    for (let i = 0; i < status.learningCurve.length; i += step) {
+      const point = status.learningCurve[i];
+      const bar = '█'.repeat(Math.floor(point.approvalRate / 5));
+      const line = `    w${String(point.window).padStart(3)}: ${bar} ${point.approvalRate}%`;
+      console.log(`║  ${line.padEnd(38)}║`);
+    }
+  } else {
+    console.log('║  Not enough data for learning curve      ║');
+  }
+
+  console.log('╚══════════════════════════════════════════╝');
+}
+
+if (require.main === module) {
+  const { FEEDBACK_DIR } = getFeedbackPaths();
+  const status = generateStatus(FEEDBACK_DIR);
+  printDashboard(status);
+}
+
+module.exports = { generateStatus, printDashboard };

--- a/tests/jsonl-watcher.test.js
+++ b/tests/jsonl-watcher.test.js
@@ -1,0 +1,143 @@
+// tests/jsonl-watcher.test.js
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { processNewEntries, shouldIngest, ingestEntry } = require('../scripts/jsonl-watcher');
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rlhf-watcher-test-'));
+}
+
+function appendJSONL(filePath, record) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(filePath, `${JSON.stringify(record)}\n`);
+}
+
+// -- shouldIngest --
+
+test('shouldIngest: returns false for entries without source', () => {
+  const entry = { signal: 'positive', context: 'good work', tags: [] };
+  assert.strictEqual(shouldIngest(entry), false);
+});
+
+test('shouldIngest: returns false for entries with watcher-ingested tag', () => {
+  const entry = {
+    signal: 'positive',
+    source: 'amp-plugin-bridge',
+    tags: ['watcher-ingested'],
+  };
+  assert.strictEqual(shouldIngest(entry), false);
+});
+
+test('shouldIngest: returns true for source=amp-plugin-bridge entries', () => {
+  const entry = {
+    signal: 'positive',
+    source: 'amp-plugin-bridge',
+    context: 'ran tests',
+    tags: ['verification'],
+  };
+  assert.strictEqual(shouldIngest(entry), true);
+});
+
+test('shouldIngest: respects sourceFilter parameter', () => {
+  const entry = {
+    signal: 'positive',
+    source: 'amp-plugin-bridge',
+    tags: [],
+  };
+  assert.strictEqual(shouldIngest(entry, 'amp-plugin-bridge'), true);
+  assert.strictEqual(shouldIngest(entry, 'other-source'), false);
+});
+
+// -- processNewEntries --
+
+test('processNewEntries: processes new bridged entries and returns correct counts', (t) => {
+  const tmpDir = makeTmpDir();
+  process.env.RLHF_FEEDBACK_DIR = tmpDir;
+  t.after(() => {
+    delete process.env.RLHF_FEEDBACK_DIR;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch {}
+  });
+
+  const logPath = path.join(tmpDir, 'feedback-log.jsonl');
+  appendJSONL(logPath, {
+    signal: 'positive',
+    source: 'amp-plugin-bridge',
+    context: 'ran tests and verified output',
+    whatWorked: 'evidence-first approach',
+    tags: ['verification'],
+  });
+  appendJSONL(logPath, {
+    signal: 'negative',
+    source: 'amp-plugin-bridge',
+    context: 'skipped tests before claiming done',
+    whatWentWrong: 'no tests run',
+    whatToChange: 'always run tests',
+    tags: ['testing'],
+  });
+
+  const result = processNewEntries(tmpDir, logPath);
+  assert.strictEqual(result.processed, 2);
+  assert.strictEqual(typeof result.promoted, 'number');
+});
+
+test('processNewEntries: skips already-processed entries (idempotency via offset)', (t) => {
+  const tmpDir = makeTmpDir();
+  process.env.RLHF_FEEDBACK_DIR = tmpDir;
+  t.after(() => {
+    delete process.env.RLHF_FEEDBACK_DIR;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch {}
+  });
+
+  const logPath = path.join(tmpDir, 'feedback-log.jsonl');
+  appendJSONL(logPath, {
+    signal: 'positive',
+    source: 'amp-plugin-bridge',
+    context: 'first entry',
+    whatWorked: 'worked well',
+    tags: ['testing'],
+  });
+
+  const first = processNewEntries(tmpDir, logPath);
+  assert.strictEqual(first.processed, 1);
+
+  // Second call with no new entries should process zero
+  const second = processNewEntries(tmpDir, logPath);
+  assert.strictEqual(second.processed, 0);
+  assert.strictEqual(second.promoted, 0);
+});
+
+test('processNewEntries: creates memory records for accepted entries', (t) => {
+  const tmpDir = makeTmpDir();
+  process.env.RLHF_FEEDBACK_DIR = tmpDir;
+  t.after(() => {
+    delete process.env.RLHF_FEEDBACK_DIR;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch {}
+  });
+
+  const logPath = path.join(tmpDir, 'feedback-log.jsonl');
+  appendJSONL(logPath, {
+    signal: 'positive',
+    source: 'amp-plugin-bridge',
+    context: 'ran full test suite with evidence',
+    whatWorked: 'evidence-first verification',
+    tags: ['verification', 'testing'],
+  });
+
+  const result = processNewEntries(tmpDir, logPath);
+  assert.ok(result.processed >= 1, `expected at least 1 processed, got ${result.processed}`);
+
+  // captureFeedback writes to memory-log.jsonl for accepted entries
+  const memoryLogPath = path.join(tmpDir, 'memory-log.jsonl');
+  if (result.promoted > 0) {
+    assert.ok(fs.existsSync(memoryLogPath), 'memory-log.jsonl should exist when entries are promoted');
+    const memories = fs.readFileSync(memoryLogPath, 'utf-8').trim().split('\n').filter(Boolean);
+    assert.ok(memories.length >= 1, `expected at least 1 memory record, got ${memories.length}`);
+  }
+});


### PR DESCRIPTION
## What

- **JSONL File Watcher** (`scripts/jsonl-watcher.js`): Watches `feedback-log.jsonl` for entries written by external sources (Amp plugins, shell hooks, CI scripts) and routes them through `captureFeedback()` for full pipeline processing — memory promotion, vector indexing, sequence tracking, DPO eligibility.

- **Status Dashboard** (`scripts/status-dashboard.js`): CLI learning curve dashboard showing approval rate trend, failure domains, memory count, prevention rule count, and sliding-window approval curve.

- **CLI Commands**: `watch` (daemon or `--once`), `status` (dashboard)

- **Serve Integration**: `serve` command now starts the watcher as a background daemon alongside MCP server. Watcher logs to stderr to avoid corrupting stdout JSON-RPC.

- **README Rewrite**: Technical focus, documents watcher + dashboard, removes marketing copy.

## Why

The Amp plugin bridge (and any external source) writes raw JSONL directly to `feedback-log.jsonl`, bypassing `captureFeedback()`. This means 5 out of 7 downstream systems never fire: memory promotion, vector indexing, DPO export, prevention rules, schema validation. The watcher closes this gap.

## Tests

- `tests/jsonl-watcher.test.js`: 7 tests — `shouldIngest` (4 cases), `processNewEntries` (3 cases: correct counts, idempotency, memory creation)
- All 4 `serve` transport tests pass (watcher stderr doesn't corrupt stdout)
- Pre-existing failures unchanged (funnel event ENOENT, missing stripe module)