### PR TITLE
fix: remove --service flag from railway up (project token auto-detects)

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy to Railway
-        run: railway up --detach --service rlhf-feedback-loop-production
+        run: railway up --detach
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes `--service rlhf-feedback-loop-production` flag from the `railway up` command in the deploy workflow
- When using a Railway project token (`RAILWAY_TOKEN`), the CLI already scopes the deployment to the correct project and service — the `--service` flag causes a "Service not found" error because it tries to match by name and fails

## Root Cause

The `--service` flag performs a name lookup within the project. The project token already binds the deploy to the right environment; supplying an explicit service name that doesn't match exactly causes the CLI to reject the command.

## Fix

```diff
- run: railway up --detach --service rlhf-feedback-loop-production
+ run: railway up --detach
```

## Test plan

- [ ] Merge and verify the next push to `main` triggers a successful Railway deployment without "Service not found" error