### PR TITLE
chore: v0.6.13 — fix mcpName casing for MCP registry

### DIFF
--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "rlhf-feedback-loop",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Production RLHF & DPO data pipeline for AI agents. Capture human preference signals, generate automated guardrails, and export DPO training pairs.",
   "homepage": "https://github.com/IgorGanapolsky/mcp-memory-gateway",
   "transport": "stdio",

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,6 +3,6 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx -y rlhf-feedback-loop@0.6.12 serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx -y rlhf-feedback-loop@0.6.13 serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/rlhf-feedback/SKILL.md`: Amp skill template.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.6.12", "serve"]
+      "args": ["-y", "rlhf-feedback-loop@0.6.13", "serve"]
     }
   }
 }

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -1,4 +1,4 @@
 # Codex MCP profile (copy into ~/.codex/config.toml or merge section)
 [mcp_servers.rlhf]
 command = "npx"
-args = ["-y", "rlhf-feedback-loop@0.6.12", "serve"]
+args = ["-y", "rlhf-feedback-loop@0.6.13", "serve"]

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.12 serve
+claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.13 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.6.12", "serve"],
+      "args": ["-y", "rlhf-feedback-loop@0.6.13", "serve"],
       "env": {
         "RLHF_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.6.12", "serve"],
+      "args": ["-y", "rlhf-feedback-loop@0.6.13", "serve"],
       "env": {
         "RLHF_BASE_URL": "https://rlhf-feedback-loop-710216278770.us-central1.run.app",
         "RLHF_API_KEY": "rlhf_YOUR_KEY_HERE"
@@ -123,7 +123,7 @@ Verification evidence: https://github.com/IgorGanapolsky/rlhf-feedback-loop/blob
 
 ## Transport
 
-- **stdio** (primary): `npx -y rlhf-feedback-loop@0.6.12 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y rlhf-feedback-loop@0.6.13 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -170,7 +170,7 @@ MIT
 
 ## Version
 
-0.6.12
+0.6.13
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rlhf-feedback-loop",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "Feedback-Driven Development (FDD) for AI agents — capture preference signals, steer behavior via Thompson Sampling, and export KTO/DPO training pairs for downstream fine-tuning.",
   "homepage": "https://rlhf-feedback-loop-production.up.railway.app",
   "repository": {
@@ -136,5 +136,5 @@
     "apache-arrow": "^18.1.0",
     "stripe": "^20.4.1"
   },
-  "mcpName": "io.github.igorganapolsky/rlhf-feedback-loop"
+  "mcpName": "io.github.IgorGanapolsky/rlhf-feedback-loop"
 }

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.IgorGanapolsky/mcp-memory-gateway",
+  "name": "io.github.IgorGanapolsky/rlhf-feedback-loop",
   "description": "MCP Memory Gateway: RLHF feedback loop for AI agents. Capture feedback, block mistakes, export DPO training data.",
   "repository": {
     "url": "https://github.com/IgorGanapolsky/mcp-memory-gateway",
     "source": "github"
   },
-  "version": "0.6.12",
+  "version": "0.6.13",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "rlhf-feedback-loop",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Bumps package version from 0.6.12 to 0.6.13
- Fixes `mcpName` from `io.github.igorganapolsky/rlhf-feedback-loop` to `io.github.IgorGanapolsky/rlhf-feedback-loop` (capital I and G) to match GitHub identity for registry.modelcontextprotocol.io submission
- Fixes `server.json` name from `mcp-memory-gateway` to `rlhf-feedback-loop` for registry alignment
- Updates all version-pinned references across adapters and docs

## Files changed

- `package.json`: version bump + mcpName casing fix
- `server.json`: version bump + name corrected to rlhf-feedback-loop
- `.well-known/mcp/server-card.json`: version bump
- `adapters/claude/.mcp.json`: pinned version bumped
- `adapters/codex/config.toml`: pinned version bumped
- `adapters/README.md`: version reference updated
- `docs/mcp-hub-submission.md`: all version references updated

## Test plan

- [x] `npm test` passes — all 0 failures across full test suite
- [x] `tests/version-metadata.test.js` passes (verifies package.json, server.json, and server-card.json are in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)