### PR TITLE
fix: use correct Railway service name (rlhf-feedback-loop)

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy to Railway
-        run: railway up --detach
+        run: railway up --detach --service rlhf-feedback-loop
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## Summary
- Updates `railway up --detach` to `railway up --detach --service rlhf-feedback-loop` so the CLI targets the correct Railway service instead of prompting or guessing
- No logic changes — deploy workflow fix only

## Test plan
- [x] `npm test` passes (55 tests, 0 failures)
- [ ] Verify Railway deploy succeeds on merge to main with the correct service targeted

Generated with [Claude Code](https://claude.com/claude-code)