### PR TITLE
fix: align server.json name with npm mcpName

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.IgorGanapolsky/mcp-memory-gateway",
+  "name": "io.github.IgorGanapolsky/rlhf-feedback-loop",
   "description": "Agent quality feedback loop with prevention rules and commerce quality scores.",
   "title": "MCP Memory Gateway",
   "websiteUrl": "https://rlhf-feedback-loop-production.up.railway.app",


### PR DESCRIPTION
Registry validates server.json name == npm mcpName. Aligning to io.github.IgorGanapolsky/rlhf-feedback-loop.