### PR TITLE
chore: bump to v0.6.14 for MCP registry publish

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,6 +3,6 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx -y rlhf-feedback-loop@0.6.13 serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx -y rlhf-feedback-loop@0.6.14 serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/rlhf-feedback/SKILL.md`: Amp skill template.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.6.13", "serve"]
+      "args": ["-y", "rlhf-feedback-loop@0.6.14", "serve"]
     }
   }
 }

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -1,4 +1,4 @@
 # Codex MCP profile (copy into ~/.codex/config.toml or merge section)
 [mcp_servers.rlhf]
 command = "npx"
-args = ["-y", "rlhf-feedback-loop@0.6.13", "serve"]
+args = ["-y", "rlhf-feedback-loop@0.6.14", "serve"]

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.13 serve
+claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.14 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.6.13", "serve"],
+      "args": ["-y", "rlhf-feedback-loop@0.6.14", "serve"],
       "env": {
         "RLHF_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.6.13", "serve"],
+      "args": ["-y", "rlhf-feedback-loop@0.6.14", "serve"],
       "env": {
         "RLHF_BASE_URL": "https://rlhf-feedback-loop-710216278770.us-central1.run.app",
         "RLHF_API_KEY": "rlhf_YOUR_KEY_HERE"
@@ -123,7 +123,7 @@ Verification evidence: https://github.com/IgorGanapolsky/rlhf-feedback-loop/blob
 
 ## Transport
 
-- **stdio** (primary): `npx -y rlhf-feedback-loop@0.6.13 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y rlhf-feedback-loop@0.6.14 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -170,7 +170,7 @@ MIT
 
 ## Version
 
-0.6.13
+0.6.14
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-gateway",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "The Universal Context & Memory Layer for Model Context Protocol (MCP) Agents. Centralized hub to consolidate failures and enforce architectural guardrails.",
   "homepage": "https://mcp-memory-gateway.up.railway.app",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/mcp-memory-gateway"
   },
-  "version": "0.6.13",
+  "version": "0.6.14",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "rlhf-feedback-loop",
-      "version": "0.6.13",
+      "version": "0.6.14",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Registry rejected duplicate v0.6.13. Aligns all version references.