### PR TITLE
chore: bump to v0.6.15, fix mcpName casing for MCP registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-gateway",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "The Universal Context & Memory Layer for Model Context Protocol (MCP) Agents. Centralized hub to consolidate failures and enforce architectural guardrails.",
   "homepage": "https://mcp-memory-gateway.up.railway.app",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/mcp-memory-gateway"
   },
-  "version": "0.6.14",
+  "version": "0.6.15",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-memory-gateway",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Aligns all versions with npm publish. npm mcpName now io.github.IgorGanapolsky/mcp-memory-gateway (case-sensitive). Registry publish will succeed after merge.