### PR TITLE
fix: revenue funnel — checkout button, usage limit, Gumroad CTA

### DIFF
--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -393,6 +393,19 @@ async function callTool(name, args = {}) {
   return callToolInner(name, args);
 }
 
+const FREE_DAILY_RECALL_LIMIT = 5;
+const _recallUsage = { date: '', count: 0 };
+
+function checkRecallLimit() {
+  const today = new Date().toISOString().slice(0, 10);
+  if (_recallUsage.date !== today) {
+    _recallUsage.date = today;
+    _recallUsage.count = 0;
+  }
+  _recallUsage.count++;
+  return _recallUsage.count > FREE_DAILY_RECALL_LIMIT;
+}
+
 async function callToolInner(name, args = {}) {
   if (name === 'recall') {
     const query = args.query || '';
@@ -443,6 +456,17 @@ async function callToolInner(name, args = {}) {
     // 4. Append stats + audit trail (glass box)
     parts.push('');
     parts.push(formatStats());
+
+    // Free-tier usage nudge
+    const overLimit = checkRecallLimit();
+    if (overLimit) {
+      parts.push('');
+      parts.push('---');
+      parts.push('## Upgrade to Context Gateway');
+      parts.push(`You've used ${_recallUsage.count}/${FREE_DAILY_RECALL_LIMIT} free recalls today. Upgrade for unlimited recalls + shared team memory:`);
+      parts.push('- Context Gateway: https://rlhf-feedback-loop-production.up.railway.app');
+      parts.push('- Pro Pack (one-time): https://iganapolsky.gumroad.com/l/tjovof');
+    }
 
     const text = parts.length > 1
       ? parts.join('\n')

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -807,7 +807,8 @@
               <li>Built for Claude Code, Codex, Gemini, and custom runners</li>
               <li>Best when attached to one workflow that creates or saves money</li>
             </ul>
-            <button class='button primary' id='checkout-btn-bottom' type='button'>Join as Founding Member — $5/mo forever</button>
+            <button class='button primary' id='checkout-btn-bottom' type='button'>Join as Founding Member — $10/mo</button>
+            <a class='button' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer' style='margin-left:12px;background:var(--accent-dark,#8f451f);color:white;text-decoration:none;display:inline-block;padding:12px 18px;border-radius:10px;font-weight:700;'>Pro Pack — $9 one-time</a>
           </div>
         </div>
       </div>
@@ -889,7 +890,7 @@
 
       document.getElementById('checkout-btn').addEventListener('click', () => startCheckout({ oneTime: false }));
       document.getElementById('one-time-btn').addEventListener('click', () => startCheckout({ oneTime: true }));
-      // document.getElementById('checkout-btn-bottom').addEventListener('click', () => startCheckout({ oneTime: false }));
+      document.getElementById('checkout-btn-bottom').addEventListener('click', () => startCheckout({ oneTime: false }));
     }());
   </script>
 </body>

--- a/tests/recall-limit.test.js
+++ b/tests/recall-limit.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rlhf-recall-limit-'));
+process.env.RLHF_FEEDBACK_DIR = tmpDir;
+process.env.RLHF_MCP_PROFILE = 'default';
+
+const { callTool } = require('../adapters/mcp/server-stdio');
+
+test('recall returns results without upgrade nudge for first 5 calls', async () => {
+  for (let i = 0; i < 5; i++) {
+    const result = await callTool('recall', { query: 'test task' });
+    const text = result.content[0].text;
+    assert.ok(!text.includes('Upgrade to Context Gateway'), `Call ${i + 1} should not show upgrade nudge`);
+  }
+});
+
+test('recall shows upgrade nudge after 5 calls in a day', async () => {
+  // The 5 calls above already consumed the limit
+  const result = await callTool('recall', { query: 'test task 6' });
+  const text = result.content[0].text;
+  assert.ok(text.includes('Upgrade to Context Gateway'), 'Call 6 should show upgrade nudge');
+  assert.ok(text.includes('gumroad.com'), 'Should include Gumroad link');
+  assert.ok(text.includes('rlhf-feedback-loop-production'), 'Should include hosted API link');
+});
+
+test('recall still returns actual results even when over limit', async () => {
+  const result = await callTool('recall', { query: 'test task' });
+  const text = result.content[0].text;
+  // Should have both results AND the nudge
+  assert.ok(text.length > 50, 'Should still return content, not just the nudge');
+});
+
+test.after(() => {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
+});

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -26,7 +26,7 @@ test('public docs render the current package version', () => {
   const mcpSubmission = readText('docs/mcp-hub-submission.md');
 
   assert.match(landingPage, /v__PACKAGE_VERSION__/);
-  assert.match(landingPage, /Join as Founding Member — \$5\/mo forever/);
+  assert.match(landingPage, /Join as Founding Member — \$10\/mo/);
   assert.match(mcpSubmission, new RegExp(`## Version\\s+${packageJson.version}`));
 });
 


### PR DESCRIPTION
## Fixes
- Bottom checkout button was commented out (dead) — now live
- Button said $5/mo but actual price is $10/mo — corrected
- Added Gumroad Pro Pack ($9 one-time) as second CTA
- Added free-tier recall limit: 5/day, then upgrade nudge

## Revenue impact
- Every landing page visitor now sees 2 payment options (subscription + one-time)
- Every MCP user hitting 6th recall/day sees upgrade links
- Gumroad link is the fastest path to first dollar (direct purchase, no Stripe config)

## Tests
- [x] 3 new recall limit tests
- [x] Full suite: 0 failures across 15 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)