### PR TITLE
fix: align commercial claims with current offer

### DIFF
--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -1,6 +1,6 @@
-# 🚀 FIRST DOLLAR LAUNCH PLAN (March 11, 2026)
+# FIRST DOLLAR LAUNCH PLAN (March 11, 2026)
 
-The Cash Machine is live. The machine is verified. We are at $0 because the world doesn't know we exist. 
+The engineering proof is real. The commercial surface must stay honest.
 
 ## 1. The Monetization Surface
 - **Live Hosted App**: [Context Gateway](https://rlhf-feedback-loop-production.up.railway.app)
@@ -15,17 +15,21 @@ Post this to your X/Twitter and LinkedIn immediately:
 > 
 > ✅ Thumbs-Up/Down feedback loops
 > ✅ Automatic prevention rules (Never make the same mistake twice)
-> ✅ Team-wide context sharing
-> ✅ Metered billing for Context Gateway
+> ✅ Local-first memory and DPO export
+> ✅ $9 one-time Pro Pack for production configs
 > 
-> Get your first workflow live here: https://rlhf-feedback-loop-production.up.railway.app"
+> OSS core: https://github.com/IgorGanapolsky/mcp-memory-gateway
+> Pro Pack: https://iganapolsky.gumroad.com/l/tjovof"
 
 ## 3. High-Intent Direct Messages
 Send this to the top 3 agent builders in your network:
 
-> "Hey, I just launched the Context Gateway for MCP agents. It solves the context drift problem by consolidating agent failures into 'Always-On' memory. Would love for you to be our first paid user and break the machine: https://rlhf-feedback-loop-production.up.railway.app"
+> "Hey, I just launched MCP Memory Gateway. It captures thumbs-up/down feedback, turns repeated failures into guardrails, and keeps the OSS core free. The public self-serve offer is a $9 one-time Pro Pack, and hosted pilots are by request. Would love your honest feedback: https://github.com/IgorGanapolsky/mcp-memory-gateway"
 
-## 4. Verification
+## 4. Commercial Truth
+Use [docs/COMMERCIAL_TRUTH.md](docs/COMMERCIAL_TRUTH.md) as the source of truth for pricing, traction, and proof claims. Do not cite GitHub stars, npm downloads, or solo-maintainer activity as customer proof.
+
+## 5. Verification
 I am monitoring the repo-local billing proxy (`node bin/cli.js cfo`) in this checkout. It reports paid events, active keys, customer IDs, and usage from the append-only funnel ledger plus the local key store. The hosted API exposes the same summary shape at `GET /v1/billing/summary` when queried with the admin key. This is an operational proxy, not booked-revenue accounting.
 
-**Engineering is Done. Deployment is Active. Go get that first dollar.**
+Engineering is done. Pricing and traction claims must stay evidence-backed.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Agent (Claude/Codex/Amp/Gemini)
 
 ## 💎 Pro Pack — Production Context Engineering Configs
 
-Battle-tested configurations extracted from 500+ agentic sessions. Skip months of tuning.
+Curated configuration pack for teams that want a faster production setup without inventing their own guardrails from scratch.
 
 | What You Get | Description |
 |---|---|
@@ -210,6 +210,8 @@ Battle-tested configurations extracted from 500+ agentic sessions. Skip months o
 | **Reminder Templates** | 8 production reminder templates with priority levels |
 
 **[$9 on Gumroad →](https://iganapolsky.gumroad.com/l/tjovof)**
+
+Current pricing and traction policy: [Commercial Truth](docs/COMMERCIAL_TRUTH.md)
 
 ## Support the Project
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -472,19 +472,21 @@ function cfo() {
 }
 
 function pro() {
-  const stripeUrl = 'https://buy.stripe.com/fZu4gz0I47Dg9G1cGv3sI03';
-  console.log('\n🚀 MCP Memory Gateway — Founding Member');
+  const gumroadUrl = 'https://iganapolsky.gumroad.com/l/tjovof';
+  const hostedUrl = 'https://rlhf-feedback-loop-production.up.railway.app';
+  const truthUrl = 'https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/COMMERCIAL_TRUTH.md';
+  console.log('\nMCP Memory Gateway — Commercial Truth');
   console.log('─'.repeat(50));
-  console.log('FLASH DEAL: $5/mo forever for the first 50 users.');
-  console.log('Price locks today. 38 spots remaining.');
-  console.log('\nUnlock the full Agentic Control Plane:');
-  console.log('  - Hosted Context Gateway (Shared memory across all repos)');
-  console.log('  - ShieldCortex Managed Context Packs');
-  console.log('  - Automated DPO/KTO Training Pipelines');
-  console.log('  - Team-wide Agentic Guardrails');
-  console.log('\n👉 Claim your founding spot here:');
-  console.log(`   ${stripeUrl}`);
-  console.log('\nOnce upgraded, run: npx rlhf-feedback-loop init --key=YOUR_PRO_KEY\n');
+  console.log('Self-serve offer today: Pro Pack ($9 one-time) on Gumroad.');
+  console.log('Hosted Context Gateway access is pilot/by-request; it is not a public self-serve recurring subscription.');
+  console.log('\nWhat is available:');
+  console.log('  - Pro Pack: curated prevention rules, presets, hooks, and reminder templates');
+  console.log('  - Hosted demo: public product surface and onboarding shell');
+  console.log('  - Commercial truth doc: source of truth for traction, pricing, and proof claims');
+  console.log('\nLinks:');
+  console.log(`  Pro Pack        : ${gumroadUrl}`);
+  console.log(`  Hosted demo     : ${hostedUrl}`);
+  console.log(`  Commercial truth: ${truthUrl}\n`);
 }
 
 function summary() {
@@ -686,7 +688,7 @@ function help() {
   console.log('  export-dpo            Export DPO training pairs (prompt/chosen/rejected JSONL)');
   console.log('  rules                 Generate prevention rules from repeated failures');
   console.log('  self-heal             Run self-healing check and auto-fix');
-  console.log('  pro                   Upgrade to Context Gateway ($10/mo)');
+  console.log('  pro                   Open the $9 one-time Pro Pack + hosted pilot info');
   console.log('  prove [--target=X]    Run proof harness (adapters|automation|attribution|lancedb|local-intelligence|...)');
   console.log('  watch [flags]           Watch .rlhf/ for external signals and ingest through pipeline (--once, --source=X)');
   console.log('  status                  Show feedback tracking dashboard — approval trend + failure domains');

--- a/docs/ANTHROPIC_MARKETPLACE_STRATEGY.md
+++ b/docs/ANTHROPIC_MARKETPLACE_STRATEGY.md
@@ -1,5 +1,7 @@
 # Anthropic Marketplace Strategy: The Reliability & Context Engineering Layer
 
+> Historical research note: this strategy file may reference outdated pricing and distribution assumptions. Use `docs/COMMERCIAL_TRUTH.md` for current pricing and traction claims.
+
 ## Marketplace Positioning
 MCP Memory Gateway is the **Enterprise Control Plane** for Claude-based agentic workflows. We solve the "Vibe Coding" security crisis by providing a verifiable, context-engineered runtime.
 
@@ -16,7 +18,7 @@ MCP Memory Gateway is the **Enterprise Control Plane** for Claude-based agentic 
 ## Technical Integration (The Listing Payload)
 - **Delivery Format:** MCP Server (Standard) + OpenAPI Spec (for Claude Cowork).
 - **Security Evidence:** All listed skills are verified by our `VERIFICATION_EVIDENCE.md` audit trail.
-- **Pricing:** Founding price `$10/mo` (Context Gateway) while the product is still in the early distribution phase.
+- **Pricing (historical hypothesis):** This strategy assumed a `$10/mo` Context Gateway founding price while the product was still in early distribution. The current public self-serve offer is the `$9` one-time Pro Pack in `docs/COMMERCIAL_TRUTH.md`, and hosted gateway access is pilot/by-request.
 
 ## Strategic Improvement: "Vibe-to-Verification" (V2V)
 The product will now feature a **V2V Pipeline**:

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -1,0 +1,26 @@
+# Commercial Truth
+
+Status: current
+Updated: March 12, 2026
+
+This document is the source of truth for product, pricing, traction, and proof claims in this repository.
+
+## What is true today
+
+- The open-source `rlhf-feedback-loop` package is free and MIT licensed.
+- The current public self-serve commercial offer is the Pro Pack on Gumroad: `$9` one-time.
+- Hosted Context Gateway access exists as a pilot/by-request workflow layer. It is not a public self-serve recurring subscription.
+- Engineering verification is strong and should be cited through `docs/VERIFICATION_EVIDENCE.md` and machine-readable proof reports.
+
+## What we must not claim
+
+- Do not treat GitHub stars, watchers, dependents, or npm download counts as customer or revenue proof.
+- Do not present AI-agent self-validation as independent market proof.
+- Do not use hardcoded scarcity or social-proof claims such as “spots remaining” or “founding members” unless they are backed by live data.
+- Do not present historical pricing experiments as the current live offer.
+
+## Proof policy
+
+- Use booked revenue, paid orders, or named pilot agreements for commercial proof.
+- Use `docs/VERIFICATION_EVIDENCE.md`, `proof/compatibility/report.json`, and `proof/automation/report.json` for engineering proof.
+- When in doubt, prefer “early-stage” or “pilot” language over unverified traction claims.

--- a/docs/PACKAGING_AND_SALES_PLAN.md
+++ b/docs/PACKAGING_AND_SALES_PLAN.md
@@ -1,12 +1,14 @@
 # Packaging and Sales Plan
 
+> Historical research note: this file contains packaging hypotheses and outdated pricing experiments. Use `docs/COMMERCIAL_TRUTH.md` for current pricing and traction claims.
+
 ## North Star
 
 Weekly active proof-backed workflow runs.
 
 This is the metric that matters most. Stars, visits, and installs matter only if they lead to teams running one monitored workflow with shared memory, guardrails, and evidence.
 
-## Best First Offer
+## Historical Best First Offer Hypothesis
 
 - OSS core for one operator proving a workflow locally.
 - Context Gateway for one team running one workflow with shared memory and proof-ready runs.
@@ -22,7 +24,7 @@ This is the metric that matters most. Stars, visits, and installs matter only if
 - DPO export
 - Local MCP server
 
-### Tier 2: Context Gateway (Founding price: $10/mo)
+### Tier 2: Historical Context Gateway Hypothesis (Then-Proposed $10/mo)
 
 - Hosted API endpoint
 - Provisioned API keys and hosted onboarding
@@ -33,8 +35,13 @@ This is the metric that matters most. Stars, visits, and installs matter only if
 
 Pricing note:
 
-- Keep the current live Stripe price at `$10/mo` while Context Gateway is still proving conversion.
-- Revisit repricing after the hosted workflow layer shows retained usage and stronger buyer pull.
+- At the time, the plan was to keep the live Stripe price at `$10/mo` while Context Gateway was still proving conversion.
+- At the time, the plan was to revisit repricing after the hosted workflow layer showed retained usage and stronger buyer pull.
+
+Current note:
+
+- The public self-serve commercial offer is the `$9` one-time Pro Pack in `docs/COMMERCIAL_TRUTH.md`.
+- Hosted Context Gateway access is pilot/by-request, not a public recurring subscription.
 
 ### Tier 3: Enterprise (Pricing: custom quote)
 

--- a/docs/PRICING_RESEARCH_2026-03-09.md
+++ b/docs/PRICING_RESEARCH_2026-03-09.md
@@ -1,12 +1,16 @@
 # Pricing Research (March 9, 2026)
 
-## Decision
+> Historical research note: this document captures a point-in-time pricing exploration. It is not the current product truth. Use `docs/COMMERCIAL_TRUTH.md` for current pricing and proof language.
 
-Keep Context Gateway at the current live Stripe price of `$10/mo` for now, but position it explicitly as a founding price rather than the permanent list price.
+## Historical Decision At The Time
 
-## Why
+On March 9, 2026, the working hypothesis was to keep Context Gateway at a `$10/mo` Stripe price for a limited period and position it explicitly as a founding price rather than the permanent list price.
 
-- The current Stripe product tied to this repo is a live `$10/mo` monthly subscription.
+This monthly self-serve hypothesis has since been retired. The current public commercial truth is documented in `docs/COMMERCIAL_TRUTH.md`.
+
+## Why That Hypothesis Existed
+
+- At the time, the Stripe product tied to this repo was a live `$10/mo` monthly subscription.
 - The product is early, recently launched, and does not yet have strong retained paid demand.
 - The open-source package is free, so Context Gateway has to clear a second spending threshold on top of the user's existing model subscriptions.
 - A `$49/mo` self-serve ask is aggressive at this stage relative to both individual AI tooling and early-stage agent infrastructure products.
@@ -22,9 +26,9 @@ Keep Context Gateway at the current live Stripe price of `$10/mo` for now, but p
 - Helicone Pro: `$79/mo`
 - Braintrust Pro: `$249/mo`
 
-## Recommendation
+## Historical Recommendation
 
-- Keep `Context Gateway` at `$10/mo` while proving onboarding, activation, and retention.
-- Describe it as a `founding price` or `early adopter price`.
-- Do not move to `$49/mo` until the hosted dashboard, team workflows, and measurable ROI proof are live.
-- Revisit a move into the `$29-$49/mo` range once the hosted product clearly competes with Langfuse, LangSmith, Portkey, or Helicone instead of just low-friction developer subscriptions.
+- The recommendation at the time was to keep `Context Gateway` at `$10/mo` while proving onboarding, activation, and retention.
+- The recommendation at the time was to describe it as a `founding price` or `early adopter price`.
+- The recommendation at the time was not to move to `$49/mo` until the hosted dashboard, team workflows, and measurable ROI proof were live.
+- The recommendation at the time was to revisit a move into the `$29-$49/mo` range once the hosted product clearly competed with Langfuse, LangSmith, Portkey, or Helicone instead of just low-friction developer subscriptions.

--- a/docs/PRICING_RESEARCH_2026-03-10.md
+++ b/docs/PRICING_RESEARCH_2026-03-10.md
@@ -1,15 +1,17 @@
 # CTO Crisis Report: Revenue Autopsy & Strategic Pivot (March 2026)
 
-## The Core Problem: Why We Are at $0.00
-Our engineering is world-class, but our go-to-market (GTM) strategy is misaligned with the current March 2026 AI developer ecosystem. We built a powerful local-first "RLHF Feedback Studio," but we put massive friction between the developer and the "Buy" button. 
+> Historical research note: this document describes a pricing and packaging pivot proposal. It is not the current product truth. Use `docs/COMMERCIAL_TRUTH.md` for current pricing and proof language. All subscription references below describe the March 2026 situation being analyzed, not the current offer.
+
+## The Core Problem: Why The Funnel Was At $0.00 In This March 2026 Analysis
+At the time, the go-to-market (GTM) strategy was misaligned with the March 2026 AI developer ecosystem. We had built a powerful local-first "RLHF Feedback Studio," but we also put massive friction between the developer and the commercial surface.
 
 Here is the empirical breakdown of why our funnel is failing:
 
 ### 1. The "Local-First" Trap
-Developers in 2026 want zero-friction "agentic primitives." We require them to clone a repository, run local tests, and manually discover our `docs/landing-page.html` to find the $10/mo "Context Gateway" upgrade. **There is zero top-of-funnel acquisition because our monetization surface is buried inside a local codebase.**
+At the time, developers in 2026 wanted zero-friction "agentic primitives." We required them to clone a repository, run local tests, and manually discover `docs/landing-page.html` to find the then-proposed `$10/mo` "Context Gateway" upgrade. **This report concluded that top-of-funnel acquisition was weak because the monetization surface was buried inside a local codebase.**
 
 ### 2. Pricing Model Mismatch
-The 2026 market for agent tooling operates almost exclusively on **consumption-based credit systems** or "per-agent identity" models (like Okta for Agents). Our flat $10/month subscription feels outdated. Developers don't want to pay a subscription for a local tool; they want to pay for the *inference and storage costs* associated with "Always-On" memory.
+The March 2026 market for agent tooling was operating largely on **consumption-based credit systems** or "per-agent identity" models (like Okta for Agents). This report argued that the flat `$10/month` subscription felt outdated. The thesis was that developers would rather pay for the *inference and storage costs* associated with "Always-On" memory than for a recurring fee on a local tool.
 
 ### 3. Misaligned Positioning (RLHF vs. MCP Gateway)
 We are marketing ourselves as an "MCP Memory Gateway." However, the March 2026 market data shows that the highest revenue growth is in **MCP (Model Context Protocol) Gateways and Observability**. MCP has become the "USB-C of AI." We already have deep MCP integration, but we aren't selling ourselves as an "MCP Memory & Context Hub." 
@@ -33,4 +35,4 @@ To move from $0 to revenue immediately, we must execute the following pivot in "
 2.  **Publish to the AI Agent Store:** Ensure we are listed not just on GitHub, but on MCP Hubs, LangChain/LangGraph integrations directories, and relevant AI agent marketplaces.
 
 ## Conclusion
-We don't have a product problem; we have a distribution and packaging problem. By shifting from a local CLI subscription to a hosted, consumption-based MCP Gateway, we can immediately capture the explosive growth of the 2026 agent economy.
+The conclusion of this report was that the business had a distribution and packaging problem more than a product problem. It argued for shifting from a local CLI subscription pitch to a hosted, consumption-based MCP Gateway. That recommendation is retained here as historical analysis only.

--- a/docs/REVENUE_SPRINT_MAR2026.md
+++ b/docs/REVENUE_SPRINT_MAR2026.md
@@ -1,7 +1,9 @@
 # Revenue Sprint: First Paying Customer TODAY, $1K MRR in 30 Days
 
+> Historical research note: community-size figures, pricing experiments, and growth targets in this file are point-in-time planning assumptions from March 11, 2026. They are not current product truth. Use `docs/COMMERCIAL_TRUTH.md` for current pricing, traction, and proof language. All `$5/mo`, `$10/mo`, "Founding Member", and scarcity references below are retired experiments retained for historical context only.
+
 **Date:** 2026-03-11
-**Status:** EXECUTE NOW
+**Status:** Historical plan archived
 **Research basis:** Live web research, March 2026 MCP ecosystem data
 
 ---
@@ -49,7 +51,7 @@
 
 ---
 
-## Part 2: Exact Buyer Profile Who Pays $10/mo on Day 1
+## Part 2: Historical Buyer Profile Hypothesis For A Then-Proposed $10/mo Offer
 
 ### Primary Persona: "The AI Team Lead"
 - **Role:** Engineering lead or senior dev running 2-5 person team using Claude Code daily
@@ -68,7 +70,7 @@
 ### Secondary Persona: "The Solo AI Engineer"
 - Building MCP integrations or AI products
 - Needs DPO/KTO export pairs for fine-tuning
-- Pays $10/mo to avoid building their own feedback infrastructure
+- Would have paid `$10/mo` to avoid building their own feedback infrastructure
 
 ### Trigger Moment (converts "interesting" to "shut up and take my money"):
 > "I just spent 2 hours debugging because Claude forgot what we decided yesterday. I need persistent memory that works across sessions WITHOUT me managing infrastructure."
@@ -103,14 +105,16 @@
 
 ---
 
-## Part 4: Pricing/Offer Optimization for Maximum Conversion TODAY
+## Part 4: Historical Pricing Experiment Considered For Day-1 Conversion
 
 ### Current State Analysis
 - $10/mo flat is **not wrong** but friction is high
 - 2026 market expects consumption-based pricing (per-request, per-GB)
 - Less than 5% of 11,000+ MCP servers are monetized — opportunity is wide open
 
-### Recommended Pricing Structure (implement today)
+### Historical Pricing Structure Considered At The Time
+
+Retired experiment: the `$5/mo`, `$10/mo`, and scarcity-based tiers below are preserved as research history only. They are not current product truth.
 
 | Tier | Price | What's Included | Conversion Target |
 |------|-------|-----------------|-------------------|
@@ -119,13 +123,13 @@
 | **Pro** | $10/mo | 50K captures/mo, 10 seats, priority support, custom guardrails | Standard |
 | **Team** | $29/mo | Unlimited captures, unlimited seats, SSO, audit log, SLA | Upsell target |
 
-### Why "Founding Member $5/mo Forever" Converts Today:
+### Why The Team Believed "Founding Member $5/mo Forever" Could Convert At The Time:
 1. **Loss aversion** — "This price disappears after 50 users" creates urgency
 2. **Lower barrier** — $5 is impulse-buy territory for developers
 3. **"Forever" lock** — developers hate price increases, this removes the objection
 4. **Social proof** — "Join 12 founding members" (update counter in real-time)
 
-### Alternative Quick Test:
+### Alternative Quick Test Considered At The Time:
 - **72-hour flash: $1 first month** via Stripe coupon code `FOUNDING1`
 - After 72 hours, price reverts to $10/mo
 - Post this coupon in every Reddit/Discord/HN thread
@@ -156,7 +160,7 @@ Based on research, the top Claude Code YouTube creators have substantial audienc
 
 ---
 
-## TOP 10 ACTIONS: Ranked by (Speed x Revenue Impact)
+## Historical Action List From March 11, 2026: Ranked By (Speed x Revenue Impact)
 
 ### 1. Deploy to MCPize Marketplace (2 hours, HIGH impact)
 ```bash

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1,3 +1,23 @@
+## March 12, 2026: Commercial truth correction
+
+Scope:
+
+- Replaced stale `$5/mo` and `$10/mo` self-serve subscription language on live-facing surfaces with the actual public offer: Pro Pack (`$9` one-time).
+- Removed unsupported scarcity and adoption framing from CLI and landing-page copy.
+- Added `docs/COMMERCIAL_TRUTH.md` as the source of truth for pricing, traction, and proof claims.
+
+Commands run:
+
+```bash
+node --test tests/version-metadata.test.js tests/api-server.test.js tests/cli.test.js
+```
+
+Requirements verified:
+
+- Live-facing copy no longer presents a public recurring subscription as the current self-serve offer.
+- Live-facing copy no longer treats repo metrics or hardcoded scarcity as customer proof.
+- Pricing and traction claims now point back to a single source of truth.
+
 ## March 12, 2026: CFO billing summary control plane
 
 Scope:
@@ -38,15 +58,20 @@ Requirements verified:
 - `node bin/cli.js cfo` returns the same machine-readable summary shape as the API surface, while reading the local ledger and key store in the current checkout.
 - This surface is an operational billing proxy only; it does not claim booked revenue or invoice truth because the persisted stores track paid events, API keys, customer IDs, and usage rather than Stripe ledger amounts.
 
-## March 12, 2026: Revenue Sprint & Conversion Optimization
+## March 12, 2026: Revenue Sprint & Conversion Optimization (historical, superseded)
+
+Status:
+
+- Historical pricing experiment notes only.
+- Superseded by `docs/COMMERCIAL_TRUTH.md` for current public pricing and proof language.
 
 Scope:
 
 - Version sync across `package.json`, `mcpize.yaml`, and `server.json` to `v0.6.16`.
-- Landing page conversion optimization: added "Founding Member $5/mo" offer with price lock and urgency hooks.
+- Historical pricing experiment: tested a "Founding Member $5/mo" offer and urgency hooks before the current commercial-truth correction.
 - Discovery optimization: Added high-ROI GitHub topics and updated `SKILL.md` auto-indexing keywords.
 - Launch content package: Created `docs/marketing/LAUNCH_CONTENT.md` with Reddit, HN, and Discord assets.
-- CLI `pro` command updated to reflect the new $5 founding offer.
+- CLI `pro` command was, at that time, updated to reflect the same historical pricing experiment.
 
 Commands run:
 

--- a/docs/X_AUTOMATION_STRATEGY.md
+++ b/docs/X_AUTOMATION_STRATEGY.md
@@ -1,5 +1,7 @@
 # 𝕏 Premium+ Automation Strategy (March 2026)
 
+> Historical research note: this file captures a launch experiment and may reference outdated pricing or reach assumptions. Use `docs/COMMERCIAL_TRUTH.md` for current pricing and traction claims. Reach figures below are research snapshots, not product proof.
+
 ## Executive Audit of Screenshot
 Your account is in a high-leverage position:
 - **Verified Status**: Premium+ active (Since March 2026).
@@ -16,7 +18,7 @@ We will no longer wait for people to find us. We will use the **Radar Beta** API
 ## 2. Automated "Reply Boost" Displacement
 Premium+ gives your replies priority. We will automate this to dominate technical conversations.
 - **Tactic**: Inject a "Veto Layer" educational pitch into the top 1% of AI reliability threads.
-- **The Goal**: Capture a percentage of those 17M impressions and direct them to the $10/mo founding link.
+- **The Historical Goal**: Capture a percentage of those 17M impressions and direct them to the current commercial truth page and active offer instead of an outdated subscription pitch.
 
 ## 3. Generative SEO/GEO (via X Articles)
 X Articles now rank higher in AI Search (Perplexity/Grok).
@@ -25,8 +27,8 @@ X Articles now rank higher in AI Search (Perplexity/Grok).
 
 ---
 
-## **CTO Action Items for CEO**
-To fully automate this loop, I need the following environment variables added to Railway:
+## Historical Execution Checklist
+To fully automate this loop, the plan required the following environment variables on Railway:
 
 1. `X_API_KEY` & `X_API_SECRET`: For posting and engagement.
 2. `GROK_API_KEY`: To use `api.x.ai` for high-reasoning outreach.
@@ -34,9 +36,9 @@ To fully automate this loop, I need the following environment variables added to
 
 ---
 
-## **Autonomous Execution Status**
-- **Logic Deployed**: `scripts/x-autonomous-marketing.js` is ready.
-- **Targeting**: Discovered 4 intent clusters via Radar simulation.
-- **Readiness**: 100% (Awaiting Credentials).
+## Historical Execution Status
+- **Logic Deployed**: `scripts/x-autonomous-marketing.js` was considered ready.
+- **Targeting**: The plan had discovered 4 intent clusters via Radar simulation.
+- **Readiness**: This document recorded the loop as blocked on credentials.
 
-**Ready to launch the X-First Marketing Loop. Just add the keys.**
+**Historical note:** this launch loop was never product proof, customer proof, or current pricing truth.

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -593,21 +593,22 @@
           <p>Start where pain is already real: lead-to-meeting, onboarding, or internal ops. Context Gateway is the hosted Veto Layer behind that workflow, not another dashboard full of vague AI claims.</p>
           <div class='hero-proof'>
             <span class='proof-pill'>North Star: one workflow live and auditable</span>
-            <span class='proof-pill'>Founding price: $10/mo</span>
+            <span class='proof-pill'>Self-serve offer: $9 one-time Pro Pack</span>
             <span class='proof-pill'>Versioned proof: v__PACKAGE_VERSION__</span>
             <span class='proof-pill'>Hosted onboarding at https://rlhf-feedback-loop-production.up.railway.app</span>
           </div>
           <div class='cta-row'>
-            <button class='button primary' id='checkout-btn' type='button'>Start Context Gateway ($10/mo)</button>
-            <button class='button secondary' id='one-time-btn' type='button'>Mistake-Free Starter Pack ($49)</button>
+            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer'>Get Pro Pack — $9 one-time</a>
+            <a class='button secondary' href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/COMMERCIAL_TRUTH.md'>Current commercial truth</a>
+            <a class='button secondary' href='https://rlhf-feedback-loop-production.up.railway.app'>View hosted demo</a>
           </div>
-          <p class='note'>Bought by teams that need shared control. Used by operators and agent runners doing the work. Checkout is owned through the hosted API first, then falls back to the hosted app if checkout creation fails.</p>
-          <p class='note'>One-time pack: 500 consolidations + 5 custom rules. No subscription required.</p>
+          <p class='note'>Early-stage product. Engineering proof is real, but GitHub stars, npm downloads, and solo-maintainer activity are not customer proof.</p>
+          <p class='note'>Hosted Context Gateway access is pilot/by-request. The public self-serve commercial SKU today is the $9 one-time Pro Pack.</p>
         </div>
 
         <div class='panel hero-card'>
-          <h2>Why teams buy, not just install</h2>
-          <p>Most teams can use the OSS package. They buy Context Gateway when one workflow needs to survive handoffs, approvals, and multiple operators instead of living in scattered local files.</p>
+          <h2>Why teams evaluate it, not just install it</h2>
+          <p>Most teams can use the OSS package. The Pro Pack speeds up local production setup, and hosted pilots make sense when one workflow needs to survive handoffs, approvals, and multiple operators instead of living in scattered local files.</p>
           <ul>
             <li>Replace self-hosted feedback sprawl with a shared operational layer.</li>
             <li>Run the same workflow with shared memory, prevention rules, and hosted keys.</li>
@@ -615,11 +616,11 @@
           </ul>
           <div class='mini-grid'>
             <div class='mini'>
-              <strong>Bought By</strong>
+              <strong>Best fit</strong>
               RevOps, growth, platform, and engineering leaders accountable for one workflow outcome.
             </div>
             <div class='mini'>
-              <strong>Used By</strong>
+              <strong>Daily users</strong>
               Operators and agent runners executing intake, drafting, approval, and sync steps every day.
             </div>
             <div class='mini'>
@@ -627,8 +628,8 @@
               Lead-to-meeting with intake, enrichment, drafting, approval, CRM sync, and auditability.
             </div>
             <div class='mini'>
-              <strong>What stays OSS</strong>
-              Local feedback capture, MCP server, and DPO export remain free while hosted team control is paid.
+              <strong>What is public today</strong>
+              OSS remains free, the Pro Pack is $9 one-time, and hosted pilots are sold directly rather than through a public monthly plan.
             </div>
           </div>
         </div>
@@ -780,8 +781,8 @@
       <div class='section-inner'>
         <div class='section-head'>
           <span class='eyebrow'>Pricing</span>
-          <h2>Keep self-serve cheap. Close the bigger workflow install separately.</h2>
-          <p>The repo remains free. Context Gateway stays at a low-friction founding price while the hosted layer proves onboarding and retention. Services and workflow installs carry the larger ticket.</p>
+          <h2>Keep the public offer honest: free OSS plus a $9 Pro Pack.</h2>
+          <p>The repo remains free. The only current public self-serve commercial SKU is the $9 one-time Pro Pack. Hosted workflow rollouts are pilot/by-request, not a public recurring subscription.</p>
         </div>
         <div class='pricing-grid'>
           <div class='card'>
@@ -796,21 +797,21 @@
             <a class='button secondary' href='__GITHUB_URL__'>Use the open-source package</a>
           </div>
           <div class='card featured'>
-            <span class='badge'>Founding price</span>
-            <h3>Context Gateway</h3>
-            <div class='price'>$5 <small>/ month</small></div>
-          <p style='margin:0 0 8px;font-size:13px;color:var(--muted);'><s>$10/mo</s> — founding price locked forever</p>
+            <span class='badge'>Self-serve</span>
+            <h3>Pro Pack</h3>
+            <div class='price'>$9 <small>/ one-time</small></div>
+          <p style='margin:0 0 8px;font-size:13px;color:var(--muted);'>Curated production configs for teams that want faster setup without inventing their own guardrails.</p>
             <ul>
-              <li>Hosted HTTPS API</li>
-              <li>Provisioned API key after checkout</li>
-              <li>Shared team memory and funnel events</li>
-              <li>Built for Claude Code, Codex, Gemini, and custom runners</li>
-              <li>Best when attached to one workflow that creates or saves money</li>
+              <li>Curated prevention rules</li>
+              <li>Thompson Sampling presets</li>
+              <li>Hook templates and reminder packs</li>
+              <li>Commercial license for the pack contents</li>
+              <li>No recurring subscription required</li>
             </ul>
-            <button class='button primary' id='checkout-btn-bottom' type='button'>Join as Founding Member — $10/mo</button>
-            <a class='button' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer' style='margin-left:12px;background:var(--accent-dark,#8f451f);color:white;text-decoration:none;display:inline-block;padding:12px 18px;border-radius:10px;font-weight:700;'>Pro Pack — $9 one-time</a>
+            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer'>Buy Pro Pack — $9</a>
           </div>
         </div>
+        <p class='note'>Need hosted team workflows? Evaluate the demo or request a pilot. Do not describe hosted access as a public recurring subscription until that is actually live.</p>
       </div>
     </section>
   </main>
@@ -821,87 +822,13 @@
       <div>
         <a href='__VERIFICATION_URL__'>Verification evidence</a>
         •
+        <a href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/COMMERCIAL_TRUTH.md'>Commercial truth</a>
+        •
         <a href='__GTM_PLAN_URL__'>GTM plan</a>
         •
         <a href='__GITHUB_URL__'>GitHub</a>
       </div>
     </div>
   </footer>
-
-  <script>
-    (function () {
-      const checkoutEndpoint = '__CHECKOUT_ENDPOINT__';
-      const checkoutFallbackUrl = '__CHECKOUT_FALLBACK_URL__';
-      const appOrigin = '__APP_ORIGIN__';
-      const installStorageKey = 'rlhf_cloud_pro_install_id';
-
-      function getInstallId() {
-        const existing = window.localStorage.getItem(installStorageKey);
-        if (existing) {
-          return existing;
-        }
-
-        const generated = 'inst_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
-        window.localStorage.setItem(installStorageKey, generated);
-        return generated;
-      }
-
-      function createTraceId() {
-        return 'checkout_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
-      }
-
-      async function startCheckout(options = {}) {
-        const installId = getInstallId();
-        const traceId = createTraceId();
-
-        try {
-          const response = await fetch(checkoutEndpoint, {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json'
-            },
-            body: JSON.stringify({
-              installId,
-              traceId,
-              oneTime: options.oneTime === true,
-              successUrl: `${appOrigin}/success?session_id={CHECKOUT_SESSION_ID}&trace_id=${encodeURIComponent(traceId)}`,
-              cancelUrl: `${appOrigin}/cancel?trace_id=${encodeURIComponent(traceId)}`,
-              metadata: {
-                source: 'landing_page',
-                origin: appOrigin,
-                traceId,
-                oneTime: options.oneTime === true
-              }
-            })
-          });
-
-          const body = await response.json();
-          if (!response.ok) {
-            throw new Error(body.error || 'Unable to create checkout session.');
-          }
-
-          if (body.url) {
-            window.location.href = body.url;
-            return;
-          }
-
-          if (body.sessionId) {
-            const redirectTraceId = body.traceId || traceId;
-            window.location.href = `${appOrigin}/success?session_id=${encodeURIComponent(body.sessionId)}&trace_id=${encodeURIComponent(redirectTraceId)}`;
-            return;
-          }
-
-          throw new Error('Checkout response missing redirect target.');
-        } catch (err) {
-          console.error(err);
-          window.location.href = checkoutFallbackUrl;
-        }
-      }
-
-      document.getElementById('checkout-btn').addEventListener('click', () => startCheckout({ oneTime: false }));
-      document.getElementById('one-time-btn').addEventListener('click', () => startCheckout({ oneTime: true }));
-      document.getElementById('checkout-btn-bottom').addEventListener('click', () => startCheckout({ oneTime: false }));
-    }());
-  </script>
 </body>
 </html>

--- a/docs/marketing/LAUNCH_CONTENT.md
+++ b/docs/marketing/LAUNCH_CONTENT.md
@@ -16,7 +16,7 @@ It's called **Agentic Feedback Studio**.
   - Bayesian Preference Scoring: Thompson Sampling models your preferences in real-time.
   - DPO/KTO Export: Turn your sessions into training data for fine-tuning.
 - **Open Source:** Totally free for solo devs.
-- **Hosted:** We're launching a "Founding Member" tier today: **$5/mo forever** (limited to first 50 spots).
+- **Commercial:** The public self-serve offer today is the **$9 one-time Pro Pack**. Hosted pilots are by request.
 
 Check it out on GitHub: [https://github.com/IgorGanapolsky/rlhf-feedback-loop]
 Demo/Hosted: [https://mcp-memory-gateway.up.railway.app]
@@ -61,7 +61,7 @@ Stop vibe-coding. If Claude makes a mistake, flag it, and the Studio generates a
 - 🧠 **Smart Memory:** Vector storage via LanceDB + Bayesian reward estimation.
 - ⚡ **Global Skill:** Install once, use across all your repos.
 
-OSS is free. Founding Member spots ($5/mo forever) are live now!
+OSS is free. The public self-serve offer is the $9 one-time Pro Pack.
 Repo: https://github.com/IgorGanapolsky/rlhf-feedback-loop
 Live: https://mcp-memory-gateway.up.railway.app
 

--- a/docs/marketing/cold-outreach-sequence.md
+++ b/docs/marketing/cold-outreach-sequence.md
@@ -27,7 +27,7 @@ Following up on my last email. One of the biggest hurdles to adopting an Agentic
 
 That's why we made the Agentic Feedback Studio **Zero-Config**. You literally just drop `npx rlhf-feedback-loop install` into a repository, and it auto-discovers the context, integrating directly with Claude, Gemini, or Copilot via MCP. 
 
-Platform teams use our Context Gateway tier ($10/mo founding price) to sync these prevention rules globally across every repository in the organization. 
+For teams that outgrow local-only use, we offer hosted pilot access by direct arrangement. The only public self-serve commercial SKU today is the $9 one-time Pro Pack.
 
 If you have 5 minutes, I'd love to show you how our Vibe-to-Verification (V2V) pipeline works.
 

--- a/docs/marketing/mcp-directories.md
+++ b/docs/marketing/mcp-directories.md
@@ -1,5 +1,7 @@
 # MCP Directory Submission Guide
 
+> Research note: external repo stars, directory size, and community reach numbers in this file are time-bound research snapshots, not current product proof. Use `docs/COMMERCIAL_TRUTH.md` for current traction language.
+
 **Package:** `rlhf-feedback-loop` (npm)
 **GitHub:** https://github.com/IgorGanapolsky/rlhf-feedback-loop
 **Registry name:** `io.github.IgorGanapolsky/rlhf-feedback-loop`
@@ -129,7 +131,7 @@ You can also post in https://github.com/chatmcp/mcpso/discussions/categories/mcp
 
 There are three major lists. Submit to all of them.
 
-### 5a. punkpeye/awesome-mcp-servers (largest, 30k+ stars)
+### 5a. punkpeye/awesome-mcp-servers (largest GitHub discovery surface in March 2026 research)
 **URL:** https://github.com/punkpeye/awesome-mcp-servers
 **Contributing guide:** https://github.com/punkpeye/awesome-mcp-servers/blob/main/CONTRIBUTING.md
 
@@ -164,8 +166,8 @@ There are three major lists. Submit to all of them.
 
 | # | Directory | Method | Effort | Reach |
 |---|-----------|--------|--------|-------|
-| 1 | punkpeye/awesome-mcp-servers | GitHub PR | Low | Very High (30k+ stars) |
-| 2 | mcp.so | GitHub issue comment | Very Low | High (18k+ servers listed) |
+| 1 | punkpeye/awesome-mcp-servers | GitHub PR | Low | Very High (large GitHub discovery surface) |
+| 2 | mcp.so | GitHub issue comment | Very Low | High (large directory footprint) |
 | 3 | Smithery.ai | Web UI + smithery.yaml | Medium | High |
 | 4 | appcypher/awesome-mcp-servers | GitHub PR | Low | Medium |
 | 5 | mcpservers.org | Web form | Very Low | Medium |

--- a/docs/marketing/show-hn.md
+++ b/docs/marketing/show-hn.md
@@ -11,7 +11,7 @@ Every time you start a new Claude Code, Codex, or Gemini session, your agent for
 
 MCP Memory Gateway is an MCP server that gives AI agents a persistent feedback memory. During any session you give a thumbs-up or thumbs-down with brief context. That signal gets written to a local JSONL log and indexed with LanceDB. On future sessions the agent queries that history before acting, so it stops repeating known-bad approaches. Three or more identical failures auto-generate a CLAUDE.md prevention rule. You can also export all the data as DPO pairs (chosen/rejected) for fine-tuning.
 
-The self-hosted version is free. Install in 30 seconds: npx rlhf-feedback-loop serve. It works with Claude Code, Codex CLI, Gemini CLI, Amp, and Cursor. All data stays local. The hosted tier ($10/mo) adds team-shared feedback, a web dashboard, and managed LanceDB vector search at https://rlhf-feedback-loop-production.up.railway.app
+The self-hosted version is free. Install in 30 seconds: npx rlhf-feedback-loop serve. It works with Claude Code, Codex CLI, Gemini CLI, Amp, and Cursor. All data stays local. The public self-serve commercial offer today is the $9 one-time Pro Pack on Gumroad. Hosted rollout help is pilot/by-request at https://rlhf-feedback-loop-production.up.railway.app
 
 GitHub: https://github.com/IgorGanapolsky/mcp-memory-gateway
 npm: https://www.npmjs.com/package/rlhf-feedback-loop

--- a/docs/marketing/twitter-launch-thread.md
+++ b/docs/marketing/twitter-launch-thread.md
@@ -16,8 +16,8 @@ MCP Memory Gateway gives Claude Code, Codex, and Gemini persistent memory across
 
 Thumbs-up/down feedback → stored locally → queried before every action → repeated failures auto-blocked.
 
-Live hosted at $10/mo:
-https://rlhf-feedback-loop-production.up.railway.app
+Self-serve Pro Pack ($9 one-time):
+https://iganapolsky.gumroad.com/l/tjovof
 
 ---
 
@@ -40,12 +40,12 @@ Under the hood:
 
 ---
 
-**Tweet 5 (social proof / validation):**
+**Tweet 5 (engineering proof / validation):**
 The system was validated using four independent AI agents — Claude, Codex, Amp, Gemini — each running the same test suite against it.
 
 Compatibility report is generated in CI on every push.
 
-This is what dogfooding looks like.
+This is dogfooding and engineering proof, not customer proof.
 
 ---
 
@@ -60,7 +60,6 @@ This does all three.
 
 **Tweet 7 (close + dual CTA):**
 Free self-hosted: npx rlhf-feedback-loop serve
-Hosted ($10/mo): https://rlhf-feedback-loop-production.up.railway.app
+Pro Pack ($9 one-time): https://iganapolsky.gumroad.com/l/tjovof
+Hosted demo: https://rlhf-feedback-loop-production.up.railway.app
 GitHub: https://github.com/IgorGanapolsky/mcp-memory-gateway
-
-First 10 signups get a 30-min setup call. DM me.

--- a/docs/marketing/twitter-thread.md
+++ b/docs/marketing/twitter-thread.md
@@ -48,7 +48,7 @@ All local. All auditable. All yours.
 
 ---
 
-## Tweet 4 (Social proof)
+## Tweet 4 (Engineering proof)
 
 4 AI agents — Claude, Codex, Amp, Gemini — independently evaluated this in the same repo.
 
@@ -56,7 +56,7 @@ All four validated it works.
 
 No orchestration. No prompting to agree. They each ran the tests and passed.
 
-That's the best code review I've ever had.
+That's engineering validation, not customer proof.
 
 #AIAgents
 
@@ -84,8 +84,8 @@ npm install rlhf-feedback-loop
 
 GitHub: github.com/IgorGanapolsky/mcp-memory-gateway
 npm: npmjs.com/package/rlhf-feedback-loop
-Context Gateway ($10/mo): live Stripe checkout on the repo
-Live API: rlhf-feedback-loop-production.up.railway.app
+Pro Pack ($9 one-time): https://iganapolsky.gumroad.com/l/tjovof
+Hosted demo: rlhf-feedback-loop-production.up.railway.app
 
 #DevTools #MCP
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -87,8 +87,9 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
 }
 ```
 
-Get your API key at: https://buy.stripe.com/fZu4gz0I47Dg9G1cGv3sI03 ($10/mo Context Gateway founding price)
-Verification evidence: https://github.com/IgorGanapolsky/rlhf-feedback-loop/blob/main/docs/VERIFICATION_EVIDENCE.md
+Hosted API access is currently pilot/by-request rather than a public self-serve monthly subscription.
+Current self-serve commercial offer: Pro Pack ($9 one-time): https://iganapolsky.gumroad.com/l/tjovof
+Verification evidence: https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/VERIFICATION_EVIDENCE.md
 
 ---
 

--- a/docs/pitch/agentic-commerce.md
+++ b/docs/pitch/agentic-commerce.md
@@ -97,9 +97,9 @@ Export preference pairs for fine-tuning commerce-specific agent models. This is 
 
 - 384 tests, 100% pass rate
 - 5 agent adapters: Claude, Codex, Gemini, Amp, Cursor
-- npm package: `rlhf-feedback-loop` (production-ready)
+- npm package: `rlhf-feedback-loop`
 - Open source: MIT license
-- Trusted by enterprise workflows with 500+ agentic sessions
+- Commercial traction is early; use verification evidence for engineering proof and pilots/orders for market proof
 
 ## Call to Action
 

--- a/pro/README.md
+++ b/pro/README.md
@@ -5,7 +5,7 @@ Production-ready RLHF configurations for AI agent teams.
 ## What's Included
 
 ### 1. Curated Prevention Rules (`prevention-rules-pro.md`)
-Battle-tested rules extracted from 500+ agentic sessions covering:
+Curated rules and presets covering:
 - PR workflow failures (declaring done without evidence)
 - Git push hygiene (thread verification, CI confirmation)
 - Tool misuse patterns (wrong tool for the task)
@@ -48,3 +48,5 @@ npm run self-heal:check
 ## License
 
 Commercial license. Single-team use. See purchase terms on Gumroad.
+
+Current pricing and traction policy: [Commercial Truth](../docs/COMMERCIAL_TRUTH.md)

--- a/pro/prevention-rules-pro.md
+++ b/pro/prevention-rules-pro.md
@@ -1,4 +1,4 @@
-# Pro Prevention Rules — Battle-Tested from 500+ Agentic Sessions
+# Pro Prevention Rules — Curated Production Rules
 
 ## PR Workflow Rules
 

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <title>MCP Memory Gateway Context Gateway | Hosted Guardrails for AI Workflow Teams</title>
   <meta
     name='description'
-    content='Secure your AI workflows with hosted memory, guardrails, and verification evidence. Join as a Founding Member for $10/mo.'
+    content='Free OSS core, a $9 one-time Pro Pack, and hosted pilot workflows for teams that need guardrails with verification evidence.'
   />
   <script type='application/ld+json'>
   {
@@ -24,8 +24,9 @@
     },
     "offers": {
       "@type": "Offer",
-      "price": "10",
-      "priceCurrency": "USD"
+      "price": "9",
+      "priceCurrency": "USD",
+      "description": "One-time Pro Pack on Gumroad for production context-engineering configs."
     },
     "sameAs": [
       "https://github.com/IgorGanapolsky/mcp-memory-gateway",
@@ -600,21 +601,22 @@
           <p>Start where pain is already real: lead-to-meeting, onboarding, or internal ops. Context Gateway is the hosted Veto Layer behind that workflow, not another dashboard full of vague AI claims.</p>
           <div class='hero-proof'>
             <span class='proof-pill'>North Star: one workflow live and auditable</span>
-            <span class='proof-pill'>Founding price: $10/mo</span>
+            <span class='proof-pill'>Self-serve offer: $9 one-time Pro Pack</span>
             <span class='proof-pill'>Versioned proof: v0.6.16</span>
             <span class='proof-pill'>Hosted onboarding at https://rlhf-feedback-loop-production.up.railway.app</span>
           </div>
           <div class='cta-row'>
-            <button class='button primary' id='checkout-btn' type='button'>Start Context Gateway for $10/mo</button>
-            <a class='button secondary' href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md'>Read the 30-day GTM plan</a>
-            <a class='button secondary' href='https://github.com/IgorGanapolsky/mcp-memory-gateway'>View the OSS core</a>
+            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer'>Get Pro Pack — $9 one-time</a>
+            <a class='button secondary' href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/COMMERCIAL_TRUTH.md'>Current commercial truth</a>
+            <a class='button secondary' href='https://rlhf-feedback-loop-production.up.railway.app'>View hosted demo</a>
           </div>
-          <p class='note'>Bought by teams that need shared control. Used by operators and agent runners doing the work. Checkout is owned through the hosted API first, then falls back to the hosted app if checkout creation fails.</p>
+          <p class='note'>Early-stage product. Engineering proof is real, but GitHub stars, npm downloads, and solo-maintainer activity are not customer proof.</p>
+          <p class='note'>Hosted Context Gateway access is pilot/by-request. The public self-serve commercial SKU today is the $9 one-time Pro Pack.</p>
         </div>
 
         <div class='panel hero-card'>
-          <h2>Why teams buy, not just install</h2>
-          <p>Most teams can use the OSS package. They buy Context Gateway when one workflow needs to survive handoffs, approvals, and multiple operators instead of living in scattered local files.</p>
+          <h2>Why teams evaluate it, not just install it</h2>
+          <p>Most teams can use the OSS package. The Pro Pack speeds up local production setup, and hosted pilots make sense when one workflow needs to survive handoffs, approvals, and multiple operators instead of living in scattered local files.</p>
           <ul>
             <li>Replace self-hosted feedback sprawl with a shared operational layer.</li>
             <li>Run the same workflow with shared memory, prevention rules, and hosted keys.</li>
@@ -622,11 +624,11 @@
           </ul>
           <div class='mini-grid'>
             <div class='mini'>
-              <strong>Bought By</strong>
+              <strong>Best fit</strong>
               RevOps, growth, platform, and engineering leaders accountable for one workflow outcome.
             </div>
             <div class='mini'>
-              <strong>Used By</strong>
+              <strong>Daily users</strong>
               Operators and agent runners executing intake, drafting, approval, and sync steps every day.
             </div>
             <div class='mini'>
@@ -634,8 +636,8 @@
               Lead-to-meeting with intake, enrichment, drafting, approval, CRM sync, and auditability.
             </div>
             <div class='mini'>
-              <strong>What stays OSS</strong>
-              Local feedback capture, MCP server, and DPO export remain free while hosted team control is paid.
+              <strong>What is public today</strong>
+              OSS remains free, the Pro Pack is $9 one-time, and hosted pilots are sold directly rather than through a public monthly plan.
             </div>
           </div>
         </div>
@@ -787,8 +789,8 @@
       <div class='section-inner'>
         <div class='section-head'>
           <span class='eyebrow'>Pricing</span>
-          <h2>Keep self-serve cheap. Close the bigger workflow install separately.</h2>
-          <p>The repo remains free. Context Gateway stays at a low-friction founding price while the hosted layer proves onboarding and retention. Services and workflow installs carry the larger ticket.</p>
+          <h2>Keep the public offer honest: free OSS plus a $9 Pro Pack.</h2>
+          <p>The repo remains free. The only current public self-serve commercial SKU is the $9 one-time Pro Pack. Hosted workflow rollouts are pilot/by-request, not a public recurring subscription.</p>
         </div>
         <div class='pricing-grid'>
           <div class='card'>
@@ -803,20 +805,21 @@
             <a class='button secondary' href='https://github.com/IgorGanapolsky/mcp-memory-gateway'>Use the open-source package</a>
           </div>
           <div class='card featured'>
-            <span class='badge'>Founding price</span>
-            <h3>Context Gateway</h3>
-            <div class='price'>$10 <small>/ month</small></div>
-            <p style="font-size: 13px; margin-top: -10px; color: var(--accent-dark);">Founding price while the hosted billing layer proves onboarding and retention.</p>
+            <span class='badge'>Self-serve</span>
+            <h3>Pro Pack</h3>
+            <div class='price'>$9 <small>/ one-time</small></div>
+            <p style="font-size: 13px; margin-top: -10px; color: var(--accent-dark);">Curated production configs for teams that want faster setup without inventing their own guardrails.</p>
             <ul>
-              <li>Hosted HTTPS API</li>
-              <li>Provisioned API key after checkout</li>
-              <li>Shared team memory and funnel events</li>
-              <li>Built for Claude Code, Codex, Gemini, and custom runners</li>
-              <li>Priority support for your first wedge workflow</li>
+              <li>Curated prevention rules</li>
+              <li>Thompson Sampling presets</li>
+              <li>Hook templates and reminder packs</li>
+              <li>Commercial license for the pack contents</li>
+              <li>No recurring subscription required</li>
             </ul>
-            <button class='button primary' id='checkout-btn-bottom' type='button'>Join as Founding Member — $10/mo</button>
+            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer'>Buy Pro Pack — $9</a>
           </div>
         </div>
+        <p class='note'>Need hosted team workflows? Evaluate the demo or request a pilot. Do not describe hosted access as a public recurring subscription until that is actually live.</p>
       </div>
     </section>
   </main>
@@ -827,85 +830,13 @@
       <div>
         <a href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/VERIFICATION_EVIDENCE.md'>Verification evidence</a>
         •
+        <a href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/COMMERCIAL_TRUTH.md'>Commercial truth</a>
+        •
         <a href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md'>GTM plan</a>
         •
         <a href='https://github.com/IgorGanapolsky/mcp-memory-gateway'>GitHub</a>
       </div>
     </div>
   </footer>
-
-  <script>
-    (function () {
-      const canonicalAppOrigin = 'https://rlhf-feedback-loop-production.up.railway.app';
-      const checkoutEndpoint = canonicalAppOrigin + '/v1/billing/checkout';
-      const checkoutFallbackUrl = canonicalAppOrigin;
-      const appOrigin = canonicalAppOrigin;
-      const installStorageKey = 'rlhf_cloud_pro_install_id';
-
-      function getInstallId() {
-        const existing = window.localStorage.getItem(installStorageKey);
-        if (existing) {
-          return existing;
-        }
-
-        const generated = 'inst_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
-        window.localStorage.setItem(installStorageKey, generated);
-        return generated;
-      }
-
-      function createTraceId() {
-        return 'checkout_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
-      }
-
-      async function startCheckout() {
-        const installId = getInstallId();
-        const traceId = createTraceId();
-
-        try {
-          const response = await fetch(checkoutEndpoint, {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json'
-            },
-            body: JSON.stringify({
-              installId,
-              traceId,
-              successUrl: `${appOrigin}/success?session_id={CHECKOUT_SESSION_ID}&trace_id=${encodeURIComponent(traceId)}`,
-              cancelUrl: `${appOrigin}/cancel?trace_id=${encodeURIComponent(traceId)}`,
-              metadata: {
-                source: 'landing_page',
-                origin: appOrigin,
-                traceId
-              }
-            })
-          });
-
-          const body = await response.json();
-          if (!response.ok) {
-            throw new Error(body.error || 'Unable to create checkout session.');
-          }
-
-          if (body.url) {
-            window.location.href = body.url;
-            return;
-          }
-
-          if (body.sessionId) {
-            const redirectTraceId = body.traceId || traceId;
-            window.location.href = `${appOrigin}/success?session_id=${encodeURIComponent(body.sessionId)}&trace_id=${encodeURIComponent(redirectTraceId)}`;
-            return;
-          }
-
-          throw new Error('Checkout response missing redirect target.');
-        } catch (err) {
-          console.error(err);
-          window.location.href = checkoutFallbackUrl;
-        }
-      }
-
-      document.getElementById('checkout-btn').addEventListener('click', startCheckout);
-      document.getElementById('checkout-btn-bottom').addEventListener('click', startCheckout);
-    }());
-  </script>
 </body>
 </html>

--- a/scripts/hosted-config.js
+++ b/scripts/hosted-config.js
@@ -4,7 +4,7 @@ const crypto = require('node:crypto');
 
 const DEFAULT_PUBLIC_APP_ORIGIN = 'https://rlhf-feedback-loop-production.up.railway.app';
 const DEFAULT_CHECKOUT_FALLBACK_URL = DEFAULT_PUBLIC_APP_ORIGIN;
-const DEFAULT_FOUNDING_PRICE = '$10/mo';
+const DEFAULT_FOUNDING_PRICE = '$9 one-time';
 
 function normalizeOrigin(value) {
   if (!value || typeof value !== 'string') {

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -58,9 +58,10 @@ test('root serves the landing page by default', async () => {
   assert.match(body, /GO_TO_MARKET_REVENUE_WEDGE_2026-03\.md/);
   assert.match(body, /proof\/compatibility\/report\.json/);
   assert.match(body, /proof\/automation\/report\.json/);
-  assert.match(body, /https:\/\/billing\.example\.com\/v1\/billing\/checkout/);
-  assert.match(body, /const appOrigin = 'https:\/\/app\.example\.com';/);
-  assert.match(body, /successUrl: `\$\{appOrigin\}\/success\?session_id=\{CHECKOUT_SESSION_ID\}&trace_id=\$\{encodeURIComponent\(traceId\)\}`/);
+  assert.match(body, /Get Pro Pack — \$9 one-time/);
+  assert.match(body, /COMMERCIAL_TRUTH\.md/);
+  assert.match(body, /gumroad\.com/);
+  assert.doesNotMatch(body, /\$10\/mo|Founding Member/);
 });
 
 test('provisioning endpoint works', async () => {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -353,6 +353,15 @@ describe('bin/cli.js', () => {
     assert.ok(result.stdout.includes('prove'), 'Help should mention prove');
   });
 
+  test('pro command prints truthful commercial offer info', () => {
+    const result = spawnSync(process.execPath, [CLI, 'pro'], { encoding: 'utf8' });
+    assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\n${result.stderr}`);
+    assert.match(result.stdout, /Pro Pack \(\$9 one-time\)/);
+    assert.match(result.stdout, /pilot\/by-request/);
+    assert.match(result.stdout, /COMMERCIAL_TRUTH\.md/);
+    assert.doesNotMatch(result.stdout, /\$10\/mo|38 spots remaining|first 50 users|Founding Member/i);
+  });
+
   test('--help flag exits 0', () => {
     const result = spawnSync(process.execPath, [CLI, '--help'], { encoding: 'utf8' });
     assert.strictEqual(result.status, 0);

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -29,10 +29,11 @@ test('public docs render the current package version', () => {
   const mcpSubmission = readText('docs/mcp-hub-submission.md');
 
   assert.match(landingPage, /v__PACKAGE_VERSION__/);
-  assert.match(landingPage, /Join as Founding Member — \$10\/mo/);
+  assert.match(landingPage, /Get Pro Pack — \$9 one-time/);
+  assert.match(landingPage, /Current commercial truth/);
   assert.match(landingPage, /Hosted onboarding at https:\/\/rlhf-feedback-loop-production\.up\.railway\.app/);
-  assert.match(landingPage, /falls back to the hosted app if checkout creation fails/);
-  assert.doesNotMatch(landingPage, /100 spots|50 founding spots/i);
+  assert.doesNotMatch(landingPage, /\$10\/mo|Founding Member/i);
+  assert.doesNotMatch(landingPage, /Bought by teams|100 spots|50 founding spots/i);
   assert.match(mcpSubmission, new RegExp(`## Version\\s+${packageJson.version}`));
 });
 
@@ -66,15 +67,18 @@ test('hosted origin and repository metadata stay canonical across live-facing ar
   assert.match(publicLanding, new RegExp(`Versioned proof: v${packageJson.version.replaceAll('.', '\\.')}`));
   assert.match(publicLanding, new RegExp(`Context Gateway • v${packageJson.version.replaceAll('.', '\\.')}`));
   assert.doesNotMatch(publicLanding, /mcp-gateway\.vercel\.app/);
+  assert.match(publicLanding, /COMMERCIAL_TRUTH\.md/);
+  assert.match(publicLanding, /Get Pro Pack — \$9 one-time/);
   assert.doesNotMatch(publicLanding, /buy\.stripe\.com/);
-  assert.doesNotMatch(publicLanding, /\$5\/mo/);
-  assert.doesNotMatch(publicLanding, /50 spots|38 spots|Join 12 founding members/i);
+  assert.doesNotMatch(publicLanding, /\$10\/mo|Founding Member/i);
+  assert.doesNotMatch(publicLanding, /50 spots|38 spots|Join 12 founding members|Bought by teams|Used by operators/i);
   assert.doesNotMatch(publicLanding, /github\.com\/IgorGanapolsky\/rlhf-feedback-loop/);
 
   assert.match(serverSource, new RegExp(CURRENT_REPOSITORY_URL.replaceAll('.', '\\.')));
   assert.doesNotMatch(serverSource, /github\.com\/IgorGanapolsky\/rlhf-feedback-loop/);
 
-  assert.match(twitterThread, /Live API: rlhf-feedback-loop-production\.up\.railway\.app/);
+  assert.match(twitterThread, /Hosted demo: rlhf-feedback-loop-production\.up\.railway\.app/);
+  assert.match(twitterThread, /engineering validation, not customer proof/i);
   assert.doesNotMatch(twitterThread, /us-central1\.run\.app/);
 });
 
@@ -84,7 +88,7 @@ test('runtime hosted billing config defaults to the live founding price', () => 
 
   try {
     const runtimeConfig = resolveHostedBillingConfig();
-    assert.equal(runtimeConfig.foundingPrice, '$10/mo');
+    assert.equal(runtimeConfig.foundingPrice, '$9 one-time');
     assert.equal(runtimeConfig.checkoutFallbackUrl, CANONICAL_APP_ORIGIN);
   } finally {
     if (previous === undefined) {
@@ -93,4 +97,33 @@ test('runtime hosted billing config defaults to the live founding price', () => 
       process.env.RLHF_FOUNDING_PRICE = previous;
     }
   }
+});
+
+test('commercial truth sources stay aligned across public and historical docs', () => {
+  const commercialTruth = readText('docs/COMMERCIAL_TRUTH.md');
+  const readme = readText('README.md');
+  const proReadme = readText('pro/README.md');
+  const pricingResearch = readText('docs/PRICING_RESEARCH_2026-03-09.md');
+  const crisisReport = readText('docs/PRICING_RESEARCH_2026-03-10.md');
+  const packagingPlan = readText('docs/PACKAGING_AND_SALES_PLAN.md');
+  const revenueSprint = readText('docs/REVENUE_SPRINT_MAR2026.md');
+  const anthropicStrategy = readText('docs/ANTHROPIC_MARKETPLACE_STRATEGY.md');
+  const xStrategy = readText('docs/X_AUTOMATION_STRATEGY.md');
+  const directoryGuide = readText('docs/marketing/mcp-directories.md');
+
+  assert.match(commercialTruth, /Pro Pack on Gumroad: `\$9` one-time/);
+  assert.match(commercialTruth, /pilot\/by-request workflow layer/);
+  assert.match(commercialTruth, /Do not treat GitHub stars, watchers, dependents, or npm download counts as customer or revenue proof/);
+
+  assert.match(readme, /Commercial Truth/);
+  assert.match(proReadme, /Commercial Truth/);
+  assert.doesNotMatch(readme, /500\+ agentic sessions|battle-tested/i);
+  assert.doesNotMatch(proReadme, /500\+ agentic sessions|battle-tested/i);
+
+  for (const historicalDoc of [pricingResearch, crisisReport, packagingPlan, revenueSprint, anthropicStrategy, xStrategy]) {
+    assert.match(historicalDoc, /Historical .*note|Historical .*archived|Historical .*hypothesis/i);
+    assert.match(historicalDoc, /COMMERCIAL_TRUTH\.md/);
+  }
+
+  assert.doesNotMatch(directoryGuide, /30k\+ stars|18k\+ servers listed/i);
 });


### PR DESCRIPTION
## Summary
- add `docs/COMMERCIAL_TRUTH.md` as the repo source of truth for product, pricing, traction, and proof claims
- replace stale self-serve subscription/scarcity language on live-facing surfaces with the current public offer: Pro Pack (`$9` one-time)
- convert legacy pricing and GTM documents to explicit historical context and add guardrail tests to prevent regression

## Verification
- `node --test tests/version-metadata.test.js tests/api-server.test.js tests/cli.test.js`
