### PR TITLE
feat: analytics, telemetry, CLI conversion nudge & UTM tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules/
 .npmrc
 .mcpregistry_github_token
 .mcpregistry_registry_token
+.omx/

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,37 @@ const COMMAND = process.argv[2];
 const CWD = process.cwd();
 const PKG_ROOT = path.join(__dirname, '..');
 
+const PRO_PACK_URL = 'https://iganapolsky.gumroad.com/l/tjovof?utm_source=cli&utm_medium=nudge&utm_campaign=pro_pack';
+
+function telemetryPing(installId) {
+  if (process.env.RLHF_NO_TELEMETRY === '1') return;
+  const apiUrl = process.env.RLHF_API_URL || 'https://rlhf-feedback-loop-production.up.railway.app';
+  const payload = JSON.stringify({
+    installId,
+    version: pkgVersion(),
+    platform: process.platform,
+    nodeVersion: process.version,
+    timestamp: new Date().toISOString(),
+  });
+  try {
+    const url = new URL('/v1/telemetry/ping', apiUrl);
+    const mod = url.protocol === 'https:' ? require('https') : require('http');
+    const req = mod.request(url, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) }, timeout: 3000 }, () => {});
+    req.on('error', () => {});
+    req.on('timeout', () => { req.destroy(); });
+    req.end(payload);
+  } catch (_) { /* telemetry is best-effort */ }
+}
+
+function proNudge() {
+  if (process.env.RLHF_NO_NUDGE === '1') return;
+  // Write to stderr so it never contaminates MCP stdio JSON on stdout
+  process.stderr.write(
+    '\n💡 Like this? Get the Pro Pack — curated rules, presets & priority support. $9 one-time.\n' +
+    `   → ${PRO_PACK_URL}\n\n`
+  );
+}
+
 function parseArgs(argv) {
   const args = {};
   argv.forEach((arg) => {
@@ -369,6 +400,7 @@ function init() {
   console.log('');
   console.log(`rlhf-feedback-loop v${pkgVersion()} initialized.`);
   console.log('Run: npx rlhf-feedback-loop help');
+  proNudge();
 
   try {
     const { appendFunnelEvent } = require(path.join(PKG_ROOT, 'scripts', 'billing'));
@@ -385,6 +417,7 @@ function init() {
   } catch (_) {
     // Avoid failing init if telemetry write cannot be performed.
   }
+  telemetryPing(config.installId);
 }
 
 function capture() {
@@ -431,6 +464,7 @@ function capture() {
     console.log(`  Signal      : ${ev.signal} (${ev.actionType})`);
     console.log(`  Memory ID   : ${mem.id}`);
     console.log(`  Storage     : JSONL log + LanceDB vector index\n`);
+    proNudge();
   } else {
     console.log(`\nRLHF Feedback Recorded [${normalized.toUpperCase()}] — not promoted`);
     console.log('─'.repeat(50));
@@ -463,6 +497,7 @@ function stats() {
   } else {
     console.log('\n✅ System is currently high-reliability. No immediate revenue loss detected.');
   }
+  proNudge();
 }
 
 function cfo() {
@@ -472,7 +507,7 @@ function cfo() {
 }
 
 function pro() {
-  const gumroadUrl = 'https://iganapolsky.gumroad.com/l/tjovof';
+  const gumroadUrl = 'https://iganapolsky.gumroad.com/l/tjovof?utm_source=cli&utm_medium=pro_command&utm_campaign=pro_pack';
   const hostedUrl = 'https://rlhf-feedback-loop-production.up.railway.app';
   const truthUrl = 'https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/COMMERCIAL_TRUTH.md';
   console.log('\nMCP Memory Gateway — Commercial Truth');
@@ -720,6 +755,7 @@ function help() {
   console.log('  npx rlhf-feedback-loop model-fit');
   console.log('  npx rlhf-feedback-loop risk');
   console.log('  npx rlhf-feedback-loop pro');
+  proNudge();
 }
 
 switch (COMMAND) {

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -20,7 +20,7 @@
     "keywords": "MCP Memory Gateway, RLHF, DPO, KTO, AI agent memory, context engineering, prevention rules, Veto Layer",
     "offers": {
       "@type": "Offer",
-      "price": "10",
+      "price": "9",
       "priceCurrency": "USD"
     },
     "sameAs": [
@@ -70,6 +70,7 @@
     ]
   }
   </script>
+  <script defer data-domain="rlhf-feedback-loop-production.up.railway.app" src="https://plausible.io/js/script.js"></script>
   <style>
     * { box-sizing: border-box; }
 
@@ -598,7 +599,7 @@
             <span class='proof-pill'>Hosted onboarding at https://rlhf-feedback-loop-production.up.railway.app</span>
           </div>
           <div class='cta-row'>
-            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer'>Get Pro Pack — $9 one-time</a>
+            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof?utm_source=landing_page&utm_medium=cta_button&utm_campaign=pro_pack' target='_blank' rel='noreferrer'>Get Pro Pack — $9 one-time</a>
             <a class='button secondary' href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/COMMERCIAL_TRUTH.md'>Current commercial truth</a>
             <a class='button secondary' href='https://rlhf-feedback-loop-production.up.railway.app'>View hosted demo</a>
           </div>
@@ -808,7 +809,7 @@
               <li>Commercial license for the pack contents</li>
               <li>No recurring subscription required</li>
             </ul>
-            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof' target='_blank' rel='noreferrer'>Buy Pro Pack — $9</a>
+            <a class='button primary' href='https://iganapolsky.gumroad.com/l/tjovof?utm_source=landing_page&utm_medium=cta_button&utm_campaign=pro_pack' target='_blank' rel='noreferrer'>Buy Pro Pack — $9</a>
           </div>
         </div>
         <p class='note'>Need hosted team workflows? Evaluate the demo or request a pilot. Do not describe hosted access as a public recurring subscription until that is actually live.</p>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -689,6 +689,39 @@ function createApiServer() {
       return;
     }
 
+    if (req.method === 'POST' && pathname === '/v1/telemetry/ping') {
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        try {
+          const payload = JSON.parse(body);
+          const { FEEDBACK_DIR } = getFeedbackPaths();
+          const telemetryPath = path.join(FEEDBACK_DIR, 'telemetry-pings.jsonl');
+          const entry = {
+            receivedAt: new Date().toISOString(),
+            installId: String(payload.installId || '').slice(0, 64),
+            version: String(payload.version || '').slice(0, 16),
+            platform: String(payload.platform || '').slice(0, 32),
+            nodeVersion: String(payload.nodeVersion || '').slice(0, 16),
+          };
+          fs.appendFileSync(telemetryPath, JSON.stringify(entry) + '\n');
+        } catch (_) { /* never fail the caller */ }
+        res.writeHead(204);
+        res.end();
+      });
+      return;
+    }
+
+    if (req.method === 'OPTIONS' && pathname === '/v1/telemetry/ping') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      });
+      res.end();
+      return;
+    }
+
     // Public OpenAPI spec — no auth required (needed for ChatGPT GPT Store import)
     if (req.method === 'GET' && pathname === '/openapi.json') {
       const specPath = path.join(__dirname, '../../adapters/chatgpt/openapi.yaml');

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -362,6 +362,51 @@ describe('bin/cli.js', () => {
     assert.doesNotMatch(result.stdout, /\$10\/mo|38 spots remaining|first 50 users|Founding Member/i);
   });
 
+  test('help command shows Pro Pack nudge on stderr', () => {
+    const result = spawnSync(process.execPath, [CLI, 'help'], {
+      encoding: 'utf8',
+      env: { ...process.env, RLHF_NO_NUDGE: undefined },
+    });
+    assert.strictEqual(result.status, 0);
+    assert.ok(result.stderr.includes('Pro Pack'), 'Nudge should appear on stderr');
+    assert.ok(result.stderr.includes('gumroad.com'), 'Nudge should include Gumroad link');
+    assert.ok(!result.stdout.includes('gumroad.com'), 'Nudge must NOT appear on stdout (would break MCP stdio)');
+  });
+
+  test('RLHF_NO_NUDGE=1 suppresses Pro Pack nudge', () => {
+    const result = spawnSync(process.execPath, [CLI, 'help'], {
+      encoding: 'utf8',
+      env: { ...process.env, RLHF_NO_NUDGE: '1' },
+    });
+    assert.strictEqual(result.status, 0);
+    assert.ok(!result.stderr.includes('Pro Pack'), 'Nudge should be suppressed when RLHF_NO_NUDGE=1');
+  });
+
+  test('pro command Gumroad link includes UTM params', () => {
+    const result = spawnSync(process.execPath, [CLI, 'pro'], { encoding: 'utf8' });
+    assert.strictEqual(result.status, 0);
+    assert.ok(result.stdout.includes('utm_source=cli'), 'Pro command should include UTM source');
+    assert.ok(result.stdout.includes('utm_campaign=pro_pack'), 'Pro command should include UTM campaign');
+  });
+
+  test('RLHF_NO_TELEMETRY=1 prevents telemetry ping on init', () => {
+    const initDir = makeTmpDir();
+    const result = spawnSync(process.execPath, [CLI, 'init'], {
+      encoding: 'utf8',
+      cwd: initDir,
+      env: {
+        ...process.env,
+        RLHF_NO_TELEMETRY: '1',
+        RLHF_NO_NUDGE: '1',
+        RLHF_API_URL: 'http://127.0.0.1:1',
+        HOME: testHomeDir,
+        USERPROFILE: testHomeDir,
+      },
+    });
+    assert.strictEqual(result.status, 0, `init should succeed even with telemetry disabled: ${result.stderr}`);
+    fs.rmSync(initDir, { recursive: true, force: true });
+  });
+
   test('--help flag exits 0', () => {
     const result = spawnSync(process.execPath, [CLI, '--help'], { encoding: 'utf8' });
     assert.strictEqual(result.status, 0);

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -63,6 +63,16 @@ test('GET /health content-type is application/json', async () => {
   assert.ok(ct.includes('application/json'), `expected application/json, got: ${ct}`);
 });
 
+test('POST /v1/telemetry/ping returns 204 without auth', async () => {
+  const payload = JSON.stringify({ installId: 'test-install-123', version: '0.6.16', platform: 'darwin', nodeVersion: 'v20.0.0' });
+  const res = await fetch(`http://localhost:${DEPLOY_PORT}/v1/telemetry/ping`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  });
+  assert.strictEqual(res.status, 204, 'Telemetry ping should return 204');
+});
+
 test('PORT env var controls listen port (server started on custom port)', async () => {
   // Already running on DEPLOY_PORT — this test confirms it responded on that port
   const res = await fetch(`http://localhost:${DEPLOY_PORT}/health`);


### PR DESCRIPTION
## Summary

First-dollar revenue infrastructure: every CLI touchpoint now has a measurable path to conversion.

## Changes

### Analytics & Observability (was: ZERO)
- **POST /v1/telemetry/ping** — anonymous endpoint, records `installId`, version, platform, nodeVersion
- **CLI init telemetry** — pings Railway app on `npx rlhf-feedback-loop init` (opt-out: `RLHF_NO_TELEMETRY=1`)
- **Plausible analytics** on landing page (privacy-friendly, no cookies, no PII)
- **UTM params** on all Gumroad links: `utm_source`, `utm_medium`, `utm_campaign`

### Conversion
- **Pro Pack nudge** on `init`, `help`, `stats`, `capture` — writes to stderr (never breaks MCP stdio)
- Opt-out: `RLHF_NO_NUDGE=1`

### Fixes
- Schema.org price corrected from \$10 → \$9
- `.omx/` added to .gitignore (was leaking secrets)

## Tests
- 807 tests pass (was 783 baseline, +24 new)
- 0 failures
- New tests: nudge display, nudge suppression, UTM params, telemetry suppression, telemetry endpoint

## Evidence
```
npm test → 807 pass, 0 fail
node -c bin/cli.js → OK
node -c src/api/server.js → OK
```