### PR TITLE
feat!: complete package rename to mcp-memory-gateway v0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,20 +1,20 @@
 {
-  "name": "rlhf-feedback-loop",
-  "version": "0.6.6",
+  "name": "mcp-memory-gateway",
+  "version": "0.7.0",
   "plugins": [
     {
-      "name": "rlhf-feedback-loop",
+      "name": "mcp-memory-gateway",
       "description": "RLHF feedback loop for AI agents — capture feedback, block mistakes, export DPO training pairs",
       "type": "mcp",
       "source": {
         "type": "npm",
-        "package": "rlhf-feedback-loop",
+        "package": "mcp-memory-gateway",
         "command": "npx",
-        "args": ["-y", "rlhf-feedback-loop", "serve"]
+        "args": ["-y", "mcp-memory-gateway", "serve"]
       },
       "metadata": {
         "author": "Igor Ganapolsky",
-        "homepage": "https://github.com/IgorGanapolsky/rlhf-feedback-loop",
+        "homepage": "https://github.com/IgorGanapolsky/mcp-memory-gateway",
         "license": "MIT",
         "keywords": ["rlhf", "feedback", "dpo", "mcp", "prevention-rules", "memory"],
         "category": "developer-tools"

--- a/.claude/scripts/feedback/capture-feedback.js
+++ b/.claude/scripts/feedback/capture-feedback.js
@@ -110,7 +110,7 @@ function main() {
     console.log(`  Storage     : JSONL log + LanceDB vector index`);
     console.log('');
     console.log(`  Action: promoted to reusable memory. Prevention rules will auto-update.`);
-    console.log(`  DPO export: run \`npx rlhf-feedback-loop export-dpo\` to generate training pairs.`);
+    console.log(`  DPO export: run \`npx mcp-memory-gateway export-dpo\` to generate training pairs.`);
     console.log('');
     return;
   }

--- a/.github/MARKETPLACE_ANALYSIS.md
+++ b/.github/MARKETPLACE_ANALYSIS.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-03-11
 **Product**: MCP Memory Gateway
-**npm**: rlhf-feedback-loop
+**npm**: mcp-memory-gateway
 **Repo**: IgorGanapolsky/mcp-memory-gateway
 **Live URL**: https://rlhf-feedback-loop-production.up.railway.app
 
@@ -74,7 +74,7 @@ GitHub Marketplace supports **only two categories**:
 
 MCP Memory Gateway is:
 - A protocol server (Model Context Protocol)
-- An npm package (`rlhf-feedback-loop`)
+- An npm package (`mcp-memory-gateway`)
 - An agent integration tool
 - A data persistence/memory service
 
@@ -112,7 +112,7 @@ None of these are GitHub-native workflows. While we *could* create a GitHub App 
 
 ### Secondary: npm Package Registry
 
-The `rlhf-feedback-loop` package is already on npm and discoverable.
+The `mcp-memory-gateway` package is already on npm and discoverable.
 
 ### Tertiary: Documentation & Blog
 

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,5 +1,5 @@
 {
-  "name": "rlhf-feedback-loop",
+  "name": "mcp-memory-gateway",
   "version": "0.7.0",
   "description": "Production RLHF & DPO data pipeline for AI agents. Capture human preference signals, generate automated guardrails, and export DPO training pairs.",
   "homepage": "https://github.com/IgorGanapolsky/mcp-memory-gateway",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MCP Memory Gateway
 
-[![CI](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/ci.yml)
-[![Self-Healing](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/self-healing-monitor.yml/badge.svg)](https://github.com/IgorGanapolsky/rlhf-feedback-loop/actions/workflows/self-healing-monitor.yml)
-[![npm](https://img.shields.io/npm/v/rlhf-feedback-loop)](https://www.npmjs.com/package/rlhf-feedback-loop)
+[![CI](https://github.com/IgorGanapolsky/mcp-memory-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/mcp-memory-gateway/actions/workflows/ci.yml)
+[![Self-Healing](https://github.com/IgorGanapolsky/mcp-memory-gateway/actions/workflows/self-healing-monitor.yml/badge.svg)](https://github.com/IgorGanapolsky/mcp-memory-gateway/actions/workflows/self-healing-monitor.yml)
+[![npm](https://img.shields.io/npm/v/mcp-memory-gateway)](https://www.npmjs.com/package/mcp-memory-gateway)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.18.0-brightgreen)](package.json)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github)](https://github.com/sponsors/IgorGanapolsky)
@@ -44,18 +44,18 @@ feedback signal → validate → promote to memory → vector index → preventi
 
 ```bash
 # Recommended: essential profile (5 high-ROI tools)
-claude mcp add rlhf -- npx -y rlhf-feedback-loop serve
-codex mcp add rlhf -- npx -y rlhf-feedback-loop serve
-amp mcp add rlhf -- npx -y rlhf-feedback-loop serve
-gemini mcp add rlhf "npx -y rlhf-feedback-loop serve"
+claude mcp add rlhf -- npx -y mcp-memory-gateway serve
+codex mcp add rlhf -- npx -y mcp-memory-gateway serve
+amp mcp add rlhf -- npx -y mcp-memory-gateway serve
+gemini mcp add rlhf "npx -y mcp-memory-gateway serve"
 
 # Or auto-detect all installed platforms
-npx rlhf-feedback-loop init
+npx mcp-memory-gateway init
 
 # Auto-wire PreToolUse hooks (blocks known mistakes before they happen)
-npx rlhf-feedback-loop init --agent claude-code
-npx rlhf-feedback-loop init --agent codex
-npx rlhf-feedback-loop init --agent gemini
+npx mcp-memory-gateway init --agent claude-code
+npx mcp-memory-gateway init --agent codex
+npx mcp-memory-gateway init --agent gemini
 ```
 
 > **Profiles:** Set `RLHF_MCP_PROFILE=essential` for the lean 5-tool setup (recommended), or leave unset for the full 11-tool pipeline. See [MCP Tools](#mcp-tools) for details.
@@ -148,7 +148,7 @@ npx rlhf-feedback-loop dashboard
 These 5 tools deliver ~80% of the value. Use the `essential` profile for a lean setup:
 
 ```bash
-RLHF_MCP_PROFILE=essential claude mcp add rlhf -- npx -y rlhf-feedback-loop serve
+RLHF_MCP_PROFILE=essential claude mcp add rlhf -- npx -y mcp-memory-gateway serve
 ```
 
 | Tool | Description |
@@ -178,20 +178,20 @@ These tools support fine-tuning workflows, context engineering, and audit trails
 ## CLI
 
 ```bash
-npx rlhf-feedback-loop init              # Scaffold .rlhf/ + configure MCP
-npx rlhf-feedback-loop init --agent X    # + auto-wire PreToolUse hooks (claude-code/codex/gemini)
-npx rlhf-feedback-loop init --wire-hooks # Wire hooks only (auto-detect agent)
-npx rlhf-feedback-loop serve             # Start MCP server (stdio) + watcher
-npx rlhf-feedback-loop dashboard         # Full RLHF dashboard with gate stats
-npx rlhf-feedback-loop gate-stats        # Gate enforcement statistics
-npx rlhf-feedback-loop status            # Learning curve dashboard
-npx rlhf-feedback-loop watch             # Watch .rlhf/ for external signals
-npx rlhf-feedback-loop capture           # Capture feedback via CLI
-npx rlhf-feedback-loop stats             # Analytics + Revenue-at-Risk
-npx rlhf-feedback-loop rules             # Generate prevention rules
-npx rlhf-feedback-loop export-dpo        # Export DPO training pairs
-npx rlhf-feedback-loop risk              # Train/query boosted risk scorer
-npx rlhf-feedback-loop self-heal         # Run self-healing diagnostics
+npx mcp-memory-gateway init              # Scaffold .rlhf/ + configure MCP
+npx mcp-memory-gateway init --agent X    # + auto-wire PreToolUse hooks (claude-code/codex/gemini)
+npx mcp-memory-gateway init --wire-hooks # Wire hooks only (auto-detect agent)
+npx mcp-memory-gateway serve             # Start MCP server (stdio) + watcher
+npx mcp-memory-gateway dashboard         # Full RLHF dashboard with gate stats
+npx mcp-memory-gateway gate-stats        # Gate enforcement statistics
+npx mcp-memory-gateway status            # Learning curve dashboard
+npx mcp-memory-gateway watch             # Watch .rlhf/ for external signals
+npx mcp-memory-gateway capture           # Capture feedback via CLI
+npx mcp-memory-gateway stats             # Analytics + Revenue-at-Risk
+npx mcp-memory-gateway rules             # Generate prevention rules
+npx mcp-memory-gateway export-dpo        # Export DPO training pairs
+npx mcp-memory-gateway risk              # Train/query boosted risk scorer
+npx mcp-memory-gateway self-heal         # Run self-healing diagnostics
 ```
 
 ## JSONL File Watcher
@@ -200,10 +200,10 @@ The `serve` command automatically starts a background watcher that monitors `fee
 
 ```bash
 # Standalone watcher
-npx rlhf-feedback-loop watch --source amp-plugin-bridge
+npx mcp-memory-gateway watch --source amp-plugin-bridge
 
 # Process pending entries once and exit
-npx rlhf-feedback-loop watch --once
+npx mcp-memory-gateway watch --once
 ```
 
 External sources write entries with a `source` field:
@@ -216,7 +216,7 @@ The watcher tracks its position via `.rlhf/.watcher-offset` for crash-safe, idem
 ## Feedback Dashboard
 
 ```bash
-npx rlhf-feedback-loop status
+npx mcp-memory-gateway status
 ```
 
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: rlhf-feedback-loop
+name: mcp-memory-gateway
 description: The Agentic Feedback Studio & Veto Layer. Persistent agent memory, high-density context packs, and Agentic Guardrails (V2V) for Claude Code, Codex, and Gemini.
 ---
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -2,7 +2,7 @@
 tracker:
   kind: linear
   api_key: $LINEAR_API_KEY
-  project_slug: 'rlhf-feedback-loop'
+  project_slug: 'mcp-memory-gateway'
   active_states:
     - 'Ready for Agent'
     - 'In Progress'
@@ -19,7 +19,7 @@ workspace:
   root: $SYMPHONY_WORKSPACE_ROOT
 hooks:
   after_create: |
-    git clone --depth 1 https://github.com/IgorGanapolsky/rlhf-feedback-loop.git .
+    git clone --depth 1 https://github.com/IgorGanapolsky/mcp-memory-gateway.git .
     npm ci
   before_run: |
     git fetch origin --prune
@@ -42,7 +42,7 @@ codex:
 
 # MCP Memory Gateway Agent Workflow
 
-You are implementing work inside the `rlhf-feedback-loop` repository. Deliver the ticket outcome with no dead code, no vague completion claims, and proof that the result works.
+You are implementing work inside the `mcp-memory-gateway` repository. Deliver the ticket outcome with no dead code, no vague completion claims, and proof that the result works.
 
 ## Scope
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,6 +3,6 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx -y rlhf-feedback-loop@0.7.0 serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx -y mcp-memory-gateway@0.7.0 serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/rlhf-feedback/SKILL.md`: Amp skill template.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.7.0", "serve"]
+      "args": ["-y", "mcp-memory-gateway@0.7.0", "serve"]
     }
   }
 }

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -1,4 +1,4 @@
 # Codex MCP profile (copy into ~/.codex/config.toml or merge section)
 [mcp_servers.rlhf]
 command = "npx"
-args = ["-y", "rlhf-feedback-loop@0.7.0", "serve"]
+args = ["-y", "mcp-memory-gateway@0.7.0", "serve"]

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -53,7 +53,7 @@ const {
 } = require('../../scripts/gate-satisfy');
 
 const SERVER_INFO = {
-  name: 'rlhf-feedback-loop-mcp',
+  name: 'mcp-memory-gateway-mcp',
   version: '1.1.0',
 };
 const SAFE_DATA_DIR = path.resolve(path.dirname(FEEDBACK_LOG_PATH));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 /**
- * rlhf-feedback-loop CLI
+ * mcp-memory-gateway CLI
  *
  * Usage:
- *   npx rlhf-feedback-loop init          # scaffold .rlhf/ config + .mcp.json
- *   npx rlhf-feedback-loop init --wire-hooks          # wire hooks only (auto-detect agent)
- *   npx rlhf-feedback-loop init --agent claude-code   # scaffold + wire hooks for specific agent
- *   npx rlhf-feedback-loop capture       # capture feedback
- *   npx rlhf-feedback-loop export-dpo    # export DPO training pairs
- *   npx rlhf-feedback-loop stats         # feedback analytics + Revenue-at-Risk
- *   npx rlhf-feedback-loop cfo           # local operational billing summary
- *   npx rlhf-feedback-loop pro           # upgrade to Context Gateway
+ *   npx mcp-memory-gateway init          # scaffold .rlhf/ config + .mcp.json
+ *   npx mcp-memory-gateway init --wire-hooks          # wire hooks only (auto-detect agent)
+ *   npx mcp-memory-gateway init --agent claude-code   # scaffold + wire hooks for specific agent
+ *   npx mcp-memory-gateway capture       # capture feedback
+ *   npx mcp-memory-gateway export-dpo    # export DPO training pairs
+ *   npx mcp-memory-gateway stats         # feedback analytics + Revenue-at-Risk
+ *   npx mcp-memory-gateway cfo           # local operational billing summary
+ *   npx mcp-memory-gateway pro           # upgrade to Context Gateway
  */
 
 'use strict';
@@ -79,7 +79,7 @@ const PORTABLE_MCP_COMMAND = 'npx';
 const LOCAL_MCP_COMMAND = 'node';
 
 function portableMcpArgs() {
-  return ['-y', `rlhf-feedback-loop@${pkgVersion()}`, 'serve'];
+  return ['-y', `mcp-memory-gateway@${pkgVersion()}`, 'serve'];
 }
 
 function localServerEntryPath() {
@@ -439,8 +439,8 @@ function init() {
   }
 
   console.log('');
-  console.log(`rlhf-feedback-loop v${pkgVersion()} initialized.`);
-  console.log('Run: npx rlhf-feedback-loop help');
+  console.log(`mcp-memory-gateway v${pkgVersion()} initialized.`);
+  console.log('Run: npx mcp-memory-gateway help');
   proNudge();
 
   try {
@@ -532,9 +532,9 @@ function stats() {
     console.log('\n⚠️  REVENUE-AT-RISK ANALYSIS');
     console.log(`  Repeated Failures detected: ${data.totalNegative}`);
     console.log(`  Estimated Operational Loss: $${revenueAtRisk}`);
-    console.log('  Action Required: Run "npx rlhf-feedback-loop rules" to generate guardrails.');
+    console.log('  Action Required: Run "npx mcp-memory-gateway rules" to generate guardrails.');
     console.log('  Strategic Recommendation: Upgrade to Context Gateway to sync these rules across your team.');
-    console.log('  Run: npx rlhf-feedback-loop pro');
+    console.log('  Run: npx mcp-memory-gateway pro');
   } else {
     console.log('\n✅ System is currently high-reliability. No immediate revenue loss detected.');
   }
@@ -784,7 +784,7 @@ function startApi() {
 
 function help() {
   const v = pkgVersion();
-  console.log(`rlhf-feedback-loop v${v}`);
+  console.log(`mcp-memory-gateway v${v}`);
   console.log('');
   console.log('Commands:');
   console.log('  init                  Scaffold .rlhf/ config + MCP server in current project');
@@ -815,12 +815,12 @@ function help() {
   console.log('  help                  Show this help message');
   console.log('');
   console.log('Examples:');
-  console.log('  npx rlhf-feedback-loop init');
-  console.log('  npx rlhf-feedback-loop stats');
-  console.log('  npx rlhf-feedback-loop cfo');
-  console.log('  npx rlhf-feedback-loop model-fit');
-  console.log('  npx rlhf-feedback-loop risk');
-  console.log('  npx rlhf-feedback-loop pro');
+  console.log('  npx mcp-memory-gateway init');
+  console.log('  npx mcp-memory-gateway stats');
+  console.log('  npx mcp-memory-gateway cfo');
+  console.log('  npx mcp-memory-gateway model-fit');
+  console.log('  npx mcp-memory-gateway risk');
+  console.log('  npx mcp-memory-gateway pro');
   proNudge();
 }
 
@@ -906,7 +906,7 @@ switch (COMMAND) {
   default:
     if (COMMAND) {
       console.error(`Unknown command: ${COMMAND}`);
-      console.error('Run: npx rlhf-feedback-loop help');
+      console.error('Run: npx mcp-memory-gateway help');
       process.exit(1);
     } else {
       help();

--- a/docs/AUTONOMOUS_GITOPS.md
+++ b/docs/AUTONOMOUS_GITOPS.md
@@ -40,7 +40,7 @@ This repo uses PR-gated autonomous automation. No direct merge-to-main shortcuts
 ## Secret Sync Helper
 
 ```bash
-bash scripts/sync-gh-secrets-from-env.sh IgorGanapolsky/rlhf-feedback-loop
+bash scripts/sync-gh-secrets-from-env.sh IgorGanapolsky/mcp-memory-gateway
 ```
 
 The helper only sets keys present in your local environment.

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -7,7 +7,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 
 ## What is true today
 
-- The open-source `rlhf-feedback-loop` package is free and MIT licensed.
+- The open-source `mcp-memory-gateway` package is free and MIT licensed.
 - The current public self-serve commercial offer is the Pro Pack on Gumroad: `$9` one-time.
 - Hosted Context Gateway access exists as a pilot/by-request workflow layer. It is not a public self-serve recurring subscription.
 - Engineering verification is strong and should be cited through `docs/VERIFICATION_EVIDENCE.md` and machine-readable proof reports.

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -30,12 +30,12 @@ This avoids platform-specific rewrite cost and keeps the product under a `$10/mo
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y rlhf-feedback-loop@0.6.11 serve`
+- Transport: local stdio MCP server launched via `npx -y mcp-memory-gateway@0.7.0 serve`
 
 ## Codex (MCP)
 
 - Merge section from `adapters/codex/config.toml`
-- Transport: local stdio MCP server launched via `npx -y rlhf-feedback-loop@0.6.11 serve`
+- Transport: local stdio MCP server launched via `npx -y mcp-memory-gateway@0.7.0 serve`
 
 ## Gemini (Function Calling)
 

--- a/docs/REVENUE_SPRINT_MAR2026.md
+++ b/docs/REVENUE_SPRINT_MAR2026.md
@@ -118,7 +118,7 @@ Retired experiment: the `$5/mo`, `$10/mo`, and scarcity-based tiers below are pr
 
 | Tier | Price | What's Included | Conversion Target |
 |------|-------|-----------------|-------------------|
-| **Free** | $0 | `npx rlhf-feedback-loop serve` local, 1000 feedback captures/mo | Funnel entry |
+| **Free** | $0 | `npx mcp-memory-gateway serve` local, 1000 feedback captures/mo | Funnel entry |
 | **Founding Member** | **$5/mo forever** (locked, first 50 users) | Hosted gateway, 10K captures/mo, team sharing (3 seats), DPO export, dashboard | **Day-1 conversion** |
 | **Pro** | $10/mo | 50K captures/mo, 10 seats, priority support, custom guardrails | Standard |
 | **Team** | $29/mo | Unlimited captures, unlimited seats, SSO, audit log, SLA | Upsell target |
@@ -191,7 +191,7 @@ Title: "I built persistent memory for Claude Code — never lose context between
 Body:
 - Problem: Claude forgets everything between sessions
 - Solution: MCP Memory Gateway captures feedback, prevents repeated mistakes
-- Free: npx rlhf-feedback-loop serve
+- Free: npx mcp-memory-gateway serve
 - Hosted: $5/mo founding member (50 spots)
 - Demo: [Railway URL]
 - GitHub: [repo URL]

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -67,7 +67,7 @@ Status:
 
 Scope:
 
-- Version sync across `package.json`, `mcpize.yaml`, and `server.json` to `v0.6.16`.
+- Version sync across `package.json`, `mcpize.yaml`, and `server.json` to `v0.7.0`.
 - Historical pricing experiment: tested a "Founding Member $5/mo" offer and urgency hooks before the current commercial-truth correction.
 - Discovery optimization: Added high-ROI GitHub topics and updated `SKILL.md` auto-indexing keywords.
 - Launch content package: Created `docs/marketing/LAUNCH_CONTENT.md` with Reddit, HN, and Discord assets.
@@ -217,7 +217,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y rlhf-feedback-loop@0.6.11 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y mcp-memory-gateway@0.7.0 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.rlhf` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -597,7 +597,7 @@ Scope:
 
 - Added a portable `npm run test:coverage` command using Node's built-in coverage for `tests/**/*.test.js`.
 - Removed the unused `stripe` SDK dependency; billing continues to use direct HTTPS calls in `scripts/billing.js`.
-- Synced published version metadata across MCP manifests and public docs to `0.6.11`.
+- Synced published version metadata across MCP manifests and public docs to `0.7.0`.
 - Refreshed active proof artifacts and pruned stale milestone-era proof files that were no longer referenced.
 
 Commands run:

--- a/docs/feature-requests/amp-feedback-signal-hook.md
+++ b/docs/feature-requests/amp-feedback-signal-hook.md
@@ -48,7 +48,7 @@ When a feedback signal is given, Amp calls a designated MCP tool (e.g., `capture
 
 ## Context
 
-The [rlhf-feedback-loop](https://github.com/IgorGanapolsky/rlhf-feedback-loop) npm package already has full receiving infrastructure:
+The [mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway) npm package already has full receiving infrastructure:
 - `captureFeedback()` engine in `scripts/feedback-loop.js`
 - `capture_feedback` MCP tool in `adapters/mcp/server-stdio.js`
 - JSONL logging, DPO export, self-audit, prevention rules

--- a/docs/gpt-store-submission.md
+++ b/docs/gpt-store-submission.md
@@ -82,7 +82,7 @@ To import into GPT Builder:
 2. Paste the contents of `adapters/chatgpt/openapi.yaml`
 3. Set authentication to: **API Key** → Header name: `Authorization` → Format: `Bearer {key}`
 4. Server URL: `https://rlhf-feedback-loop-production.up.railway.app`
-5. Verification evidence: `https://github.com/IgorGanapolsky/rlhf-feedback-loop/blob/main/docs/VERIFICATION_EVIDENCE.md`
+5. Verification evidence: `https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/VERIFICATION_EVIDENCE.md`
 
 ### Inline Schema (minimal version for quick submission)
 
@@ -205,7 +205,7 @@ A simple icon: blue feedback loop arrow (circular) with a thumbs-up/thumbs-down 
 ## Privacy Policy URL
 
 ```
-https://github.com/IgorGanapolsky/rlhf-feedback-loop/blob/main/SECURITY.md
+https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/SECURITY.md
 ```
 
 ---

--- a/docs/guides/mcp-use-integration.md
+++ b/docs/guides/mcp-use-integration.md
@@ -17,7 +17,7 @@ client = MCPClient.from_dict({
         },
         "memory": {
             "command": "npx",
-            "args": ["-y", "rlhf-feedback-loop", "serve"]
+            "args": ["-y", "mcp-memory-gateway", "serve"]
         }
     }
 })
@@ -54,7 +54,7 @@ import { MCPClient } from "mcp-use";
 const client = new MCPClient({
   mcpServers: {
     "your-server": { command: "your-existing-server", args: ["..."] },
-    "memory": { command: "npx", args: ["-y", "rlhf-feedback-loop", "serve"] }
+    "memory": { command: "npx", args: ["-y", "mcp-memory-gateway", "serve"] }
   }
 });
 ```
@@ -88,7 +88,7 @@ httpx.post(f"{API}/v1/feedback/capture", headers=headers, json={
 For agentic commerce use cases, use the `commerce` MCP profile:
 
 ```bash
-RLHF_MCP_PROFILE=commerce npx rlhf-feedback-loop serve
+RLHF_MCP_PROFILE=commerce npx mcp-memory-gateway serve
 ```
 
 This exposes `commerce_recall` with quality scores for: product_recommendation, brand_compliance, sizing, pricing, regulatory.
@@ -97,4 +97,4 @@ This exposes `commerce_recall` with quality scores for: product_recommendation, 
 
 - [MCP Memory Gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway)
 - [mcp-use SDK](https://github.com/mcp-use/mcp-use)
-- [npm package](https://www.npmjs.com/package/rlhf-feedback-loop)
+- [npm package](https://www.npmjs.com/package/mcp-memory-gateway)

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -6,7 +6,7 @@
   <title>MCP Memory Gateway | Local-First RLHF & Context Hub for AI Agents</title>
   <meta
     name='description'
-    content='Build better AI agents with MCP Memory Gateway – local RLHF feedback, reusable memories via MCP, prevention rules, and KTO/DPO fine-tuning. Open-source, npm rlhf-feedback-loop for developers.'
+    content='Build better AI agents with MCP Memory Gateway – local RLHF feedback, reusable memories via MCP, prevention rules, and KTO/DPO fine-tuning. Open-source, npm mcp-memory-gateway for developers.'
   />
   <script type='application/ld+json'>
   {
@@ -56,7 +56,7 @@
         "name": "How does MCP Memory Gateway handle RLHF feedback loops?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "It implements an npm package 'rlhf-feedback-loop' that captures thumbs-up/down signals locally, stores them as reusable MCP resources or prompts, and automates generation of prevention rules to avoid repeated agent failures."
+          "text": "It implements an npm package 'mcp-memory-gateway' that captures thumbs-up/down signals locally, stores them as reusable MCP resources or prompts, and automates generation of prevention rules to avoid repeated agent failures."
         }
       },
       {

--- a/docs/marketing/LAUNCH_CONTENT.md
+++ b/docs/marketing/LAUNCH_CONTENT.md
@@ -12,13 +12,13 @@ It's called **Agentic Feedback Studio**.
 - **Problem:** Claude forgets what we decided yesterday. Subjective instructions (vibes) don't stick.
 - **Solution:** A Veto Layer that captures feedback (up/down) and converts it into hard architectural constraints (`CLAUDE.md`) automatically.
 - **Features:** 
-  - Zero-Config: Drop it into any repo with `npx rlhf-feedback-loop install`.
+  - Zero-Config: Drop it into any repo with `npx mcp-memory-gateway install`.
   - Bayesian Preference Scoring: Thompson Sampling models your preferences in real-time.
   - DPO/KTO Export: Turn your sessions into training data for fine-tuning.
 - **Open Source:** Totally free for solo devs.
 - **Commercial:** The public self-serve offer today is the **$9 one-time Pro Pack**. Hosted pilots are by request.
 
-Check it out on GitHub: [https://github.com/IgorGanapolsky/rlhf-feedback-loop]
+Check it out on GitHub: [https://github.com/IgorGanapolsky/mcp-memory-gateway]
 Demo/Hosted: [https://mcp-memory-gateway.up.railway.app]
 
 Would love to hear how you're managing long-term agent memory!
@@ -41,9 +41,9 @@ I built an Agentic Control Plane that implements:
 
 It works with any MCP-compatible agent (Claude Code, Codex, Gemini).
 
-**Zero-Config:** Drop it into any repo with one command: `npx rlhf-feedback-loop install`
+**Zero-Config:** Drop it into any repo with one command: `npx mcp-memory-gateway install`
 
-GitHub: [https://github.com/IgorGanapolsky/rlhf-feedback-loop]
+GitHub: [https://github.com/IgorGanapolsky/mcp-memory-gateway]
 Landing Page: [https://mcp-memory-gateway.up.railway.app]
 
 I'm here all day to answer technical questions about Agentic Control Planes!
@@ -57,12 +57,12 @@ I'm here all day to answer technical questions about Agentic Control Planes!
 
 Stop vibe-coding. If Claude makes a mistake, flag it, and the Studio generates a hard guardrail in your `CLAUDE.md` so it never happens again.
 
-- 🛠 **Zero-Config:** `npx rlhf-feedback-loop install`
+- 🛠 **Zero-Config:** `npx mcp-memory-gateway install`
 - 🧠 **Smart Memory:** Vector storage via LanceDB + Bayesian reward estimation.
 - ⚡ **Global Skill:** Install once, use across all your repos.
 
 OSS is free. The public self-serve offer is the $9 one-time Pro Pack.
-Repo: https://github.com/IgorGanapolsky/rlhf-feedback-loop
+Repo: https://github.com/IgorGanapolsky/mcp-memory-gateway
 Live: https://mcp-memory-gateway.up.railway.app
 
 ---
@@ -70,4 +70,4 @@ Live: https://mcp-memory-gateway.up.railway.app
 ## 4. Cold Outreach Hooks (Twitter DM / LinkedIn)
 
 - **Hook 1:** "I saw your work on [Project]. We're building a Veto Layer for agent fleets to stop them from repeating expensive hallucinations. Would love your feedback on the Zero-Config setup."
-- **Hook 2:** "Running Claude Code in production? We built a Revenue-at-Risk analyzer that calculates exactly how much money you lose to repeated agent failures. Try it: `npx rlhf-feedback-loop stats`."
+- **Hook 2:** "Running Claude Code in production? We built a Revenue-at-Risk analyzer that calculates exactly how much money you lose to repeated agent failures. Try it: `npx mcp-memory-gateway stats`."

--- a/docs/marketing/cold-outreach-sequence.md
+++ b/docs/marketing/cold-outreach-sequence.md
@@ -25,7 +25,7 @@ Hi {{First Name}},
 
 Following up on my last email. One of the biggest hurdles to adopting an Agentic Control Plane is the setup.
 
-That's why we made the Agentic Feedback Studio **Zero-Config**. You literally just drop `npx rlhf-feedback-loop install` into a repository, and it auto-discovers the context, integrating directly with Claude, Gemini, or Copilot via MCP. 
+That's why we made the Agentic Feedback Studio **Zero-Config**. You literally just drop `npx mcp-memory-gateway install` into a repository, and it auto-discovers the context, integrating directly with Claude, Gemini, or Copilot via MCP. 
 
 For teams that outgrow local-only use, we offer hosted pilot access by direct arrangement. The only public self-serve commercial SKU today is the $9 one-time Pro Pack.
 
@@ -41,9 +41,9 @@ Hi {{First Name}},
 
 Looks like timing isn't right to discuss agentic governance and the Veto Layer. 
 
-I'll leave you with our open-source repo. If your team starts feeling the pain of repeated AI hallucinations, you can run our Revenue-at-Risk analyzer locally (`npx rlhf-feedback-loop stats`) to see exactly what it's costing you.
+I'll leave you with our open-source repo. If your team starts feeling the pain of repeated AI hallucinations, you can run our Revenue-at-Risk analyzer locally (`npx mcp-memory-gateway stats`) to see exactly what it's costing you.
 
-Link: https://github.com/IgorGanapolsky/rlhf-feedback-loop
+Link: https://github.com/IgorGanapolsky/mcp-memory-gateway
 
 Best,
 Igor

--- a/docs/marketing/devto-article.md
+++ b/docs/marketing/devto-article.md
@@ -21,9 +21,9 @@ AI coding agents (Claude, Codex, Gemini, Cursor, Amp) are stateless by default. 
 
 The missing piece is not a better model. It is a persistent feedback signal that the agent can read before it acts.
 
-## The Solution: rlhf-feedback-loop
+## The Solution: mcp-memory-gateway
 
-[rlhf-feedback-loop](https://github.com/IgorGanapolsky/rlhf-feedback-loop) is an MCP server that gives your agent a memory. You rate its work (thumbs up or down), and those signals get captured, indexed, and turned into actionable rules — automatically.
+[mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway) is an MCP server that gives your agent a memory. You rate its work (thumbs up or down), and those signals get captured, indexed, and turned into actionable rules — automatically.
 
 The architecture is simple:
 
@@ -59,19 +59,19 @@ Pick your platform:
 
 ```bash
 # Claude
-claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
+claude mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
 
 # Codex
-codex mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
+codex mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
 
 # Gemini
-gemini mcp add rlhf "npx -y rlhf-feedback-loop@0.6.11 serve"
+gemini mcp add rlhf "npx -y mcp-memory-gateway@0.7.0 serve"
 
 # Amp
-amp mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
+amp mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
 
 # Cursor
-cursor mcp add rlhf -- npx -y rlhf-feedback-loop@0.6.11 serve
+cursor mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
 ```
 
 Run once per project. The MCP server starts automatically on each session after that.
@@ -123,5 +123,5 @@ The feedback loop is running in production on my own projects. The roadmap:
 
 If your AI agent keeps making the same mistakes, it does not need a bigger context window. It needs a feedback loop.
 
-**GitHub:** [github.com/IgorGanapolsky/rlhf-feedback-loop](https://github.com/IgorGanapolsky/rlhf-feedback-loop)
-**npm:** [npmjs.com/package/rlhf-feedback-loop](https://www.npmjs.com/package/rlhf-feedback-loop)
+**GitHub:** [github.com/IgorGanapolsky/mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway)
+**npm:** [npmjs.com/package/mcp-memory-gateway](https://www.npmjs.com/package/mcp-memory-gateway)

--- a/docs/marketing/devto-blog-post.md
+++ b/docs/marketing/devto-blog-post.md
@@ -30,11 +30,11 @@ The core loop of the Agentic Feedback Studio is the V2V pipeline. It turns subje
 ## Run the Revenue-at-Risk Analyzer
 Every time an agent repeats a mistake, it costs you developer time. We built a Revenue-at-Risk analyzer directly into the CLI. 
 
-Run `npx rlhf-feedback-loop stats` in any project, and it will calculate the estimated operational loss caused by repeated agent failures based on your local logs.
+Run `npx mcp-memory-gateway stats` in any project, and it will calculate the estimated operational loss caused by repeated agent failures based on your local logs.
 
 **Stop Vibe Coding. Start Context Engineering.**
 
 Try it now:
 ```bash
-npx rlhf-feedback-loop install
+npx mcp-memory-gateway install
 ```

--- a/docs/marketing/mcp-directories.md
+++ b/docs/marketing/mcp-directories.md
@@ -2,9 +2,9 @@
 
 > Research note: external repo stars, directory size, and community reach numbers in this file are time-bound research snapshots, not current product proof. Use `docs/COMMERCIAL_TRUTH.md` for current traction language.
 
-**Package:** `rlhf-feedback-loop` (npm)
-**GitHub:** https://github.com/IgorGanapolsky/rlhf-feedback-loop
-**Registry name:** `io.github.IgorGanapolsky/rlhf-feedback-loop`
+**Package:** `mcp-memory-gateway` (npm)
+**GitHub:** https://github.com/IgorGanapolsky/mcp-memory-gateway
+**Registry name:** `io.github.IgorGanapolsky/mcp-memory-gateway`
 **Already listed:** [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)
 
 ---
@@ -27,7 +27,7 @@
 - Valid `package.json` with `repository` field
 - MCP-compatible server implementation
 
-**URL pattern once listed:** `https://glama.ai/mcp/servers/@IgorGanapolsky/rlhf-feedback-loop`
+**URL pattern once listed:** `https://glama.ai/mcp/servers/@IgorGanapolsky/mcp-memory-gateway`
 
 ---
 
@@ -42,12 +42,12 @@
 ### Option A: Web UI (simplest)
 1. Go to https://smithery.ai/new
 2. Sign in with GitHub
-3. Provide your GitHub repo URL: `https://github.com/IgorGanapolsky/rlhf-feedback-loop`
+3. Provide your GitHub repo URL: `https://github.com/IgorGanapolsky/mcp-memory-gateway`
 4. Follow the guided setup
 
 ### Option B: CLI
 1. Install: `npm i -g @smithery/cli`
-2. Publish: `smithery mcp publish "https://github.com/IgorGanapolsky/rlhf-feedback-loop" -n IgorGanapolsky/rlhf-feedback-loop`
+2. Publish: `smithery mcp publish "https://github.com/IgorGanapolsky/mcp-memory-gateway" -n IgorGanapolsky/mcp-memory-gateway`
 
 ### Required: Add `smithery.yaml` to repo root
 
@@ -67,7 +67,7 @@ startCommand:
     command: "npx"
     args:
       - "-y"
-      - "rlhf-feedback-loop"
+      - "mcp-memory-gateway"
 ```
 
 **Requirements:**
@@ -107,12 +107,12 @@ Go to: https://github.com/chatmcp/mcpso/issues/1
 
 Leave a comment with:
 ```
-**rlhf-feedback-loop**
-https://github.com/IgorGanapolsky/rlhf-feedback-loop
+**mcp-memory-gateway**
+https://github.com/IgorGanapolsky/mcp-memory-gateway
 
 RLHF feedback loop for AI agents. Capture feedback, block mistakes, export DPO training data. Compatible with Claude, GPT-4, Gemini, and multi-agent systems.
 
-- npm: https://www.npmjs.com/package/rlhf-feedback-loop
+- npm: https://www.npmjs.com/package/mcp-memory-gateway
 - Transport: stdio
 - Runtime: Node.js
 ```
@@ -139,8 +139,8 @@ There are three major lists. Submit to all of them.
 1. Fork the repo
 2. Edit `README.md`
 3. Add entry under the appropriate category (likely "AI/LLM Integration" or "Data & Analytics")
-4. Format: `- [rlhf-feedback-loop](https://github.com/IgorGanapolsky/rlhf-feedback-loop) - RLHF feedback loop for AI agents. Capture feedback, block repeated mistakes, export DPO training pairs.`
-5. Submit PR with title: `Add rlhf-feedback-loop`
+4. Format: `- [mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway) - RLHF feedback loop for AI agents. Capture feedback, block repeated mistakes, export DPO training pairs.`
+5. Submit PR with title: `Add mcp-memory-gateway`
 
 ### 5b. appcypher/awesome-mcp-servers (well-established)
 **URL:** https://github.com/appcypher/awesome-mcp-servers
@@ -149,7 +149,7 @@ There are three major lists. Submit to all of them.
 1. Fork the repo
 2. Edit `README.md`
 3. Add entry under appropriate category
-4. Format: `- **[rlhf-feedback-loop](https://github.com/IgorGanapolsky/rlhf-feedback-loop)** - RLHF feedback loop for AI agents. Capture feedback, block repeated mistakes, export DPO training data. (Node.js)`
+4. Format: `- **[mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway)** - RLHF feedback loop for AI agents. Capture feedback, block repeated mistakes, export DPO training data. (Node.js)`
 5. Submit PR
 
 ### 5c. wong2/awesome-mcp-servers → mcpservers.org
@@ -179,22 +179,22 @@ There are three major lists. Submit to all of them.
 
 ### Entry text (punkpeye format):
 ```markdown
-- [rlhf-feedback-loop](https://github.com/IgorGanapolsky/rlhf-feedback-loop) - RLHF feedback loop for AI agents. Capture feedback, block repeated mistakes, export DPO training pairs.
+- [mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway) - RLHF feedback loop for AI agents. Capture feedback, block repeated mistakes, export DPO training pairs.
 ```
 
 ### Entry text (appcypher format):
 ```markdown
-- **[rlhf-feedback-loop](https://github.com/IgorGanapolsky/rlhf-feedback-loop)** - RLHF feedback loop for AI agents with feedback capture, mistake prevention, and DPO data export. (Node.js)
+- **[mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway)** - RLHF feedback loop for AI agents with feedback capture, mistake prevention, and DPO data export. (Node.js)
 ```
 
 ### mcp.so comment (ready to paste):
 ```
-**rlhf-feedback-loop**
-https://github.com/IgorGanapolsky/rlhf-feedback-loop
+**mcp-memory-gateway**
+https://github.com/IgorGanapolsky/mcp-memory-gateway
 
 RLHF feedback loop for AI agents. Capture feedback, block mistakes, export DPO training data.
 
-- npm: https://www.npmjs.com/package/rlhf-feedback-loop
+- npm: https://www.npmjs.com/package/mcp-memory-gateway
 - MCP Registry: https://registry.modelcontextprotocol.io
 - Transport: stdio
 - Runtime: Node.js

--- a/docs/marketing/product-hunt-launch.md
+++ b/docs/marketing/product-hunt-launch.md
@@ -26,9 +26,9 @@ It provides a **Veto Layer** for your workflows.
 2️⃣ The Studio extracts the semantic state of the failure.
 3️⃣ It auto-generates a hard architectural constraint (`CLAUDE.md`) that blocks the agent from repeating the mistake. 
 
-It is completely Zero-Config. Run `npx rlhf-feedback-loop install` in any repo, and it just works. 
+It is completely Zero-Config. Run `npx mcp-memory-gateway install` in any repo, and it just works. 
 
-**Bonus:** Run `npx rlhf-feedback-loop stats` to see our **Revenue-at-Risk Analyzer**, which calculates exactly how much money you are losing to repeated agent failures.
+**Bonus:** Run `npx mcp-memory-gateway stats` to see our **Revenue-at-Risk Analyzer**, which calculates exactly how much money you are losing to repeated agent failures.
 
 We are entirely open source, with a Context Gateway tier for teams who want to sync their Veto rules globally. 
 

--- a/docs/marketing/reddit-posts.md
+++ b/docs/marketing/reddit-posts.md
@@ -1,4 +1,4 @@
-# Reddit Posts for rlhf-feedback-loop
+# Reddit Posts for mcp-memory-gateway
 
 ---
 
@@ -12,7 +12,7 @@
 
 I've been working on a problem: when AI coding agents make mistakes and you correct them, that preference signal just disappears. There's no structured way to collect it and feed it back into training.
 
-So I built `rlhf-feedback-loop` -- an MCP server that sits inside your coding agent session and captures explicit up/down feedback with full context. The key feature for this community: it exports DPO-ready training pairs in JSONL format (chosen/rejected with prompt context), so you can actually use real human preference data for fine-tuning.
+So I built `mcp-memory-gateway` -- an MCP server that sits inside your coding agent session and captures explicit up/down feedback with full context. The key feature for this community: it exports DPO-ready training pairs in JSONL format (chosen/rejected with prompt context), so you can actually use real human preference data for fine-tuning.
 
 The pipeline: capture feedback -> validate against schema -> detect repeated failure patterns -> generate prevention rules -> export DPO pairs. It also tracks rubric scores and guardrail metadata per interaction.
 
@@ -20,7 +20,7 @@ It's agent-agnostic (Claude, Codex, Gemini, Cursor, Amp), runs locally, stores e
 
 MIT licensed. Feedback and critique welcome -- especially on the DPO export format.
 
-https://github.com/IgorGanapolsky/rlhf-feedback-loop
+https://github.com/IgorGanapolsky/mcp-memory-gateway
 
 ---
 
@@ -32,21 +32,21 @@ https://github.com/IgorGanapolsky/rlhf-feedback-loop
 
 **Body:**
 
-If you're fine-tuning local models and need preference data, I built a tool that might help. `rlhf-feedback-loop` runs entirely on your machine, stores everything in JSONL files (no cloud, no telemetry), and exports DPO training pairs you can feed into TRL/axolotl/whatever your training stack is.
+If you're fine-tuning local models and need preference data, I built a tool that might help. `mcp-memory-gateway` runs entirely on your machine, stores everything in JSONL files (no cloud, no telemetry), and exports DPO training pairs you can feed into TRL/axolotl/whatever your training stack is.
 
 How it works: you give thumbs up/down feedback during coding sessions with an AI agent. The tool captures the context, the agent's output, and your signal. Over time it builds a dataset of chosen/rejected pairs with full prompt context. It also detects repeated mistakes and generates prevention rules so the agent stops making the same errors.
 
 Everything is file-based. Feedback log, memory log, prevention rules -- all local JSONL/JSON/Markdown. No database, no API keys required for core functionality.
 
 ```bash
-npm install -g rlhf-feedback-loop
+npm install -g mcp-memory-gateway
 ```
 
 Works as an MCP server with Claude, Codex, Gemini, Cursor, and Amp. But the real value for this sub is the exported training data.
 
 MIT licensed. Would love feedback from anyone doing local fine-tuning on preference data.
 
-https://github.com/IgorGanapolsky/rlhf-feedback-loop
+https://github.com/IgorGanapolsky/mcp-memory-gateway
 
 ---
 
@@ -58,14 +58,14 @@ https://github.com/IgorGanapolsky/rlhf-feedback-loop
 
 **Body:**
 
-I built an MCP server called `rlhf-feedback-loop` that adds a structured feedback loop to Claude. When Claude does something well, you mark it up. When it fails, you mark it down with context. The server captures these signals, promotes validated patterns to memory, and generates prevention rules from repeated mistakes.
+I built an MCP server called `mcp-memory-gateway` that adds a structured feedback loop to Claude. When Claude does something well, you mark it up. When it fails, you mark it down with context. The server captures these signals, promotes validated patterns to memory, and generates prevention rules from repeated mistakes.
 
 The result: Claude stops repeating the same errors because the MCP server feeds prevention rules back into context. It's not magic -- it's just structured recall backed by real preference data.
 
 One-command install:
 
 ```bash
-npx rlhf-feedback-loop init
+npx mcp-memory-gateway init
 ```
 
 This drops a `.mcp.json` into your project and you're running. No config files to hand-edit.
@@ -74,4 +74,4 @@ It also exports DPO training pairs if you want to go further, but the immediate 
 
 Works with Claude Code, Claude Desktop, and also supports Codex, Gemini, Cursor, and Amp. All data stays local in JSONL files. MIT licensed.
 
-https://github.com/IgorGanapolsky/rlhf-feedback-loop
+https://github.com/IgorGanapolsky/mcp-memory-gateway

--- a/docs/marketing/show-hn.md
+++ b/docs/marketing/show-hn.md
@@ -11,10 +11,10 @@ Every time you start a new Claude Code, Codex, or Gemini session, your agent for
 
 MCP Memory Gateway is an MCP server that gives AI agents a persistent feedback memory. During any session you give a thumbs-up or thumbs-down with brief context. That signal gets written to a local JSONL log and indexed with LanceDB. On future sessions the agent queries that history before acting, so it stops repeating known-bad approaches. Three or more identical failures auto-generate a CLAUDE.md prevention rule. You can also export all the data as DPO pairs (chosen/rejected) for fine-tuning.
 
-The self-hosted version is free. Install in 30 seconds: npx rlhf-feedback-loop serve. It works with Claude Code, Codex CLI, Gemini CLI, Amp, and Cursor. All data stays local. The public self-serve commercial offer today is the $9 one-time Pro Pack on Gumroad. Hosted rollout help is pilot/by-request at https://rlhf-feedback-loop-production.up.railway.app
+The self-hosted version is free. Install in 30 seconds: npx mcp-memory-gateway serve. It works with Claude Code, Codex CLI, Gemini CLI, Amp, and Cursor. All data stays local. The public self-serve commercial offer today is the $9 one-time Pro Pack on Gumroad. Hosted rollout help is pilot/by-request at https://rlhf-feedback-loop-production.up.railway.app
 
 GitHub: https://github.com/IgorGanapolsky/mcp-memory-gateway
-npm: https://www.npmjs.com/package/rlhf-feedback-loop
+npm: https://www.npmjs.com/package/mcp-memory-gateway
 Live hosted: https://rlhf-feedback-loop-production.up.railway.app
 
 Happy to answer questions on the protocol, the DPO export format, or how the prevention-rule generation works.

--- a/docs/marketing/twitter-launch-thread.md
+++ b/docs/marketing/twitter-launch-thread.md
@@ -24,7 +24,7 @@ https://iganapolsky.gumroad.com/l/tjovof
 **Tweet 3 (free self-hosted CTA):**
 Self-hosting is free and takes 30 seconds.
 
-npx rlhf-feedback-loop serve
+npx mcp-memory-gateway serve
 
 That's it. Works with Claude Code, Codex CLI, Gemini CLI, Amp, Cursor. All data stays on your machine.
 
@@ -59,7 +59,7 @@ This does all three.
 ---
 
 **Tweet 7 (close + dual CTA):**
-Free self-hosted: npx rlhf-feedback-loop serve
+Free self-hosted: npx mcp-memory-gateway serve
 Pro Pack ($9 one-time): https://iganapolsky.gumroad.com/l/tjovof
 Hosted demo: https://rlhf-feedback-loop-production.up.railway.app
 GitHub: https://github.com/IgorGanapolsky/mcp-memory-gateway

--- a/docs/marketing/twitter-thread.md
+++ b/docs/marketing/twitter-thread.md
@@ -1,4 +1,4 @@
-# X/Twitter Launch Thread — rlhf-feedback-loop
+# X/Twitter Launch Thread — mcp-memory-gateway
 
 > Draft thread. Do not post without review.
 
@@ -8,7 +8,7 @@
 
 I got tired of my AI agent making the same mistakes across sessions. So I built an MCP server that captures feedback and blocks repeated failures.
 
-rlhf-feedback-loop — open source, works with Claude/Codex/Gemini/Amp/Cursor.
+mcp-memory-gateway — open source, works with Claude/Codex/Gemini/Amp/Cursor.
 
 #MCP #AIAgents #DevTools
 
@@ -19,7 +19,7 @@ rlhf-feedback-loop — open source, works with Claude/Codex/Gemini/Amp/Cursor.
 One command. Zero config.
 
 ```
-npx rlhf-feedback-loop
+npx mcp-memory-gateway
 ```
 
 It's an MCP server that plugs into Claude, Codex, Gemini, Amp, or Cursor.
@@ -79,11 +79,11 @@ Feed them into your fine-tuning pipeline. Make your agent actually improve, not 
 Get started:
 
 ```
-npm install rlhf-feedback-loop
+npm install mcp-memory-gateway
 ```
 
 GitHub: github.com/IgorGanapolsky/mcp-memory-gateway
-npm: npmjs.com/package/rlhf-feedback-loop
+npm: npmjs.com/package/mcp-memory-gateway
 Pro Pack ($9 one-time): https://iganapolsky.gumroad.com/l/tjovof
 Hosted demo: rlhf-feedback-loop-production.up.railway.app
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -15,7 +15,7 @@ Also submit to: https://mcp.so (community MCP directory)
 ## Server Name
 
 ```
-rlhf-feedback-loop
+mcp-memory-gateway
 ```
 
 ---
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add rlhf -- npx -y rlhf-feedback-loop@0.7.0 serve
+claude mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.7.0", "serve"],
+      "args": ["-y", "mcp-memory-gateway@0.7.0", "serve"],
       "env": {
         "RLHF_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "rlhf-feedback-loop@0.7.0", "serve"],
+      "args": ["-y", "mcp-memory-gateway@0.7.0", "serve"],
       "env": {
         "RLHF_BASE_URL": "https://rlhf-feedback-loop-production.up.railway.app",
         "RLHF_API_KEY": "rlhf_YOUR_KEY_HERE"
@@ -124,7 +124,7 @@ Verification evidence: https://github.com/IgorGanapolsky/mcp-memory-gateway/blob
 
 ## Transport
 
-- **stdio** (primary): `npx -y rlhf-feedback-loop@0.7.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y mcp-memory-gateway@0.7.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -132,7 +132,7 @@ Verification evidence: https://github.com/IgorGanapolsky/mcp-memory-gateway/blob
 ## Repository
 
 ```
-https://github.com/IgorGanapolsky/rlhf-feedback-loop
+https://github.com/IgorGanapolsky/mcp-memory-gateway
 ```
 
 ---
@@ -140,12 +140,12 @@ https://github.com/IgorGanapolsky/rlhf-feedback-loop
 ## npm Package
 
 ```
-https://www.npmjs.com/package/rlhf-feedback-loop
+https://www.npmjs.com/package/mcp-memory-gateway
 ```
 
 Install:
 ```bash
-npm install rlhf-feedback-loop
+npm install mcp-memory-gateway
 ```
 
 ---
@@ -190,15 +190,15 @@ npm test
 - [ ] Fork https://github.com/modelcontextprotocol/servers
 - [ ] Add entry to `README.md` under **Community Servers** in alphabetical order:
   ```markdown
-  - **[MCP Memory Gateway](https://github.com/IgorGanapolsky/rlhf-feedback-loop)** — Capture feedback from AI coding agents, prevent repeated mistakes, export DPO training pairs. Works with Claude Code, ChatGPT, Gemini, Codex, and Amp.
+  - **[MCP Memory Gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway)** — Capture feedback from AI coding agents, prevent repeated mistakes, export DPO training pairs. Works with Claude Code, ChatGPT, Gemini, Codex, and Amp.
   ```
-- [ ] Open PR titled: `Add rlhf-feedback-loop community server`
+- [ ] Open PR titled: `Add mcp-memory-gateway community server`
 - [ ] Verify CI passes on the PR
 
 ## Submission Checklist (mcp.so)
 
 - [ ] Go to https://mcp.so/submit
-- [ ] Paste GitHub URL: `https://github.com/IgorGanapolsky/rlhf-feedback-loop`
+- [ ] Paste GitHub URL: `https://github.com/IgorGanapolsky/mcp-memory-gateway`
 - [ ] Verify auto-populated fields (name, description, tools)
 - [ ] Add tags: `rlhf`, `feedback`, `dpo`, `coding-agent`
 - [ ] Submit

--- a/docs/pitch/agentic-commerce.md
+++ b/docs/pitch/agentic-commerce.md
@@ -59,7 +59,7 @@ UCP, ACP, and AMP all support MCP transport. Our server runs as a standard MCP t
 - **DPO export**: Training data to fine-tune platform-specific shopping agents
 
 ### For Agent Builders (OpenAI, Google, Anthropic ecosystem)
-- **Drop-in MCP server**: `claude mcp add rlhf -- npx -y rlhf-feedback-loop serve`
+- **Drop-in MCP server**: `claude mcp add rlhf -- npx -y mcp-memory-gateway serve`
 - **Protocol-native**: Works with UCP, ACP, AMP without custom adapters
 - **Local-first**: No data leaves the merchant's infrastructure
 
@@ -97,7 +97,7 @@ Export preference pairs for fine-tuning commerce-specific agent models. This is 
 
 - 384 tests, 100% pass rate
 - 5 agent adapters: Claude, Codex, Gemini, Amp, Cursor
-- npm package: `rlhf-feedback-loop`
+- npm package: `mcp-memory-gateway`
 - Open source: MIT license
 - Commercial traction is early; use verification evidence for engineering proof and pilots/orders for market proof
 
@@ -113,4 +113,4 @@ Export preference pairs for fine-tuning commerce-specific agent models. This is 
 
 Contact: Igor Ganapolsky, CEO
 GitHub: https://github.com/IgorGanapolsky/mcp-memory-gateway
-npm: https://www.npmjs.com/package/rlhf-feedback-loop
+npm: https://www.npmjs.com/package/mcp-memory-gateway

--- a/plugins/amp-skill/INSTALL.md
+++ b/plugins/amp-skill/INSTALL.md
@@ -11,8 +11,8 @@ cp plugins/amp-skill/SKILL.md .amp/skills/rlhf-feedback.md
 Or from the npm package:
 
 ```bash
-npx rlhf-feedback-loop init
-cp node_modules/rlhf-feedback-loop/plugins/amp-skill/SKILL.md .amp/skills/rlhf-feedback.md
+npx mcp-memory-gateway init
+cp node_modules/mcp-memory-gateway/plugins/amp-skill/SKILL.md .amp/skills/rlhf-feedback.md
 ```
 
 ## What This Does
@@ -43,7 +43,7 @@ node .rlhf/capture-feedback.js --feedback=down --context="..." --what-went-wrong
 
 - Amp (any version with skills support)
 - Node.js 18+ in PATH
-- `.rlhf/` directory (created by `npx rlhf-feedback-loop init`)
+- `.rlhf/` directory (created by `npx mcp-memory-gateway init`)
 
 ## Uninstall
 

--- a/plugins/amp-skill/SKILL.md
+++ b/plugins/amp-skill/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: rlhf-feedback
-description: Dual-write feedback to Amp MCP memory AND rlhf-feedback-loop for DPO export, analytics, and cross-platform portability
+description: Dual-write feedback to Amp MCP memory AND mcp-memory-gateway for DPO export, analytics, and cross-platform portability
 ---
 
 # RLHF Feedback Skill (Dual-Write)
 
 This skill captures feedback in TWO places simultaneously:
 1. **Amp MCP memory** — for immediate in-session recall (native to Amp)
-2. **rlhf-feedback-loop** — for DPO export, LanceDB vectors, prevention rules, and cross-platform analytics
+2. **mcp-memory-gateway** — for DPO export, LanceDB vectors, prevention rules, and cross-platform analytics
 
 ## On thumbs up / positive feedback
 
@@ -16,9 +16,9 @@ First, store in Amp's native memory for in-session recall:
 Use mcp__memory__remember to store: "GOOD: {context}. What worked: {details}"
 ```
 
-Then, pipe to rlhf-feedback-loop for DPO export and analytics:
+Then, pipe to mcp-memory-gateway for DPO export and analytics:
 ```bash
-npx -y rlhf-feedback-loop capture --feedback=up --context="..." --what-worked="..." --tags="..."
+npx -y mcp-memory-gateway capture --feedback=up --context="..." --what-worked="..." --tags="..."
 ```
 
 ## On thumbs down / negative feedback
@@ -28,9 +28,9 @@ First, store in Amp's native memory so the mistake is recalled immediately:
 Use mcp__memory__remember to store: "BAD: {context}. What went wrong: {details}. Fix: {what to change}"
 ```
 
-Then, pipe to rlhf-feedback-loop for prevention rules and DPO pairs:
+Then, pipe to mcp-memory-gateway for prevention rules and DPO pairs:
 ```bash
-npx -y rlhf-feedback-loop capture --feedback=down --context="..." --what-went-wrong="..." --what-to-change="..." --tags="..."
+npx -y mcp-memory-gateway capture --feedback=down --context="..." --what-went-wrong="..." --what-to-change="..." --tags="..."
 ```
 
 ## Before starting a new task
@@ -40,9 +40,9 @@ Recall from Amp's memory (instant, in-session):
 Use mcp__memory__recall with query describing the current task
 ```
 
-Also check rlhf-feedback-loop for cross-session prevention rules:
+Also check mcp-memory-gateway for cross-session prevention rules:
 ```bash
-npx -y rlhf-feedback-loop rules
+npx -y mcp-memory-gateway rules
 ```
 
 ## Triggers
@@ -56,7 +56,7 @@ npx -y rlhf-feedback-loop rules
 
 ## Why dual-write?
 
-Amp's MCP memory gives you instant in-session recall. rlhf-feedback-loop gives you:
+Amp's MCP memory gives you instant in-session recall. mcp-memory-gateway gives you:
 - **DPO training pairs** for fine-tuning your model
 - **Prevention rules** that block repeated mistakes
 - **Cross-platform portability** — same feedback works in Claude, Codex, Gemini

--- a/plugins/claude-skill/INSTALL.md
+++ b/plugins/claude-skill/INSTALL.md
@@ -11,8 +11,8 @@ cp plugins/claude-skill/SKILL.md .claude/skills/rlhf-feedback.md
 Or from the published npm package:
 
 ```bash
-npx rlhf-feedback-loop init
-cp node_modules/rlhf-feedback-loop/plugins/claude-skill/SKILL.md .claude/skills/rlhf-feedback.md
+npx mcp-memory-gateway init
+cp node_modules/mcp-memory-gateway/plugins/claude-skill/SKILL.md .claude/skills/rlhf-feedback.md
 ```
 
 ## What This Does
@@ -46,7 +46,7 @@ node .rlhf/capture-feedback.js --feedback=up --context="skill install verified" 
 
 - Claude Code (any version)
 - Node.js 18+ in PATH
-- `.rlhf/` directory (created by `npx rlhf-feedback-loop init`)
+- `.rlhf/` directory (created by `npx mcp-memory-gateway init`)
 
 ## Uninstall
 

--- a/scripts/context-engine.js
+++ b/scripts/context-engine.js
@@ -9,7 +9,7 @@
  * topical bundles and route queries to the most relevant subset. This reduces
  * MCP tool calls and context window consumption.
  *
- * Ported from Subway_RN_Demo/scripts/context-engine.js for rlhf-feedback-loop.
+ * Ported from Subway_RN_Demo/scripts/context-engine.js for mcp-memory-gateway.
  * PATH: PROJECT_ROOT = path.join(__dirname, '..') — 1 level up from scripts/
  */
 

--- a/scripts/contract-audit.js
+++ b/scripts/contract-audit.js
@@ -94,7 +94,7 @@ function buildMarkdownReport(results) {
   lines.push('');
   lines.push(`Generated: ${now}`);
   lines.push('');
-  lines.push('This report is machine-generated evidence for CNTR-01: export mapping audit confirming compatibility between rlhf-feedback-loop and Subway_RN_Demo shared scripts.');
+  lines.push('This report is machine-generated evidence for CNTR-01: export mapping audit confirming compatibility between mcp-memory-gateway and Subway_RN_Demo shared scripts.');
   lines.push('');
 
   for (const result of results) {

--- a/scripts/install-mcp.js
+++ b/scripts/install-mcp.js
@@ -22,7 +22,7 @@ const PKG_VERSION = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, 'package.json
 function portableMcpConfig() {
   return {
     command: 'npx',
-    args: ['-y', `rlhf-feedback-loop@${PKG_VERSION}`, 'serve'],
+    args: ['-y', `mcp-memory-gateway@${PKG_VERSION}`, 'serve'],
   };
 }
 

--- a/scripts/perplexity-marketing.js
+++ b/scripts/perplexity-marketing.js
@@ -28,7 +28,7 @@ const SONAR_URL = 'https://api.perplexity.ai/chat/completions';
 
 const PRODUCT = {
   name: 'MCP Memory Gateway',
-  npm: 'rlhf-feedback-loop',
+  npm: 'mcp-memory-gateway',
   repo: 'https://github.com/IgorGanapolsky/mcp-memory-gateway',
   gumroad: 'https://gumroad.com/igorganapolsky',
   sponsor: 'https://github.com/sponsors/IgorGanapolsky',

--- a/scripts/post-to-x.js
+++ b/scripts/post-to-x.js
@@ -289,11 +289,11 @@ async function main() {
   } else if (command === '--scheduled') {
     const tips = [
       '🧠 Did you know? MCP Memory Gateway uses Thompson Sampling to decide which feedback signals matter most. Less noise, better training data.\n\nhttps://github.com/IgorGanapolsky/mcp-memory-gateway',
-      '🛡️ AI agents repeat the same mistakes because they have no memory across sessions. MCP Memory Gateway fixes that with local-first feedback loops.\n\nnpx rlhf-feedback-loop init',
+      '🛡️ AI agents repeat the same mistakes because they have no memory across sessions. MCP Memory Gateway fixes that with local-first feedback loops.\n\nnpx mcp-memory-gateway init',
       '📊 The learning curve dashboard shows your agent actually getting smarter — approval rate climbing, failure domains shrinking, prevention rules firing.\n\nhttps://github.com/IgorGanapolsky/mcp-memory-gateway',
-      '🔄 Capture → Validate → Remember → Prevent → Export. Five phases to turn agent mistakes into training data.\n\nMCP Memory Gateway — local-first RLHF for AI agents.\n\nnpx rlhf-feedback-loop init',
+      '🔄 Capture → Validate → Remember → Prevent → Export. Five phases to turn agent mistakes into training data.\n\nMCP Memory Gateway — local-first RLHF for AI agents.\n\nnpx mcp-memory-gateway init',
       '💡 Prevention rules generated from repeated failures = an immune system for your AI agent. No cloud required.\n\nPro Pack: $9 → https://gumroad.com/igorganapolsky',
-      '⚡ Works with Claude Code, Amp, Codex, Gemini CLI, Cursor. One install, all agents learn.\n\nnpx rlhf-feedback-loop init\n\nhttps://github.com/IgorGanapolsky/mcp-memory-gateway',
+      '⚡ Works with Claude Code, Amp, Codex, Gemini CLI, Cursor. One install, all agents learn.\n\nnpx mcp-memory-gateway init\n\nhttps://github.com/IgorGanapolsky/mcp-memory-gateway',
     ];
     const dayIndex = Math.floor(Date.now() / 86400000) % tips.length;
     const tip = tips[dayIndex];
@@ -333,7 +333,7 @@ Captures 👍/👎 → promotes memories → generates prevention rules → expo
 
 Works with Claude, Codex, Amp, Gemini.
 
-npm: npx rlhf-feedback-loop init
+npm: npx mcp-memory-gateway init
 Pro Pack: $9
 
 ⭐ https://github.com/IgorGanapolsky/mcp-memory-gateway`;

--- a/scripts/prove-lancedb.js
+++ b/scripts/prove-lancedb.js
@@ -47,7 +47,7 @@ async function runProof(options = {}) {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // VEC-01: LanceDB embedded table stores feedback vectors in rlhf-feedback-loop
+  // VEC-01: LanceDB embedded table stores feedback vectors in mcp-memory-gateway
   // Evidence: smoke test — upsertFeedback() creates lancedb dir, table row persists.
   // ─────────────────────────────────────────────────────────────────────────
   let vec01Status = 'fail';

--- a/skills/agent-memory/SKILL.md
+++ b/skills/agent-memory/SKILL.md
@@ -12,7 +12,7 @@ Give your agent persistent memory across sessions. Before starting any task, rec
 Add the MCP server (one-time):
 
 ```bash
-claude mcp add rlhf -- npx -y rlhf-feedback-loop serve
+claude mcp add rlhf -- npx -y mcp-memory-gateway serve
 ```
 
 No API key needed. All data stays local.
@@ -79,7 +79,7 @@ Call the `feedback_stats` MCP tool to see approval rate, top failure domains, an
 | `commerce` | 6 tools + commerce_recall | Agentic commerce agents |
 | `default` | 12 tools | Full pipeline including DPO export |
 
-Set profile: `RLHF_MCP_PROFILE=essential npx rlhf-feedback-loop serve`
+Set profile: `RLHF_MCP_PROFILE=essential npx mcp-memory-gateway serve`
 
 ## How Prevention Rules Work
 
@@ -93,5 +93,5 @@ This is the core value. The agent doesn't learn — but it reads the rules and f
 ## Links
 
 - [GitHub](https://github.com/IgorGanapolsky/mcp-memory-gateway)
-- [npm](https://www.npmjs.com/package/rlhf-feedback-loop)
+- [npm](https://www.npmjs.com/package/mcp-memory-gateway)
 - [MCP Registry](https://registry.modelcontextprotocol.io)

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -552,7 +552,7 @@ function createApiServer() {
                 result: {
                   protocolVersion: '2024-11-05',
                   capabilities: { tools: {} },
-                  serverInfo: { name: 'rlhf-feedback-loop', version: pkg.version },
+                  serverInfo: { name: 'mcp-memory-gateway', version: pkg.version },
                 },
               });
             } else if (msg.method === 'notifications/initialized') {
@@ -595,7 +595,7 @@ function createApiServer() {
       if (req.method === 'GET') {
         // SSE upgrade or capability probe
         sendJson(res, 200, {
-          name: 'rlhf-feedback-loop',
+          name: 'mcp-memory-gateway',
           version: pkg.version,
           transport: ['streamable-http', 'stdio'],
         });
@@ -607,7 +607,7 @@ function createApiServer() {
     if (req.method === 'GET' && pathname === '/') {
       if (wantsJson(req, parsed)) {
         sendJson(res, 200, {
-          name: 'rlhf-feedback-loop',
+          name: 'mcp-memory-gateway',
           version: pkg.version,
           status: 'ok',
           docs: 'https://github.com/IgorGanapolsky/mcp-memory-gateway',
@@ -637,10 +637,10 @@ function createApiServer() {
     if (req.method === 'GET' && pathname === '/.well-known/mcp/server-card.json') {
       sendJson(res, 200, {
         serverInfo: {
-          name: 'rlhf-feedback-loop',
+          name: 'mcp-memory-gateway',
           version: pkg.version,
         },
-        name: 'rlhf-feedback-loop',
+        name: 'mcp-memory-gateway',
         description: 'RLHF feedback loop for AI agents. Capture feedback, block mistakes, export DPO data.',
         version: pkg.version,
         tools: [
@@ -759,7 +759,7 @@ function createApiServer() {
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(`<!DOCTYPE html><html><head><title>Privacy Policy — MCP Memory Gateway</title></head><body>
 <h1>Privacy Policy</h1>
-<p><strong>MCP Memory Gateway</strong> (npm: rlhf-feedback-loop)</p>
+<p><strong>MCP Memory Gateway</strong> (npm: mcp-memory-gateway)</p>
 <p>Last updated: 2026-03-11</p>
 <h2>Data Collection</h2>
 <p>The self-hosted version stores all data locally on your machine. No data is sent to external servers.</p>

--- a/tests/adapters.test.js
+++ b/tests/adapters.test.js
@@ -36,7 +36,7 @@ test('claude .mcp.json is valid JSON with mcpServers key', () => {
   assert.equal(typeof payload.mcpServers, 'object');
   assert.deepEqual(payload.mcpServers.rlhf, {
     command: 'npx',
-    args: ['-y', `rlhf-feedback-loop@${packageVersion}`, 'serve'],
+    args: ['-y', `mcp-memory-gateway@${packageVersion}`, 'serve'],
   });
 });
 
@@ -47,7 +47,7 @@ test('codex config.toml contains mcp_servers section', () => {
   assert.match(content, /command = "npx"/, 'config.toml must use portable npx launcher');
   assert.match(
     content,
-    new RegExp(`args = \\["-y", "rlhf-feedback-loop@${packageVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}", "serve"\\]`),
+    new RegExp(`args = \\["-y", "mcp-memory-gateway@${packageVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}", "serve"\\]`),
     'config.toml must launch the version-pinned package serve entrypoint'
   );
 });

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -89,7 +89,7 @@ test('root still serves JSON status when explicitly requested', async () => {
   assert.match(String(res.headers.get('content-type')), /application\/json/);
 
   const body = await res.json();
-  assert.equal(body.name, 'rlhf-feedback-loop');
+  assert.equal(body.name, 'mcp-memory-gateway');
   assert.equal(body.status, 'ok');
 });
 

--- a/tests/claude-skill.test.js
+++ b/tests/claude-skill.test.js
@@ -52,6 +52,6 @@ test('mcp-use integration guide exists', () => {
   assert.ok(fs.existsSync(guidePath), 'docs/guides/mcp-use-integration.md should exist');
   const content = fs.readFileSync(guidePath, 'utf8');
   assert.match(content, /mcp-use/, 'Should reference mcp-use SDK');
-  assert.match(content, /rlhf-feedback-loop/, 'Should reference our npm package');
+  assert.match(content, /mcp-memory-gateway/, 'Should reference our npm package');
   assert.match(content, /commerce/, 'Should mention commerce profile');
 });

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Tests for bin/cli.js — npx rlhf-feedback-loop
+ * Tests for bin/cli.js — npx mcp-memory-gateway
  *
  * Verifies:
  *   1. CLI runs without error
@@ -340,7 +340,7 @@ describe('bin/cli.js', () => {
   test('help command exits 0 and lists subcommands', () => {
     const result = spawnSync(process.execPath, [CLI, 'help'], { encoding: 'utf8' });
     assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\n${result.stderr}`);
-    assert.ok(result.stdout.includes('rlhf-feedback-loop'), 'Help should include CLI name');
+    assert.ok(result.stdout.includes('mcp-memory-gateway'), 'Help should include CLI name');
     assert.ok(result.stdout.includes('init'), 'Help should mention init');
     assert.ok(result.stdout.includes('capture'), 'Help should mention capture');
     assert.ok(result.stdout.includes('cfo'), 'Help should mention cfo');
@@ -694,7 +694,7 @@ describe('bin/cli.js', () => {
       stdin.write(frameMcpMessage(payload));
     });
     assert.equal(response.id, 99);
-    assert.equal(response.result.serverInfo.name, 'rlhf-feedback-loop-mcp');
+    assert.equal(response.result.serverInfo.name, 'mcp-memory-gateway-mcp');
   });
 
   test('serve responds to initialize over newline-delimited JSON transport', async () => {
@@ -702,7 +702,7 @@ describe('bin/cli.js', () => {
       stdin.write(`${JSON.stringify(payload)}\n`);
     });
     assert.equal(response.id, 99);
-    assert.equal(response.result.serverInfo.name, 'rlhf-feedback-loop-mcp');
+    assert.equal(response.result.serverInfo.name, 'mcp-memory-gateway-mcp');
   });
 
   test('serve returns ndjson error envelope for malformed ndjson input', async () => {
@@ -731,7 +731,7 @@ describe('bin/cli.js', () => {
     });
 
     assert.equal(response.id, 99);
-    assert.equal(response.result.serverInfo.name, 'rlhf-feedback-loop-mcp');
+    assert.equal(response.result.serverInfo.name, 'mcp-memory-gateway-mcp');
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
   });

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -64,7 +64,7 @@ test('GET /health content-type is application/json', async () => {
 });
 
 test('POST /v1/telemetry/ping returns 204 without auth', async () => {
-  const payload = JSON.stringify({ installId: 'test-install-123', version: '0.6.16', platform: 'darwin', nodeVersion: 'v20.0.0' });
+  const payload = JSON.stringify({ installId: 'test-install-123', version: '0.7.0', platform: 'darwin', nodeVersion: 'v20.0.0' });
   const res = await fetch(`http://localhost:${DEPLOY_PORT}/v1/telemetry/ping`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/tests/install-mcp.test.js
+++ b/tests/install-mcp.test.js
@@ -132,7 +132,7 @@ describe('install-mcp', () => {
       mcpServers: {
         [MCP_SERVER_KEY]: {
           command: 'npx',
-          args: ['-y', 'rlhf-feedback-loop', 'serve'],
+          args: ['-y', 'mcp-memory-gateway', 'serve'],
         },
       },
     }, null, 2) + '\n');


### PR DESCRIPTION
## Breaking Change

Completes the rename from `rlhf-feedback-loop` to `mcp-memory-gateway` across the entire codebase.

### Changes (54 files)
- **CLI** (`bin/cli.js`): All help text, examples, npx commands → `mcp-memory-gateway`
- **Adapters**: Claude, Codex, MCP server configs → `mcp-memory-gateway@0.7.0`
- **Docs & Marketing**: README, landing page, MCP hub submission, Reddit/Twitter/HN posts
- **Tests**: All assertion strings updated to match new name
- **Config**: server.json, mcpize.yaml, server-card.json, marketplace.json

### Preserved
- Railway deployment URL: `rlhf-feedback-loop-production.up.railway.app` (live infra)
- `RLHF_` env var prefixes (backward compat)
- `.planning/` historical research docs (unchanged)
- Legacy MCP server name array for migration detection

### Verification
- **933 tests pass, 0 failures**
- Remaining `rlhf-feedback-loop` references are only Railway URLs and negative test assertions