### PR TITLE
chore: add mcp-memory-gateway bin alias + files field for lean npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,24 @@
   },
   "main": "scripts/feedback-loop.js",
   "bin": {
+    "mcp-memory-gateway": "bin/cli.js",
     "rlhf": "bin/cli.js"
   },
+  "files": [
+    "bin/",
+    "src/",
+    "scripts/",
+    "adapters/",
+    "config/",
+    "plugins/",
+    "skills/",
+    "openapi/",
+    "public/",
+    ".well-known/",
+    ".claude-plugin/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "start": "node src/api/server.js",
     "budget:status": "node scripts/budget-guard.js --status",


### PR DESCRIPTION
Prepares for npm publish of mcp-memory-gateway@0.7.0.

### Changes
- **bin**: Add `mcp-memory-gateway` entry so `npx mcp-memory-gateway` works (keeps `rlhf` for backward compat)
- **files**: Whitelist shipping dirs — package drops from **2.9 MB / 483 files** to **256 kB / 131 files**
- Excludes: tests, .planning, proof, .rlhf, .claude/memory, docs, .github

### Verification
- 933 tests pass, 0 failures
- `npm pack --dry-run` confirms no junk in tarball