### PR TITLE
chore: bump to v0.7.1 for npm publish

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-gateway",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "plugins": [
     {
       "name": "mcp-memory-gateway",

--- a/.rlhf/verification-model.json
+++ b/.rlhf/verification-model.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "created": "2026-03-12T20:09:44.489Z",
-  "updated": "2026-03-12T20:10:05.856Z",
-  "total_entries": 22,
+  "updated": "2026-03-13T13:26:53.331Z",
+  "total_entries": 88,
   "categories": {
     "code_edit": {
       "alpha": 1,
@@ -17,10 +17,10 @@
       "last_updated": null
     },
     "testing": {
-      "alpha": 5,
+      "alpha": 16.999999995415692,
       "beta": 1,
-      "samples": 4,
-      "last_updated": "2026-03-12T20:10:05.845Z"
+      "samples": 16,
+      "last_updated": "2026-03-13T13:26:53.318Z"
     },
     "pr_review": {
       "alpha": 1,
@@ -83,16 +83,16 @@
       "last_updated": null
     },
     "uncategorized": {
-      "alpha": 15,
+      "alpha": 56.99999999885392,
       "beta": 1,
-      "samples": 14,
-      "last_updated": "2026-03-12T20:10:05.837Z"
+      "samples": 56,
+      "last_updated": "2026-03-13T13:26:53.271Z"
     },
     "api": {
-      "alpha": 5,
+      "alpha": 16.999999998853923,
       "beta": 1,
-      "samples": 4,
-      "last_updated": "2026-03-12T20:10:05.856Z"
+      "samples": 16,
+      "last_updated": "2026-03-13T13:26:53.331Z"
     }
   }
 }

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-gateway",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Production RLHF & DPO data pipeline for AI agents. Capture human preference signals, generate automated guardrails, and export DPO training pairs.",
   "homepage": "https://github.com/IgorGanapolsky/mcp-memory-gateway",
   "transport": "stdio",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npx mcp-memory-gateway init --agent gemini
 
 > **Profiles:** Set `RLHF_MCP_PROFILE=essential` for the lean 5-tool setup (recommended), or leave unset for the full 11-tool pipeline. See [MCP Tools](#mcp-tools) for details.
 
-## Pre-Action Gates (v0.7.0)
+## Pre-Action Gates (v0.7.1)
 
 Gates are the enforcement layer. They physically block tool calls that match known failure patterns — no agent cooperation required.
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,6 +3,6 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx -y mcp-memory-gateway@0.7.0 serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx -y mcp-memory-gateway@0.7.1 serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/rlhf-feedback/SKILL.md`: Amp skill template.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "mcp-memory-gateway@0.7.0", "serve"]
+      "args": ["-y", "mcp-memory-gateway@0.7.1", "serve"]
     }
   }
 }

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -1,4 +1,4 @@
 # Codex MCP profile (copy into ~/.codex/config.toml or merge section)
 [mcp_servers.rlhf]
 command = "npx"
-args = ["-y", "mcp-memory-gateway@0.7.0", "serve"]
+args = ["-y", "mcp-memory-gateway@0.7.1", "serve"]

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -30,12 +30,12 @@ This avoids platform-specific rewrite cost and keeps the product under a `$10/mo
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y mcp-memory-gateway@0.7.0 serve`
+- Transport: local stdio MCP server launched via `npx -y mcp-memory-gateway@0.7.1 serve`
 
 ## Codex (MCP)
 
 - Merge section from `adapters/codex/config.toml`
-- Transport: local stdio MCP server launched via `npx -y mcp-memory-gateway@0.7.0 serve`
+- Transport: local stdio MCP server launched via `npx -y mcp-memory-gateway@0.7.1 serve`
 
 ## Gemini (Function Calling)
 

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -67,7 +67,7 @@ Status:
 
 Scope:
 
-- Version sync across `package.json`, `mcpize.yaml`, and `server.json` to `v0.7.0`.
+- Version sync across `package.json`, `mcpize.yaml`, and `server.json` to `v0.7.1`.
 - Historical pricing experiment: tested a "Founding Member $5/mo" offer and urgency hooks before the current commercial-truth correction.
 - Discovery optimization: Added high-ROI GitHub topics and updated `SKILL.md` auto-indexing keywords.
 - Launch content package: Created `docs/marketing/LAUNCH_CONTENT.md` with Reddit, HN, and Discord assets.
@@ -217,7 +217,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y mcp-memory-gateway@0.7.0 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y mcp-memory-gateway@0.7.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.rlhf` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -597,7 +597,7 @@ Scope:
 
 - Added a portable `npm run test:coverage` command using Node's built-in coverage for `tests/**/*.test.js`.
 - Removed the unused `stripe` SDK dependency; billing continues to use direct HTTPS calls in `scripts/billing.js`.
-- Synced published version metadata across MCP manifests and public docs to `0.7.0`.
+- Synced published version metadata across MCP manifests and public docs to `0.7.1`.
 - Refreshed active proof artifacts and pruned stale milestone-era proof files that were no longer referenced.
 
 Commands run:

--- a/docs/marketing/devto-article.md
+++ b/docs/marketing/devto-article.md
@@ -59,19 +59,19 @@ Pick your platform:
 
 ```bash
 # Claude
-claude mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
+claude mcp add rlhf -- npx -y mcp-memory-gateway@0.7.1 serve
 
 # Codex
-codex mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
+codex mcp add rlhf -- npx -y mcp-memory-gateway@0.7.1 serve
 
 # Gemini
-gemini mcp add rlhf "npx -y mcp-memory-gateway@0.7.0 serve"
+gemini mcp add rlhf "npx -y mcp-memory-gateway@0.7.1 serve"
 
 # Amp
-amp mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
+amp mcp add rlhf -- npx -y mcp-memory-gateway@0.7.1 serve
 
 # Cursor
-cursor mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
+cursor mcp add rlhf -- npx -y mcp-memory-gateway@0.7.1 serve
 ```
 
 Run once per project. The MCP server starts automatically on each session after that.

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add rlhf -- npx -y mcp-memory-gateway@0.7.0 serve
+claude mcp add rlhf -- npx -y mcp-memory-gateway@0.7.1 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "mcp-memory-gateway@0.7.0", "serve"],
+      "args": ["-y", "mcp-memory-gateway@0.7.1", "serve"],
       "env": {
         "RLHF_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "rlhf": {
       "command": "npx",
-      "args": ["-y", "mcp-memory-gateway@0.7.0", "serve"],
+      "args": ["-y", "mcp-memory-gateway@0.7.1", "serve"],
       "env": {
         "RLHF_BASE_URL": "https://rlhf-feedback-loop-production.up.railway.app",
         "RLHF_API_KEY": "rlhf_YOUR_KEY_HERE"
@@ -124,7 +124,7 @@ Verification evidence: https://github.com/IgorGanapolsky/mcp-memory-gateway/blob
 
 ## Transport
 
-- **stdio** (primary): `npx -y mcp-memory-gateway@0.7.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y mcp-memory-gateway@0.7.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -171,7 +171,7 @@ MIT
 
 ## Version
 
-0.7.0
+0.7.1
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,5 +1,5 @@
 # mcpize configuration for MCP Memory Gateway
 project: "mcp-memory-gateway"
-version: "0.7.0"
+version: "0.7.1"
 start_command: "npx -y mcp-memory-gateway serve"
 mcp_profile: "default"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-gateway",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Universal Context & Memory Layer for Model Context Protocol (MCP) Agents. Centralized hub to consolidate failures and enforce architectural guardrails.",
   "homepage": "https://rlhf-feedback-loop-production.up.railway.app",
   "repository": {

--- a/public/index.html
+++ b/public/index.html
@@ -602,7 +602,7 @@
           <div class='hero-proof'>
             <span class='proof-pill'>North Star: one workflow live and auditable</span>
             <span class='proof-pill'>Self-serve offer: $9 one-time Pro Pack</span>
-            <span class='proof-pill'>Versioned proof: v0.7.0</span>
+            <span class='proof-pill'>Versioned proof: v0.7.1</span>
             <span class='proof-pill'>Hosted onboarding at https://rlhf-feedback-loop-production.up.railway.app</span>
           </div>
           <div class='cta-row'>
@@ -826,7 +826,7 @@
 
   <footer class='footer'>
     <div class='footer-inner'>
-      <div>MCP Memory Gateway Context Gateway • v0.7.0</div>
+      <div>MCP Memory Gateway Context Gateway • v0.7.1</div>
       <div>
         <a href='https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/main/docs/VERIFICATION_EVIDENCE.md'>Verification evidence</a>
         •

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/mcp-memory-gateway"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-memory-gateway",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
v0.7.0 was already published on npm. Bumps all version refs to 0.7.1 to match the published package. 933 tests pass.