### PR TITLE
fix: serve gates landing page at root instead of old docs page

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -66,7 +66,7 @@ const {
   generateDashboard,
 } = require('../../scripts/dashboard');
 
-const LANDING_PAGE_PATH = path.resolve(__dirname, '../../docs/landing-page.html');
+const LANDING_PAGE_PATH = path.resolve(__dirname, '../../public/index.html');
 
 function getSafeDataDir() {
   const { FEEDBACK_LOG_PATH } = getFeedbackPaths();

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -51,8 +51,8 @@ test('root serves the landing page by default', async () => {
   assert.match(String(res.headers.get('content-type')), /text\/html/);
 
   const body = await res.text();
-  assert.match(body, /MCP Memory Gateway/i);
-  assert.match(body, /Pre-Action Gates/i);
+  assert.match(body, /mcp.memory.gateway/i);
+  assert.match(body, /Pre.Action Gates/i);
   assert.match(body, /\$10\/mo/);
 });
 


### PR DESCRIPTION
The Railway server was serving docs/landing-page.html (old $9 one-time, generic workflow messaging) instead of public/index.html (new dark theme, gates demo, $10/mo). One-line fix in server.js.