### PR TITLE
feat: GTM launch content for Reddit, Show HN, and X/Twitter

### DIFF
--- a/docs/marketing/reddit-claude-code-post.md
+++ b/docs/marketing/reddit-claude-code-post.md
@@ -1,0 +1,37 @@
+# Reddit Post: r/ClaudeCode
+
+**Title:** My Claude Code agent kept making the same mistakes every session, so I built it a memory
+
+**Body:**
+
+I've been using Claude Code full-time for about 6 months. Love it, but one thing kept driving me crazy: it forgets everything between sessions. Same bugs, same wrong approaches, same "oh sorry, I'll fix that" — over and over.
+
+So I built [mcp-memory-gateway](https://github.com/IgorGanapolsky/mcp-memory-gateway) — an MCP server that gives your AI agent persistent memory with a feedback loop.
+
+**How it works:**
+
+1. You give thumbs up/down on what your agent does
+2. It auto-generates prevention rules from repeated mistakes
+3. Those rules become **pre-action gates** that physically block the agent from repeating known failures
+4. Uses Thompson Sampling to adapt which gates fire, so it gets smarter over time
+
+**Install in 30 seconds:**
+
+```
+npx mcp-memory-gateway serve
+```
+
+Then add it to your Claude Code MCP config. That's it.
+
+**What it actually does for you:**
+
+- Captures feedback with schema validation (not just "good/bad" — structured context)
+- Auto-generates prevention rules from repeated failures
+- Exports DPO/KTO training pairs if you want to fine-tune
+- Works with Claude Code, Codex, Gemini CLI, and Amp
+
+It's open source and free for local use. There's a [$29/mo Pro tier](https://rlhf-feedback-loop-production.up.railway.app) if you want hosted dashboard, auto-gate promotion, and multi-repo sync for teams — but the core is fully functional without it.
+
+314 tests, 12 proof reports, MIT licensed. Would love feedback from other Claude Code users on what failure patterns you'd want gates for.
+
+GitHub: https://github.com/IgorGanapolsky/mcp-memory-gateway

--- a/docs/marketing/show-hn-post.md
+++ b/docs/marketing/show-hn-post.md
@@ -1,0 +1,26 @@
+# Show HN Post
+
+**Title:** Show HN: MCP Memory Gateway – RLHF feedback loops and pre-action gates for AI coding agents
+
+**URL:** https://github.com/IgorGanapolsky/mcp-memory-gateway
+
+**Body:**
+
+MCP Memory Gateway is an open-source MCP server that adds persistent memory and behavioral guardrails to AI coding agents (Claude Code, Codex, Gemini CLI, Amp).
+
+The core idea: capture explicit feedback (up/down with structured context), auto-generate prevention rules from recurring mistakes, and enforce them as pre-action gates that physically block the agent before it repeats a known failure.
+
+Technical details:
+- Thompson Sampling for adaptive gate selection (balances exploration vs exploitation of prevention rules)
+- DPO/KTO export pairs for fine-tuning from your feedback history
+- RLAIF self-audit loop that validates rule quality
+- LanceDB vector store for semantic memory retrieval
+- Budget guard ($10/mo cost cap) with intent routing
+
+The gate engine uses a default-deny model for high-risk actions — the agent must pass through checkpoint validation before executing anything flagged by prior failures.
+
+Stack: Node.js, MCP stdio protocol, LanceDB (vector), ONNX (embeddings). 314 tests, 12 machine-readable proof reports.
+
+Free and MIT licensed. `npx mcp-memory-gateway serve` to try it.
+
+Pro tier ($29/mo) adds hosted dashboard, auto-gate promotion, and team sync: https://rlhf-feedback-loop-production.up.railway.app

--- a/docs/marketing/x-launch-thread.md
+++ b/docs/marketing/x-launch-thread.md
@@ -1,0 +1,77 @@
+# X/Twitter Launch Thread
+
+## Posting Notes
+- Best times: Tue-Thu 8-10am PT
+- Cross-post highlights to LinkedIn
+- Reply to your own thread to boost engagement
+
+---
+
+**Tweet 1 (Hook)**
+Claude Code is incredible but it has one fatal flaw: it forgets everything between sessions.
+
+Same bugs. Same wrong approaches. Same apologies.
+
+I spent 6 months building a fix. Here's what I learned:
+
+**Tweet 2 (What it does)**
+mcp-memory-gateway is an MCP server that gives your AI agent persistent memory.
+
+It captures your feedback, auto-generates prevention rules, and physically blocks your agent from repeating known mistakes.
+
+**Tweet 3 (How it works)**
+The loop:
+
+1. You give thumbs up/down with context
+2. Repeated failures become prevention rules
+3. Rules become pre-action gates
+4. Gates block the agent BEFORE it makes the mistake
+
+Your agent builds an immune system from your corrections.
+
+**Tweet 4 (The tech)**
+Under the hood:
+
+- Thompson Sampling decides which gates fire (exploration vs exploitation)
+- DPO/KTO export pairs for fine-tuning from your history
+- LanceDB vector store for semantic retrieval
+- ONNX embeddings, all local, no cloud required
+
+**Tweet 5 (Install)**
+Try it in 30 seconds:
+
+npx mcp-memory-gateway serve
+
+Add it to your Claude Code MCP config. Done.
+
+Works with Codex, Gemini CLI, and Amp too.
+
+**Tweet 6 (Differentiation)**
+There are other memory MCP servers (Mem0, Zep, official reference).
+
+None of them are MCP-native AND have RLHF feedback loops. None generate prevention rules. None have pre-action gates.
+
+This is the only one that learns from your corrections.
+
+**Tweet 7 (Proof)**
+Engineering proof, not marketing claims:
+
+- 314 tests, 0 failures
+- 12 machine-readable proof reports
+- 82% code coverage
+- 5 platform adapters
+- Built on $0 budget
+
+Every claim is backed by evidence in the repo.
+
+**Tweet 8 (The ask)**
+Free and open source (MIT). Install and use locally forever.
+
+$29/mo Pro for teams: hosted dashboard, auto-gate promotion, unlimited gates, multi-repo sync.
+
+https://github.com/IgorGanapolsky/mcp-memory-gateway
+
+**Tweet 9 (Engagement)**
+What's the most annoying mistake your AI coding agent keeps repeating?
+
+Reply and I'll show you how to write a prevention gate for it.


### PR DESCRIPTION
## Summary
- Research-backed launch content for the 3 highest-ROI distribution channels (March 2026 deep research)
- Reddit r/ClaudeCode post — problem-first, peer tone, 290 words
- Show HN post — technical, ML-focused (Thompson Sampling, DPO/KTO), 190 words
- X/Twitter 9-tweet build-in-public thread with engagement CTA
- All content priced at $29/mo Pro (consistent with COMMERCIAL_TRUTH.md)

## Context
Deep research identified these as the top channels:
1. X/Twitter build-in-public (one post drove $10K MRR for Sleek.design)
2. Reddit r/ClaudeCode (4,200+ weekly active, highest-intent MCP audience)
3. Show HN (dev tools with ML sophistication perform well)

No paid MCP-native memory server exists as of March 2026. We are first movers.

## Test plan
- [ ] Review Reddit post tone — should read as peer sharing, not marketing
- [ ] Review Show HN for technical accuracy
- [ ] Review X thread — all tweets under 280 chars
- [ ] Verify $29/mo pricing throughout
- [ ] Post to r/ClaudeCode after merge
- [ ] Post Show HN after merge
- [ ] Post X thread after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)