### PR TITLE
feat: add partner-aware orchestration

### DIFF
--- a/adapters/chatgpt/openapi.yaml
+++ b/adapters/chatgpt/openapi.yaml
@@ -81,6 +81,8 @@ components:
           type: string
         bundleId:
           type: string
+        partnerProfile:
+          type: string
         approved:
           type: boolean
     BillingCheckoutRequest:
@@ -295,6 +297,10 @@ paths:
             type: string
         - in: query
           name: bundleId
+          schema:
+            type: string
+        - in: query
+          name: partnerProfile
           schema:
             type: string
       responses:

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -136,6 +136,7 @@ const TOOLS = [
       properties: {
         mcpProfile: { type: 'string' },
         bundleId: { type: 'string' },
+        partnerProfile: { type: 'string' },
       },
     },
   },
@@ -150,6 +151,7 @@ const TOOLS = [
         context: { type: 'string' },
         mcpProfile: { type: 'string' },
         bundleId: { type: 'string' },
+        partnerProfile: { type: 'string' },
         approved: { type: 'boolean' },
       },
     },
@@ -618,6 +620,7 @@ async function callToolInner(name, args = {}) {
     const result = listIntents({
       mcpProfile: args.mcpProfile,
       bundleId: args.bundleId,
+      partnerProfile: args.partnerProfile,
     });
     return { content: [{ type: 'text', text: toText(result) }] };
   }
@@ -628,6 +631,7 @@ async function callToolInner(name, args = {}) {
       context: args.context || '',
       mcpProfile: args.mcpProfile,
       bundleId: args.bundleId,
+      partnerProfile: args.partnerProfile,
       approved: args.approved === true,
     });
     return { content: [{ type: 'text', text: toText(result) }] };

--- a/config/partner-routing.json
+++ b/config/partner-routing.json
@@ -1,0 +1,132 @@
+{
+  "version": 1,
+  "defaultProfile": "balanced",
+  "aliases": {
+    "default": "balanced",
+    "reviewer": "strict_reviewer",
+    "strict-reviewer": "strict_reviewer",
+    "strict_reviewer": "strict_reviewer",
+    "fast": "fast_executor",
+    "fast-executor": "fast_executor",
+    "fast_executor": "fast_executor",
+    "blocker": "silent_blocker",
+    "silent-blocker": "silent_blocker",
+    "silent_blocker": "silent_blocker",
+    "limited": "tool_limited",
+    "tool-limited": "tool_limited",
+    "tool_limited": "tool_limited"
+  },
+  "rewardModel": {
+    "accepted": 1,
+    "rejected": -1,
+    "attemptPenalty": 0.15,
+    "violationPenalty": 0.1,
+    "maxViolationPenalty": 0.3
+  },
+  "profiles": {
+    "balanced": {
+      "label": "Balanced",
+      "description": "Mixed-pool default for unknown or steady collaborators.",
+      "verificationMode": "standard",
+      "maxRetryDelta": 0,
+      "rewardBias": 0,
+      "tokenBudgetMultiplier": {
+        "total": 1,
+        "perAction": 1,
+        "contextPack": 1
+      },
+      "recommendedChecks": [
+        "Keep default approval thresholds",
+        "Use the standard verification loop"
+      ],
+      "actionBiases": {}
+    },
+    "strict_reviewer": {
+      "label": "Strict Reviewer",
+      "description": "Prefers explicit evidence, provenance, and audit-friendly plans.",
+      "verificationMode": "evidence_first",
+      "maxRetryDelta": 1,
+      "rewardBias": 0.1,
+      "tokenBudgetMultiplier": {
+        "total": 1.15,
+        "perAction": 1.1,
+        "contextPack": 1.4
+      },
+      "recommendedChecks": [
+        "Front-load context packs and provenance",
+        "Bias toward evidence-producing actions"
+      ],
+      "actionBiases": {
+        "construct_context_pack": 0.22,
+        "context_provenance": 0.2,
+        "evaluate_context_pack": 0.16,
+        "feedback_summary": 0.08
+      }
+    },
+    "fast_executor": {
+      "label": "Fast Executor",
+      "description": "Optimizes for low drag and quick convergence when the partner is responsive.",
+      "verificationMode": "fast_path",
+      "maxRetryDelta": -1,
+      "rewardBias": -0.05,
+      "tokenBudgetMultiplier": {
+        "total": 0.85,
+        "perAction": 0.85,
+        "contextPack": 0.7
+      },
+      "recommendedChecks": [
+        "Keep action order lean",
+        "Avoid oversized context packs unless the model strongly prefers them"
+      ],
+      "actionBiases": {
+        "feedback_summary": 0.16,
+        "capture_feedback": 0.1,
+        "construct_context_pack": -0.08,
+        "context_provenance": -0.05
+      }
+    },
+    "silent_blocker": {
+      "label": "Silent Blocker",
+      "description": "Looks cooperative but tends to surface blockers late.",
+      "verificationMode": "blocker_hunt",
+      "maxRetryDelta": 1,
+      "rewardBias": 0.05,
+      "tokenBudgetMultiplier": {
+        "total": 1.2,
+        "perAction": 1.1,
+        "contextPack": 1.3
+      },
+      "recommendedChecks": [
+        "Pull provenance earlier",
+        "Spend extra verification budget before claiming completion"
+      ],
+      "actionBiases": {
+        "context_provenance": 0.2,
+        "construct_context_pack": 0.14,
+        "feedback_summary": 0.1,
+        "evaluate_context_pack": 0.08
+      }
+    },
+    "tool_limited": {
+      "label": "Tool Limited",
+      "description": "Operates with fewer tools or weaker environmental visibility.",
+      "verificationMode": "explicit_contracts",
+      "maxRetryDelta": 0,
+      "rewardBias": -0.02,
+      "tokenBudgetMultiplier": {
+        "total": 0.95,
+        "perAction": 0.9,
+        "contextPack": 0.8
+      },
+      "recommendedChecks": [
+        "Use smaller context packs with sharper instructions",
+        "Favor actions that reduce ambiguity quickly"
+      ],
+      "actionBiases": {
+        "feedback_summary": 0.12,
+        "capture_feedback": 0.08,
+        "construct_context_pack": 0.05
+      }
+    }
+  }
+}

--- a/docs/INTENT_ROUTER.md
+++ b/docs/INTENT_ROUTER.md
@@ -39,6 +39,40 @@ Risk levels: `low`, `medium`, `high`, `critical`.
 Each bundle defines which risk levels require human approval for each MCP profile.
 If approval is required and `approved` is not set, plan status is `checkpoint_required`.
 
+## Partner-Aware Orchestration
+
+The MVP now accepts `partnerProfile` on both `list_intents` and `plan_intent`.
+
+Supported profiles:
+
+- `balanced`: mixed-pool default with no special bias
+- `strict_reviewer`: bias toward evidence, provenance, and larger context packs
+- `fast_executor`: favor faster execution with tighter token budgets
+- `silent_blocker`: spend more budget surfacing hidden blockers before claiming done
+- `tool_limited`: reduce ambiguity quickly when the counterpart has weaker tools
+
+Runtime hooks:
+
+1. `plan_intent` resolves a partner strategy from `config/partner-routing.json`
+2. Token budgets are scaled per partner profile
+3. Action ranking combines Thompson samples for the action category with partner-specific action bias
+4. The verification loop records the outcome under both the task tags and `partner_<profile>`
+
+Reward function:
+
+```text
+reward = clamp(
+  baseOutcome
+  - (attempts - 1) * attemptPenalty
+  - min(violationCount * violationPenalty, maxViolationPenalty)
+  + rewardBias,
+  -1,
+  1
+)
+```
+
+The resulting reward drives a weighted Thompson update so clean one-shot successes and repeated failures shift partner-specific reliability faster than neutral runs.
+
 ## Examples
 
 ```bash

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1,3 +1,46 @@
+## March 13, 2026: Partner-aware orchestration MVP
+
+Scope:
+
+- Added `config/partner-routing.json` and `scripts/partner-orchestration.js` to define reusable partner profiles, aliases, token-budget rules, and reward coefficients.
+- Threaded optional `partnerProfile` through the HTTP API, MCP adapter, and OpenAPI surfaces so intent planning can return a partner-specific strategy summary.
+- Updated the intent router and verification loop to adapt action ranking, token budgets, retry behavior, and Thompson updates for `partner_<profile>` reliability learning.
+- Extended the automation proof harness and regression suite to verify partner-aware planning and emitted strategy metadata.
+
+Commands run:
+
+```bash
+npm ci
+node --test tests/intent-router.test.js tests/verification-loop.test.js tests/thompson-sampling.test.js tests/async-job-runner.test.js
+node --test tests/api-server.test.js tests/mcp-server.test.js tests/prove-automation.test.js
+npm test
+npm run test:coverage
+env RLHF_PROOF_DIR="$(mktemp -d)" npm run prove:adapters
+env RLHF_PROOF_DIR="$(mktemp -d)" npm run prove:automation
+env RLHF_PROOF_DIR="$(mktemp -d)" npm run self-heal:check
+```
+
+Observed result:
+
+- Both targeted regression commands passed with `0` failures across partner orchestration, API, MCP, and automation-proof coverage.
+- `npm test` passed end-to-end after adding partner-aware orchestration.
+- `npm run test:coverage` passed with all-files coverage at `82.52%` lines, `68.69%` branches, and `85.19%` functions.
+- `env RLHF_PROOF_DIR="$(mktemp -d)" npm run prove:adapters`: `38` passed, `0` failed.
+- `env RLHF_PROOF_DIR="$(mktemp -d)" npm run prove:automation`: `37` passed, `0` failed.
+- `env RLHF_PROOF_DIR="$(mktemp -d)" npm run self-heal:check`: `Overall: HEALTHY` with `4/4` checks healthy.
+
+Evidence artifacts:
+
+- Targeted `node --test` output covering `tests/intent-router.test.js`, `tests/verification-loop.test.js`, `tests/thompson-sampling.test.js`, `tests/async-job-runner.test.js`, `tests/api-server.test.js`, `tests/mcp-server.test.js`, and `tests/prove-automation.test.js`.
+- Ephemeral adapter and automation proof reports emitted under temporary `RLHF_PROOF_DIR` directories so verification did not leave tracked proof churn in the repository.
+
+Requirements verified:
+
+- `partnerProfile` is accepted by the public API and MCP `plan_intent` and `list_intents` surfaces and reaches the runtime planner.
+- Intent plans now emit partner strategy metadata and adapt token budgets plus action ranking for strict, fast, silent-blocker, tool-limited, and balanced counterparts.
+- Verification updates now learn partner-specific reliability in Thompson sampling under `partner_<profile>` categories without weakening the existing hard gate model.
+- The automation proof harness now checks for `intent.partner_strategy`, so the new orchestration behavior is covered by proof, not only by unit tests.
+
 ## March 12, 2026: Commercial truth correction
 
 Scope:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -81,6 +81,8 @@ components:
           type: string
         bundleId:
           type: string
+        partnerProfile:
+          type: string
         approved:
           type: boolean
     BillingCheckoutRequest:
@@ -295,6 +297,10 @@ paths:
             type: string
         - in: query
           name: bundleId
+          schema:
+            type: string
+        - in: query
+          name: partnerProfile
           schema:
             type: string
       responses:

--- a/scripts/async-job-runner.js
+++ b/scripts/async-job-runner.js
@@ -48,6 +48,7 @@ function recallContext(params) {
  * @param {string} job.context - The task output to verify
  * @param {string[]} [job.tags] - Domain tags
  * @param {string} [job.skill] - Originating skill
+ * @param {string} [job.partnerProfile] - Counterpart behavior profile used for orchestration
  * @param {function} [job.taskFn] - Optional function that produces output (called with recall context)
  * @param {function} [job.onRetry] - Retry handler passed to verification loop
  * @param {number} [job.maxRetries] - Max retries for verification (default 3)
@@ -72,6 +73,7 @@ function executeJob(job) {
     context: taskOutput,
     tags,
     skill: job.skill,
+    partnerProfile: job.partnerProfile,
     onRetry: job.onRetry,
     maxRetries: job.maxRetries,
   });
@@ -101,6 +103,9 @@ function executeJob(job) {
         accepted: verification.accepted,
         attempts: verification.attempts,
         score: verification.finalVerification.score,
+        partnerProfile: verification.partnerStrategy.profile,
+        verificationMode: verification.partnerStrategy.verificationMode,
+        reward: verification.partnerReward.reward,
       },
       feedback: {
         accepted: feedbackResult.accepted,

--- a/scripts/intent-router.js
+++ b/scripts/intent-router.js
@@ -3,6 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { getActiveMcpProfile, getAllowedTools } = require('./mcp-policy');
 const { loadModel, samplePosteriors } = require('./thompson-sampling');
+const {
+  buildPartnerStrategy,
+  getPartnerActionBias,
+} = require('./partner-orchestration');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 const DEFAULT_BUNDLE_DIR = path.join(PROJECT_ROOT, 'config', 'policy-bundles');
@@ -69,10 +73,19 @@ function listIntents(options = {}) {
   const bundle = loadPolicyBundle(options.bundleId);
   const profile = assertKnownMcpProfile(options.mcpProfile || getActiveMcpProfile());
   const requiredRisks = getRequiredApprovalRisks(bundle, profile);
+  const partnerStrategy = buildPartnerStrategy({
+    partnerProfile: options.partnerProfile,
+    tokenBudget: DEFAULT_TOKEN_BUDGET,
+  });
 
   return {
     bundleId: bundle.bundleId,
     mcpProfile: profile,
+    partnerProfile: partnerStrategy.profile,
+    partnerStrategy: {
+      verificationMode: partnerStrategy.verificationMode,
+      recommendedChecks: partnerStrategy.recommendedChecks,
+    },
     intents: bundle.intents.map((intent) => ({
       id: intent.id,
       description: intent.description,
@@ -144,11 +157,23 @@ function planIntent(options = {}) {
   const requiredRisks = getRequiredApprovalRisks(bundle, profile);
   const requiresApproval = requiredRisks.includes(intent.risk);
   const checkpointRequired = requiresApproval && !approved;
-  const phases = decomposeActions(intent.actions);
+  const partnerStrategy = buildPartnerStrategy({
+    partnerProfile: options.partnerProfile,
+    tokenBudget,
+  });
+  const rankedActions = rankActions(intent.actions, {
+    modelPath: options.modelPath,
+    partnerStrategy,
+  });
+  const plannedActions = partnerStrategy.profile === 'balanced'
+    ? intent.actions
+    : rankedActions.ranked;
+  const phases = decomposeActions(plannedActions);
 
   return {
     bundleId: bundle.bundleId,
     mcpProfile: profile,
+    partnerProfile: partnerStrategy.profile,
     generatedAt: new Date().toISOString(),
     status: checkpointRequired ? 'checkpoint_required' : 'ready',
     intent: {
@@ -166,9 +191,11 @@ function planIntent(options = {}) {
         requiredForRiskLevels: requiredRisks,
       }
       : null,
-    actions: intent.actions,
+    actions: plannedActions,
     phases,
-    tokenBudget,
+    tokenBudget: partnerStrategy.tokenBudget || tokenBudget,
+    partnerStrategy,
+    actionScores: rankedActions.scores,
   };
 }
 
@@ -188,23 +215,53 @@ function getDefaultModelPath() {
   return path.join(feedbackDir, 'feedback_model.json');
 }
 
-function scoreActions(actions, modelPath) {
+function scoreActions(actions, modelPath, options = {}) {
+  const partnerStrategy = options.partnerStrategy || buildPartnerStrategy({
+    partnerProfile: options.partnerProfile,
+  });
   const model = loadModel(modelPath || getDefaultModelPath());
   const posteriors = samplePosteriors(model);
+  const partnerScore = posteriors[partnerStrategy.partnerCategory] !== undefined
+    ? posteriors[partnerStrategy.partnerCategory]
+    : 0.5;
 
-  return actions.map((action) => {
+  return actions.map((action, index) => {
     const category = ACTION_CATEGORY_MAP[action.name] || 'uncategorized';
-    const score = posteriors[category] !== undefined ? posteriors[category] : 0.5;
-    return { action, category, score };
-  }).sort((a, b) => b.score - a.score);
+    const categoryScore = posteriors[category] !== undefined ? posteriors[category] : 0.5;
+    const partnerBias = getPartnerActionBias(action, partnerStrategy);
+    const score = Math.max(0, Math.min(1, (categoryScore * 0.7) + (partnerScore * 0.3) + partnerBias));
+    return {
+      action,
+      category,
+      actionScore: categoryScore,
+      partnerProfile: partnerStrategy.profile,
+      partnerCategory: partnerStrategy.partnerCategory,
+      partnerScore,
+      partnerBias,
+      score,
+      index,
+    };
+  }).sort((a, b) => b.score - a.score || a.index - b.index);
 }
 
 function rankActions(actions, options = {}) {
   const modelPath = options.modelPath || getDefaultModelPath();
-  const scored = scoreActions(actions, modelPath);
+  const partnerStrategy = options.partnerStrategy || buildPartnerStrategy({
+    partnerProfile: options.partnerProfile,
+  });
+  const scored = scoreActions(actions, modelPath, { partnerStrategy });
   return {
     ranked: scored.map((s) => s.action),
-    scores: scored.map((s) => ({ name: s.action.name, category: s.category, score: s.score })),
+    scores: scored.map((s) => ({
+      name: s.action.name,
+      category: s.category,
+      partnerProfile: s.partnerProfile,
+      partnerCategory: s.partnerCategory,
+      actionScore: s.actionScore,
+      partnerScore: s.partnerScore,
+      partnerBias: s.partnerBias,
+      score: s.score,
+    })),
   };
 }
 

--- a/scripts/partner-orchestration.js
+++ b/scripts/partner-orchestration.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+const DEFAULT_CONFIG_PATH = path.join(PROJECT_ROOT, 'config', 'partner-routing.json');
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function loadPartnerRoutingConfig(configPath = DEFAULT_CONFIG_PATH) {
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  const parsed = JSON.parse(raw);
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Invalid partner routing config: expected object');
+  }
+  if (!parsed.defaultProfile || typeof parsed.defaultProfile !== 'string') {
+    throw new Error('Invalid partner routing config: missing defaultProfile');
+  }
+  if (!parsed.profiles || typeof parsed.profiles !== 'object') {
+    throw new Error('Invalid partner routing config: missing profiles');
+  }
+
+  return parsed;
+}
+
+function normalizePartnerProfile(partnerProfile, config = loadPartnerRoutingConfig()) {
+  if (!partnerProfile) {
+    return config.defaultProfile;
+  }
+
+  const raw = String(partnerProfile).trim().toLowerCase();
+  const alias = config.aliases && config.aliases[raw];
+  const resolved = alias || raw;
+
+  if (!config.profiles[resolved]) {
+    throw new Error(`Unknown partner profile: ${partnerProfile}`);
+  }
+
+  return resolved;
+}
+
+function getPartnerCategory(partnerProfile) {
+  return `partner_${partnerProfile}`;
+}
+
+function scaleBudgetValue(value, multiplier) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return value;
+  }
+  const effectiveMultiplier = Number.isFinite(multiplier) && multiplier > 0 ? multiplier : 1;
+  return Math.max(1, Math.round(value * effectiveMultiplier));
+}
+
+function scaleTokenBudget(tokenBudget, multipliers = {}) {
+  if (!tokenBudget || typeof tokenBudget !== 'object') {
+    return null;
+  }
+
+  return {
+    total: scaleBudgetValue(tokenBudget.total, multipliers.total),
+    perAction: scaleBudgetValue(tokenBudget.perAction, multipliers.perAction),
+    contextPack: scaleBudgetValue(tokenBudget.contextPack, multipliers.contextPack),
+  };
+}
+
+function buildPartnerStrategy(options = {}) {
+  const config = loadPartnerRoutingConfig(options.configPath);
+  const profile = normalizePartnerProfile(options.partnerProfile, config);
+  const profileConfig = config.profiles[profile] || {};
+
+  return {
+    profile,
+    label: profileConfig.label || profile,
+    description: profileConfig.description || '',
+    verificationMode: profileConfig.verificationMode || 'standard',
+    maxRetryDelta: Number.isFinite(profileConfig.maxRetryDelta) ? profileConfig.maxRetryDelta : 0,
+    rewardBias: Number.isFinite(profileConfig.rewardBias) ? profileConfig.rewardBias : 0,
+    partnerCategory: getPartnerCategory(profile),
+    actionBiases: profileConfig.actionBiases || {},
+    recommendedChecks: Array.isArray(profileConfig.recommendedChecks) ? profileConfig.recommendedChecks.slice() : [],
+    tokenBudget: scaleTokenBudget(options.tokenBudget, profileConfig.tokenBudgetMultiplier || {}),
+  };
+}
+
+function getPartnerActionBias(action, partnerStrategy) {
+  if (!action || !partnerStrategy || !partnerStrategy.actionBiases) {
+    return 0;
+  }
+  return Number(partnerStrategy.actionBiases[action.name] || 0);
+}
+
+function resolveVerificationRetries(baseMaxRetries, partnerStrategy) {
+  const requested = Number.isFinite(baseMaxRetries) ? baseMaxRetries : 3;
+  const delta = partnerStrategy && Number.isFinite(partnerStrategy.maxRetryDelta)
+    ? partnerStrategy.maxRetryDelta
+    : 0;
+  return Math.max(1, requested + delta);
+}
+
+function computePartnerReward(params = {}) {
+  const config = loadPartnerRoutingConfig(params.configPath);
+  const rewardModel = config.rewardModel || {};
+  const accepted = params.accepted === true;
+  const attempts = Number.isFinite(params.attempts) ? params.attempts : 1;
+  const violationCount = Number.isFinite(params.violationCount) ? params.violationCount : 0;
+  const partnerStrategy = params.partnerStrategy || buildPartnerStrategy({
+    partnerProfile: params.partnerProfile,
+  });
+
+  const baseReward = accepted ? Number(rewardModel.accepted || 1) : Number(rewardModel.rejected || -1);
+  const attemptPenalty = Math.max(0, attempts - 1) * Number(rewardModel.attemptPenalty || 0);
+  const violationPenalty = Math.min(
+    violationCount * Number(rewardModel.violationPenalty || 0),
+    Number(rewardModel.maxViolationPenalty || 0),
+  );
+  const rawReward = baseReward - attemptPenalty - violationPenalty + Number(partnerStrategy.rewardBias || 0);
+  const reward = Math.round(clamp(rawReward, -1, 1) * 1000) / 1000;
+
+  return {
+    profile: partnerStrategy.profile,
+    reward,
+    weightMultiplier: 1 + Math.abs(reward),
+    components: {
+      baseReward,
+      attemptPenalty,
+      violationPenalty,
+      rewardBias: Number(partnerStrategy.rewardBias || 0),
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_CONFIG_PATH,
+  loadPartnerRoutingConfig,
+  normalizePartnerProfile,
+  getPartnerCategory,
+  scaleTokenBudget,
+  buildPartnerStrategy,
+  getPartnerActionBias,
+  resolveVerificationRetries,
+  computePartnerReward,
+};

--- a/scripts/prove-automation.js
+++ b/scripts/prove-automation.js
@@ -253,7 +253,27 @@ async function runAutomationProof(options = {}) {
       });
     }
 
-    // 10) context evaluate stores rubric evaluation
+    // 10) partner-aware planning returns execution strategy
+    {
+      currentCheck = 'intent.partner_strategy';
+      const partnerPlan = planIntent({
+        intentId: 'incident_postmortem',
+        mcpProfile: 'default',
+        partnerProfile: 'strict-reviewer',
+      });
+      check(partnerPlan.partnerProfile === 'strict_reviewer', 'expected normalized strict_reviewer partner profile');
+      check(Boolean(partnerPlan.partnerStrategy), 'expected partner strategy metadata');
+      check(partnerPlan.partnerStrategy.verificationMode === 'evidence_first', 'expected evidence_first verification mode');
+      check(partnerPlan.tokenBudget.contextPack > 6000, 'expected boosted contextPack budget for strict reviewer');
+      check(Array.isArray(partnerPlan.actionScores), 'expected action scores for partner-aware plan');
+      addResult('intent.partner_strategy', true, {
+        partnerProfile: partnerPlan.partnerProfile,
+        verificationMode: partnerPlan.partnerStrategy.verificationMode,
+        contextPack: partnerPlan.tokenBudget.contextPack,
+      });
+    }
+
+    // 11) context evaluate stores rubric evaluation
     {
       currentCheck = 'context.evaluate.construct';
       const construct = await fetchWithRetry(`${baseUrl}/v1/context/construct`, {
@@ -291,7 +311,7 @@ async function runAutomationProof(options = {}) {
       addResult('context.evaluate.rubric', true, { rubricId: evalBody.rubricEvaluation.rubricId });
     }
 
-    // 11) semantic cache hit on equivalent query
+    // 12) semantic cache hit on equivalent query
     {
       currentCheck = 'context.semantic_cache.hit.first';
       fs.rmSync(path.join(CONTEXTFS_ROOT, NAMESPACES.provenance, 'semantic-cache.jsonl'), { force: true });
@@ -326,7 +346,7 @@ async function runAutomationProof(options = {}) {
       });
     }
 
-    // 12) self-healing helpers produce healthy reports in baseline state
+    // 13) self-healing helpers produce healthy reports in baseline state
     {
       const health = collectHealthReport({
         checks: [
@@ -346,7 +366,7 @@ async function runAutomationProof(options = {}) {
       });
     }
 
-    // 13) code reasoning traces verify DPO pair quality
+    // 14) code reasoning traces verify DPO pair quality
     {
       const { MEMORY_LOG_PATH } = getFeedbackPaths();
       const memories = readJSONL(MEMORY_LOG_PATH);
@@ -367,7 +387,7 @@ async function runAutomationProof(options = {}) {
       }
     }
 
-    // 14) code reasoning traces attached to proof checks
+    // 15) code reasoning traces attached to proof checks
     {
       const proofTraces = report.checks.map((chk) => traceForProofCheck(chk));
       const aggregate = aggregateTraces(proofTraces);

--- a/scripts/thompson-sampling.js
+++ b/scripts/thompson-sampling.js
@@ -152,8 +152,8 @@ function saveModel(model, modelPath) {
 /**
  * Apply a single weighted Beta-Bernoulli update to the model.
  *
- * For positive signal:  alpha += timeDecayWeight(timestamp)
- * For negative signal:  beta  += timeDecayWeight(timestamp)
+ * For positive signal:  alpha += timeDecayWeight(timestamp) * weightMultiplier
+ * For negative signal:  beta  += timeDecayWeight(timestamp) * weightMultiplier
  *
  * Updates all provided categories. If a category is not in the model yet,
  * it is added with default priors before applying the update.
@@ -165,10 +165,12 @@ function saveModel(model, modelPath) {
  * @param {'positive'|'negative'} params.signal - Feedback direction
  * @param {string} params.timestamp - ISO 8601 timestamp for decay calculation
  * @param {string[]} [params.categories] - Categories to update; defaults to ['uncategorized']
+ * @param {number} [params.weightMultiplier] - Optional multiplier for stronger/slower updates
  * @returns {Object} The mutated model
  */
-function updateModel(model, { signal, timestamp, categories }) {
-  const weight = timeDecayWeight(timestamp);
+function updateModel(model, { signal, timestamp, categories, weightMultiplier }) {
+  const multiplier = Number.isFinite(weightMultiplier) && weightMultiplier > 0 ? weightMultiplier : 1;
+  const weight = timeDecayWeight(timestamp) * multiplier;
   const isPositive = signal === 'positive';
   const cats = categories && categories.length ? categories : ['uncategorized'];
 

--- a/scripts/verification-loop.js
+++ b/scripts/verification-loop.js
@@ -2,6 +2,11 @@
 
 const path = require('path');
 const { readJSONL, getFeedbackPaths } = require('./feedback-loop');
+const {
+  buildPartnerStrategy,
+  computePartnerReward,
+  resolveVerificationRetries,
+} = require('./partner-orchestration');
 
 const MAX_RETRIES = 3;
 const DEFAULT_MODEL_PATH = path.join(__dirname, '..', '.rlhf', 'verification-model.json');
@@ -77,7 +82,11 @@ function extractKeywords(text) {
  * @returns {object} { accepted, attempts, finalVerification, history, thompsonUpdate }
  */
 function runVerificationLoop(params) {
-  const maxRetries = params.maxRetries || MAX_RETRIES;
+  const requestedMaxRetries = Number.isFinite(params.maxRetries) ? params.maxRetries : MAX_RETRIES;
+  const partnerStrategy = buildPartnerStrategy({
+    partnerProfile: params.partnerProfile,
+  });
+  const maxRetries = resolveVerificationRetries(requestedMaxRetries, partnerStrategy);
   const modelPath = params.modelPath || DEFAULT_MODEL_PATH;
   const tags = Array.isArray(params.tags) ? params.tags : [];
   const history = [];
@@ -122,14 +131,29 @@ function runVerificationLoop(params) {
   const ts = require('./thompson-sampling');
   const model = ts.loadModel(modelPath);
   const signal = accepted ? 'positive' : 'negative';
+  const partnerReward = computePartnerReward({
+    accepted,
+    attempts: history.length,
+    violationCount: finalVerification && Array.isArray(finalVerification.violations)
+      ? finalVerification.violations.length
+      : 0,
+    partnerStrategy,
+  });
+  const categories = [...new Set([
+    ...(tags.length ? tags : ['uncategorized']),
+    partnerStrategy.partnerCategory,
+  ])];
   ts.updateModel(model, {
     signal,
     timestamp: new Date().toISOString(),
-    categories: tags.length ? tags : ['uncategorized'],
+    categories,
+    weightMultiplier: partnerReward.weightMultiplier,
   });
   ts.saveModel(model, modelPath);
   const thompsonUpdate = {
     signal,
+    partnerCategory: partnerStrategy.partnerCategory,
+    weightMultiplier: partnerReward.weightMultiplier,
     reliability: ts.getReliability(model),
   };
 
@@ -137,8 +161,11 @@ function runVerificationLoop(params) {
     accepted,
     attempts: history.length,
     maxRetries,
+    requestedMaxRetries,
     finalVerification,
     history,
+    partnerStrategy,
+    partnerReward,
     thompsonUpdate,
   };
 }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -573,8 +573,8 @@ function createApiServer() {
                     { name: 'construct_context_pack', description: 'Build bounded context pack', inputSchema: { type: 'object', properties: { task: { type: 'string' } }, required: ['task'] } },
                     { name: 'evaluate_context_pack', description: 'Record context pack outcome', inputSchema: { type: 'object', properties: { packId: { type: 'string' }, outcome: { type: 'string' } }, required: ['packId', 'outcome'] } },
                     { name: 'context_provenance', description: 'Audit trail of context decisions', inputSchema: { type: 'object', properties: {} } },
-                    { name: 'list_intents', description: 'Available action plans', inputSchema: { type: 'object', properties: {} } },
-                    { name: 'plan_intent', description: 'Generate execution plan', inputSchema: { type: 'object', properties: { intent: { type: 'string' } }, required: ['intent'] } },
+                    { name: 'list_intents', description: 'Available action plans', inputSchema: { type: 'object', properties: { mcpProfile: { type: 'string' }, bundleId: { type: 'string' }, partnerProfile: { type: 'string' } } } },
+                    { name: 'plan_intent', description: 'Generate execution plan', inputSchema: { type: 'object', properties: { intentId: { type: 'string' }, context: { type: 'string' }, mcpProfile: { type: 'string' }, bundleId: { type: 'string' }, partnerProfile: { type: 'string' }, approved: { type: 'boolean' } }, required: ['intentId'] } },
                   ],
                 },
               });
@@ -946,8 +946,9 @@ function createApiServer() {
       if (req.method === 'GET' && pathname === '/v1/intents/catalog') {
         const mcpProfile = parsed.searchParams.get('mcpProfile') || undefined;
         const bundleId = parsed.searchParams.get('bundleId') || undefined;
+        const partnerProfile = parsed.searchParams.get('partnerProfile') || undefined;
         try {
-          const catalog = listIntents({ mcpProfile, bundleId });
+          const catalog = listIntents({ mcpProfile, bundleId, partnerProfile });
           sendJson(res, 200, catalog);
         } catch (err) {
           throw createHttpError(400, err.message || 'Invalid intent catalog request');
@@ -963,6 +964,7 @@ function createApiServer() {
             context: body.context || '',
             mcpProfile: body.mcpProfile,
             bundleId: body.bundleId,
+            partnerProfile: body.partnerProfile,
             approved: body.approved === true,
           });
           sendJson(res, 200, plan);

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -178,6 +178,14 @@ test('intent catalog endpoint returns configured intents', async () => {
   assert.ok(body.intents.length >= 3);
 });
 
+test('intent catalog endpoint accepts partner profile', async () => {
+  const res = await fetch('http://localhost:8790/v1/intents/catalog?mcpProfile=default&partnerProfile=strict-reviewer', { headers: authHeader });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.partnerProfile, 'strict_reviewer');
+  assert.equal(body.partnerStrategy.verificationMode, 'evidence_first');
+});
+
 test('intent catalog rejects invalid mcp profile', async () => {
   const res = await fetch('http://localhost:8790/v1/intents/catalog?mcpProfile=bad-profile', {
     headers: authHeader,
@@ -200,6 +208,25 @@ test('intent plan returns checkpoint for unapproved high-risk action', async () 
   const body = await res.json();
   assert.equal(body.status, 'checkpoint_required');
   assert.equal(body.requiresApproval, true);
+});
+
+test('intent plan returns partner-aware strategy metadata', async () => {
+  const res = await fetch('http://localhost:8790/v1/intents/plan', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...authHeader },
+    body: JSON.stringify({
+      intentId: 'incident_postmortem',
+      mcpProfile: 'default',
+      partnerProfile: 'strict-reviewer',
+    }),
+  });
+
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.partnerProfile, 'strict_reviewer');
+  assert.equal(body.partnerStrategy.verificationMode, 'evidence_first');
+  assert.ok(body.tokenBudget.contextPack > 6000);
+  assert.ok(Array.isArray(body.actionScores));
 });
 
 test('summary endpoint returns markdown text payload', async () => {

--- a/tests/async-job-runner.test.js
+++ b/tests/async-job-runner.test.js
@@ -85,6 +85,19 @@ describe('async-job-runner', () => {
     assert.equal(result.status, 'completed');
   });
 
+  it('executeJob carries partner profile through verification', () => {
+    const result = m.executeJob({
+      id: 'partner-job',
+      context: 'verified output',
+      tags: ['testing'],
+      partnerProfile: 'strict-reviewer',
+    });
+
+    assert.equal(result.phases.verification.partnerProfile, 'strict_reviewer');
+    assert.equal(result.phases.verification.verificationMode, 'evidence_first');
+    assert.ok(typeof result.phases.verification.reward === 'number');
+  });
+
   it('executeJob writes to job log', () => {
     const before = m.readJobLog();
     m.executeJob({

--- a/tests/intent-router.test.js
+++ b/tests/intent-router.test.js
@@ -32,6 +32,17 @@ test('listIntents returns approval metadata for profile', () => {
   assert.equal(mediumIntent.requiresApproval, true);
 });
 
+test('listIntents normalizes partner profile and exposes partner strategy', () => {
+  const catalog = listIntents({
+    bundleId: 'default-v1',
+    mcpProfile: 'default',
+    partnerProfile: 'strict-reviewer',
+  });
+  assert.equal(catalog.partnerProfile, 'strict_reviewer');
+  assert.equal(catalog.partnerStrategy.verificationMode, 'evidence_first');
+  assert.ok(Array.isArray(catalog.partnerStrategy.recommendedChecks));
+});
+
 test('high-risk intent requires approval by default profile', () => {
   const plan = planIntent({
     bundleId: 'default-v1',
@@ -192,6 +203,38 @@ test('planIntent accepts custom token budget', () => {
   assert.equal(plan.tokenBudget.total, 8000);
   assert.equal(plan.tokenBudget.perAction, 2000);
   assert.equal(plan.tokenBudget.contextPack, DEFAULT_TOKEN_BUDGET.contextPack);
+});
+
+test('planIntent applies partner-aware token budget and action scoring', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ir-plan-partner-'));
+  const modelPath = path.join(tmpDir, 'feedback_model.json');
+  try {
+    const model = createInitialModel();
+    for (let i = 0; i < 20; i++) {
+      updateModel(model, { signal: 'positive', timestamp: new Date().toISOString(), categories: ['architecture'] });
+    }
+    saveModel(model, modelPath);
+
+    const plan = planIntent({
+      bundleId: 'default-v1',
+      mcpProfile: 'default',
+      intentId: 'incident_postmortem',
+      partnerProfile: 'strict-reviewer',
+      tokenBudget: { total: 10000, perAction: 3000, contextPack: 5000 },
+      modelPath,
+    });
+
+    assert.equal(plan.partnerProfile, 'strict_reviewer');
+    assert.equal(plan.partnerStrategy.verificationMode, 'evidence_first');
+    assert.ok(plan.tokenBudget.contextPack > 5000);
+    assert.equal(plan.actionScores.length, 3);
+    assert.ok(
+      ['construct_context_pack', 'context_provenance'].includes(plan.actions[0].name),
+      `expected evidence action first, got ${plan.actions[0].name}`,
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 /* ── Token Budget Tests ────────────────────────────────────────── */

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -118,6 +118,26 @@ test('intent tools list and plan enforce checkpoint flow', async () => {
   assert.equal(plan.requiresApproval, true);
 });
 
+test('plan_intent exposes partner-aware strategy over MCP', async () => {
+  const planResult = await handleRequest({
+    jsonrpc: '2.0',
+    id: 25,
+    method: 'tools/call',
+    params: {
+      name: 'plan_intent',
+      arguments: {
+        intentId: 'incident_postmortem',
+        mcpProfile: 'default',
+        partnerProfile: 'strict-reviewer',
+      },
+    },
+  });
+  const plan = JSON.parse(planResult.content[0].text);
+  assert.equal(plan.partnerProfile, 'strict_reviewer');
+  assert.equal(plan.partnerStrategy.verificationMode, 'evidence_first');
+  assert.ok(Array.isArray(plan.actionScores));
+});
+
 test('prevention_rules blocks external output paths', async () => {
   await assert.rejects(async () => {
     await handleRequest({

--- a/tests/prove-automation.test.js
+++ b/tests/prove-automation.test.js
@@ -29,8 +29,8 @@ test('automation proof: zero failures', () => {
   assert.equal(report.summary.failed, 0);
 });
 
-test('automation proof: at least 14 checks pass', () => {
-  assert.ok(report.summary.passed >= 14, `expected >= 14 passed, got ${report.summary.passed}`);
+test('automation proof: at least 15 checks pass', () => {
+  assert.ok(report.summary.passed >= 15, `expected >= 15 passed, got ${report.summary.passed}`);
 });
 
 test('automation proof: report.json written', () => {
@@ -52,6 +52,7 @@ const requiredChecks = [
   'api.rubric_gate',
   'mcp.rubric_gate',
   'intent.checkpoint_enforcement',
+  'intent.partner_strategy',
   'context.evaluate.rubric',
   'context.semantic_cache.hit',
   'self_healing.helpers',
@@ -114,6 +115,13 @@ test('automation proof: intent checkpoint enforced', () => {
   const check = getCheck('intent.checkpoint_enforcement');
   assert.equal(check.details.blocked, 'checkpoint_required');
   assert.equal(check.details.approved, 'ready');
+});
+
+test('automation proof: partner strategy exposed in intent plan', () => {
+  const check = getCheck('intent.partner_strategy');
+  assert.equal(check.details.partnerProfile, 'strict_reviewer');
+  assert.equal(check.details.verificationMode, 'evidence_first');
+  assert.ok(check.details.contextPack > 6000);
 });
 
 test('automation proof: semantic cache hit on equivalent query', () => {

--- a/tests/thompson-sampling.test.js
+++ b/tests/thompson-sampling.test.js
@@ -104,6 +104,18 @@ describe('updateModel', () => {
     updateModel(model, { signal: 'negative', timestamp: ts, categories: ['git'] });
     assert.strictEqual(model.total_entries, 2);
   });
+
+  it('weightMultiplier scales posterior updates', () => {
+    const model = createInitialModel();
+    const ts = new Date().toISOString();
+    updateModel(model, {
+      signal: 'positive',
+      timestamp: ts,
+      categories: ['testing'],
+      weightMultiplier: 2,
+    });
+    assert.ok(model.categories.testing.alpha > 2.9, `alpha should reflect weighted update, got ${model.categories.testing.alpha}`);
+  });
 });
 
 describe('getReliability', () => {

--- a/tests/verification-loop.test.js
+++ b/tests/verification-loop.test.js
@@ -198,6 +198,31 @@ describe('verification-loop', () => {
     assert.ok(model.categories.architecture.alpha > 1);
   });
 
+  it('runVerificationLoop records partner-aware strategy and model updates', () => {
+    fs.writeFileSync(path.join(tmpDir, 'memory-log.jsonl'), '');
+    delete require.cache[require.resolve('../scripts/verification-loop')];
+    const fresh = require('../scripts/verification-loop');
+
+    const modelPath = path.join(tmpDir, 'partner-model.json');
+    const result = fresh.runVerificationLoop({
+      context: 'verified output with evidence',
+      tags: ['testing'],
+      partnerProfile: 'strict-reviewer',
+      maxRetries: 1,
+      modelPath,
+    });
+
+    assert.equal(result.partnerStrategy.profile, 'strict_reviewer');
+    assert.equal(result.requestedMaxRetries, 1);
+    assert.equal(result.maxRetries, 2);
+    assert.ok(result.partnerReward.reward > 0);
+    assert.equal(result.thompsonUpdate.partnerCategory, 'partner_strict_reviewer');
+
+    const model = JSON.parse(fs.readFileSync(modelPath, 'utf-8'));
+    assert.ok(model.categories.partner_strict_reviewer);
+    assert.ok(model.categories.partner_strict_reviewer.alpha > 1);
+  });
+
   it('getVerificationReliability returns per-category reliability', () => {
     const modelPath = path.join(tmpDir, 'rel-model.json');
     fs.writeFileSync(path.join(tmpDir, 'memory-log.jsonl'), '');


### PR DESCRIPTION
## Summary
- add partner-aware orchestration profiles and shared strategy runtime
- thread partnerProfile through API, MCP, and OpenAPI plan/list intent surfaces
- teach intent planning, verification, and automation proof to adapt to partner profiles

## Verification
- npm ci
- node --test tests/intent-router.test.js tests/verification-loop.test.js tests/thompson-sampling.test.js tests/async-job-runner.test.js
- node --test tests/api-server.test.js tests/mcp-server.test.js tests/prove-automation.test.js
- npm test
- npm run test:coverage
- env RLHF_PROOF_DIR="$(mktemp -d)" npm run prove:adapters
- env RLHF_PROOF_DIR="$(mktemp -d)" npm run prove:automation
- env RLHF_PROOF_DIR="$(mktemp -d)" npm run self-heal:check

## Evidence
- docs/VERIFICATION_EVIDENCE.md records the March 13, 2026 partner-aware orchestration verification entry.