### PR TITLE
feat: add truthful revenue analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ RLHF_API_KEY=change-me
 # STRIPE_WEBHOOK_SECRET_ROTATED_AT=2026-03-12T00:00:00.000Z
 # GITHUB_MARKETPLACE_WEBHOOK_SECRET=github_webhook_secret
 # GITHUB_MARKETPLACE_WEBHOOK_SECRET_ROTATED_AT=2026-03-12T00:00:00.000Z
+# RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON={"1":{"amountCents":2900,"currency":"USD","recurringInterval":"month"}}
 
 # Railway deploy
 # RAILWAY_TOKEN=railway_token
@@ -28,6 +29,7 @@ RLHF_API_KEY=change-me
 # Optional local paths
 # RLHF_FEEDBACK_DIR=.claude/memory/feedback
 # RLHF_CONTEXTFS_DIR=.claude/memory/feedback/contextfs
+# RLHF_REVENUE_LEDGER_PATH=.claude/memory/feedback/revenue-events.jsonl
 
 # Optional strictness toggles
 # RLHF_ALLOW_INSECURE=false

--- a/adapters/chatgpt/openapi.yaml
+++ b/adapters/chatgpt/openapi.yaml
@@ -151,13 +151,25 @@ components:
               type: string
             tracksBookedRevenue:
               type: boolean
+            tracksPaidOrders:
+              type: boolean
             tracksInvoices:
               type: boolean
+            tracksAttribution:
+              type: boolean
+            providerCoverage:
+              type: object
+              additionalProperties:
+                type: string
         funnel:
           allOf:
             - $ref: '#/components/schemas/FunnelAnalyticsResponse'
             - type: object
               properties:
+                uniqueAcquisitionLeads:
+                  type: integer
+                uniquePaidCustomers:
+                  type: integer
                 firstPaidAt:
                   type: string
                   nullable: true
@@ -183,6 +195,124 @@ components:
                     traceId:
                       type: string
                       nullable: true
+        signups:
+          type: object
+          properties:
+            total:
+              type: integer
+            uniqueLeads:
+              type: integer
+            bySource:
+              type: object
+              additionalProperties:
+                type: integer
+            byCampaign:
+              type: object
+              additionalProperties:
+                type: integer
+        revenue:
+          type: object
+          properties:
+            paidOrders:
+              type: integer
+            paidCustomers:
+              type: integer
+            bookedRevenueCents:
+              type: integer
+            bookedRevenueByCurrency:
+              type: object
+              additionalProperties:
+                type: integer
+            amountKnownOrders:
+              type: integer
+            amountUnknownOrders:
+              type: integer
+            amountKnownCoverageRate:
+              type: number
+            unreconciledPaidEvents:
+              type: integer
+            latestPaidAt:
+              type: string
+              nullable: true
+            latestPaidOrder:
+              type: object
+              nullable: true
+              properties:
+                timestamp:
+                  type: string
+                  nullable: true
+                provider:
+                  type: string
+                  nullable: true
+                event:
+                  type: string
+                  nullable: true
+                orderId:
+                  type: string
+                  nullable: true
+                customerId:
+                  type: string
+                  nullable: true
+                amountCents:
+                  type: integer
+                  nullable: true
+                currency:
+                  type: string
+                  nullable: true
+                amountKnown:
+                  type: boolean
+            byProvider:
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  paidOrders:
+                    type: integer
+                  bookedRevenueCents:
+                    type: integer
+                  amountKnownOrders:
+                    type: integer
+                  amountUnknownOrders:
+                    type: integer
+                  bookedRevenueByCurrency:
+                    type: object
+                    additionalProperties:
+                      type: integer
+        attribution:
+          type: object
+          properties:
+            acquisitionBySource:
+              type: object
+              additionalProperties:
+                type: integer
+            acquisitionByCampaign:
+              type: object
+              additionalProperties:
+                type: integer
+            paidBySource:
+              type: object
+              additionalProperties:
+                type: integer
+            paidByCampaign:
+              type: object
+              additionalProperties:
+                type: integer
+            bookedRevenueBySourceCents:
+              type: object
+              additionalProperties:
+                type: integer
+            bookedRevenueByCampaignCents:
+              type: object
+              additionalProperties:
+                type: integer
+            conversionBySource:
+              type: object
+              additionalProperties:
+                type: number
+            conversionByCampaign:
+              type: object
+              additionalProperties:
+                type: number
         keys:
           type: object
           properties:
@@ -278,7 +408,7 @@ paths:
       operationId: getBillingSummary
       responses:
         '200':
-          description: Admin-only operational billing summary from the funnel ledger and key store
+          description: Admin-only business summary from the funnel ledger, revenue ledger, and key store
           content:
             application/json:
               schema:

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -40,6 +40,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 ## Proof policy
 
 - Use booked revenue, paid orders, or named pilot agreements for commercial proof.
+- Use the admin billing summary and CLI CFO output to distinguish `bookedRevenueCents` from `paidOrders`; not every paid provider event carries a verifiable amount by default.
 - Use `docs/VERIFICATION_EVIDENCE.md`, `proof/compatibility/report.json`, and `proof/automation/report.json` for engineering proof.
 - When in doubt, prefer "early-stage" or "pilot" language over unverified traction claims.
  

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -666,6 +666,55 @@ Artifacts updated:
 - `proof/automation/report.json`
 - `proof/automation/report.md`
 
+## 2026-03-13 Truthful Revenue Analytics Verification
+
+Scope:
+
+- Added a dedicated revenue ledger to separate booked revenue from generic paid-stage funnel telemetry.
+- Preserved honest provider coverage: Stripe records booked revenue; GitHub Marketplace records paid orders and only records booked revenue when plan pricing is explicitly configured.
+- Threaded attribution metadata (`source`, UTM fields, referrer, landing path, CTA id) through public checkout creation, funnel events, revenue events, API summaries, CLI CFO output, and the hosted landing page.
+- Replaced hardcoded marketing proof-strip vanity numbers with stable evidence-backed claims on the public landing page.
+
+Commands run:
+
+```bash
+npm ci
+env RLHF_API_KEY=test-api-key node --test tests/billing.test.js tests/api-server.test.js tests/github-billing.test.js tests/cli.test.js tests/stripe-webhook-route.test.js
+env RLHF_API_KEY=test-api-key node --test tests/openapi-parity.test.js tests/adapters.test.js tests/commerce-quality.test.js
+env RLHF_API_KEY=ci-secret npm test
+env RLHF_API_KEY=ci-secret npm run test:coverage
+npm run prove:adapters
+npm run prove:automation
+npm run self-heal:check
+```
+
+Observed results:
+
+- `npm ci`: completed successfully; `audited 151 packages` and `found 0 vulnerabilities`.
+- Targeted changed-surface suite: `76 passed`, `0 failed`.
+- OpenAPI / adapter / commerce suite: `27 passed`, `0 failed`.
+- `npm test`: completed successfully across schema, loop, API, proof, E2E, billing, CLI, watcher, workflow, autoresearch, gates, and hardening phases.
+- `npm run test:coverage`: `971 passed`, `0 failed`, `1 skipped`; coverage `82.59%` lines, `68.77%` branches, `85.37%` functions.
+- `npm run prove:adapters`: `38 passed`, `0 failed`.
+- `npm run prove:automation`: `37 passed`, `0 failed`.
+- `npm run self-heal:check`: `Overall: HEALTHY` with `4/4 healthy` checks.
+
+Behavioral proof points:
+
+- `scripts/billing.js` now emits `bookedRevenueCents`, `paidOrders`, `amountKnownCoverageRate`, `unreconciledPaidEvents`, and attribution breakdowns from a dedicated revenue ledger instead of inferring money from stage counts.
+- `tests/billing.test.js` proves Stripe booked revenue is summarized truthfully and GitHub Marketplace remains amount-unknown unless plan pricing is configured.
+- `tests/api-server.test.js` proves checkout attribution survives the API path and shows up in the admin billing summary.
+- `tests/cli.test.js` proves `node bin/cli.js cfo` emits the richer revenue + attribution summary shape.
+- `tests/github-billing.test.js` proves GitHub Marketplace purchase events create paid-order records and optionally booked revenue when plan pricing config is present.
+- `tests/openapi-parity.test.js` and `tests/adapters.test.js` prove the machine-readable adapter surface stayed in sync after the summary shape expansion.
+
+Artifacts updated:
+
+- `proof/compatibility/report.json`
+- `proof/compatibility/report.md`
+- `proof/automation/report.json`
+- `proof/automation/report.md`
+
 ## 2026-03-09 Local Intelligence Verification
 
 Scope:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -151,13 +151,25 @@ components:
               type: string
             tracksBookedRevenue:
               type: boolean
+            tracksPaidOrders:
+              type: boolean
             tracksInvoices:
               type: boolean
+            tracksAttribution:
+              type: boolean
+            providerCoverage:
+              type: object
+              additionalProperties:
+                type: string
         funnel:
           allOf:
             - $ref: '#/components/schemas/FunnelAnalyticsResponse'
             - type: object
               properties:
+                uniqueAcquisitionLeads:
+                  type: integer
+                uniquePaidCustomers:
+                  type: integer
                 firstPaidAt:
                   type: string
                   nullable: true
@@ -183,6 +195,124 @@ components:
                     traceId:
                       type: string
                       nullable: true
+        signups:
+          type: object
+          properties:
+            total:
+              type: integer
+            uniqueLeads:
+              type: integer
+            bySource:
+              type: object
+              additionalProperties:
+                type: integer
+            byCampaign:
+              type: object
+              additionalProperties:
+                type: integer
+        revenue:
+          type: object
+          properties:
+            paidOrders:
+              type: integer
+            paidCustomers:
+              type: integer
+            bookedRevenueCents:
+              type: integer
+            bookedRevenueByCurrency:
+              type: object
+              additionalProperties:
+                type: integer
+            amountKnownOrders:
+              type: integer
+            amountUnknownOrders:
+              type: integer
+            amountKnownCoverageRate:
+              type: number
+            unreconciledPaidEvents:
+              type: integer
+            latestPaidAt:
+              type: string
+              nullable: true
+            latestPaidOrder:
+              type: object
+              nullable: true
+              properties:
+                timestamp:
+                  type: string
+                  nullable: true
+                provider:
+                  type: string
+                  nullable: true
+                event:
+                  type: string
+                  nullable: true
+                orderId:
+                  type: string
+                  nullable: true
+                customerId:
+                  type: string
+                  nullable: true
+                amountCents:
+                  type: integer
+                  nullable: true
+                currency:
+                  type: string
+                  nullable: true
+                amountKnown:
+                  type: boolean
+            byProvider:
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  paidOrders:
+                    type: integer
+                  bookedRevenueCents:
+                    type: integer
+                  amountKnownOrders:
+                    type: integer
+                  amountUnknownOrders:
+                    type: integer
+                  bookedRevenueByCurrency:
+                    type: object
+                    additionalProperties:
+                      type: integer
+        attribution:
+          type: object
+          properties:
+            acquisitionBySource:
+              type: object
+              additionalProperties:
+                type: integer
+            acquisitionByCampaign:
+              type: object
+              additionalProperties:
+                type: integer
+            paidBySource:
+              type: object
+              additionalProperties:
+                type: integer
+            paidByCampaign:
+              type: object
+              additionalProperties:
+                type: integer
+            bookedRevenueBySourceCents:
+              type: object
+              additionalProperties:
+                type: integer
+            bookedRevenueByCampaignCents:
+              type: object
+              additionalProperties:
+                type: integer
+            conversionBySource:
+              type: object
+              additionalProperties:
+                type: number
+            conversionByCampaign:
+              type: object
+              additionalProperties:
+                type: number
         keys:
           type: object
           properties:
@@ -278,7 +408,7 @@ paths:
       operationId: getBillingSummary
       responses:
         '200':
-          description: Admin-only operational billing summary from the funnel ledger and key store
+          description: Admin-only business summary from the funnel ledger, revenue ledger, and key store
           content:
             application/json:
               schema:

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://rlhf-feedback-loop-production.up.railway.app" />
   <link rel="canonical" href="https://rlhf-feedback-loop-production.up.railway.app" />
+  <script defer data-domain="rlhf-feedback-loop-production.up.railway.app" src="https://plausible.io/js/script.js"></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -724,11 +725,11 @@
     <!-- ── Social proof strip ── -->
     <div class="proof-strip">
       <div class="wrap" style="display:flex;gap:32px;justify-content:center;flex-wrap:wrap;">
-        <span class="proof-item"><strong>935</strong> tests passing</span>
-        <span class="proof-item"><strong>0</strong> failures</span>
-        <span class="proof-item"><strong>4</strong> agents supported</span>
+        <span class="proof-item"><strong>Verification</strong> evidence published</span>
+        <span class="proof-item"><strong>CLI + API + MCP</strong> same control plane</span>
+        <span class="proof-item"><strong>Claude, Codex, Gemini, Amp</strong> supported</span>
         <span class="proof-item"><strong>MIT</strong> licensed</span>
-        <span class="proof-item"><strong>Local-first</strong> no cloud required</span>
+        <span class="proof-item"><strong>Local-first</strong> or hosted Pro</span>
       </div>
     </div>
 
@@ -764,7 +765,7 @@
               <li>Unlimited custom gates with auto-gate promotion</li>
               <li>Priority support</li>
             </ul>
-            <a class="btn btn-primary" href="https://iganapolsky.gumroad.com/l/tjovof" target="_blank" rel="noreferrer">Get Pro &mdash; $29/mo</a>
+            <a class="btn btn-primary" id="pro-cta" data-cta-id="pricing_pro" href="https://iganapolsky.gumroad.com/l/tjovof?utm_source=website&utm_medium=cta_button&utm_campaign=pro_pack" target="_blank" rel="noreferrer">Get Pro &mdash; $29/mo</a>
           </div>
         </div>
       </div>
@@ -781,5 +782,114 @@
       </div>
     </div>
   </footer>
+  <script>
+    (function () {
+      const checkoutCta = document.getElementById('pro-cta');
+      if (!checkoutCta) return;
+
+      const fallbackBase = 'https://iganapolsky.gumroad.com/l/tjovof';
+      const originalLabel = checkoutCta.textContent;
+
+      function getInstallId() {
+        const storageKey = 'rlhf_install_id';
+        const existing = window.localStorage.getItem(storageKey);
+        if (existing) return existing;
+        const generated = window.crypto && window.crypto.randomUUID
+          ? window.crypto.randomUUID()
+          : 'inst_' + Math.random().toString(16).slice(2);
+        window.localStorage.setItem(storageKey, generated);
+        return generated;
+      }
+
+      function getAttributionValue(params, key, fallbackValue) {
+        const value = params.get(key);
+        return value && value.trim() ? value.trim() : fallbackValue;
+      }
+
+      function buildAttribution(ctaId) {
+        const params = new URLSearchParams(window.location.search);
+        return {
+          source: getAttributionValue(params, 'utm_source', 'website'),
+          utmSource: getAttributionValue(params, 'utm_source', 'website'),
+          utmMedium: getAttributionValue(params, 'utm_medium', 'cta_button'),
+          utmCampaign: getAttributionValue(params, 'utm_campaign', 'pro_pack'),
+          utmContent: getAttributionValue(params, 'utm_content', ctaId),
+          utmTerm: getAttributionValue(params, 'utm_term', null),
+          referrer: document.referrer || null,
+          landingPath: window.location.pathname,
+          ctaId: ctaId
+        };
+      }
+
+      function buildFallbackUrl(attribution) {
+        const url = new URL(fallbackBase);
+        url.searchParams.set('utm_source', attribution.utmSource || attribution.source || 'website');
+        url.searchParams.set('utm_medium', attribution.utmMedium || 'cta_button');
+        url.searchParams.set('utm_campaign', attribution.utmCampaign || 'pro_pack');
+        if (attribution.utmContent) url.searchParams.set('utm_content', attribution.utmContent);
+        if (attribution.utmTerm) url.searchParams.set('utm_term', attribution.utmTerm);
+        return url.toString();
+      }
+
+      async function startCheckout(event) {
+        event.preventDefault();
+        const ctaId = checkoutCta.dataset.ctaId || 'pricing_pro';
+        const attribution = buildAttribution(ctaId);
+        const fallbackUrl = buildFallbackUrl(attribution);
+        checkoutCta.href = fallbackUrl;
+        checkoutCta.setAttribute('aria-busy', 'true');
+        checkoutCta.textContent = 'Opening checkout...';
+
+        if (window.plausible) {
+          window.plausible('Checkout Started', {
+            props: {
+              source: attribution.source || 'website',
+              campaign: attribution.utmCampaign || 'pro_pack',
+              ctaId: ctaId
+            }
+          });
+        }
+
+        try {
+          const response = await fetch('/v1/billing/checkout', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              installId: getInstallId(),
+              metadata: attribution
+            })
+          });
+
+          if (!response.ok) {
+            throw new Error('checkout_request_failed');
+          }
+
+          const payload = await response.json();
+          if (payload.url) {
+            window.location.assign(payload.url);
+            return;
+          }
+
+          if (payload.sessionId) {
+            const successUrl = new URL('/success', window.location.origin);
+            successUrl.searchParams.set('sessionId', payload.sessionId);
+            if (payload.traceId) successUrl.searchParams.set('traceId', payload.traceId);
+            window.location.assign(successUrl.toString());
+            return;
+          }
+
+          throw new Error('missing_checkout_redirect');
+        } catch (_) {
+          window.location.assign(fallbackUrl);
+        } finally {
+          checkoutCta.removeAttribute('aria-busy');
+          checkoutCta.textContent = originalLabel;
+        }
+      }
+
+      checkoutCta.href = buildFallbackUrl(buildAttribution(checkoutCta.dataset.ctaId || 'pricing_pro'));
+      checkoutCta.addEventListener('click', startCheckout);
+    }());
+  </script>
 </body>
 </html>

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -19,6 +19,7 @@ const CONFIG = {
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || '',
   STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET || '',
   GITHUB_MARKETPLACE_WEBHOOK_SECRET: process.env.GITHUB_MARKETPLACE_WEBHOOK_SECRET || '',
+  GITHUB_MARKETPLACE_PLAN_PRICES_JSON: process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON || '',
   STRIPE_PRICE_ID: process.env.STRIPE_PRICE_ID || 'price_1RNdUBGGBpd520QYG1A9SWF4',
   STRIPE_ONE_TIME_PRICE_ID: process.env.STRIPE_ONE_TIME_PRICE_ID || 'price_1RNeMBGGBpd520QYNmZYZY12',
   get API_KEYS_PATH() {
@@ -26,6 +27,9 @@ const CONFIG = {
   },
   get FUNNEL_LEDGER_PATH() {
     return process.env._TEST_FUNNEL_LEDGER_PATH || process.env.RLHF_FUNNEL_LEDGER_PATH || path.resolve(__dirname, '../.claude/memory/feedback/funnel-events.jsonl');
+  },
+  get REVENUE_LEDGER_PATH() {
+    return process.env._TEST_REVENUE_LEDGER_PATH || process.env.RLHF_REVENUE_LEDGER_PATH || path.resolve(__dirname, '../.claude/memory/feedback/revenue-events.jsonl');
   },
   get LOCAL_CHECKOUT_SESSIONS_PATH() {
     return process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH || path.resolve(__dirname, '../.claude/memory/feedback/local-checkout-sessions.json');
@@ -71,7 +75,88 @@ function ensureParentDir(filePath) {
 
 function sanitizeMetadata(metadata) {
   if (!metadata || typeof metadata !== 'object') return {};
-  return { ...metadata };
+  try {
+    return JSON.parse(JSON.stringify(metadata));
+  } catch {
+    return { ...metadata };
+  }
+}
+
+function appendJsonlRecord(filePath, payload) {
+  try {
+    ensureParentDir(filePath);
+    fs.appendFileSync(filePath, `${JSON.stringify(payload)}\n`, 'utf-8');
+    return { written: true, payload };
+  } catch (err) {
+    return { written: false, reason: 'write_failed', error: err.message };
+  }
+}
+
+function loadJsonlRecords(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    return fs.readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch { return []; }
+}
+
+function normalizeText(value) {
+  if (value === undefined || value === null) return null;
+  const text = String(value).trim();
+  return text || null;
+}
+
+function normalizeCurrency(value) {
+  const text = normalizeText(value);
+  return text ? text.toUpperCase() : null;
+}
+
+function normalizeInteger(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string' && value.trim() === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? Math.trunc(num) : null;
+}
+
+function safeRate(num, den) {
+  return den ? Number((num / den).toFixed(4)) : 0;
+}
+
+function incrementCounter(target, key, amount = 1) {
+  const resolvedKey = normalizeText(key) || 'unknown';
+  target[resolvedKey] = (target[resolvedKey] || 0) + amount;
+}
+
+function extractAttribution(metadata = {}) {
+  const safe = sanitizeMetadata(metadata);
+  return {
+    source: normalizeText(safe.utmSource || safe.source),
+    medium: normalizeText(safe.utmMedium || safe.medium),
+    campaign: normalizeText(safe.utmCampaign || safe.campaign),
+    content: normalizeText(safe.utmContent || safe.content),
+    term: normalizeText(safe.utmTerm || safe.term),
+    referrer: normalizeText(safe.referrer),
+    landingPath: normalizeText(safe.landingPath),
+    ctaId: normalizeText(safe.ctaId),
+  };
+}
+
+function resolveAttributionSource(attribution, fallback = null) {
+  return attribution.source || normalizeText(fallback) || 'unknown';
+}
+
+function resolveAttributionCampaign(attribution) {
+  return attribution.campaign || 'unassigned';
 }
 
 function appendFunnelEvent({ stage, event, installId = null, traceId = null, evidence, metadata = {} } = {}) {
@@ -85,22 +170,57 @@ function appendFunnelEvent({ stage, event, installId = null, traceId = null, evi
     traceId: traceId || metadata.traceId || null,
     metadata: sanitizeMetadata(metadata),
   };
-  try {
-    const target = CONFIG.FUNNEL_LEDGER_PATH;
-    ensureParentDir(target);
-    fs.appendFileSync(target, `${JSON.stringify(payload)}\n`, 'utf-8');
-    return { written: true, payload };
-  } catch (err) {
-    return { written: false, reason: 'write_failed', error: err.message };
-  }
+  return appendJsonlRecord(CONFIG.FUNNEL_LEDGER_PATH, payload);
 }
 
 function loadFunnelLedger() {
-  try {
-    const target = CONFIG.FUNNEL_LEDGER_PATH;
-    if (!fs.existsSync(target)) return [];
-    return fs.readFileSync(target, 'utf-8').split('\n').map(l => l.trim()).filter(Boolean).map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
-  } catch { return []; }
+  return loadJsonlRecords(CONFIG.FUNNEL_LEDGER_PATH);
+}
+
+function loadRevenueLedger() {
+  return loadJsonlRecords(CONFIG.REVENUE_LEDGER_PATH);
+}
+
+function appendRevenueEvent({
+  provider,
+  event,
+  status = 'paid',
+  customerId,
+  orderId = null,
+  installId = null,
+  traceId = null,
+  evidence = null,
+  amountCents = null,
+  currency = null,
+  amountKnown = false,
+  recurringInterval = null,
+  attribution = {},
+  metadata = {},
+} = {}) {
+  if (!provider || !event || !customerId) {
+    return { written: false, reason: 'missing_required_fields' };
+  }
+
+  const normalizedAmount = normalizeInteger(amountCents);
+  const payload = {
+    timestamp: new Date().toISOString(),
+    provider: normalizeText(provider),
+    event,
+    status: normalizeText(status) || 'paid',
+    orderId: normalizeText(orderId) || normalizeText(evidence) || null,
+    evidence: evidence || orderId || event,
+    customerId,
+    installId: installId || null,
+    traceId: traceId || metadata.traceId || null,
+    amountCents: normalizedAmount,
+    currency: normalizeCurrency(currency),
+    amountKnown: Boolean(amountKnown && normalizedAmount !== null),
+    recurringInterval: normalizeText(recurringInterval),
+    attribution: extractAttribution({ ...sanitizeMetadata(metadata), ...sanitizeMetadata(attribution) }),
+    metadata: sanitizeMetadata(metadata),
+  };
+
+  return appendJsonlRecord(CONFIG.REVENUE_LEDGER_PATH, payload);
 }
 
 function loadLocalCheckoutSessions() {
@@ -118,6 +238,56 @@ function saveLocalCheckoutSessions(store) {
   fs.writeFileSync(target, JSON.stringify(store, null, 2), 'utf-8');
 }
 
+function serializeStripeMetadata(metadata) {
+  const safe = sanitizeMetadata(metadata);
+  const serialized = {};
+  for (const [key, value] of Object.entries(safe)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'object') continue;
+    serialized[key] = String(value);
+  }
+  return serialized;
+}
+
+function parseGithubPlanPricing() {
+  if (!CONFIG.GITHUB_MARKETPLACE_PLAN_PRICES_JSON) return {};
+  try {
+    const parsed = JSON.parse(CONFIG.GITHUB_MARKETPLACE_PLAN_PRICES_JSON);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function resolveGithubPlanPricing(planId) {
+  const pricing = parseGithubPlanPricing();
+  const raw = pricing[String(planId)];
+  if (raw === undefined) {
+    return { amountKnown: false, amountCents: null, currency: null, recurringInterval: null };
+  }
+
+  if (typeof raw === 'number') {
+    return {
+      amountKnown: Number.isFinite(raw),
+      amountCents: normalizeInteger(raw),
+      currency: 'USD',
+      recurringInterval: 'month',
+    };
+  }
+
+  if (!raw || typeof raw !== 'object') {
+    return { amountKnown: false, amountCents: null, currency: null, recurringInterval: null };
+  }
+
+  const amountCents = normalizeInteger(raw.amountCents ?? raw.amount ?? raw.priceCents);
+  return {
+    amountKnown: amountCents !== null,
+    amountCents,
+    currency: normalizeCurrency(raw.currency) || 'USD',
+    recurringInterval: normalizeText(raw.recurringInterval || raw.interval) || 'month',
+  };
+}
+
 function getFunnelAnalytics() {
   const events = loadFunnelLedger();
   const stageCounts = { acquisition: 0, activation: 0, paid: 0 };
@@ -129,18 +299,177 @@ function getFunnelAnalytics() {
       eventCounts[key] = (eventCounts[key] || 0) + 1;
     }
   }
-  const safeRate = (num, den) => den ? Number((num / den).toFixed(4)) : 0;
-  return { totalEvents: events.length, stageCounts, eventCounts, conversionRates: { acquisitionToActivation: safeRate(stageCounts.activation, stageCounts.acquisition), activationToPaid: safeRate(stageCounts.paid, stageCounts.activation), acquisitionToPaid: safeRate(stageCounts.paid, stageCounts.acquisition) } };
+  return {
+    totalEvents: events.length,
+    stageCounts,
+    eventCounts,
+    conversionRates: {
+      acquisitionToActivation: safeRate(stageCounts.activation, stageCounts.acquisition),
+      activationToPaid: safeRate(stageCounts.paid, stageCounts.activation),
+      acquisitionToPaid: safeRate(stageCounts.paid, stageCounts.acquisition),
+    },
+  };
+}
+
+function getBusinessAnalytics() {
+  const events = loadFunnelLedger();
+  const revenueEvents = loadRevenueLedger();
+  const funnel = getFunnelAnalytics();
+  const acquisitionEvents = events.filter((entry) => entry && entry.stage === 'acquisition');
+  const paidEvents = events.filter((entry) => entry && entry.stage === 'paid');
+  const paidOrders = revenueEvents.filter((entry) => entry && entry.status === 'paid');
+  const firstPaid = paidEvents[0] || null;
+  const lastPaid = paidEvents[paidEvents.length - 1] || null;
+
+  const signupsBySource = {};
+  const signupsByCampaign = {};
+  const acquisitionLeadKeys = new Set();
+  for (const entry of acquisitionEvents) {
+    const attribution = extractAttribution(entry.metadata);
+    const sourceKey = resolveAttributionSource(attribution);
+    const campaignKey = resolveAttributionCampaign(attribution);
+    incrementCounter(signupsBySource, sourceKey);
+    incrementCounter(signupsByCampaign, campaignKey);
+    acquisitionLeadKeys.add(entry.traceId || entry.installId || entry.evidence || `${entry.timestamp}:${entry.event}`);
+  }
+
+  const paidBySource = {};
+  const paidByCampaign = {};
+  const bookedRevenueBySourceCents = {};
+  const bookedRevenueByCampaignCents = {};
+  const bookedRevenueByCurrency = {};
+  const paidCustomerIds = new Set();
+  const revenueByProvider = {};
+  let bookedRevenueCents = 0;
+  let amountKnownOrders = 0;
+  let amountUnknownOrders = 0;
+  let latestPaidAt = null;
+  let latestPaidOrder = null;
+
+  for (const entry of paidOrders) {
+    const providerKey = normalizeText(entry.provider) || 'unknown';
+    const sourceKey = resolveAttributionSource(entry.attribution || {}, providerKey);
+    const campaignKey = resolveAttributionCampaign(entry.attribution || {});
+    incrementCounter(paidBySource, sourceKey);
+    incrementCounter(paidByCampaign, campaignKey);
+    paidCustomerIds.add(entry.customerId);
+
+    if (!revenueByProvider[providerKey]) {
+      revenueByProvider[providerKey] = {
+        paidOrders: 0,
+        bookedRevenueCents: 0,
+        amountKnownOrders: 0,
+        amountUnknownOrders: 0,
+        bookedRevenueByCurrency: {},
+      };
+    }
+
+    const providerSummary = revenueByProvider[providerKey];
+    providerSummary.paidOrders += 1;
+
+    if (entry.amountKnown && Number.isInteger(entry.amountCents)) {
+      const currency = normalizeCurrency(entry.currency) || 'UNKNOWN';
+      amountKnownOrders += 1;
+      bookedRevenueCents += entry.amountCents;
+      incrementCounter(bookedRevenueBySourceCents, sourceKey, entry.amountCents);
+      incrementCounter(bookedRevenueByCampaignCents, campaignKey, entry.amountCents);
+      incrementCounter(bookedRevenueByCurrency, currency, entry.amountCents);
+      providerSummary.bookedRevenueCents += entry.amountCents;
+      providerSummary.amountKnownOrders += 1;
+      incrementCounter(providerSummary.bookedRevenueByCurrency, currency, entry.amountCents);
+    } else {
+      amountUnknownOrders += 1;
+      providerSummary.amountUnknownOrders += 1;
+    }
+
+    if (!latestPaidAt || String(entry.timestamp || '') > latestPaidAt) {
+      latestPaidAt = entry.timestamp || null;
+      latestPaidOrder = {
+        timestamp: entry.timestamp || null,
+        provider: entry.provider || null,
+        event: entry.event || null,
+        orderId: entry.orderId || null,
+        customerId: entry.customerId || null,
+        amountCents: entry.amountCents ?? null,
+        currency: entry.currency || null,
+        amountKnown: Boolean(entry.amountKnown),
+      };
+    }
+  }
+
+  const conversionBySource = {};
+  for (const sourceKey of new Set([...Object.keys(signupsBySource), ...Object.keys(paidBySource)])) {
+    conversionBySource[sourceKey] = safeRate(paidBySource[sourceKey] || 0, signupsBySource[sourceKey] || 0);
+  }
+
+  const conversionByCampaign = {};
+  for (const campaignKey of new Set([...Object.keys(signupsByCampaign), ...Object.keys(paidByCampaign)])) {
+    conversionByCampaign[campaignKey] = safeRate(paidByCampaign[campaignKey] || 0, signupsByCampaign[campaignKey] || 0);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    coverage: {
+      source: 'funnel_ledger+revenue_ledger',
+      tracksBookedRevenue: true,
+      tracksPaidOrders: true,
+      tracksInvoices: false,
+      tracksAttribution: true,
+      providerCoverage: {
+        stripe: 'booked_revenue',
+        githubMarketplace: CONFIG.GITHUB_MARKETPLACE_PLAN_PRICES_JSON ? 'configured_plan_prices' : 'paid_orders_only',
+      },
+    },
+    funnel: {
+      ...funnel,
+      uniqueAcquisitionLeads: acquisitionLeadKeys.size,
+      uniquePaidCustomers: paidCustomerIds.size,
+      firstPaidAt: firstPaid ? firstPaid.timestamp || null : null,
+      lastPaidAt: lastPaid ? lastPaid.timestamp || null : null,
+      lastPaidEvent: lastPaid ? {
+        timestamp: lastPaid.timestamp || null,
+        event: lastPaid.event || null,
+        evidence: lastPaid.evidence || null,
+        customerId: lastPaid.metadata?.customerId || null,
+        traceId: lastPaid.traceId || null,
+      } : null,
+    },
+    signups: {
+      total: acquisitionEvents.length,
+      uniqueLeads: acquisitionLeadKeys.size,
+      bySource: signupsBySource,
+      byCampaign: signupsByCampaign,
+    },
+    revenue: {
+      paidOrders: paidOrders.length,
+      paidCustomers: paidCustomerIds.size,
+      bookedRevenueCents,
+      bookedRevenueByCurrency,
+      amountKnownOrders,
+      amountUnknownOrders,
+      amountKnownCoverageRate: safeRate(amountKnownOrders, paidOrders.length),
+      unreconciledPaidEvents: Math.max(0, paidEvents.length - paidOrders.length),
+      latestPaidAt,
+      latestPaidOrder,
+      byProvider: revenueByProvider,
+    },
+    attribution: {
+      acquisitionBySource: signupsBySource,
+      acquisitionByCampaign: signupsByCampaign,
+      paidBySource,
+      paidByCampaign,
+      bookedRevenueBySourceCents,
+      bookedRevenueByCampaignCents,
+      conversionBySource,
+      conversionByCampaign,
+    },
+  };
 }
 
 function getBillingSummary() {
-  const events = loadFunnelLedger();
-  const funnel = getFunnelAnalytics();
+  const business = getBusinessAnalytics();
   const store = loadKeyStore();
   const keyEntries = Object.values(store.keys || {});
-  const paidEvents = events.filter((entry) => entry && entry.stage === 'paid');
-  const firstPaid = paidEvents[0] || null;
-  const lastPaid = paidEvents[paidEvents.length - 1] || null;
   const customers = new Map();
   const bySource = {};
   const activeBySource = {};
@@ -204,24 +533,15 @@ function getBillingSummary() {
   });
 
   return {
-    generatedAt: new Date().toISOString(),
+    generatedAt: business.generatedAt,
     coverage: {
-      source: 'funnel_ledger+key_store',
-      tracksBookedRevenue: false,
-      tracksInvoices: false,
+      ...business.coverage,
+      source: 'funnel_ledger+revenue_ledger+key_store',
     },
-    funnel: {
-      ...funnel,
-      firstPaidAt: firstPaid ? firstPaid.timestamp || null : null,
-      lastPaidAt: lastPaid ? lastPaid.timestamp || null : null,
-      lastPaidEvent: lastPaid ? {
-        timestamp: lastPaid.timestamp || null,
-        event: lastPaid.event || null,
-        evidence: lastPaid.evidence || null,
-        customerId: lastPaid.metadata?.customerId || null,
-        traceId: lastPaid.traceId || null,
-      } : null,
-    },
+    funnel: business.funnel,
+    signups: business.signups,
+    revenue: business.revenue,
+    attribution: business.attribution,
     keys: {
       total: keyEntries.length,
       active: activeKeys,
@@ -256,7 +576,7 @@ function saveKeyStore(store) {
 
 async function createCheckoutSession({ successUrl, cancelUrl, customerEmail, installId, traceId, metadata = {} } = {}) {
   const resolvedTraceId = traceId || metadata.traceId || createTraceId('checkout');
-  const checkoutMetadata = { ...metadata, installId: installId || 'unknown', traceId: resolvedTraceId };
+  const checkoutMetadata = sanitizeMetadata({ ...metadata, installId: installId || 'unknown', traceId: resolvedTraceId });
 
   if (LOCAL_MODE()) {
     const localSessionId = `test_session_${crypto.randomBytes(8).toString('hex')}`;
@@ -283,7 +603,7 @@ async function createCheckoutSession({ successUrl, cancelUrl, customerEmail, ins
     payment_method_types: ['card', 'link'],
     mode: metadata.oneTime ? 'payment' : 'subscription',
     line_items: [{ price: metadata.oneTime ? CONFIG.STRIPE_ONE_TIME_PRICE_ID : CONFIG.STRIPE_PRICE_ID, quantity: 1 }],
-    metadata: checkoutMetadata,
+    metadata: serializeStripeMetadata(checkoutMetadata),
   });
 
   appendFunnelEvent({
@@ -477,6 +797,7 @@ async function handleWebhook(rawBody, signature) {
       const customerId = session.customer;
       const installId = session.metadata?.installId;
       const traceId = session.metadata?.traceId || null;
+      const attribution = extractAttribution(session.metadata);
       const result = provisionApiKey(customerId, { installId, source: 'stripe_webhook_checkout_completed' });
       appendFunnelEvent({
         stage: 'paid',
@@ -484,7 +805,27 @@ async function handleWebhook(rawBody, signature) {
         installId,
         traceId,
         evidence: session.id,
-        metadata: { customerId, subscriptionId: session.subscription, traceId },
+        metadata: { customerId, subscriptionId: session.subscription, traceId, ...attribution },
+      });
+      appendRevenueEvent({
+        provider: 'stripe',
+        event: 'stripe_checkout_completed',
+        status: 'paid',
+        customerId,
+        orderId: session.id,
+        installId,
+        traceId,
+        evidence: session.id,
+        amountCents: session.amount_total,
+        currency: session.currency,
+        amountKnown: session.amount_total !== undefined && session.amount_total !== null,
+        recurringInterval: session.mode === 'subscription' ? 'month' : null,
+        attribution,
+        metadata: {
+          subscriptionId: session.subscription || null,
+          mode: session.mode || null,
+          paymentStatus: session.payment_status || null,
+        },
       });
       return { handled: true, action: 'provisioned_api_key', result };
     }
@@ -510,22 +851,97 @@ function handleGithubWebhook(event) {
   const { action, marketplace_purchase: mp } = event;
   if (!action || !mp || !mp.account?.id) return { handled: false, reason: 'missing_payload_data' };
   const customerId = `github_${String(mp.account.type).toLowerCase()}_${mp.account.id}`;
+  const planPricing = resolveGithubPlanPricing(mp.plan?.id);
   switch (action) {
     case 'purchased': {
       const result = provisionApiKey(customerId, { source: 'github_marketplace_purchased' });
-      appendFunnelEvent({ stage: 'paid', event: 'github_marketplace_purchased', evidence: 'github_marketplace_purchased', metadata: { provider: 'github', customerId, accountId: String(mp.account.id), accountType: String(mp.account.type) } });
+      appendFunnelEvent({
+        stage: 'paid',
+        event: 'github_marketplace_purchased',
+        evidence: 'github_marketplace_purchased',
+        metadata: {
+          provider: 'github_marketplace',
+          customerId,
+          accountId: String(mp.account.id),
+          accountType: String(mp.account.type),
+          source: 'github_marketplace',
+          planId: mp.plan?.id || null,
+          planName: mp.plan?.name || null,
+        },
+      });
+      appendRevenueEvent({
+        provider: 'github_marketplace',
+        event: 'github_marketplace_purchased',
+        status: 'paid',
+        customerId,
+        orderId: mp.id || null,
+        evidence: 'github_marketplace_purchased',
+        amountCents: planPricing.amountCents,
+        currency: planPricing.currency,
+        amountKnown: planPricing.amountKnown,
+        recurringInterval: planPricing.recurringInterval,
+        attribution: { source: 'github_marketplace' },
+        metadata: {
+          accountId: String(mp.account.id),
+          accountType: String(mp.account.type),
+          planId: mp.plan?.id || null,
+          planName: mp.plan?.name || null,
+        },
+      });
       return { handled: true, action: 'provisioned_api_key', result };
     }
-    case 'cancelled': return { handled: true, action: 'disabled_customer_keys', result: disableCustomerKeys(customerId) };
-    case 'changed': return { handled: true, action: 'plan_changed', result: provisionApiKey(customerId, { source: 'github_marketplace_changed' }) };
+    case 'cancelled':
+      appendRevenueEvent({
+        provider: 'github_marketplace',
+        event: 'github_marketplace_cancelled',
+        status: 'cancelled',
+        customerId,
+        orderId: mp.id || null,
+        evidence: 'github_marketplace_cancelled',
+        amountCents: planPricing.amountCents,
+        currency: planPricing.currency,
+        amountKnown: planPricing.amountKnown,
+        recurringInterval: planPricing.recurringInterval,
+        attribution: { source: 'github_marketplace' },
+        metadata: {
+          accountId: String(mp.account.id),
+          accountType: String(mp.account.type),
+          planId: mp.plan?.id || null,
+          planName: mp.plan?.name || null,
+        },
+      });
+      return { handled: true, action: 'disabled_customer_keys', result: disableCustomerKeys(customerId) };
+    case 'changed': {
+      appendRevenueEvent({
+        provider: 'github_marketplace',
+        event: 'github_marketplace_changed',
+        status: 'changed',
+        customerId,
+        orderId: mp.id || null,
+        evidence: 'github_marketplace_changed',
+        amountCents: planPricing.amountCents,
+        currency: planPricing.currency,
+        amountKnown: planPricing.amountKnown,
+        recurringInterval: planPricing.recurringInterval,
+        attribution: { source: 'github_marketplace' },
+        metadata: {
+          accountId: String(mp.account.id),
+          accountType: String(mp.account.type),
+          planId: mp.plan?.id || null,
+          planName: mp.plan?.name || null,
+        },
+      });
+      return { handled: true, action: 'plan_changed', result: provisionApiKey(customerId, { source: 'github_marketplace_changed' }) };
+    }
     default: return { handled: false, reason: `unhandled_action:${action}` };
   }
 }
 
 module.exports = {
-  createCheckoutSession, getCheckoutSessionStatus, provisionApiKey, rotateApiKey, validateApiKey, recordUsage, reportUsageToStripe, disableCustomerKeys, handleWebhook, verifyWebhookSignature, verifyGithubWebhookSignature, handleGithubWebhook, loadKeyStore, appendFunnelEvent, loadFunnelLedger, getFunnelAnalytics, getBillingSummary,
+  createCheckoutSession, getCheckoutSessionStatus, provisionApiKey, rotateApiKey, validateApiKey, recordUsage, reportUsageToStripe, disableCustomerKeys, handleWebhook, verifyWebhookSignature, verifyGithubWebhookSignature, handleGithubWebhook, loadKeyStore, appendFunnelEvent, appendRevenueEvent, loadFunnelLedger, loadRevenueLedger, getFunnelAnalytics, getBusinessAnalytics, getBillingSummary,
   _API_KEYS_PATH: () => CONFIG.API_KEYS_PATH,
   _FUNNEL_LEDGER_PATH: () => CONFIG.FUNNEL_LEDGER_PATH,
+  _REVENUE_LEDGER_PATH: () => CONFIG.REVENUE_LEDGER_PATH,
   _LOCAL_CHECKOUT_SESSIONS_PATH: () => CONFIG.LOCAL_CHECKOUT_SESSIONS_PATH,
   _LOCAL_MODE: () => LOCAL_MODE(),
 };

--- a/scripts/funnel-analytics.js
+++ b/scripts/funnel-analytics.js
@@ -1,27 +1,28 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const path = require('path');
-const { loadFunnelLedger, getFunnelAnalytics } = require('./billing');
+const { getBusinessAnalytics } = require('./billing');
+
 function generateFunnelReport() {
-  const events = loadFunnelLedger();
-  const analytics = getFunnelAnalytics();
+  const analytics = getBusinessAnalytics();
   console.log('╔══════════════════════════════════════════════════════╗');
   console.log('║      Marketing & Revenue Funnel Analytics            ║');
   console.log('╠══════════════════════════════════════════════════════╣');
-  console.log(`║  Total Acquisition Events (Leads):  ${String(analytics.stageCounts.acquisition).padStart(6)}           ║`);
-  console.log(`║  Total Activation Events (Usage):   ${String(analytics.stageCounts.activation).padStart(6)}           ║`);
-  console.log(`║  Total Paid Events (Revenue):       ${String(analytics.stageCounts.paid).padStart(6)}           ║`);
+  console.log(`║  Total Acquisition Events (Leads):  ${String(analytics.funnel.stageCounts.acquisition).padStart(6)}           ║`);
+  console.log(`║  Unique Leads:                      ${String(analytics.signups.uniqueLeads).padStart(6)}           ║`);
+  console.log(`║  Paid Orders Tracked:               ${String(analytics.revenue.paidOrders).padStart(6)}           ║`);
+  console.log(`║  Known Booked Revenue (cents):      ${String(analytics.revenue.bookedRevenueCents).padStart(6)}           ║`);
   console.log('╠══════════════════════════════════════════════════════╣');
-  const acquisitionEvents = events.filter(e => e.stage === 'acquisition');
-  const eventsBySource = {};
-  acquisitionEvents.forEach(e => {
-    const s = e.metadata?.source || 'unknown';
-    const ev = e.event || 'unknown';
-    const key = `${s}:${ev}`;
-    eventsBySource[key] = (eventsBySource[key] || 0) + 1;
+  console.log('║  Acquisition by Source:                              ║');
+  Object.entries(analytics.signups.bySource).forEach(([key, count]) => {
+    const line = `    ${key}: ${count}`;
+    console.log(`║  ${line.padEnd(52)}║`);
   });
-  console.log('║  Campaign Breakdown:                                 ║');
-  Object.entries(eventsBySource).forEach(([key, count]) => {
+  console.log('║  Paid Orders by Source:                              ║');
+  Object.entries(analytics.attribution.paidBySource).forEach(([key, count]) => {
+    const line = `    ${key}: ${count}`;
+    console.log(`║  ${line.padEnd(52)}║`);
+  });
+  console.log('║  Revenue by Source (cents):                          ║');
+  Object.entries(analytics.attribution.bookedRevenueBySourceCents).forEach(([key, count]) => {
     const line = `    ${key}: ${count}`;
     console.log(`║  ${line.padEnd(52)}║`);
   });

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -86,6 +86,40 @@ function createHttpError(statusCode, message) {
   return err;
 }
 
+function normalizeNullableText(value) {
+  if (value === undefined || value === null) return null;
+  const text = String(value).trim();
+  return text || null;
+}
+
+function pickFirstText(...values) {
+  for (const value of values) {
+    const normalized = normalizeNullableText(value);
+    if (normalized) return normalized;
+  }
+  return null;
+}
+
+function buildCheckoutAttributionMetadata(body, req, traceId) {
+  const rawMetadata = body && body.metadata && typeof body.metadata === 'object' ? body.metadata : {};
+  const utmSource = pickFirstText(rawMetadata.utmSource, body.utmSource, rawMetadata.source, body.source);
+  const utmMedium = pickFirstText(rawMetadata.utmMedium, body.utmMedium, 'checkout_api');
+
+  return {
+    ...rawMetadata,
+    traceId,
+    source: pickFirstText(rawMetadata.source, body.source, utmSource, 'direct'),
+    utmSource,
+    utmMedium,
+    utmCampaign: pickFirstText(rawMetadata.utmCampaign, body.utmCampaign),
+    utmContent: pickFirstText(rawMetadata.utmContent, body.utmContent),
+    utmTerm: pickFirstText(rawMetadata.utmTerm, body.utmTerm),
+    referrer: pickFirstText(rawMetadata.referrer, req.headers.referer, req.headers.referrer),
+    landingPath: pickFirstText(rawMetadata.landingPath, body.landingPath),
+    ctaId: pickFirstText(rawMetadata.ctaId, body.ctaId),
+  };
+}
+
 function sendJson(res, statusCode, payload, extraHeaders = {}) {
   const body = JSON.stringify(payload);
   res.writeHead(statusCode, {
@@ -888,6 +922,7 @@ function createApiServer() {
         const responseHeaders = getPublicBillingHeaders(traceId);
         // Pro plan: $29/mo recurring subscription
         const isOneTime = body.oneTime === true;
+        const analyticsMetadata = buildCheckoutAttributionMetadata(body, req, traceId);
         
         const result = await createCheckoutSession({
           successUrl: body.successUrl || buildHostedSuccessUrl(hostedConfig.appOrigin, traceId),
@@ -896,8 +931,7 @@ function createApiServer() {
           installId: body.installId,
           traceId,
           metadata: { 
-            ...body.metadata, 
-            traceId,
+            ...analyticsMetadata,
             oneTime: isOneTime,
             credits: isOneTime ? 500 : 0 
           },

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -9,6 +9,7 @@ process.env.RLHF_FEEDBACK_DIR = tmpFeedbackDir;
 process.env.RLHF_API_KEY = 'test-api-key';
 process.env._TEST_API_KEYS_PATH = path.join(tmpFeedbackDir, 'api-keys.json');
 process.env._TEST_FUNNEL_LEDGER_PATH = path.join(tmpFeedbackDir, 'funnel-events.jsonl');
+process.env._TEST_REVENUE_LEDGER_PATH = path.join(tmpFeedbackDir, 'revenue-events.jsonl');
 process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH = path.join(tmpFeedbackDir, 'local-checkout-sessions.json');
 
 // Force local mode for billing tests by clearing Stripe keys
@@ -54,6 +55,8 @@ test('root serves the landing page by default', async () => {
   assert.match(body, /mcp.memory.gateway/i);
   assert.match(body, /Pre.Action Gates/i);
   assert.match(body, /\$29\/mo/);
+  assert.match(body, /plausible\.io\/js\/script\.js/);
+  assert.match(body, /\/v1\/billing\/checkout/);
 });
 
 test('provisioning endpoint works', async () => {
@@ -405,6 +408,25 @@ test('billing summary returns admin-only operational proxy', async () => {
     evidence: 'cs_admin_summary',
     metadata: { customerId: 'cus_admin_summary' },
   });
+  billing.appendRevenueEvent({
+    provider: 'stripe',
+    event: 'stripe_checkout_completed',
+    status: 'paid',
+    customerId: 'cus_admin_summary',
+    orderId: 'cs_admin_summary',
+    installId: 'inst_admin_summary',
+    traceId: 'trace_admin_summary',
+    amountCents: 2900,
+    currency: 'USD',
+    amountKnown: true,
+    recurringInterval: 'month',
+    attribution: {
+      source: 'website',
+      utmSource: 'website',
+      utmMedium: 'cta_button',
+      utmCampaign: 'pro_pack',
+    },
+  });
 
   const res = await fetch('http://localhost:8790/v1/billing/summary', {
     headers: authHeader,
@@ -412,10 +434,13 @@ test('billing summary returns admin-only operational proxy', async () => {
   assert.equal(res.status, 200);
 
   const body = await res.json();
-  assert.equal(body.coverage.source, 'funnel_ledger+key_store');
-  assert.equal(body.coverage.tracksBookedRevenue, false);
+  assert.equal(body.coverage.source, 'funnel_ledger+revenue_ledger+key_store');
+  assert.equal(body.coverage.tracksBookedRevenue, true);
   assert.ok(body.funnel.stageCounts.paid >= 1);
   assert.ok(body.keys.active >= 1);
+  assert.equal(body.revenue.bookedRevenueCents, 2900);
+  assert.equal(body.revenue.paidOrders, 1);
+  assert.equal(body.attribution.bookedRevenueByCampaignCents.pro_pack, 2900);
   assert.ok(Array.isArray(body.customers));
 });
 
@@ -445,6 +470,13 @@ test('funnel analytics returns counts and conversion rates', async () => {
     headers: { 'content-type': 'application/json', ...authHeader },
     body: JSON.stringify({
       installId: 'inst_api_server_test',
+      metadata: {
+        source: 'website',
+        utmSource: 'website',
+        utmMedium: 'cta_button',
+        utmCampaign: 'spring_launch',
+        ctaId: 'pricing_pro',
+      },
     }),
   });
   assert.equal(checkoutRes.status, 200);
@@ -460,4 +492,12 @@ test('funnel analytics returns counts and conversion rates', async () => {
   assert.ok(typeof body.conversionRates === 'object');
   assert.ok(body.stageCounts.acquisition >= 1);
   assert.ok(typeof body.conversionRates.acquisitionToActivation === 'number');
+
+  const summaryRes = await fetch('http://localhost:8790/v1/billing/summary', {
+    headers: authHeader,
+  });
+  assert.equal(summaryRes.status, 200);
+  const summary = await summaryRes.json();
+  assert.ok(summary.signups.bySource.website >= 1);
+  assert.ok(summary.attribution.acquisitionByCampaign.spring_launch >= 1);
 });

--- a/tests/billing.test.js
+++ b/tests/billing.test.js
@@ -16,17 +16,21 @@ let tmpDir;
 const billingTestRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'billing-suite-'));
 const testApiKeysPath = path.join(billingTestRoot, 'api-keys.json');
 const testFunnelLedgerPath = path.join(billingTestRoot, 'funnel-events.jsonl');
+const testRevenueLedgerPath = path.join(billingTestRoot, 'revenue-events.jsonl');
 const testLocalCheckoutSessionsPath = path.join(billingTestRoot, 'local-checkout-sessions.json');
 
 const savedApiKeysPath = process.env._TEST_API_KEYS_PATH;
 const savedFunnelPath = process.env._TEST_FUNNEL_LEDGER_PATH;
+const savedRevenuePath = process.env._TEST_REVENUE_LEDGER_PATH;
 const savedLocalCheckoutSessionsPath = process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH;
+const savedGithubPlanPricing = process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
 const savedStripeSecretKey = process.env.STRIPE_SECRET_KEY;
 const savedStripePriceId = process.env.STRIPE_PRICE_ID;
 
 // Initial setup
 process.env._TEST_API_KEYS_PATH = testApiKeysPath;
 process.env._TEST_FUNNEL_LEDGER_PATH = testFunnelLedgerPath;
+process.env._TEST_REVENUE_LEDGER_PATH = testRevenueLedgerPath;
 process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH = testLocalCheckoutSessionsPath;
 process.env.STRIPE_SECRET_KEY = '';
 process.env.STRIPE_PRICE_ID = '';
@@ -38,8 +42,12 @@ after(() => {
   else process.env._TEST_API_KEYS_PATH = savedApiKeysPath;
   if (savedFunnelPath === undefined) delete process.env._TEST_FUNNEL_LEDGER_PATH;
   else process.env._TEST_FUNNEL_LEDGER_PATH = savedFunnelPath;
+  if (savedRevenuePath === undefined) delete process.env._TEST_REVENUE_LEDGER_PATH;
+  else process.env._TEST_REVENUE_LEDGER_PATH = savedRevenuePath;
   if (savedLocalCheckoutSessionsPath === undefined) delete process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH;
   else process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH = savedLocalCheckoutSessionsPath;
+  if (savedGithubPlanPricing === undefined) delete process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
+  else process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON = savedGithubPlanPricing;
   fs.rmSync(billingTestRoot, { recursive: true, force: true });
 });
 
@@ -59,7 +67,7 @@ function requireFreshBilling(stripeKey = '') {
 }
 
 function clearBillingArtifacts() {
-  for (const t of [testApiKeysPath, testFunnelLedgerPath, testLocalCheckoutSessionsPath]) {
+  for (const t of [testApiKeysPath, testFunnelLedgerPath, testRevenueLedgerPath, testLocalCheckoutSessionsPath]) {
     if (fs.existsSync(t)) fs.rmSync(t, { force: true });
   }
 }
@@ -67,6 +75,11 @@ function clearBillingArtifacts() {
 function readLedgerEvents() {
   if (!fs.existsSync(testFunnelLedgerPath)) return [];
   return fs.readFileSync(testFunnelLedgerPath, 'utf-8').split('\n').map(l => l.trim()).filter(Boolean).map(l => JSON.parse(l));
+}
+
+function readRevenueEvents() {
+  if (!fs.existsSync(testRevenueLedgerPath)) return [];
+  return fs.readFileSync(testRevenueLedgerPath, 'utf-8').split('\n').map((line) => line.trim()).filter(Boolean).map((line) => JSON.parse(line));
 }
 
 describe('billing.js — provisionApiKey', () => {
@@ -96,11 +109,21 @@ describe('billing.js — funnel ledger', () => {
     clearBillingArtifacts(); 
     delete require.cache[require.resolve('../scripts/billing')];
     process.env._TEST_FUNNEL_LEDGER_PATH = testFunnelLedgerPath;
+    process.env._TEST_REVENUE_LEDGER_PATH = testRevenueLedgerPath;
+    delete process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
   });
 
   test('createCheckoutSession emits acquisition event', async () => {
     const billing = require('../scripts/billing');
-    const result = await billing.createCheckoutSession({ installId: 'inst_123', metadata: { campaign: 'test' } });
+    const result = await billing.createCheckoutSession({
+      installId: 'inst_123',
+      metadata: {
+        source: 'website',
+        utmSource: 'website',
+        utmMedium: 'cta_button',
+        utmCampaign: 'test',
+      },
+    });
     assert.ok(result.sessionId.startsWith('test_session_'));
     assert.match(result.traceId, /^checkout_/);
     const events = readLedgerEvents();
@@ -108,6 +131,8 @@ describe('billing.js — funnel ledger', () => {
     assert.ok(acq);
     assert.equal(acq.installId, 'inst_123');
     assert.equal(acq.traceId, result.traceId);
+    assert.equal(acq.metadata.utmSource, 'website');
+    assert.equal(acq.metadata.utmCampaign, 'test');
   });
 
   test('checkout session status preserves trace id for cross-service lookup', async () => {
@@ -146,22 +171,63 @@ describe('billing.js — funnel ledger', () => {
       event: 'checkout_session_created',
       installId: 'inst_summary_a',
       evidence: 'sess_summary_a',
-      metadata: { customerId: 'cus_summary_a' },
+      metadata: {
+        customerId: 'cus_summary_a',
+        source: 'website',
+        utmSource: 'website',
+        utmMedium: 'cta_button',
+        utmCampaign: 'pro_pack',
+      },
     });
     billing.appendFunnelEvent({
       stage: 'paid',
       event: 'stripe_checkout_completed',
       installId: 'inst_summary_a',
       evidence: 'cs_summary_a',
-      metadata: { customerId: 'cus_summary_a' },
+      traceId: 'trace_summary_a',
+      metadata: {
+        customerId: 'cus_summary_a',
+        source: 'website',
+        utmSource: 'website',
+        utmMedium: 'cta_button',
+        utmCampaign: 'pro_pack',
+      },
+    });
+    billing.appendRevenueEvent({
+      provider: 'stripe',
+      event: 'stripe_checkout_completed',
+      status: 'paid',
+      customerId: 'cus_summary_a',
+      orderId: 'cs_summary_a',
+      installId: 'inst_summary_a',
+      traceId: 'trace_summary_a',
+      amountCents: 2900,
+      currency: 'usd',
+      amountKnown: true,
+      recurringInterval: 'month',
+      attribution: {
+        source: 'website',
+        utmSource: 'website',
+        utmMedium: 'cta_button',
+        utmCampaign: 'pro_pack',
+      },
+      metadata: { subscriptionId: 'sub_summary_a' },
     });
 
     const summary = billing.getBillingSummary();
-    assert.equal(summary.coverage.source, 'funnel_ledger+key_store');
-    assert.equal(summary.coverage.tracksBookedRevenue, false);
+    assert.equal(summary.coverage.source, 'funnel_ledger+revenue_ledger+key_store');
+    assert.equal(summary.coverage.tracksBookedRevenue, true);
+    assert.equal(summary.coverage.tracksPaidOrders, true);
     assert.equal(summary.funnel.stageCounts.acquisition, 1);
     assert.equal(summary.funnel.stageCounts.activation, 1);
     assert.equal(summary.funnel.stageCounts.paid, 1);
+    assert.equal(summary.signups.uniqueLeads, 1);
+    assert.equal(summary.revenue.paidOrders, 1);
+    assert.equal(summary.revenue.bookedRevenueCents, 2900);
+    assert.equal(summary.revenue.amountKnownCoverageRate, 1);
+    assert.equal(summary.attribution.acquisitionBySource.website, 1);
+    assert.equal(summary.attribution.paidByCampaign.pro_pack, 1);
+    assert.equal(summary.attribution.bookedRevenueBySourceCents.website, 2900);
     assert.equal(summary.keys.total, 2);
     assert.equal(summary.keys.active, 1);
     assert.equal(summary.keys.disabled, 1);
@@ -180,6 +246,43 @@ describe('billing.js — funnel ledger', () => {
     assert.equal(disabledCustomer.activeKeys, 0);
     assert.equal(disabledCustomer.source, 'github_marketplace_purchased');
     assert.equal(disabledKey.customerId, 'cus_summary_b');
+  });
+
+  test('handleGithubWebhook records paid order with unknown amount when plan pricing is not configured', () => {
+    const billing = require('../scripts/billing');
+    billing.handleGithubWebhook({
+      action: 'purchased',
+      marketplace_purchase: {
+        account: { type: 'User', id: 42, login: 'octocat' },
+        plan: { id: 1, name: 'Pro' },
+      },
+    });
+
+    const revenueEvents = readRevenueEvents();
+    assert.equal(revenueEvents.length, 1);
+    assert.equal(revenueEvents[0].provider, 'github_marketplace');
+    assert.equal(revenueEvents[0].amountKnown, false);
+    assert.equal(revenueEvents[0].amountCents, null);
+  });
+
+  test('handleGithubWebhook records booked revenue when plan pricing is configured', () => {
+    process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON = JSON.stringify({
+      7: { amountCents: 2900, currency: 'USD', recurringInterval: 'month' },
+    });
+    const billing = requireFreshBilling('');
+    billing.handleGithubWebhook({
+      action: 'purchased',
+      marketplace_purchase: {
+        account: { type: 'Organization', id: 77, login: 'team' },
+        plan: { id: 7, name: 'Pro' },
+      },
+    });
+
+    const revenueEvents = readRevenueEvents();
+    assert.equal(revenueEvents.length, 1);
+    assert.equal(revenueEvents[0].amountKnown, true);
+    assert.equal(revenueEvents[0].amountCents, 2900);
+    assert.equal(revenueEvents[0].currency, 'USD');
   });
 });
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -426,6 +426,7 @@ describe('bin/cli.js', () => {
     const isolatedDir = makeTmpDir();
     const apiKeysPath = path.join(isolatedDir, 'api-keys.json');
     const ledgerPath = path.join(isolatedDir, 'funnel-events.jsonl');
+    const revenuePath = path.join(isolatedDir, 'revenue-events.jsonl');
     fs.writeFileSync(apiKeysPath, JSON.stringify({
       keys: {
         rlhf_active_cli: {
@@ -467,6 +468,29 @@ describe('bin/cli.js', () => {
       }),
       '',
     ].join('\n'));
+    fs.writeFileSync(revenuePath, [
+      JSON.stringify({
+        timestamp: '2026-03-12T00:15:00.000Z',
+        provider: 'stripe',
+        event: 'stripe_checkout_completed',
+        status: 'paid',
+        orderId: 'cs_cli_summary',
+        evidence: 'cs_cli_summary',
+        customerId: 'cus_cli_summary',
+        installId: 'inst_cli_summary',
+        traceId: 'trace_cli_summary',
+        amountCents: 2900,
+        currency: 'USD',
+        amountKnown: true,
+        recurringInterval: 'month',
+        attribution: {
+          source: 'website',
+          campaign: 'pro_pack',
+        },
+        metadata: {},
+      }),
+      '',
+    ].join('\n'));
 
     const result = spawnSync(process.execPath, [CLI, 'cfo'], {
       encoding: 'utf8',
@@ -475,16 +499,19 @@ describe('bin/cli.js', () => {
         ...process.env,
         _TEST_API_KEYS_PATH: apiKeysPath,
         _TEST_FUNNEL_LEDGER_PATH: ledgerPath,
+        _TEST_REVENUE_LEDGER_PATH: revenuePath,
       },
     });
     assert.equal(result.status, 0, `cfo failed:\n${result.stderr}`);
 
     const payload = JSON.parse(result.stdout);
-    assert.equal(payload.coverage.source, 'funnel_ledger+key_store');
+    assert.equal(payload.coverage.source, 'funnel_ledger+revenue_ledger+key_store');
     assert.equal(payload.keys.active, 1);
     assert.equal(payload.keys.bySource.stripe_webhook_checkout_completed, 1);
     assert.equal(payload.keys.bySource.github_marketplace_purchased, 1);
     assert.equal(payload.funnel.stageCounts.paid, 1);
+    assert.equal(payload.revenue.bookedRevenueCents, 2900);
+    assert.equal(payload.revenue.paidOrders, 1);
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
   });

--- a/tests/commerce-quality.test.js
+++ b/tests/commerce-quality.test.js
@@ -12,6 +12,7 @@ process.env.RLHF_FEEDBACK_DIR = tmpDir;
 process.env.RLHF_API_KEY = 'test-commerce-key';
 process.env._TEST_API_KEYS_PATH = path.join(tmpDir, 'api-keys.json');
 process.env._TEST_FUNNEL_LEDGER_PATH = path.join(tmpDir, 'funnel-events.jsonl');
+process.env._TEST_REVENUE_LEDGER_PATH = path.join(tmpDir, 'revenue-events.jsonl');
 process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH = path.join(tmpDir, 'local-checkout-sessions.json');
 process.env.STRIPE_SECRET_KEY = '';
 process.env.STRIPE_PRICE_ID = '';

--- a/tests/github-billing.test.js
+++ b/tests/github-billing.test.js
@@ -15,11 +15,14 @@ const crypto = require('crypto');
 
 let tmpDir;
 let keyStorePath;
+let revenueLedgerPath;
 
 function setupTempStore() {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'github-billing-test-'));
   keyStorePath = path.join(tmpDir, 'api-keys.json');
+  revenueLedgerPath = path.join(tmpDir, 'revenue-events.jsonl');
   process.env._TEST_API_KEYS_PATH = keyStorePath;
+  process.env._TEST_REVENUE_LEDGER_PATH = revenueLedgerPath;
   fs.writeFileSync(keyStorePath, JSON.stringify({ keys: {} }), 'utf-8');
 }
 
@@ -28,6 +31,17 @@ function cleanupTempStore() {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
   delete process.env._TEST_API_KEYS_PATH;
+  delete process.env._TEST_REVENUE_LEDGER_PATH;
+  delete process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
+}
+
+function readRevenueEvents() {
+  if (!revenueLedgerPath || !fs.existsSync(revenueLedgerPath)) return [];
+  return fs.readFileSync(revenueLedgerPath, 'utf-8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
 }
 
 describe('billing.js — GitHub Marketplace Webhooks', () => {
@@ -67,6 +81,44 @@ describe('billing.js — GitHub Marketplace Webhooks', () => {
     const validation = billing.validateApiKey(result.result.key);
     assert.equal(validation.valid, true);
     assert.equal(validation.customerId, 'github_user_12345');
+
+    const revenueEvents = readRevenueEvents();
+    assert.equal(revenueEvents.length, 1);
+    assert.equal(revenueEvents[0].provider, 'github_marketplace');
+    assert.equal(revenueEvents[0].amountKnown, false);
+  });
+
+  test('handleGithubWebhook — purchased uses configured plan pricing when available', () => {
+    process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON = JSON.stringify({
+      11: { amountCents: 2900, currency: 'USD', recurringInterval: 'month' },
+    });
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
+
+    const event = {
+      action: 'purchased',
+      marketplace_purchase: {
+        account: {
+          type: 'Organization',
+          id: 2026,
+          login: 'memory-gateway'
+        },
+        plan: { id: 11, name: 'Pro' }
+      }
+    };
+
+    const result = billing.handleGithubWebhook(event);
+    assert.equal(result.handled, true);
+
+    const revenueEvents = readRevenueEvents();
+    const latest = revenueEvents[revenueEvents.length - 1];
+    assert.equal(latest.amountKnown, true);
+    assert.equal(latest.amountCents, 2900);
+    assert.equal(latest.currency, 'USD');
+
+    delete process.env.RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
   });
 
   test('handleGithubWebhook — cancelled disables API keys', () => {

--- a/tests/stripe-webhook-route.test.js
+++ b/tests/stripe-webhook-route.test.js
@@ -16,6 +16,7 @@ const savedEnv = {
   RLHF_ALLOW_INSECURE: process.env.RLHF_ALLOW_INSECURE,
   _TEST_API_KEYS_PATH: process.env._TEST_API_KEYS_PATH,
   _TEST_FUNNEL_LEDGER_PATH: process.env._TEST_FUNNEL_LEDGER_PATH,
+  _TEST_REVENUE_LEDGER_PATH: process.env._TEST_REVENUE_LEDGER_PATH,
   _TEST_LOCAL_CHECKOUT_SESSIONS_PATH: process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH,
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
   STRIPE_PRICE_ID: process.env.STRIPE_PRICE_ID,
@@ -36,6 +37,7 @@ function primeBillingEnv() {
   process.env.RLHF_ALLOW_INSECURE = 'true';
   process.env._TEST_API_KEYS_PATH = path.join(tmpRoot, 'api-keys.json');
   process.env._TEST_FUNNEL_LEDGER_PATH = path.join(tmpRoot, 'funnel-events.jsonl');
+  process.env._TEST_REVENUE_LEDGER_PATH = path.join(tmpRoot, 'revenue-events.jsonl');
   process.env._TEST_LOCAL_CHECKOUT_SESSIONS_PATH = path.join(tmpRoot, 'local-checkout-sessions.json');
   process.env.STRIPE_SECRET_KEY = '';
   process.env.STRIPE_PRICE_ID = '';


### PR DESCRIPTION
## Summary
- add a dedicated revenue ledger so booked revenue is separated from generic paid-stage funnel events
- thread attribution metadata through checkout, billing summaries, CLI CFO output, and the public landing page
- document the truthful provider coverage model and expand OpenAPI plus verification evidence to match

## Verification
- `npm ci`
- `env RLHF_API_KEY=test-api-key node --test tests/billing.test.js tests/api-server.test.js tests/github-billing.test.js tests/cli.test.js tests/stripe-webhook-route.test.js`
- `env RLHF_API_KEY=test-api-key node --test tests/openapi-parity.test.js tests/adapters.test.js tests/commerce-quality.test.js`
- `env RLHF_API_KEY=ci-secret npm test`
- `env RLHF_API_KEY=ci-secret npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`

## Evidence
- [VERIFICATION_EVIDENCE.md](https://github.com/IgorGanapolsky/mcp-memory-gateway/blob/feat/truthful-revenue-analytics/docs/VERIFICATION_EVIDENCE.md)
- coverage from `npm run test:coverage`: `82.59%` lines, `68.77%` branches, `85.37%` functions
- `npm audit --json`: `0` vulnerabilities

## Notes
- Stripe now records booked revenue directly from webhook payload amounts.
- GitHub Marketplace remains paid-order-only unless `RLHF_GITHUB_MARKETPLACE_PLAN_PRICES_JSON` is configured, which keeps the summary truthful instead of guessing revenue.
- Public Pro CTA now prefers first-party checkout for attribution and falls back to Gumroad if checkout is unavailable.