### PR TITLE
feat: AI authenticity enforcement positioning across all discovery surfaces

### DIFF
--- a/.changeset/ai-authenticity-enforcement-positioning.md
+++ b/.changeset/ai-authenticity-enforcement-positioning.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Weave AI authenticity enforcement angle across all discovery surfaces (README, landing page hero, FAQ, llm-context, marketing docs, NPM keywords).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThumbGate
 
-Make your AI coding agent self-improving. ThumbGate turns thumbs-up and thumbs-down into a learned control plane for autonomous development: pre-action gates, a trained intervention policy, workflow governance, and isolated execution guidance for high-risk runs.
+Make your AI coding agent self-improving — and authentically yours. ThumbGate turns thumbs-up and thumbs-down into a learned control plane for autonomous development: pre-action gates, a trained intervention policy, workflow governance, and isolated execution guidance for high-risk runs. Every gate enforces your team's actual standards, not generic AI patterns.
 
 [![CI](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/thumbgate)](https://www.npmjs.com/package/thumbgate)
@@ -39,6 +39,7 @@ ThumbGate is the control plane for AI coding agents:
 - Workflow Sentinel scores blast radius before execution, so risky PR, release, and publish flows are visible early.
 - High-risk local actions can be routed into Docker Sandboxes, while hosted team automations use a signed isolated sandbox lane.
 - Team rollout stays tied to [Verification Evidence](docs/VERIFICATION_EVIDENCE.md) instead of trust-me operator claims.
+- AI agent outputs stay grounded in your team's actual standards — not generic patterns — because every gate enforces human judgment before the action executes.
 
 ## Release Confidence
 

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -41,6 +41,26 @@
 ## GitHub Metadata
 **Automation:** CI syncs the live GitHub About section from `config/github-about.json` on `main` and verifies it after the write.
 
+## AI Authenticity Angle (New)
+
+**Context**: In the age of AI slop — oversaturation with generic, low-quality AI-generated outputs — brands and engineering teams are actively seeking ways to ensure AI acts with human-backed standards. Merriam-Webster named "slop" its 2025 Word of the Year. The antidote the market wants: "human insight leads, AI supports."
+
+**ThumbGate's answer**: ThumbGate is the authenticity enforcement layer for AI agents. The thumbs-up/down mechanism is a hard gate between AI intent and execution — not a soft suggestion. Every thumbs-down becomes a prevention rule specific to your team's actual standards.
+
+**Key messages to use on this angle:**
+- "Your AI's outputs should reflect your standards, not generic patterns."
+- "Human judgment leads. ThumbGate enforces it."
+- "Stop AI slop before it ships — at the tool-call level."
+- "The authenticity enforcement layer for AI coding agents."
+
+**When to use**: On authenticity-conscious buyer surfaces, developer community content (AI slop is acutely felt by developers), and comparison pages where differentiating from unconstrained agent tools matters.
+
+**Terminology rules for this angle:**
+- Say: "AI authenticity enforcement" (not "AI content quality")
+- Say: "human judgment as a hard gate" (not "human oversight")
+- Say: "your team's actual standards" (not "best practices")
+- Avoid claiming ThumbGate prevents "bad content" — it prevents bad *agent actions*
+
 ## Surface Rules
 - Root landing page stays vendor-neutral. Claude-first positioning belongs only on Claude-specific distribution pages, extension docs, and Anthropic-facing partner assets.
 - Promote shipped surfaces explicitly: Claude Code, Cursor plugin, Codex, Gemini CLI, Amp, OpenCode, and any MCP-compatible agent.

--- a/package.json
+++ b/package.json
@@ -289,7 +289,11 @@
     "enforcement",
     "ai agent memory",
     "repeated mistakes",
-    "agent error prevention"
+    "agent error prevention",
+    "ai-authenticity",
+    "prevent-ai-slop",
+    "human-led-ai",
+    "ai-standards-enforcement"
   ],
   "author": "Igor Ganapolsky",
   "license": "MIT",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:title" content="ThumbGate — Agent governance for AI coding workflows">
 <meta property="og:description" content="CLI-first agent governance for teams shipping AI-generated changes. 👎 Thumbs down distills history-aware lessons from up to 8 prior entries and stays linked to a 60-second feedback session. 👍 Thumbs up reinforces safe patterns. Pre-action gates, workflow governance, shared lessons and org visibility, release confidence, and isolated execution guidance turn vibe coding mistakes into shared enforcement and proof-ready rollout.">
 <meta property="og:type" content="website">
-<meta name="keywords" content="ThumbGate, thumbgate, agent governance, AI coding workflow governance, workflow hardening sprint, pre-action gates, CLI-first agent safety, Claude Code, Cursor, Codex, Gemini, Amp, OpenCode, approval policies, audit trail, release confidence, Docker Sandboxes, feedback enforcement, context engineering">
+<meta name="keywords" content="ThumbGate, thumbgate, agent governance, AI coding workflow governance, workflow hardening sprint, pre-action gates, CLI-first agent safety, Claude Code, Cursor, Codex, Gemini, Amp, OpenCode, approval policies, audit trail, release confidence, Docker Sandboxes, feedback enforcement, context engineering, AI authenticity, prevent AI slop, human-led AI, AI agent standards enforcement, brand authenticity AI">
 
 <!-- Privacy-friendly analytics by Plausible -->
 <script defer data-domain="thumbgate-production.up.railway.app" src="https://plausible.io/js/script.js"></script>
@@ -51,7 +51,7 @@ __GA_BOOTSTRAP__
   "url": "https://github.com/IgorGanapolsky/ThumbGate",
   "downloadUrl": "https://www.npmjs.com/package/thumbgate",
   "installUrl": "https://www.npmjs.com/package/thumbgate",
-  "dateModified": "2026-04-03",
+  "dateModified": "2026-04-09",
   "creator": {
     "@type": "Person",
     "name": "Igor Ganapolsky",
@@ -71,7 +71,8 @@ __GA_BOOTSTRAP__
     "Prompt-Level DLP — scans tool call inputs before execution",
     "Per-Step Scoring — every gate decision becomes a DPO/KTO training signal",
     "HuggingFace Export — share PII-redacted agent traces as open training datasets",
-    "Unified Context — one-call context assembly with session, lessons, guards, and code-graph"
+    "Unified Context — one-call context assembly with session, lessons, guards, and code-graph",
+    "AI Authenticity Enforcement — every gate reflects your team's actual standards, not generic AI patterns"
   ],
   "offers": [
     {
@@ -197,6 +198,14 @@ __GA_BOOTSTRAP__
       "acceptedAnswer": {
         "@type": "Answer",
         "text": "Prompt rules are suggestions agents can ignore. Pre-Action Gates are enforcement — they block the action before execution via PreToolUse hooks. Gates are auto-generated from feedback and use Thompson Sampling to adapt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does ThumbGate prevent AI slop and protect brand authenticity?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "AI slop happens when agents act without human judgment as a hard gate — generating repetitive, generic outputs that erode trust and dilute your brand. ThumbGate inserts human thumbs-up/down between AI intent and execution. Every thumbs-down becomes a prevention rule that blocks the bad pattern permanently. Every thumbs-up reinforces what 'good' looks like for your specific context. Your agent's outputs reflect your actual standards, not generic AI patterns. This is authenticity enforcement at the tool-call level."
       }
     },
     {
@@ -448,6 +457,7 @@ __GA_BOOTSTRAP__
     <div class="hero-signals">
       <div class="signal-pill signal-down">👎 Repeated failure becomes enforcement before the next run</div>
       <div class="signal-pill signal-up">👍 Safe pattern reinforced across the shared workflow</div>
+      <div class="signal-pill">🛡️ Human judgment gates every AI action — your standards, not AI slop</div>
     </div>
     <p class="hero-persona">For consultancies, platform teams, and AI product teams with one workflow owner, one repeated failure, and one buyer who needs proof before a wider rollout.</p>
     <p><strong>Best first paid motion:</strong> start with one repo, one workflow, and one repeat failure. ThumbGate turns the blocker into enforcement, routes risky runs toward isolated execution, and gives the buyer a proof-ready story around shared memory, approval boundaries, release confidence, and auditability.</p>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -97,4 +97,17 @@ npx thumbgate dashboard
 - Comparison: https://thumbgate-production.up.railway.app/compare
 - Team sprint intake: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
 
+## How ThumbGate Promotes AI Authenticity
+
+In an era of AI slop — where agents generate repetitive, generic outputs that erode brand trust — ThumbGate is the enforcement layer that keeps AI behavior grounded in human judgment.
+
+The core thesis: AI slop happens when agents act without human judgment as a hard gate. ThumbGate solves this at the tool-call level, not through prompt suggestions the agent can ignore.
+
+- **Human insight leads**: The thumbs-up/down mechanism is a literal human gate between AI intent and execution. The agent cannot proceed on blocked patterns.
+- **Standards, not patterns**: Every thumbs-down distills into a prevention rule specific to your team's context — not a generic best practice.
+- **Authenticity over volume**: ThumbGate reinforces what "good" looks like for your specific codebase, standards, and risk tolerance. Agents learn your standards, not average AI behavior.
+- **Discovery advantage**: As platforms and search engines increasingly reward authentic, human-verified outputs over high-volume AI generation, ThumbGate provides the enforcement infrastructure that proves human oversight was applied.
+
+**Positioning for authenticity-conscious audiences**: ThumbGate is the authenticity enforcement layer for AI coding agents. Where AI slop is the symptom, unconstrained agent autonomy is the cause. ThumbGate addresses the cause.
+
 *Last updated: 2026-04-09*


### PR DESCRIPTION
## Summary

Connects ThumbGate to the "AI slop" conversation (Merriam-Webster 2025 Word of the Year) by weaving an AI authenticity enforcement angle across every discovery surface.

**Article context**: [How to Navigate Brand Authenticity in the Age of AI Slop](https://www.entrepreneur.com/growing-a-business/how-to-navigate-brand-authenticity-in-the-age-of-ai-slop/503454) — the thesis is "human insight leads, AI supports." ThumbGate is literally the enforcement infrastructure for that thesis.

## Changes

- **README.md**: Hero subtitle updated + new Enterprise Story bullet — "AI agent outputs stay grounded in your team's actual standards, not generic patterns"
- **public/index.html**: New hero signal pill ("Human judgment gates every AI action — your standards, not AI slop"), new FAQ entry on AI slop prevention, schema.org featureList entry, 5 new meta keywords, `dateModified` bumped to 2026-04-09
- **public/llm-context.md**: New "How ThumbGate Promotes AI Authenticity" section for AI-driven discovery (Perplexity, ChatGPT, etc.)
- **docs/MARKETING_COPY_CONGRUENCE.md**: New AI Authenticity Angle section with approved messaging, terminology rules, and placement guidance
- **package.json**: 4 new NPM keywords — `ai-authenticity`, `prevent-ai-slop`, `human-led-ai`, `ai-standards-enforcement`

## Key messages introduced

- "Your AI's outputs should reflect your standards, not generic patterns."
- "Human judgment leads. ThumbGate enforces it."
- "Stop AI slop before it ships — at the tool-call level."
- "The authenticity enforcement layer for AI coding agents."

## Test plan
- [ ] CI green
- [ ] `node scripts/check-congruence.js` passes
- [ ] No broken links or schema errors in index.html

https://claude.ai/code/session_01TtykdVRr1Y3qhqBNXDNL9f