### PR TITLE
fix: submit automerge PRs through trunk

### DIFF
--- a/.changeset/trunk-merge-submission.md
+++ b/.changeset/trunk-merge-submission.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Submit main-branch automerge requests to Trunk without polling helper workflow checks or waiting for a final merge commit inside GitHub Actions.

--- a/.github/workflows/agent-automerge.yml
+++ b/.github/workflows/agent-automerge.yml
@@ -14,9 +14,18 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
+  issues: write
+
+concurrency:
+  group: agent-automerge-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  THUMBGATE_MAIN_MERGE_PROVIDER: trunk
 
 jobs:
-  auto-merge:
+  agent-automerge:
+    name: agent-automerge
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -30,43 +39,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Wait for required and critical quality checks
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          set -euo pipefail
-
-          timeout_seconds=1800
-          interval_seconds=20
-          elapsed=0
-
-          while true; do
-            checks_json="$(gh pr checks "$PR_URL" --json bucket,name,state,workflow,link,event --jq '.' || echo '[]')"
-
-            if jq -e 'length == 0' <<<"$checks_json" >/dev/null; then
-              echo "No quality checks configured."
-              break
-            elif jq -e 'any(.[]; .bucket == "fail" or .bucket == "cancel")' <<<"$checks_json" >/dev/null; then
-              echo "A critical quality check failed. Auto-merge skipped."
-              jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "- \(.name): \(.state) \(.link)"' <<<"$checks_json"
-              exit 1
-            elif jq -e 'all(.[]; .bucket == "pass" or .bucket == "skipping")' <<<"$checks_json" >/dev/null; then
-              echo "All critical quality checks completed successfully."
-              break
-            else
-              echo "Quality checks are still running."
-            fi
-
-            sleep "$interval_seconds"
-            elapsed=$((elapsed + interval_seconds))
-
-            if [ "$elapsed" -ge "$timeout_seconds" ]; then
-              echo "Timed out waiting for required checks to complete."
-              exit 1
-            fi
-          done
-
       - name: Auto-approve PR
         continue-on-error: true
         uses: actions/github-script@v8
@@ -81,62 +53,50 @@ jobs:
               body: "Auto-approved by agent automerge policy.",
             });
 
-      - name: Enable auto-merge
+      - name: Request merge automation
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
+          if [ "$BASE_REF" = "main" ] && [ "${THUMBGATE_MAIN_MERGE_PROVIDER}" = "trunk" ]; then
+            existing_comment_id="$(
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                --jq '.[] | select(.user.login == "github-actions[bot]" and .body == "/trunk merge") | .id' \
+                | head -n 1
+            )"
+
+            if [ -n "${existing_comment_id:-}" ]; then
+              echo "Trunk merge request already exists for $PR_URL"
+            else
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                --method POST \
+                -f body='/trunk merge' >/dev/null
+              echo "Requested Trunk merge for $PR_URL"
+            fi
+
+            {
+              echo "### Merge automation"
+              echo "- Provider: trunk"
+              echo "- PR: $PR_URL"
+              echo "- Queue request: \`/trunk merge\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           if gh pr merge --auto --squash --delete-branch "$PR_URL"; then
-            echo "Auto-merge enabled for $PR_URL"
+            echo "GitHub auto-merge enabled for $PR_URL"
           else
-            echo "Auto-merge not available; trying direct squash merge"
+            echo "GitHub auto-merge unavailable; trying direct squash merge"
             gh pr merge --squash --delete-branch "$PR_URL"
           fi
 
-      - name: Resolve final merge commit
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          set -euo pipefail
-
-          timeout_seconds=1800
-          interval_seconds=20
-          elapsed=0
-
-          while true; do
-            pr_json="$(gh pr view "$PR_URL" --json state,mergeCommit,url,title --jq '.')"
-            pr_state="$(jq -r '.state' <<<"$pr_json")"
-            merge_commit="$(jq -r '.mergeCommit.oid // empty' <<<"$pr_json")"
-
-            if [ "$pr_state" = "MERGED" ] && [ -n "$merge_commit" ]; then
-              echo "Final merge commit: $merge_commit"
-              {
-                echo "### Merge result"
-                echo "- PR: $PR_URL"
-                echo "- Merge commit: \`$merge_commit\`"
-              } >> "$GITHUB_STEP_SUMMARY"
-              break
-            fi
-
-            if [ "$pr_state" = "CLOSED" ]; then
-              echo "PR closed without a merge commit."
-              exit 1
-            fi
-
-            if [ "$elapsed" -ge "$timeout_seconds" ]; then
-              echo "Final merge commit is not available yet; auto-merge remains queued."
-              {
-                echo "### Merge result"
-                echo "- PR: $PR_URL"
-                echo "- Final merge commit: pending (merge queue still processing)"
-              } >> "$GITHUB_STEP_SUMMARY"
-              break
-            fi
-
-            sleep "$interval_seconds"
-            elapsed=$((elapsed + interval_seconds))
-          done
+          {
+            echo "### Merge automation"
+            echo "- Provider: github"
+            echo "- PR: $PR_URL"
+            echo "- Mode: auto-merge or direct squash fallback"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,9 +13,18 @@ permissions:
   contents: write
   pull-requests: write
   checks: read
+  issues: write
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  THUMBGATE_MAIN_MERGE_PROVIDER: trunk
 
 jobs:
-  auto-merge:
+  dependabot-automerge:
+    name: dependabot-automerge
     if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
@@ -54,45 +63,50 @@ jobs:
               body: "Auto-approved Dependabot update.",
             });
 
-      - name: Wait for checks and merge
+      - name: Request merge automation
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
-          timeout_seconds=1800
-          interval_seconds=20
-          elapsed=0
+          if [ "$BASE_REF" = "main" ] && [ "${THUMBGATE_MAIN_MERGE_PROVIDER}" = "trunk" ]; then
+            existing_comment_id="$(
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                --jq '.[] | select(.user.login == "github-actions[bot]" and .body == "/trunk merge") | .id' \
+                | head -n 1
+            )"
 
-          while true; do
-            checks_json="$(gh pr checks "$PR_URL" --required --json state,conclusion --jq '.' || echo '[]')"
-
-            if jq -e 'length == 0' <<<"$checks_json" >/dev/null; then
-              echo "No required checks configured."
-              break
-            elif jq -e 'any(.[]; .state == "COMPLETED" and (.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT" or .conclusion == "ACTION_REQUIRED" or .conclusion == "STARTUP_FAILURE"))' <<<"$checks_json" >/dev/null; then
-              echo "A required check failed. Skipping merge."
-              exit 1
-            elif jq -e 'all(.[]; .state == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))' <<<"$checks_json" >/dev/null; then
-              echo "All required checks completed successfully."
-              break
+            if [ -n "${existing_comment_id:-}" ]; then
+              echo "Trunk merge request already exists for $PR_URL"
             else
-              echo "Required checks are still running."
+              gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                --method POST \
+                -f body='/trunk merge' >/dev/null
+              echo "Requested Trunk merge for $PR_URL"
             fi
 
-            sleep "$interval_seconds"
-            elapsed=$((elapsed + interval_seconds))
+            {
+              echo "### Merge automation"
+              echo "- Provider: trunk"
+              echo "- PR: $PR_URL"
+              echo "- Queue request: \`/trunk merge\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
-            if [ "$elapsed" -ge "$timeout_seconds" ]; then
-              echo "Timed out waiting for required checks to complete."
-              exit 1
-            fi
-          done
-
-          if gh pr merge --auto --squash "$PR_URL"; then
-            echo "Auto-merge enabled."
+          if gh pr merge --auto --squash --delete-branch "$PR_URL"; then
+            echo "GitHub auto-merge enabled."
           else
-            echo "Auto-merge unavailable; merging directly."
+            echo "GitHub auto-merge unavailable; merging directly."
             gh pr merge --squash --delete-branch "$PR_URL"
           fi
+
+          {
+            echo "### Merge automation"
+            echo "- Provider: github"
+            echo "- PR: $PR_URL"
+            echo "- Mode: auto-merge or direct squash fallback"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/merge-branch.yml
+++ b/.github/workflows/merge-branch.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
+
+env:
+  THUMBGATE_MAIN_MERGE_PROVIDER: trunk
 
 jobs:
   merge:
@@ -62,5 +66,24 @@ jobs:
           fi
 
           if [ "${{ github.event.inputs.auto_merge }}" = "true" ]; then
-            gh pr merge --auto --squash --delete-branch "$PR_URL" || true
+            PR_NUMBER="$(gh pr view "$PR_URL" --json number --jq '.number')"
+
+            if [ "${THUMBGATE_MAIN_MERGE_PROVIDER}" = "trunk" ]; then
+              existing_comment_id="$(
+                gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                  --jq '.[] | select(.user.login == "github-actions[bot]" and .body == "/trunk merge") | .id' \
+                  | head -n 1
+              )"
+
+              if [ -n "${existing_comment_id:-}" ]; then
+                echo "Trunk merge request already exists for $PR_URL"
+              else
+                gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                  --method POST \
+                  -f body='/trunk merge' >/dev/null
+                echo "Requested Trunk merge for $PR_URL"
+              fi
+            else
+              gh pr merge --auto --squash --delete-branch "$PR_URL" || true
+            fi
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ On explicit user preference signals (`up/down`, `correct/wrong`, or subjective "
 - Start PR work by checking open PRs, review state, branch status, and CI.
 - Merge ready PRs autonomously once required checks are green and no actionable comments remain.
 - Pending CI checks and `REVIEW_REQUIRED` are blockers, not mergeable states; do not admin-merge around them.
+- `main` is Trunk-managed. Automation should submit `/trunk merge` and exit; do not long-poll helper workflow checks or wait inside the workflow for a final merge commit.
 - Verify `main` CI on the exact merge commit before claiming the work is finished.
 - Delete disposable worktrees and stale merged local branches after merge.
 - If a closed-unmerged branch still contains unique local commits, archive it before deletion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ curl -s https://thumbgate-production.up.railway.app/dashboard | grep 'ThumbGate 
 6. Merge only when: CI green AND 0 unresolved threads.
 7. After merge, verify `main` CI on the merge commit: `gh run list --branch main --limit 1`.
 8. Delete the feature branch after merge.
+9. For `main`, merge submission is Trunk-managed: request `/trunk merge` and let the queue finish asynchronously. Do not build helper workflows that poll their own required check or block on the final merge commit.
 
 **NEVER say "done" or "pushed" without showing `gh pr view` output first.**
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,6 +45,7 @@ Source of truth for Gemini declarations:
 - Prefer clean worktrees for verification and branch maintenance rather than a dirty primary checkout.
 - Do not report PR completion until the exact merge commit is green on `main`.
 - Pending CI checks and `REVIEW_REQUIRED` are blockers, not mergeable states; do not admin-merge around them.
+- For `main`, merge automation should submit `/trunk merge` and exit. Do not long-poll helper workflow checks or wait inside the helper workflow for the final merge commit.
 - Archive unique orphan branches before deletion and remove clean redundant worktrees once they are no longer needed.
 
 ## Suggested Runtime Mapping

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -501,6 +501,13 @@ test('Dependabot auto-merge trusts the pull request author instead of the trigge
   assert.match(workflow, /pull_request_target:/);
   assert.match(workflow, /github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'/);
   assert.doesNotMatch(workflow, /if:\s*github\.actor == 'dependabot\[bot\]'/);
+  assert.match(workflow, /issues:\s+write/s);
+  assert.match(workflow, /group:\s*dependabot-automerge-\$\{\{\s*github\.event\.pull_request\.number \|\| github\.run_id\s*\}\}/);
+  assert.match(workflow, /jobs:\s+dependabot-automerge:\s+name:\s*dependabot-automerge/s);
+  assert.match(workflow, /THUMBGATE_MAIN_MERGE_PROVIDER:\s*trunk/);
+  assert.match(workflow, /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/issues\/\$\{PR_NUMBER\}\/comments"/);
+  assert.match(workflow, /-f body='\/trunk merge'/);
+  assert.doesNotMatch(workflow, /gh pr checks "\$PR_URL"/);
 });
 
 test('Publish Claude Plugin workflow builds the MCPB and uploads channel-safe release assets', () => {
@@ -527,23 +534,37 @@ test('Publish Claude Plugin workflow builds the MCPB and uploads channel-safe re
   assert.match(workflow, /--prerelease/);
 });
 
-test('Agent auto-merge workflow blocks any failing quality check, not only required checks', () => {
+test('Agent auto-merge workflow submits queue requests instead of polling its own check state', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'agent-automerge.yml'), 'utf8');
 
-  assert.match(workflow, /name: Wait for required and critical quality checks/);
-  assert.match(workflow, /gh pr checks "\$PR_URL" --json bucket,name,state,workflow,link,event/);
-  assert.doesNotMatch(workflow, /gh pr checks "\$PR_URL" --required/);
-  assert.match(workflow, /any\(\.\[\]; \.bucket == "fail" or \.bucket == "cancel"\)/);
-  assert.match(workflow, /All critical quality checks completed successfully\./);
+  assert.match(workflow, /issues:\s+write/s);
+  assert.match(workflow, /group:\s*agent-automerge-\$\{\{\s*github\.event\.pull_request\.number \|\| github\.run_id\s*\}\}/);
+  assert.match(workflow, /jobs:\s+agent-automerge:\s+name:\s*agent-automerge/s);
+  assert.match(workflow, /THUMBGATE_MAIN_MERGE_PROVIDER:\s*trunk/);
+  assert.match(workflow, /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/issues\/\$\{PR_NUMBER\}\/comments"/);
+  assert.match(workflow, /-f body='\/trunk merge'/);
+  assert.doesNotMatch(workflow, /gh pr checks "\$PR_URL"/);
+  assert.doesNotMatch(workflow, /timeout_seconds=1800/);
 });
 
-test('Agent auto-merge workflow reports the final merge commit instead of the branch head SHA', () => {
+test('Agent auto-merge workflow records merge submission without waiting for the final merge commit', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'agent-automerge.yml'), 'utf8');
 
-  assert.match(workflow, /name: Resolve final merge commit/);
-  assert.match(workflow, /gh pr view "\$PR_URL" --json state,mergeCommit,url,title/);
-  assert.match(workflow, /Final merge commit: \$merge_commit/);
-  assert.match(workflow, /Final merge commit: pending \(merge queue still processing\)/);
+  assert.match(workflow, /name: Request merge automation/);
+  assert.match(workflow, /### Merge automation/);
+  assert.match(workflow, /Queue request: \\`\/trunk merge\\`/);
+  assert.doesNotMatch(workflow, /gh pr view "\$PR_URL" --json state,mergeCommit,url,title/);
+  assert.doesNotMatch(workflow, /Final merge commit:/);
+});
+
+test('Merge branch workflow requests trunk merge for main instead of forcing GitHub auto-merge', () => {
+  const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'merge-branch.yml'), 'utf8');
+
+  assert.match(workflow, /issues:\s+write/s);
+  assert.match(workflow, /THUMBGATE_MAIN_MERGE_PROVIDER:\s*trunk/);
+  assert.match(workflow, /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/issues\/\$\{PR_NUMBER\}\/comments"/);
+  assert.match(workflow, /-f body='\/trunk merge'/);
+  assert.match(workflow, /if \[ "\$\{THUMBGATE_MAIN_MERGE_PROVIDER\}" = "trunk" \]/);
 });
 
 test('Sentry release workflow serializes main release stamping', () => {


### PR DESCRIPTION
## Summary
- stop ThumbGate helper workflows from waiting on their own check state or on a final merge commit
- make automerge helpers submit `/trunk merge` for `main` so protected-branch merges flow through Trunk instead of deadlocking inside GitHub Actions
- add regression coverage and sync repo directives so future workflow changes keep the same contract

## Root cause
The automerge workflows were polling `gh pr checks` from inside the helper workflow itself and then waiting for a final merge commit. On `main`, this is the wrong control plane: Trunk owns the merge queue. That created a self-referential hold-up where the helper workflow could wait on a state that only resolves after queue submission.

## Verification
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`
