### PR TITLE
fix: align team pricing congruence

### DIFF
--- a/.agents/skills/thumbgate/SKILL.md
+++ b/.agents/skills/thumbgate/SKILL.md
@@ -108,13 +108,15 @@ When the MCP server is running, these tools are available to your agent:
 
 ## Pro Features
 
-Pro users ($19/mo, founder license) unlock:
+Pro users ($19/mo or $149/yr, founder license) unlock:
 
 - **Visual gate debugger** — see every blocked action and the gate that fired
 - **Multi-hop recall** — chain related lessons across hops for deeper context
 - **Synthetic DPO augmentation** — expand real feedback into larger training datasets
-- **Shared team lesson DB** — one dev's thumbs-down protects every agent on the team
 - **Gate wiring support** — help enforcing your riskiest flows in the first week
+
+Team rollout ($99/seat/mo, 3-seat minimum after intake) adds the shared hosted lesson DB,
+org dashboard, approval boundaries, and proof-backed workflow hardening sprint.
 
 Upgrade: https://buy.stripe.com/aFa4gz1M84r419v7mb3sI05
 

--- a/.changeset/pricing-congruence-99.md
+++ b/.changeset/pricing-congruence-99.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+Align Team pricing across the public landing page, README, marketing materials,
+runtime commercial constants, and congruence tests at $99/seat/mo with a 3-seat
+minimum.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ One workflow. One owner. One proof review. That is the fastest path to a paid te
 
 **Best first technical motion:** install the local CLI and let `init` wire the hooks and MCP transport for the agent you already use.
 
-Free stays for individual developers. The commercial path is enterprise-first: Team pricing anchors at **$12/seat/mo with a 3-seat minimum**, and the public paid motion starts with the Workflow Hardening Sprint so one blocker gets qualified before a wider rollout. [See pricing →](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=pricing_link#pricing)
+Free stays for individual developers. The commercial path is enterprise-first: Team pricing anchors at **$99/seat/mo with a 3-seat minimum**, and the public paid motion starts with the Workflow Hardening Sprint so one blocker gets qualified before a wider rollout. [See pricing →](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=pricing_link#pricing)
 
 **Paid path for individual operators:** [ThumbGate Pro](https://thumbgate-production.up.railway.app/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page) remains the self-serve side lane for the personal local dashboard, DPO export, and review-ready evidence. It is useful when one operator wants proof and debugging help without the team rollout motion.
 
@@ -184,7 +184,7 @@ Free and self-hosted users can invoke `search_lessons` directly through MCP, and
 
 ```
 ┌──────────────┬──────────────────────────────┬──────────────────────┐
-│    FREE      │   TEAM $12/seat/mo (min 3)   │ PRO $19/mo or $149/yr│
+│    FREE      │   TEAM $99/seat/mo (min 3)   │ PRO $19/mo or $149/yr│
 ├──────────────┼──────────────────────────────┼──────────────────────┤
 │ Local CLI    │ Workflow hardening sprint    │ Personal dashboard   │
 │ enforcement  │ Shared hosted lesson DB      │ DPO export           │

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -811,7 +811,7 @@ function pro() {
     console.log('Every licensed Pro user gets a personal local dashboard on localhost.');
     console.log('\nWhat is available:');
     console.log('  - Local Pro dashboard: your own browser dashboard for search, gates, and DPO export');
-    console.log('  - Optional hosted API key: shared lesson DB for teams and multi-agent workflows');
+    console.log('  - Team rollout path: shared hosted lessons, org visibility, and workflow proof');
     console.log('  - Commercial truth doc: source of truth for traction, pricing, and proof claims');
     console.log('\nLinks:');
     console.log(`  Buy Pro         : ${PRO_CHECKOUT_URL}`);

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -15,6 +15,7 @@ if (isCI || isQuiet) process.exit(0);
 const {
   PRO_MONTHLY_PAYMENT_LINK,
   PRO_PRICE_LABEL,
+  TEAM_PRICE_LABEL,
 } = require('../scripts/commercial-offer');
 const WORKFLOW_SPRINT_URL = 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake';
 
@@ -31,8 +32,9 @@ process.stderr.write(`
   │   Sprint: ${WORKFLOW_SPRINT_URL} │
   │                                                     │
   │   Solo side lane: Pro (personal local dashboard,    │
-  │   DPO export, optional hosted API key) — ${PRO_PRICE_LABEL}: │
+  │   DPO export) — ${PRO_PRICE_LABEL}: │
   │     ${PRO_MONTHLY_PAYMENT_LINK}       │
+  │   Team: ${TEAM_PRICE_LABEL} after intake. │
   │                                                     │
   │   Or run: npx thumbgate pro                │
   │                                                     │

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -1,7 +1,7 @@
 # Commercial Truth
 
 Status: current
-Updated: April 1, 2026
+Updated: April 10, 2026
 
 This document is the source of truth for product, pricing, traction, and proof claims in this repository.
 
@@ -12,7 +12,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 - The primary commercial motion is the **Workflow Hardening Sprint** for one workflow, followed by Team expansion when shared enforcement, approval boundaries, and auditability matter across operators.
 - The current public self-serve commercial offer is **Pro at $19/mo or $149/yr** via Stripe checkout.
 - The preserved founder one-time Stripe link still exists for legacy founder buyers, but it is not the default commercial offer.
-- The current Team pricing anchor is **$12/seat/mo with a 3-seat minimum**, and the public Team path remains an **intake-led pilot for the first workflow** until hosted rollout scope is qualified.
+- The current Team pricing anchor is **$99/seat/mo with a 3-seat minimum**, and the public Team path remains an **intake-led pilot for the first workflow** until hosted rollout scope is qualified.
 - The open-source runtime now supports history-aware lesson distillation from up to 8 prior recorded entries in the current Claude auto-capture path, linked 60-second feedback sessions, and reflector rule proposals across CLI, hosted API, Cursor, and Claude Desktop surfaces.
 - The runtime now supports Workflow Sentinel blast-radius scoring plus Docker Sandboxes routing guidance for high-risk local actions, and the hosted path supports signed sandbox dispatch for isolated team automations.
 - Package publishing is governed by Changesets, SemVer, version-sync checks, and verification evidence; release claims should stay inspectable instead of being inferred from a diff.
@@ -41,7 +41,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 - Unlimited custom gates with auto-gate promotion
 - Secondary self-serve lane for solo operators, not the default enterprise pitch
 
-### Team ($12/seat/mo, min 3, hosted rollout intake-first)
+### Team ($99/seat/mo, min 3, hosted rollout intake-first)
 
 - Workflow hardening sprint as the first paid step
 - Shared hosted lesson database

--- a/docs/MONETIZATION_EXEC_SUMMARY_2026-04-08.md
+++ b/docs/MONETIZATION_EXEC_SUMMARY_2026-04-08.md
@@ -14,7 +14,7 @@ The job of go-to-market is to turn ThumbGate from an interesting open-source rel
 
 - The open-source `thumbgate` package is free and MIT licensed.
 - The current public self-serve commercial offer is **Pro at `$19/mo` or `$149/yr`**.
-- The current Team pricing anchor is **`$12/seat/mo` with a `3`-seat minimum**, and the Team path is still intake-led.
+- The current Team pricing anchor is **`$99/seat/mo` with a `3`-seat minimum**, and the Team path is still intake-led.
 - Verified commercial proof is still early-stage. Public claims must stay aligned with [COMMERCIAL_TRUTH.md](COMMERCIAL_TRUTH.md).
 - Weekly npm installs, GitHub stars, and directory listings are acquisition signals, not revenue proof.
 
@@ -40,8 +40,8 @@ These signals matter because they show demand and discovery, but they do not pro
 | Path | Formula | Monthly revenue |
 | --- | --- | ---: |
 | Pro only | `226 x $19` | `$4,294` |
-| Mixed target | `150 Pro x $19 + 12 teams x 10 seats x $12` | `$4,290` |
-| Team-heavier | `90 Pro x $19 + 18 teams x 12 seats x $12` | `$4,302` |
+| Mixed target | `150 Pro x $19 + 2 teams x 8 seats x $99` | `$4,434` |
+| Team-heavier | `45 Pro x $19 + 4 teams x 9 seats x $99` | `$4,419` |
 
 Recommended planning path:
 
@@ -51,7 +51,7 @@ Recommended planning path:
 
 ## Funnel Math
 
-The original research target of `2,000` monthly visitors and `4.2%` overall conversion is too loose if it is meant to support `150` Pro subscribers plus `12` paying team accounts.
+The original research target of `2,000` monthly visitors and `4.2%` overall conversion is too loose if it is meant to support `150` Pro subscribers plus multiple paying team accounts.
 
 If the target is `162` paying accounts:
 

--- a/docs/WORKFLOW_HARDENING_SPRINT.md
+++ b/docs/WORKFLOW_HARDENING_SPRINT.md
@@ -54,7 +54,7 @@ Only move forward when the buyer has:
 
 - This is a pilot-by-request service offer, not a new public self-serve subscription tier.
 - The public self-serve offer remains Pro at `$19/mo or $149/yr` per [COMMERCIAL_TRUTH.md](COMMERCIAL_TRUTH.md).
-- Team pricing currently anchors at `$12/seat/mo` with a `3`-seat minimum, but the public Team path is still intake-first.
+- Team pricing currently anchors at `$99/seat/mo` with a `3`-seat minimum, but the public Team path is still intake-first.
 - Use booked pilots, paid orders, or named pilot agreements as commercial proof.
 - Same-day next step after a qualified call: send the sprint brief, the proof pack, and the proposed buyer review path.
 

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -645,7 +645,7 @@
             <a class='button secondary' href='https://thumbgate-production.up.railway.app'>View hosted demo</a>
           </div>
           <p class='note'>Early-stage product. Engineering proof is real, but GitHub stars, npm downloads, and solo-maintainer activity are not customer proof.</p>
-          <p class='note'>The public commercial motion starts with the Workflow Hardening Sprint, then expands into Team at $12/seat/mo with a 3-seat minimum after qualification. Pro at $19/mo or $149/yr stays available for solo operators who want a personal dashboard.</p>
+          <p class='note'>The public commercial motion starts with the Workflow Hardening Sprint, then expands into Team at $99/seat/mo with a 3-seat minimum after qualification. Pro at $19/mo or $149/yr stays available for solo operators who want a personal dashboard.</p>
         </div>
 
         <div class='panel hero-card'>
@@ -966,7 +966,7 @@
         <div class='section-head'>
           <span class='eyebrow'>Pricing</span>
           <h2>Install free. Buy with the Workflow Hardening Sprint. Keep Pro as the solo side lane.</h2>
-          <p>The OSS core is free and always will be. Team rollout stays intake-first at $12/seat/mo with a 3-seat minimum after qualification. Pro is $19/mo or $149/yr for individual operators.</p>
+          <p>The OSS core is free and always will be. Team rollout stays intake-first at $99/seat/mo with a 3-seat minimum after qualification. Pro is $19/mo or $149/yr for individual operators.</p>
         </div>
         <div class='pricing-grid'>
           <div class='card'>
@@ -985,7 +985,7 @@
           <div class='card featured'>
             <span class='badge'>Primary motion</span>
             <h3>Team</h3>
-            <div class='price'>$12 <small>/ seat / mo</small></div>
+            <div class='price'>$99 <small>/ seat / mo</small></div>
           <p style='margin:0 0 8px;font-size:15px;color:var(--muted);font-style:italic;'>Start with one workflow, one owner, and one repeated blocker. Expand into shared governance after proof.</p>
             <ul>
               <li>Workflow Hardening Sprint intake</li>

--- a/docs/marketing/devhunt-battle-plan.md
+++ b/docs/marketing/devhunt-battle-plan.md
@@ -17,9 +17,9 @@
 > One thumbs-down permanently blocks that AI mistake
 
 **Description:**
-> ThumbGate puts a gate before every AI agent action. One thumbs-down captures the mistake, generates a prevention rule, and permanently blocks that pattern from recurring — across Claude Code, Cursor, Codex, Gemini, Amp, and OpenCode. Free to start; Pro at $19/mo adds team dashboards and DPO export.
+> ThumbGate puts a gate before every AI agent action. One thumbs-down captures the mistake, generates a prevention rule, and permanently blocks that pattern from recurring — across Claude Code, Cursor, Codex, Gemini, Amp, and OpenCode. Free to start; Pro at $19/mo adds the personal dashboard and DPO export. Team at $99/seat/mo adds shared governance for engineering teams.
 
-**Pricing:** Freemium (Free + Pro $19/mo + Team $12/seat/mo)
+**Pricing:** Freemium (Free + Pro $19/mo + Team $99/seat/mo)
 
 **URLs:**
 - Homepage: https://thumbgate-production.up.railway.app

--- a/docs/marketing/devto-article.md
+++ b/docs/marketing/devto-article.md
@@ -99,7 +99,7 @@ npx thumbgate serve
 GitHub: [github.com/IgorGanapolsky/ThumbGate](https://github.com/IgorGanapolsky/ThumbGate)
 npm: [thumbgate](https://www.npmjs.com/package/thumbgate)
 
-If you want a personal local dashboard, DPO export, and an optional hosted API key for team workflows, there is a [Pro tier at $19/mo or $149/yr](https://thumbgate-production.up.railway.app/checkout/pro). The core local feedback loop still works on its own.
+If you want a personal local dashboard and DPO export, there is a [Pro tier at $19/mo or $149/yr](https://thumbgate-production.up.railway.app/checkout/pro). Team workflows start with the Workflow Hardening Sprint when shared lessons, org visibility, and hosted rollout proof matter. The core local feedback loop still works on its own.
 
 I have been running this on my own projects for months. The difference between session 1 and session 50 is noticeable — the agent stops making the same classes of mistakes. Not because it got smarter, but because the gates will not let it repeat what already failed.
 

--- a/docs/marketing/product-hunt-launch-kit.md
+++ b/docs/marketing/product-hunt-launch-kit.md
@@ -60,11 +60,11 @@ I'm here all day — ask me anything.
 
 Happy launch day! A few things to know before you try it:
 
-The free tier does everything described above — unlimited feedback capture, auto-generated prevention rules, local enforcement via PreToolUse hooks. No cloud account, no credit card.
+The free tier gives you the local loop: 3 daily feedback captures, 5 daily lesson searches, auto-generated prevention rules, and local enforcement via PreToolUse hooks. No cloud account, no credit card.
 
 Pro ($19/mo) adds the personal local dashboard, DPO export pairs for downstream fine-tuning, and a gate debugger to trace exactly why a rule fired.
 
-Team plan is $12/seat/mo if you want shared lesson libraries across an engineering team.
+Team anchors at $99/seat/mo if you want shared lesson libraries, org visibility, and approval boundaries across an engineering team.
 
 The quickest way to see it work: install it, give your agent a thumbs down on the next mistake, and watch the gate appear.
 
@@ -118,7 +118,7 @@ $ git push --force
 **Purpose:** Developers respond to real terminal output over marketing copy. Shows zero-config setup and a gate firing end-to-end.
 
 ### Screenshot 5: Pricing Tiers
-**What to capture:** Clean pricing comparison — Free vs Pro ($19/mo) vs Team ($12/seat/mo).  
+**What to capture:** Clean pricing comparison — Free vs Pro ($19/mo or $149/yr) vs Team ($99/seat/mo).
 Pull from https://thumbgate-production.up.railway.app/#pricing  
 Highlight "Free forever" tier prominently to reduce friction on PH visitors.  
 **Purpose:** Removes the "how much does this cost?" friction before visitors click through.
@@ -300,7 +300,7 @@ What free does NOT include:
 - DPO export pairs (for downstream fine-tuning your own models)
 - Gate debugger (trace why a specific rule fired, with confidence scores)
 
-Pro is $19/mo or $149/yr. Team is $12/seat/mo.
+Pro is $19/mo or $149/yr. Team is $99/seat/mo.
 
 ---
 

--- a/docs/marketing/reddit-posts/r-webdev.md
+++ b/docs/marketing/reddit-posts/r-webdev.md
@@ -31,6 +31,6 @@ Things I would especially love feedback on:
 - Are there gates you would want out of the box that are not included?
 - Any thoughts on the local-first approach vs. a hosted service?
 
-The project also has a Pro tier for team features (shared lesson database, team dashboard, DPO export) but the core tool is fully functional and free.
+The project also has Pro for individual dashboard/export workflows and Team for shared lesson databases, org dashboards, and rollout proof, but the core local gate loop is usable without a paid account.
 
 Thanks in advance for any feedback.

--- a/docs/marketing/reddit-seeding-posts.md
+++ b/docs/marketing/reddit-seeding-posts.md
@@ -141,7 +141,7 @@ Things I would especially love feedback on:
 - Are there gates you would want out of the box that are not included?
 - Any thoughts on the local-first approach vs. a hosted service?
 
-The project also has a Pro tier for team features (shared lesson database, team dashboard, DPO export) but the core tool is fully functional and free.
+The project also has Pro for individual dashboard/export workflows and Team for shared lesson databases, org dashboards, and rollout proof, but the core local gate loop is usable without a paid account.
 
 Thanks in advance for any feedback.
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -89,7 +89,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
 
 Hosted API access is currently pilot/by-request rather than a public self-serve monthly subscription.
 Current self-serve commercial offer: Pro ($19/mo or $149/yr): https://thumbgate-production.up.railway.app/checkout/pro
-Team rollout pricing anchor: $12/seat/mo (min 3 seats), intake-first on the landing page.
+Team rollout pricing anchor: $99/seat/mo (min 3 seats), intake-first on the landing page.
 Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
 ---

--- a/public/compare.html
+++ b/public/compare.html
@@ -62,7 +62,7 @@
       "name": "Is ThumbGate free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate has a free tier that includes local enforcement with 3 daily feedback captures, 5 lesson searches, unlimited recall, blocking, and history-aware lesson distillation. Pro ($19/mo or $149/yr) adds a personal local dashboard and DPO export. Team rollout ($12/seat/mo) adds a shared lesson database and org dashboard."
+        "text": "ThumbGate has a free tier that includes local enforcement with 3 daily feedback captures, 5 lesson searches, unlimited recall, blocking, and history-aware lesson distillation. Pro ($19/mo or $149/yr) adds a personal local dashboard and DPO export. Team rollout ($99/seat/mo) adds a shared lesson database and org dashboard."
       }
     },
     {
@@ -287,7 +287,7 @@
 
 <div class="card">
   <h3>Is ThumbGate free?</h3>
-  <p>ThumbGate has a free tier that includes local enforcement with 3 daily feedback captures, 5 lesson searches, unlimited recall, and pre-action gate blocking. Pro ($19/mo or $149/yr) adds a personal local dashboard and DPO export. Team rollout ($12/seat/mo) adds a shared lesson database and org dashboard.</p>
+  <p>ThumbGate has a free tier that includes local enforcement with 3 daily feedback captures, 5 lesson searches, unlimited recall, and pre-action gate blocking. Pro ($19/mo or $149/yr) adds a personal local dashboard and DPO export. Team rollout ($99/seat/mo) adds a shared lesson database and org dashboard.</p>
 </div>
 
 <div class="card">

--- a/public/guide.html
+++ b/public/guide.html
@@ -292,7 +292,7 @@ npx thumbgate init --agent gemini</code></pre>
   <tr><td>Auto-generates rules</td><td>Yes — from repeated failures</td><td>No</td><td>No</td></tr>
   <tr><td>Agent support</td><td>Claude Code, Codex, Gemini, Amp, Cursor, OpenCode</td><td>Claude Code, Cursor, Windsurf, Cline</td><td>Claude, Cursor</td></tr>
   <tr><td>Install</td><td><code>npx thumbgate init</code></td><td><code>npx speclock setup</code></td><td>Cloud signup</td></tr>
-  <tr><td>Cost</td><td>Free (Pro $19/mo or $149/yr, Team rollout $12/seat/mo)</td><td>Free</td><td>Free tier + paid</td></tr>
+  <tr><td>Cost</td><td>Free (Pro $19/mo or $149/yr, Team rollout $99/seat/mo)</td><td>Free</td><td>Free tier + paid</td></tr>
 </table>
 
 <h2>Common Scenarios</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,7 @@ __GA_BOOTSTRAP__
     {
       "@type": "Offer",
       "name": "Team",
-      "price": "12",
+      "price": "99",
       "priceCurrency": "USD",
       "description": "Intake-led team rollout with a workflow hardening sprint, shared enforcement memory, org dashboard visibility, approval boundaries, release confidence, Docker Sandboxes guidance for risky local autonomy, and pilot support for teams shipping AI-generated changes",
       "url": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
@@ -759,7 +759,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="price-card team">
         <div class="tier">Team</div>
-        <div class="price">$12<span style="font-size:16px;color:var(--text-dim)">/seat/mo</span></div>
+        <div class="price">$99<span style="font-size:16px;color:var(--text-dim)">/seat/mo</span></div>
         <div class="price-sub">3-seat minimum · intake-led rollout for the first workflow</div>
         <p style="font-size:13px;color:var(--green);margin-bottom:16px;font-weight:500;">For teams shipping AI-generated changes across shared repos who need one correction to protect every reviewer and runtime. This is the primary buying motion.</p>
         <div class="pro-upgrade-triggers" style="font-size:12px;color:#aaa;margin-bottom:12px;">

--- a/public/pro.html
+++ b/public/pro.html
@@ -948,7 +948,7 @@ __GA_BOOTSTRAP__
     <div class="pricing-card">
       <div class="section-label" style="text-align:left;margin-bottom:8px;">Pricing</div>
       <h3>ThumbGate Team — Agent Governance</h3>
-      <div class="price">$12<span>/seat/mo</span></div>
+      <div class="price">$99<span>/seat/mo</span></div>
       <div class="annual">Billed monthly or annually · Starts with a 30-min pilot call</div>
       <p class="pricing-note">Shared enforcement memory, CI gates, approval policies, sandbox routing, and a full audit trail of every blocked agent action across your team.</p>
       <ul>
@@ -963,7 +963,7 @@ __GA_BOOTSTRAP__
         <a class="btn-primary" href="/#workflow-sprint-intake">Book a Team Pilot Call</a>
         <a class="btn-secondary btn-demo" href="/dashboard?utm_source=website&utm_medium=pro_page_pricing&utm_campaign=team">Open dashboard demo</a>
       </div>
-      <div class="pricing-meta">Starts with one workflow, one repo, one repeat failure. We measure before/after and expand only when the results are real.</div>
+      <div class="pricing-meta">Team pricing anchors at $99/seat/mo with a 3-seat minimum. Starts with one workflow, one repo, one repeat failure. We measure before/after and expand only when the results are real.</div>
     </div>
 
     <div class="pricing-sidebar">

--- a/scripts/check-congruence.js
+++ b/scripts/check-congruence.js
@@ -18,13 +18,48 @@ const {
   PRODUCTHUNT_URL,
   getClaudePluginLatestDownloadUrl,
 } = require('./distribution-surfaces');
+const {
+  TEAM_MIN_SEATS,
+  TEAM_MONTHLY_PRICE_DOLLARS,
+  TEAM_PRICE_LABEL,
+} = require('./commercial-offer');
 
 const ROOT = path.join(__dirname, '..');
+const PRICING_SURFACE_ROOTS = [
+  'README.md',
+  'bin',
+  'docs',
+  'public',
+  '.agents/skills/thumbgate/SKILL.md',
+];
+const PRICING_SURFACE_EXTENSIONS = new Set(['.html', '.js', '.json', '.md', '.txt']);
+const LEGACY_TEAM_PRICE_PATTERN = /\$12\s*\/\s*seat\s*\/\s*mo|\$12\/seat|\bTEAM \$12\b|"price":\s*"12"/i;
 
 function read(rel) {
   const full = path.join(ROOT, rel);
   if (!fs.existsSync(full)) return null;
   return fs.readFileSync(full, 'utf-8');
+}
+
+function listTextFiles(rel) {
+  const full = path.join(ROOT, rel);
+  if (!fs.existsSync(full)) return [];
+  const stat = fs.statSync(full);
+  if (stat.isFile()) {
+    return PRICING_SURFACE_EXTENSIONS.has(path.extname(full)) ? [rel] : [];
+  }
+  if (!stat.isDirectory()) return [];
+
+  const files = [];
+  for (const entry of fs.readdirSync(full, { withFileTypes: true })) {
+    const childRel = path.join(rel, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listTextFiles(childRel));
+    } else if (PRICING_SURFACE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(childRel);
+    }
+  }
+  return files;
 }
 
 async function main() {
@@ -43,16 +78,26 @@ async function main() {
 
   const landingHtml = read('public/index.html') || '';
   const guideHtml = read('public/guide.html') || '';
+  const compareHtml = read('public/compare.html') || '';
+  const proHtml = read('public/pro.html') || '';
   const readmeMd = read('README.md') || '';
   const commercialTruth = read('docs/COMMERCIAL_TRUTH.md') || '';
+  const docsLandingHtml = read('docs/landing-page.html') || '';
   const agentsMd = read('AGENTS.md') || '';
   const claudeMd = read('CLAUDE.md') || '';
   const geminiMd = read('GEMINI.md') || '';
   const serverStdio = read('adapters/mcp/server-stdio.js') || '';
   const productHuntKit = read('docs/marketing/product-hunt-launch.md') || '';
+  const productHuntLaunchKit = read('docs/marketing/product-hunt-launch-kit.md') || '';
   const claudePluginReadme = read('.claude-plugin/README.md') || '';
   const claudeDesktopPacket = read('docs/CLAUDE_DESKTOP_EXTENSION.md') || '';
   const latestClaudePluginUrl = getClaudePluginLatestDownloadUrl(ROOT);
+  const teamSeatPrice = `$${TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`;
+  const teamSeatPricePattern = new RegExp(`\\$${TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`, 'i');
+  const pricingSurfaceFiles = PRICING_SURFACE_ROOTS.flatMap(listTextFiles);
+  const legacyTeamPricingHits = pricingSurfaceFiles.filter((rel) => (
+    LEGACY_TEAM_PRICE_PATTERN.test(read(rel) || '')
+  ));
 
   check(
     landingHtml.includes(`v${version}`),
@@ -137,12 +182,28 @@ async function main() {
     'public/guide.html must advertise the current Pro monthly and annual pricing'
   );
   check(
-    /\$12\/seat\/mo/i.test(guideHtml),
+    TEAM_MONTHLY_PRICE_DOLLARS === 99 && TEAM_MIN_SEATS === 3,
+    'scripts/commercial-offer.js must anchor Team at $99/seat/mo with a 3-seat minimum'
+  );
+  check(
+    TEAM_PRICE_LABEL.includes(teamSeatPrice),
+    'scripts/commercial-offer.js Team label must match the canonical Team seat price'
+  );
+  check(
+    legacyTeamPricingHits.length === 0,
+    `Legacy $12 Team pricing found in public pricing surfaces: ${legacyTeamPricingHits.join(', ')}`
+  );
+  check(
+    teamSeatPricePattern.test(guideHtml),
     'public/guide.html must advertise the current Team pricing anchor'
   );
   check(
     /Pro at \$19\/mo or \$149\/yr/i.test(commercialTruth),
     'docs/COMMERCIAL_TRUTH.md must record the current Pro offer'
+  );
+  check(
+    teamSeatPricePattern.test(commercialTruth),
+    'docs/COMMERCIAL_TRUTH.md must record the current Team pricing anchor'
   );
   check(
     /shared lessons and org visibility/i.test(githubAbout.metaDescription),
@@ -153,9 +214,21 @@ async function main() {
     'README.md must advertise the current Pro monthly and annual pricing'
   );
   check(
-    /\$12\/seat\/mo/i.test(readmeMd),
+    teamSeatPricePattern.test(readmeMd),
     'README.md must advertise the current Team pricing anchor'
   );
+  for (const [surface, text] of Object.entries({
+    'public/index.html': landingHtml,
+    'public/compare.html': compareHtml,
+    'public/pro.html': proHtml,
+    'docs/landing-page.html': docsLandingHtml,
+    'docs/marketing/product-hunt-launch-kit.md': productHuntLaunchKit,
+  })) {
+    check(
+      teamSeatPricePattern.test(text),
+      `${surface} must advertise the current Team pricing anchor`
+    );
+  }
   check(
     /shared hosted lesson db/i.test(readmeMd),
     'README.md must describe the shared hosted Team lesson database'

--- a/scripts/commercial-offer.js
+++ b/scripts/commercial-offer.js
@@ -10,12 +10,12 @@ const TEAM_MONTHLY_PRICE_ID = 'price_1TKLUhGGBpd520QYr5pgEZit';
 
 const PRO_MONTHLY_PRICE_DOLLARS = 19;
 const PRO_ANNUAL_PRICE_DOLLARS = 149;
-const TEAM_MONTHLY_PRICE_DOLLARS = 12;
-const TEAM_ANNUAL_PRICE_DOLLARS = 144;
+const TEAM_MONTHLY_PRICE_DOLLARS = 99;
+const TEAM_ANNUAL_PRICE_DOLLARS = 1188;
 const TEAM_MIN_SEATS = 3;
 
 const PRO_PRICE_LABEL = '$19/mo or $149/yr (individual)';
-const TEAM_PRICE_LABEL = '$12/seat/mo — Agent governance for engineering teams';
+const TEAM_PRICE_LABEL = '$99/seat/mo — Agent governance for engineering teams';
 
 function normalizePlanId(value) {
   const text = String(value || '').trim().toLowerCase();

--- a/scripts/rate-limiter.js
+++ b/scripts/rate-limiter.js
@@ -21,7 +21,7 @@ const FREE_TIER_LIMITS = {
 
 const FREE_TIER_MAX_GATES = 5;
 
-const UPGRADE_MESSAGE = `Founding Member deal: $49 once, Pro forever — includes dashboard, DPO export, and hosted API key: ${PRO_FOUNDER_PAYMENT_LINK}\n  Or subscribe: $19/mo — ${PRO_MONTHLY_PAYMENT_LINK}`;
+const UPGRADE_MESSAGE = `Founding Member deal: $49 once, Pro forever — includes dashboard and DPO export: ${PRO_FOUNDER_PAYMENT_LINK}\n  Or subscribe: $19/mo — ${PRO_MONTHLY_PAYMENT_LINK}`;
 
 function isProTier(authContext) {
   if (authContext && authContext.tier === 'pro') return true;

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1917,7 +1917,7 @@ test('billing checkout supports annual Pro and Team seat selection', async () =>
   assert.equal(teamBody.planId, 'team');
   assert.equal(teamBody.billingCycle, 'monthly');
   assert.equal(teamBody.seatCount, 3);
-  assert.equal(teamBody.price, 36);
+  assert.equal(teamBody.price, 297);
   assert.equal(teamBody.type, 'subscription');
 });
 

--- a/tests/check-congruence.test.js
+++ b/tests/check-congruence.test.js
@@ -49,13 +49,14 @@ test('GitHub About config keeps a rich landing description and a valid GitHub de
 test('README commercial copy stays aligned with current Pro and Team packaging', () => {
   const readme = execSync('sed -n \'1,320p\' README.md', { cwd: ROOT, encoding: 'utf-8' });
   assert.match(readme, /\$19\/mo or \$149\/yr/);
-  assert.match(readme, /\$12\/seat\/mo/);
+  assert.match(readme, /\$99\/seat\/mo/);
   assert.match(readme, /shared hosted lesson DB/i);
   assert.match(readme, /org dashboard/i);
   assert.match(readme, /history-aware/i);
   assert.match(readme, /feedback session|open_feedback_session|append_feedback_context|finalize_feedback_session/i);
   assert.match(readme, /3 daily feedback captures/i);
   assert.match(readme, /5 daily lesson searches/i);
+  assert.doesNotMatch(readme, /\$12\/seat\/mo/i);
   assert.doesNotMatch(readme, /shared team DB/i);
   assert.doesNotMatch(readme, /\/mo\$19/i);
 });

--- a/tests/e2e-product-flows.test.js
+++ b/tests/e2e-product-flows.test.js
@@ -123,8 +123,8 @@ test('E2E: public checkout -> paid local session -> usable dashboard key -> admi
   assert.equal(checkoutBody.localMode, true);
   assert.equal(checkoutBody.planId, 'team');
   assert.equal(checkoutBody.seatCount, 4);
-  assert.equal(checkoutBody.price, 48);
-  assert.equal(checkoutBody.priceLabel, '$12/seat/mo');
+  assert.equal(checkoutBody.price, 396);
+  assert.equal(checkoutBody.priceLabel, '$99/seat/mo');
   assert.ok(checkoutBody.sessionId);
   assert.ok(checkoutBody.traceId);
 

--- a/tests/postinstall.test.js
+++ b/tests/postinstall.test.js
@@ -46,7 +46,8 @@ describe('postinstall banner', () => {
     assert.ok(stderr.includes('npx thumbgate'), 'should include quick start');
     assert.match(stderr, /Workflow Hardening[\s\S]*Sprint/i);
     assert.match(stderr, /personal local dashboard/i);
-    assert.match(stderr, /optional hosted API key/i);
+    assert.match(stderr, /Team: \$99\/seat\/mo/i);
+    assert.doesNotMatch(stderr, /optional hosted API key/i);
     assert.match(stderr, /\$19\/mo or \$149\/yr/i);
   });
 

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -289,7 +289,7 @@ test('commercial truth sources stay aligned across public and historical docs', 
   const directoryGuide = readText('docs/marketing/mcp-directories.md');
 
   assert.match(commercialTruth, /Pro at \$19\/mo or \$149\/yr/);
-  assert.match(commercialTruth, /Team pricing anchor is \*\*\$12\/seat\/mo/i);
+  assert.match(commercialTruth, /Team pricing anchor is \*\*\$99\/seat\/mo/i);
   assert.match(commercialTruth, /auto-gate promotion/);
   assert.match(commercialTruth, /Do not treat GitHub stars, watchers, dependents, or npm download counts as customer or revenue proof/);
 


### PR DESCRIPTION
## Summary
- Align Team pricing across README, public landing/pro/compare/guide pages, commercial docs, launch materials, CLI/postinstall copy, and runtime offer constants at /seat/mo.
- Clarify Pro as the individual plan and Team as shared hosted governance with a 3-seat minimum.
- Harden congruence checks so stale /seat surfaces fail CI and add a changeset for the package release path.

## Verification
- npm ci
- node scripts/check-congruence.js
- node --test tests/postinstall.test.js tests/cli.test.js tests/rate-limiter.test.js tests/check-congruence.test.js tests/version-metadata.test.js tests/e2e-product-flows.test.js tests/api-server.test.js tests/billing.test.js tests/thumbgate-skill.test.js tests/positioning-contract.test.js
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check
- git diff --check
- stale pricing grep: no /seat or  Team offer hits