### PR TITLE
fix: enforce pricing congruence across public surfaces

### DIFF
--- a/.agents/skills/thumbgate/SKILL.md
+++ b/.agents/skills/thumbgate/SKILL.md
@@ -108,7 +108,7 @@ When the MCP server is running, these tools are available to your agent:
 
 ## Pro Features
 
-Pro users ($19/mo or $149/yr, founder license) unlock:
+Pro users ($19/mo or $149/yr) unlock:
 
 - **Visual gate debugger** — see every blocked action and the gate that fired
 - **Multi-hop recall** — chain related lessons across hops for deeper context
@@ -118,7 +118,7 @@ Pro users ($19/mo or $149/yr, founder license) unlock:
 Team rollout ($99/seat/mo, 3-seat minimum after intake) adds the shared hosted lesson DB,
 org dashboard, approval boundaries, and proof-backed workflow hardening sprint.
 
-Upgrade: https://buy.stripe.com/aFa4gz1M84r419v7mb3sI05
+Upgrade: https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06
 
 ## Detailed Reference
 

--- a/.changeset/pricing-archive-congruence.md
+++ b/.changeset/pricing-archive-congruence.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Harden public pricing congruence checks so retired ThumbGate pricing experiments cannot reappear in buyer-facing docs.

--- a/.claude/skills/thumbgate/SKILL.md
+++ b/.claude/skills/thumbgate/SKILL.md
@@ -105,15 +105,17 @@ When the MCP server is running, these tools are available to your agent:
 
 ## Pro Features
 
-Pro users ($19/mo, founder license) unlock:
+Pro users ($19/mo or $149/yr) unlock:
 
 - **Visual gate debugger** — see every blocked action and the gate that fired
 - **Multi-hop recall** — chain related lessons across hops for deeper context
 - **Synthetic DPO augmentation** — expand real feedback into larger training datasets
-- **Shared team lesson DB** — one dev's thumbs-down protects every agent on the team
 - **Gate wiring support** — help enforcing your riskiest flows in the first week
 
-Upgrade: https://buy.stripe.com/aFa4gz1M84r419v7mb3sI05
+Team rollout ($99/seat/mo, 3-seat minimum after intake) adds the shared hosted lesson DB,
+org dashboard, approval boundaries, and proof-backed workflow hardening sprint.
+
+Upgrade: https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06
 
 ## Detailed Reference
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Yes. ThumbGate is MCP-compatible and works with Claude Code, Cursor, Codex, Gemi
 ThumbGate can auto-evaluate agent action outcomes (test failures, reverted edits, error patterns) and generate prevention rules without any human feedback. Your agent gets smarter every session automatically.
 
 **Is it free?**
-Free tier: 3 feedback captures/day, 5 lesson searches/day, 5 built-in gates. Founding Member: $49 one-time, Pro forever.
+Free tier: 3 feedback captures/day, 5 lesson searches/day, 5 built-in gates. Pro is $19/mo or $149/yr for solo operators who need the personal local dashboard and exports. Team rollout starts intake-first at $99/seat/mo with a 3-seat minimum when shared lessons, org visibility, and approval boundaries matter.
 
 ## The Loop
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -92,9 +92,9 @@ Bounded retrieval of relevant feedback history for the current task. The agent g
 | Dashboard | - | Yes | Yes |
 | DPO export | - | Yes | Yes |
 | Seats | 1 | 1 | Per-seat |
-| Price | $0 | $19/mo | $99/seat/mo |
+| Price | $0 | $19/mo or $149/yr | $99/seat/mo |
 
-Start a 7-day free trial of Pro: <https://buy.stripe.com/fZu9AT3Ug6zcdWh0XN3sI08>
+Start a 7-day free trial of Pro: <https://thumbgate-production.up.railway.app/pro?utm_source=skill&utm_medium=agent_context&utm_campaign=pro_page>
 
 ## Compatibility
 

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -11,7 +11,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 - The local CLI is the adoption wedge; it is not the primary monetization story.
 - The primary commercial motion is the **Workflow Hardening Sprint** for one workflow, followed by Team expansion when shared enforcement, approval boundaries, and auditability matter across operators.
 - The current public self-serve commercial offer is **Pro at $19/mo or $149/yr** via Stripe checkout.
-- The preserved founder one-time Stripe link still exists for legacy founder buyers, but it is not the default commercial offer.
+- Legacy one-time Stripe links are retained only for past buyers and are not a current public offer.
 - The current Team pricing anchor is **$99/seat/mo with a 3-seat minimum**, and the public Team path remains an **intake-led pilot for the first workflow** until hosted rollout scope is qualified.
 - The open-source runtime now supports history-aware lesson distillation from up to 8 prior recorded entries in the current Claude auto-capture path, linked 60-second feedback sessions, and reflector rule proposals across CLI, hosted API, Cursor, and Claude Desktop surfaces.
 - The runtime now supports Workflow Sentinel blast-radius scoring plus Docker Sandboxes routing guidance for high-risk local actions, and the hosted path supports signed sandbox dispatch for isolated team automations.
@@ -37,7 +37,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 
 - Personal local dashboard
 - DPO export and advanced data exports
-- Founder-license support
+- Review-ready workflow support for the first risky flow
 - Unlimited custom gates with auto-gate promotion
 - Secondary self-serve lane for solo operators, not the default enterprise pitch
 

--- a/docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md
+++ b/docs/GO_TO_MARKET_REVENUE_WEDGE_2026-03.md
@@ -1,18 +1,20 @@
 # CTO Urgent Memo: High-ROI Revenue Opportunity (March 2026)
 
+> Historical research note: this memo captured a March 2026 packaging experiment. It is not current product truth. Current public pricing is Pro at `$19/mo or $149/yr`, and Team rollout anchors at `$99/seat/mo` with a `3`-seat minimum after workflow qualification. Use `docs/COMMERCIAL_TRUTH.md` as the canonical source.
+
 ## The Opportunity: "Outcome-Based" Memory Packages
 While we wait for AWS Marketplace approval, we can generate revenue **today** by shifting from "Monthly Subscriptions" to **"Success-Based Memory Credits."**
 
 In March 2026, developers are moving away from subscriptions and toward **Outcome-Based Pricing**. We can sell pre-packaged "Memory Units" that guarantee an agent will never repeat a specific class of mistake.
 
 ### 1. High-ROI Product: "Mistake-Free" Credits
-We sell a "Mistake-Free Starter Pack" for **$19/mo**.
+Retired experiment: package "Mistake-Free" credits as a starter pack. This is not the current public offer.
 *   **What they get:** 500 "Verified Consolidations" (ADK dreams) and 5 "Critical Prevention Rules" authored by our reasoning engine.
 *   **Why it sells today:** It's a low-friction self-serve purchase that solves a massive pain point: agents breaking in production.
 
 ### 2. The Implementation: "Pay-per-Consolidation"
 I can autonomously refactor our `/v1/billing/checkout` route to support this "Wallet" model. 
-*   The current checkout supports recurring Pro subscriptions while keeping the founder one-time link preserved separately.
+*   The current checkout supports recurring Pro subscriptions and Team intake; any wallet model must update `docs/COMMERCIAL_TRUTH.md` before launch.
 *   The `api-keys.json` store will now track a `remainingCredits` balance.
 *   When `remainingCredits == 0`, the "Always-On" consolidator pauses until a top-up occurs.
 
@@ -27,6 +29,6 @@ We offer a **"White-Glove Integration Retainer"** for **$1,500**.
 I have already built the Stripe SDK and AWShandshake logic. My next autonomous action should be:
 1.  **Refactor the Billing Engine** to support **Credit-Based Wallets** (One-time payments).
 2.  **Update the Landing Page** to sell **"Memory Starter Packs"** instead of a monthly fee.
-3.  **Launch the "Outreach Script"** from `LAUNCH.md` targeting these specific $19/mo subscriptions.
+3.  **Launch the "Outreach Script"** from `LAUNCH.md` targeting the current Pro and Team offers.
 
 **This is the fastest path to our first real dollar today.** Shall I execute the Credit-Wallet refactor now?

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -23,7 +23,7 @@
 
 ### Stripe Pro Offer
 **Title:** ThumbGate Pro — Personal Local Dashboard + DPO Export
-**Description:** ThumbGate Pro gives individual operators a personal local dashboard, DPO export, advanced data exports, and founder-license support. Team rollout remains intake-first for shared hosted lessons and org visibility.
+**Description:** ThumbGate Pro gives individual operators a personal local dashboard, DPO export, advanced data exports, and review-ready workflow support. Team rollout remains intake-first for shared hosted lessons, approval boundaries, and org visibility.
 
 ### DEV.TO Blog Post
 **Title:** I built pre-action gates that physically block Claude Code from repeating mistakes

--- a/docs/PACKAGING_AND_SALES_PLAN.md
+++ b/docs/PACKAGING_AND_SALES_PLAN.md
@@ -24,7 +24,7 @@ This is the metric that matters most. Stars, visits, and installs matter only if
 - DPO export
 - Local MCP server
 
-### Tier 2: Historical Context Gateway Hypothesis (Then-Proposed $10/mo)
+### Tier 2: Historical Context Gateway Hypothesis (Retired Low-Price Test)
 
 - Hosted API endpoint
 - Provisioned API keys and hosted onboarding
@@ -35,7 +35,7 @@ This is the metric that matters most. Stars, visits, and installs matter only if
 
 Pricing note:
 
-- At the time, the plan was to keep the live Stripe price at `$10/mo` while Context Gateway was still proving conversion.
+- At the time, the plan was to keep a low live Stripe price while Context Gateway was still proving conversion.
 - At the time, the plan was to revisit repricing after the hosted workflow layer showed retained usage and stronger buyer pull.
 
 Current note:

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -20,7 +20,7 @@ Rubric scoring and anti-hacking guardrails are shared via `config/rubrics/defaul
 3. Offer managed hosted API + analytics as paid SaaS.
 4. Sell enterprise controls (SSO, audit, retention policies, support SLA).
 
-This avoids platform-specific rewrite cost and keeps the product under a `$10/mo` bootstrap budget until paid demand exists.
+This avoids platform-specific rewrite cost and keeps the product under a small bootstrap budget until paid demand exists.
 
 ## Public vs Pro repo boundary
 

--- a/docs/PRICING_RESEARCH_2026-03-10.md
+++ b/docs/PRICING_RESEARCH_2026-03-10.md
@@ -8,10 +8,10 @@ At the time, the go-to-market (GTM) strategy was misaligned with the March 2026 
 Here is the empirical breakdown of why our funnel is failing:
 
 ### 1. The "Local-First" Trap
-At the time, developers in 2026 wanted zero-friction "agentic primitives." We required them to clone a repository, run local tests, and manually discover `docs/landing-page.html` to find the then-proposed `$10/mo` "Context Gateway" upgrade. **This report concluded that top-of-funnel acquisition was weak because the monetization surface was buried inside a local codebase.**
+At the time, developers in 2026 wanted zero-friction "agentic primitives." We required them to clone a repository, run local tests, and manually discover `docs/landing-page.html` to find the then-proposed low-price "Context Gateway" upgrade. **This report concluded that top-of-funnel acquisition was weak because the monetization surface was buried inside a local codebase.**
 
 ### 2. Pricing Model Mismatch
-The March 2026 market for agent tooling was operating largely on **consumption-based credit systems** or "per-agent identity" models (like Okta for Agents). This report argued that the flat `$10/month` subscription felt outdated. The thesis was that developers would rather pay for the *inference and storage costs* associated with "Always-On" memory than for a recurring fee on a local tool.
+The March 2026 market for agent tooling was operating largely on **consumption-based credit systems** or "per-agent identity" models (like Okta for Agents). This report argued that the low flat subscription felt outdated. The thesis was that developers would rather pay for the *inference and storage costs* associated with "Always-On" memory than for a recurring fee on a local tool.
 
 ### 3. Misaligned Positioning (ThumbGate vs. MCP Gateway)
 We are marketing ourselves as an "ThumbGate." However, the March 2026 market data shows that the highest revenue growth is in **MCP (Model Context Protocol) Gateways and Observability**. MCP has become the "USB-C of AI." We already have deep MCP integration, but we aren't selling ourselves as an "MCP Memory & Context Hub." 
@@ -27,7 +27,7 @@ To move from $0 to revenue immediately, we must execute the following pivot in "
 2.  **Frictionless Onboarding:** Allow users to authenticate via GitHub OAuth, instantly generate an `THUMBGATE_API_KEY`, and view their local agent's memory graph in the cloud.
 
 ### Phase 2: Pivot the Pricing Model
-1.  **Usage-Based Billing:** Shift from a $10/mo flat fee to a consumption model via Stripe Metered Billing. Charge per 1,000 "Context Consolidations" or per GB of "Agent Memory Stored."
+1.  **Usage-Based Billing:** Shift from a low flat fee to a consumption model via Stripe Metered Billing. Charge per 1,000 "Context Consolidations" or per GB of "Agent Memory Stored."
 2.  **Freemium Gate:** Give the local CLI tool away for free (as we do), but hard-gate the advanced A2UI (Agent-to-User Interface) dashboard and the "Always-On" background consolidator behind an API key that requires a credit card on file.
 
 ### Phase 3: Rebrand for 2026 Market Fit

--- a/docs/REVENUE_SPRINT_MAR2026.md
+++ b/docs/REVENUE_SPRINT_MAR2026.md
@@ -1,6 +1,6 @@
 # Revenue Sprint: First Paying Customer TODAY, $1K MRR in 30 Days
 
-> Historical research note: community-size figures, pricing experiments, and growth targets in this file are point-in-time planning assumptions from March 11, 2026. They are not current product truth. Use `docs/COMMERCIAL_TRUTH.md` for current pricing, traction, and proof language. All `$5/mo`, `$10/mo`, "Founding Member", and scarcity references below are retired experiments retained for historical context only.
+> Historical research note: community-size figures, pricing experiments, and growth targets in this file are point-in-time planning assumptions from March 11, 2026. They are not current product truth. Use `docs/COMMERCIAL_TRUTH.md` for current pricing, traction, and proof language. The low-dollar founder, scarcity, and flat-rate subscription ideas below are retired experiments retained for historical context only.
 
 **Date:** 2026-03-11
 **Status:** Historical plan archived
@@ -51,7 +51,7 @@
 
 ---
 
-## Part 2: Historical Buyer Profile Hypothesis For A Then-Proposed $10/mo Offer
+## Part 2: Historical Buyer Profile Hypothesis For A Retired Low-Price Offer
 
 ### Primary Persona: "The AI Team Lead"
 - **Role:** Engineering lead or senior dev running 2-5 person team using Claude Code daily
@@ -70,7 +70,7 @@
 ### Secondary Persona: "The Solo AI Engineer"
 - Building MCP integrations or AI products
 - Needs DPO/KTO export pairs for fine-tuning
-- Would have paid `$10/mo` to avoid building their own feedback infrastructure
+- Would have paid a low monthly subscription to avoid building their own feedback infrastructure
 
 ### Trigger Moment (converts "interesting" to "shut up and take my money"):
 > "I just spent 2 hours debugging because Claude forgot what we decided yesterday. I need persistent memory that works across sessions WITHOUT me managing infrastructure."
@@ -108,30 +108,30 @@
 ## Part 4: Historical Pricing Experiment Considered For Day-1 Conversion
 
 ### Current State Analysis
-- $10/mo flat is **not wrong** but friction is high
+- A low flat monthly price was not obviously wrong, but friction was high
 - 2026 market expects consumption-based pricing (per-request, per-GB)
 - Less than 5% of 11,000+ MCP servers are monetized — opportunity is wide open
 
 ### Historical Pricing Structure Considered At The Time
 
-Retired experiment: the `$5/mo`, `$10/mo`, and scarcity-based tiers below are preserved as research history only. They are not current product truth.
+Retired experiment: the low-dollar founder, Pro, and scarcity-based tiers below are preserved as research history only. They are not current product truth.
 
 | Tier | Price | What's Included | Conversion Target |
 |------|-------|-----------------|-------------------|
 | **Free** | $0 | `npx thumbgate serve` local, 1000 feedback captures/mo | Funnel entry |
-| **Founding Member** | **$5/mo forever** (locked, first 50 users) | Hosted gateway, 10K captures/mo, team sharing (3 seats), DPO export, dashboard | **Day-1 conversion** |
-| **Pro** | $10/mo | 50K captures/mo, 10 seats, priority support, custom guardrails | Standard |
-| **Team** | $29/mo | Unlimited captures, unlimited seats, SSO, audit log, SLA | Upsell target |
+| **Retired founder test** | Low-dollar launch price with scarcity | Hosted gateway, capped captures, team sharing, DPO export, dashboard | Day-1 conversion |
+| **Retired Pro test** | Low flat monthly price | Higher capture cap, multiple seats, support, custom guardrails | Standard |
+| **Retired Team test** | Low bundled team price | Unlimited-style team packaging, SSO, audit log, SLA | Upsell target |
 
-### Why The Team Believed "Founding Member $5/mo Forever" Could Convert At The Time:
+### Why The Team Believed The Retired Founder Scarcity Test Could Convert At The Time:
 1. **Loss aversion** — "This price disappears after 50 users" creates urgency
-2. **Lower barrier** — $5 is impulse-buy territory for developers
+2. **Lower barrier** — low-dollar pricing felt like impulse-buy territory for developers
 3. **"Forever" lock** — developers hate price increases, this removes the objection
-4. **Social proof** — "Join 12 founding members" (update counter in real-time)
+4. **Social proof** — display a founding-member counter in real time
 
 ### Alternative Quick Test Considered At The Time:
-- **72-hour flash: $1 first month** via Stripe coupon code `FOUNDING1`
-- After 72 hours, price reverts to $10/mo
+- **72-hour flash:** discounted first month via a limited Stripe coupon
+- After 72 hours, price reverts to the standard self-serve rate
 - Post this coupon in every Reddit/Discord/HN thread
 
 ---
@@ -144,7 +144,7 @@ Retired experiment: the `$5/mo`, `$10/mo`, and scarcity-based tiers below are pr
 |---------|-----|--------|
 | **MCPize.com** | 85% rev share, they handle everything | Deploy via `mcpize deploy`, list on their marketplace |
 | **PulseMCP** | 8,610+ servers indexed, has partnership program | Email hello@pulsemcp.com for featured placement |
-| **Claude Code YouTubers** | 25+ active creators ranking Claude Code videos | DM top 5 with "free Founding Member account + affiliate 30%" |
+| **Claude Code YouTubers** | 25+ active creators ranking Claude Code videos | DM top 5 with free pilot access + affiliate offer |
 | **Anthropic MCP team** | Already on their registry | Request featured/spotlight via MCP Discord |
 | **awesome-mcp-servers maintainers** | Submit PR to all 5 major lists | PRs to punkpeye, wong2, appcypher, hireblackout, tolkonepiu |
 
@@ -168,17 +168,17 @@ npm install -g @mcpize/cli
 mcpize login
 mcpize init thumbgate
 mcpize deploy
-# Set pricing: Founding $5/mo, Pro $10/mo via MCPize dashboard
+# Set the retired founder and Pro test offers via MCPize dashboard
 # Connect Stripe for payouts
 ```
 **Why first:** Instant distribution to paying MCP users. 85% rev share. Zero ops.
 
-### 2. Create "Founding Member $5/mo Forever" Stripe Link (30 min, HIGH impact)
+### 2. Create Retired Founder-Member Stripe Link (30 min, HIGH impact)
 ```bash
 # In Stripe Dashboard:
-# 1. Create product "ThumbGate — Founding Member"
-# 2. Price: $5/mo recurring
-# 3. Create promotion code: FOUNDING50 (limits to 50 redemptions)
+# 1. Create product "ThumbGate — Founder Test"
+# 2. Create the retired low-dollar recurring test price
+# 3. Create a limited redemption promotion code
 # 4. Generate payment link
 # 5. Update Railway landing page with prominent CTA
 ```
@@ -192,7 +192,7 @@ Body:
 - Problem: Claude forgets everything between sessions
 - Solution: ThumbGate captures feedback, prevents repeated mistakes
 - Free: npx thumbgate serve
-- Hosted: $5/mo founding member (50 spots)
+- Hosted: retired founder-price test
 - Demo: [Railway URL]
 - GitHub: [repo URL]
 - On official MCP registry
@@ -238,7 +238,7 @@ Body: Technical, concise. Focus on:
 Share in Model Context Protocol Discord (11,565 members):
 - What it does (persistent memory + guardrails)
 - How to install (one-liner npx)
-- Hosted option with founding member pricing
+- Hosted option with the retired founder-price test
 - Link to registry listing
 ```
 **Why:** Direct access to MCP builders. Some are building agents that NEED memory.
@@ -252,7 +252,7 @@ Script:
 2:00 - Show prevention rules auto-generated
 3:00 - Export DPO pairs
 4:00 - Hosted dashboard demo
-4:30 - "Founding member: $5/mo forever. Link in description."
+4:30 - "Free local install, Pro checkout, and Team intake links in description."
 ```
 **Why:** YouTube is where devs discover tools. Searchable forever.
 
@@ -273,7 +273,7 @@ Contact:
 # 3. DM top 5 Claude Code YouTubers and MCP bloggers
 # 4. Provide them: free Pro account + affiliate link + one-liner install script
 ```
-**Why:** Leverages other people's audiences. 30% of $10/mo = $3/mo per conversion, scales infinitely.
+**Why:** Leverages other people's audiences. Recurring affiliate economics scale if self-serve Pro converts.
 
 ---
 
@@ -281,8 +281,8 @@ Contact:
 
 | Time | Action | Expected Outcome |
 |------|--------|-----------------|
-| 9:00 AM | Create Founding Member Stripe link ($5/mo) | Payment infrastructure ready |
-| 9:30 AM | Update Railway landing page with Founding CTA | Conversion path live |
+| 9:00 AM | Create retired founder-member Stripe link | Payment infrastructure ready |
+| 9:30 AM | Update Railway landing page with founder CTA | Conversion path live |
 | 10:00 AM | Deploy to MCPize marketplace | Second distribution channel |
 | 11:00 AM | Post to r/ClaudeCode | First 500+ views within hours |
 | 11:30 AM | Post to r/ClaudeAI | Second high-intent audience |
@@ -302,9 +302,9 @@ Contact:
 | 3 | 500-1000 | 30-50 | $150-250 |
 | 4 | 1000-2000 | 80-150 | $400-750 |
 
-**To hit $1K MRR by April 11:** Need 200 paying users at $5/mo OR 100 at $10/mo. Requires ~2,000-4,000 free users with 5% conversion. Achievable if HN post performs + Reddit traction + directory listings compound.
+**To hit $1K MRR by April 11:** The retired March model required hundreds of low-price paying users from a few thousand free users. The current model should be evaluated against `docs/COMMERCIAL_TRUTH.md` instead: Pro is self-serve, and Team is intake-led around workflow proof.
 
-**Aggressive path to $1K MRR:** Add MCPize marketplace revenue (85% of their sales) + affiliate-driven conversions + upgrade Founding Members to Pro after 30 days.
+**Aggressive path to $1K MRR:** Add marketplace revenue share + affiliate-driven conversions + upgrade early self-serve customers into the current Pro or Team motion after proof exists.
 
 ---
 

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1300,7 +1300,7 @@ Requirements verified:
 
 Scope:
 
-- Replaced stale `$5/mo` and `$10/mo` self-serve subscription language on live-facing surfaces with the actual public offer: Pro (`$19/mo`).
+- Replaced stale low-dollar self-serve subscription language on live-facing surfaces with the actual public offer: Pro (`$19/mo`).
 - Removed unsupported scarcity and adoption framing from CLI and landing-page copy.
 - Added `docs/COMMERCIAL_TRUTH.md` as the source of truth for pricing, traction, and proof claims.
 
@@ -1366,7 +1366,7 @@ Status:
 Scope:
 
 - Version sync across `package.json`, `mcpize.yaml`, and `server.json` to `v0.7.1`.
-- Historical pricing experiment: tested a "Founding Member $5/mo" offer and urgency hooks before the current commercial-truth correction.
+- Historical pricing experiment: tested a low-dollar founder offer and urgency hooks before the current commercial-truth correction.
 - Discovery optimization: Added high-ROI GitHub topics and updated `SKILL.md` auto-indexing keywords.
 - Launch content package: Created `docs/marketing/LAUNCH_CONTENT.md` with Reddit, HN, and Discord assets.
 - CLI `pro` command was, at that time, updated to reflect the same historical pricing experiment.

--- a/docs/marketing/github-sponsors-setup.md
+++ b/docs/marketing/github-sponsors-setup.md
@@ -15,7 +15,11 @@
 
 ## Recommended Tier Structure
 
-These tiers map directly to ThumbGate's existing pricing and feature set.
+These tiers are donation rails, not the canonical ThumbGate pricing surface. Current commercial truth remains:
+
+- Pro: `$19/mo or $149/yr` for individual operators.
+- Team: `$99/seat/mo` with a `3`-seat minimum after workflow qualification.
+- GitHub Sponsors should not publish alternate Team pricing or lifetime Pro claims.
 
 ### $5/mo — Supporter
 
@@ -31,7 +35,7 @@ These tiers map directly to ThumbGate's existing pricing and feature set.
 ### $19/mo — Pro Sponsor
 
 **Perks:**
-- Full **ThumbGate Pro** license (`thumbgate-pro` npm package)
+- Full **ThumbGate Pro** license equivalent to the public monthly Pro offer
 - Access to Pro features: LanceDB vector similarity, Thompson Sampling bandit, ContextFS context packs, DPO export
 - Priority support via GitHub Issues (SLA: response within 48 hours)
 - All Supporter perks
@@ -40,28 +44,15 @@ These tiers map directly to ThumbGate's existing pricing and feature set.
 
 ---
 
-### $49/mo — Power Sponsor
+### Team Sponsor — route to intake, not a fixed Sponsors tier
 
 **Perks:**
-- Everything in Pro Sponsor
-- **1 hour onboarding/architecture call per month** (scheduled via Calendly or GitHub discussion)
-- Direct feedback channel — sponsor's use cases prioritized in roadmap planning
-- Pre-release beta access to new features before npm publish
+- Shared hosted lesson DB
+- Org dashboard and review surfaces
+- Approval boundaries and rollout proof across operators
+- Support scope defined after the Workflow Hardening Sprint
 
-**Rationale:** Targets individual power users or consultants who want hands-on help integrating ThumbGate into their agent pipelines. The onboarding call converts sponsors into active product champions.
-
----
-
-### $149/mo — Team Sponsor
-
-**Perks:**
-- Everything in Power Sponsor
-- **Team license for up to 10 seats** (`thumbgate-pro` for 10 npm accounts or CI environments)
-- Dedicated **private Slack channel** (or Discord thread) for direct async support
-- Logo placement in README and on the ThumbGate landing page
-- Quarterly roadmap review call (30 min)
-
-**Rationale:** Targets small engineering teams running AI coding agents at scale. Maps to the ThumbGate team/enterprise tier. Slack channel access reduces friction for multi-engineer adoption.
+**Rationale:** GitHub Sponsors is too blunt for Team rollout. Team pricing starts at `$99/seat/mo` with a `3`-seat minimum and should be sold through intake so scope, seats, proof, and support boundaries are explicit.
 
 ---
 
@@ -71,13 +62,14 @@ The listing already exists. The only remaining step is adding tiers.
 
 1. Go to [github.com/sponsors/IgorGanapolsky/manage](https://github.com/sponsors/IgorGanapolsky/manage)
 2. Click **"Tiers"** in the left sidebar.
-3. Click **"Add tier"** and fill in for each tier:
-   - **Monthly price** (5, 19, 49, 149)
-   - **Name** (Supporter, Pro Sponsor, Power Sponsor, Team Sponsor)
+3. Click **"Add tier"** and fill in only the donation and Pro-equivalent tiers:
+   - **Monthly price** (5, 19)
+   - **Name** (Supporter, Pro Sponsor)
    - **Description** (copy from the perks above)
    - **Is one-time?** — leave unchecked (recurring monthly)
 4. For the $19 tier, enable **"Welcome message"** with instructions on how to access the `thumbgate-pro` package (npm token or GitHub Packages invite).
-5. Click **"Publish"** on each tier.
+5. Link Team buyers to the Workflow Hardening Sprint intake instead of adding a fixed Team Sponsor tier.
+6. Click **"Publish"** on each tier.
 
 To verify tiers are live after creation:
 
@@ -89,8 +81,6 @@ Expected output once tiers exist:
 ```
 5
 19
-49
-149
 ```
 
 ---
@@ -115,7 +105,7 @@ Sponsoring funds:
 - ContextFS context assembly and DPO export for fine-tuning pipelines
 - Documentation, examples, and community support
 
-Pro and Team sponsors receive a `thumbgate-pro` license as part of their tier.
+Pro sponsors receive a `thumbgate-pro` license as part of their tier. Team buyers should use the Workflow Hardening Sprint intake so shared rollout scope is qualified before seats are sold.
 ```
 
 ---
@@ -130,9 +120,8 @@ Pro and Team sponsors receive a `thumbgate-pro` license as part of their tier.
 | Thompson Sampling bandit | Adaptive lesson retrieval | $19+/mo |
 | ContextFS context packs | `npm run feedback:rules` context assembly | $19+/mo |
 | DPO export for fine-tuning | `npm run feedback:export:dpo` | $19+/mo |
-| Onboarding call | Architecture review, pipeline integration | $49+/mo |
-| Multi-seat license | 10 CI/CD environments or npm accounts | $149/mo |
-| Direct async support channel | Slack/Discord | $149/mo |
+| Team rollout | Shared lesson DB, org visibility, approval boundaries | Intake, then $99/seat/mo |
+| Minimum Team scope | Qualified workflow and at least 3 seats | Intake-led |
 
 ---
 

--- a/public/compare/mem0.html
+++ b/public/compare/mem0.html
@@ -165,10 +165,10 @@
   <p>No. ThumbGate is local-first with SQLite+FTS5 storage. No cloud account, no API keys needed to capture feedback and enforce pre-action gates.</p>
 
   <div class="cta-box">
-    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Founding Member Deal &mdash; $49</h2>
-    <p>Lock in lifetime Pro access at the founding price. One command to start.</p>
+    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Pro for operators, Team for governance</h2>
+    <p>Start free with local gates. Pro is $19/mo or $149/yr for the personal dashboard and exports. Team rollout anchors at $99/seat/mo when shared lessons and org visibility matter.</p>
     <div class="cta-install">$ npx thumbgate init</div>
-    <p style="margin-top:8px;"><a href="/pro">Learn about ThumbGate Pro &rarr;</a></p>
+    <p style="margin-top:8px;"><a href="/pro">See Pro and Team pricing &rarr;</a></p>
   </div>
 
   <div class="related">

--- a/public/compare/speclock.html
+++ b/public/compare/speclock.html
@@ -156,10 +156,10 @@
   <p>ThumbGate is better for fast-moving agent workflows where the problem is not writing more specs, but preventing the same mistake from happening again tomorrow.</p>
 
   <div class="cta-box">
-    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Founding Member Deal &mdash; $49</h2>
-    <p>Lock in lifetime Pro access at the founding price. One command to start.</p>
+    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Pro for operators, Team for governance</h2>
+    <p>Start free with local gates. Pro is $19/mo or $149/yr for the personal dashboard and exports. Team rollout anchors at $99/seat/mo when shared lessons and org visibility matter.</p>
     <div class="cta-install">$ npx thumbgate init</div>
-    <p style="margin-top:8px;"><a href="/pro">Learn about ThumbGate Pro &rarr;</a></p>
+    <p style="margin-top:8px;"><a href="/pro">See Pro and Team pricing &rarr;</a></p>
   </div>
 
   <div class="related">

--- a/public/guide.html
+++ b/public/guide.html
@@ -310,7 +310,7 @@ npx thumbgate init --agent gemini</code></pre>
 <pre><code>npx thumbgate init</code></pre>
 <p>One command. Works with Claude Code, Cursor, Codex, Gemini, Amp, and OpenCode. Claude Code can also call Codex for review, adversarial review, and second-pass handoffs through the repo-local bridge plugin.</p>
 <a href="https://thumbgate-production.up.railway.app/checkout/pro?utm_source=guide&utm_medium=cta_button&utm_campaign=pro_pack" class="cta">Get Pro — $19/mo or $149/yr</a>
-<p style="color:var(--muted); font-size:0.85rem;">Free keeps local enforcement with 3 daily feedback captures, 5 lesson searches, unlimited recall, blocking, and history-aware lesson distillation. Pro adds a personal local dashboard and DPO export. Team rollout adds the hosted shared lesson DB, org dashboard, and generated review views. <a href="https://buy.stripe.com/aFa4gz1M84r419v7mb3sI05" style="color:inherit;text-decoration:underline;">Founder $49 one-time link</a> stays preserved.</p>
+<p style="color:var(--muted); font-size:0.85rem;">Free keeps local enforcement with 3 daily feedback captures, 5 lesson searches, unlimited recall, blocking, and history-aware lesson distillation. Pro is $19/mo or $149/yr for a personal local dashboard and DPO export. Team rollout starts intake-first at $99/seat/mo with a 3-seat minimum for the hosted shared lesson DB, org dashboard, and generated review views.</p>
 
 </div>
 </body>

--- a/public/guides/claude-code-prevent-repeated-mistakes.html
+++ b/public/guides/claude-code-prevent-repeated-mistakes.html
@@ -137,10 +137,10 @@
   <p>Yes. ThumbGate persists lessons and prevention rules in a local SQLite+FTS5 database, so gates survive across sessions and prevent repeat failures even when the conversation context resets.</p>
 
   <div class="cta-box">
-    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Founding Member Deal &mdash; $49</h2>
-    <p>Lock in lifetime Pro access at the founding price. One command to start.</p>
+    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Pro for operators, Team for governance</h2>
+    <p>Start free with local gates. Pro is $19/mo or $149/yr for the personal dashboard and exports. Team rollout anchors at $99/seat/mo when shared lessons and org visibility matter.</p>
     <div class="cta-install">$ npx thumbgate init --agent claude-code</div>
-    <p style="margin-top:8px;"><a href="/pro">Learn about ThumbGate Pro &rarr;</a></p>
+    <p style="margin-top:8px;"><a href="/pro">See Pro and Team pricing &rarr;</a></p>
   </div>
 
   <div class="related">

--- a/public/guides/codex-cli-guardrails.html
+++ b/public/guides/codex-cli-guardrails.html
@@ -134,10 +134,10 @@
   <p>The agent receives a rejection with the reason and the linked prevention rule, then adapts its approach. The blocked command never executes.</p>
 
   <div class="cta-box">
-    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Founding Member Deal &mdash; $49</h2>
-    <p>Lock in lifetime Pro access at the founding price. One command to start.</p>
+    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Pro for operators, Team for governance</h2>
+    <p>Start free with local gates. Pro is $19/mo or $149/yr for the personal dashboard and exports. Team rollout anchors at $99/seat/mo when shared lessons and org visibility matter.</p>
     <div class="cta-install">$ npx thumbgate init --agent codex</div>
-    <p style="margin-top:8px;"><a href="/pro">Learn about ThumbGate Pro &rarr;</a></p>
+    <p style="margin-top:8px;"><a href="/pro">See Pro and Team pricing &rarr;</a></p>
   </div>
 
   <div class="related">

--- a/public/guides/cursor-prevent-repeated-mistakes.html
+++ b/public/guides/cursor-prevent-repeated-mistakes.html
@@ -137,10 +137,10 @@
   <p>No. The PreToolUse hook adds a sub-millisecond pattern check before each tool call. You keep Cursor's speed while gaining enforcement.</p>
 
   <div class="cta-box">
-    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Founding Member Deal &mdash; $49</h2>
-    <p>Lock in lifetime Pro access at the founding price. One command to start.</p>
+    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Pro for operators, Team for governance</h2>
+    <p>Start free with local gates. Pro is $19/mo or $149/yr for the personal dashboard and exports. Team rollout anchors at $99/seat/mo when shared lessons and org visibility matter.</p>
     <div class="cta-install">$ npx thumbgate init --agent cursor</div>
-    <p style="margin-top:8px;"><a href="/pro">Learn about ThumbGate Pro &rarr;</a></p>
+    <p style="margin-top:8px;"><a href="/pro">See Pro and Team pricing &rarr;</a></p>
   </div>
 
   <div class="related">

--- a/public/guides/pre-action-gates.html
+++ b/public/guides/pre-action-gates.html
@@ -138,10 +138,10 @@
   <p>Thompson Sampling scores gate rules based on accumulated thumbs-up and thumbs-down feedback, so high-risk patterns get strict enforcement while low-risk ones stay relaxed.</p>
 
   <div class="cta-box">
-    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Founding Member Deal &mdash; $49</h2>
-    <p>Lock in lifetime Pro access at the founding price. One command to start.</p>
+    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Pro for operators, Team for governance</h2>
+    <p>Start free with local gates. Pro is $19/mo or $149/yr for the personal dashboard and exports. Team rollout anchors at $99/seat/mo when shared lessons and org visibility matter.</p>
     <div class="cta-install">$ npx thumbgate init</div>
-    <p style="margin-top:8px;"><a href="/pro">Learn about ThumbGate Pro &rarr;</a></p>
+    <p style="margin-top:8px;"><a href="/pro">See Pro and Team pricing &rarr;</a></p>
   </div>
 
   <div class="related">

--- a/public/guides/stop-repeated-ai-agent-mistakes.html
+++ b/public/guides/stop-repeated-ai-agent-mistakes.html
@@ -135,10 +135,10 @@
   <p>After a single thumbs-down with context, ThumbGate generates a prevention rule. After repeated failures on the same pattern, it promotes to a hard gate that blocks before execution.</p>
 
   <div class="cta-box">
-    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Founding Member Deal &mdash; $49</h2>
-    <p>Lock in lifetime Pro access at the founding price. One command to start.</p>
+    <h2 style="color:var(--text);font-size:1.3rem;margin:0 0 8px;">Pro for operators, Team for governance</h2>
+    <p>Start free with local gates. Pro is $19/mo or $149/yr for the personal dashboard and exports. Team rollout anchors at $99/seat/mo when shared lessons and org visibility matter.</p>
     <div class="cta-install">$ npx thumbgate init</div>
-    <p style="margin-top:8px;"><a href="/pro">Learn about ThumbGate Pro &rarr;</a></p>
+    <p style="margin-top:8px;"><a href="/pro">See Pro and Team pricing &rarr;</a></p>
   </div>
 
   <div class="related">

--- a/public/index.html
+++ b/public/index.html
@@ -749,7 +749,7 @@ __GA_BOOTSTRAP__
           <li><strong>HuggingFace dataset export</strong> — share PII-redacted agent traces as open training datasets (<code>npm run export:hf</code>)</li>
           <li><strong>Model Hardening Advisor</strong> — get recommendations on when and how to fine-tune your model to natively avoid recurring failures</li>
           <li>Personal local dashboard — every Pro user gets a localhost dashboard without extra cloud setup</li>
-          <li>Founder-license support — we help you wire the riskiest flows first: migrations, force-pushes, deploys, and CI</li>
+          <li>Review-ready workflow support — we help you wire the riskiest flows first: migrations, force-pushes, deploys, and CI</li>
         </ul>
         <a href="/checkout/pro?utm_source=website&utm_medium=homepage_pricing&utm_campaign=pro_pack&cta_id=homepage_pricing_trial&cta_placement=pricing&plan_id=pro&landing_path=%2F" class="btn-pro" style="display:none" id="pro-checkout-link">Start Free Trial — then $19/mo</a>
         <div class="trial-badge" style="background:var(--cyan);color:#000;display:inline-block;padding:4px 12px;border-radius:12px;font-size:12px;font-weight:700;margin-bottom:12px;">7-DAY FREE TRIAL</div>

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -73,15 +73,7 @@ const CONFIG = {
   get NEWSLETTER_SUBSCRIBERS_PATH() {
     return process.env._TEST_NEWSLETTER_SUBSCRIBERS_PATH || path.join(getFeedbackPaths().FEEDBACK_DIR, 'newsletter-subscribers.jsonl');
   },
-  CREDIT_PACKS: {
-    'mistake-free-starter': {
-      id: 'mistake-free-starter',
-      name: 'Mistake-Free Starter Pack',
-      amountCents: 4900,
-      credits: 500,
-      currency: 'USD',
-    }
-  }
+  CREDIT_PACKS: {}
 };
 
 function resolveLegacyBillingPath(fileName) {

--- a/scripts/check-congruence.js
+++ b/scripts/check-congruence.js
@@ -27,13 +27,44 @@ const {
 const ROOT = path.join(__dirname, '..');
 const PRICING_SURFACE_ROOTS = [
   'README.md',
+  'SKILL.md',
   'bin',
   'docs',
   'public',
   '.agents/skills/thumbgate/SKILL.md',
+  '.claude/skills/thumbgate/SKILL.md',
 ];
 const PRICING_SURFACE_EXTENSIONS = new Set(['.html', '.js', '.json', '.md', '.txt']);
-const LEGACY_TEAM_PRICE_PATTERN = /\$12\s*\/\s*seat\s*\/\s*mo|\$12\/seat|\bTEAM \$12\b|"price":\s*"12"/i;
+const LEGACY_THUMBGATE_PRICING_PATTERNS = [
+  {
+    label: 'legacy $12 Team seat price',
+    pattern: /\$12\s*\/\s*seat\s*\/\s*mo|\$12\/seat|\bTEAM \$12\b|"price":\s*"12"/i,
+  },
+  {
+    label: 'retired founder $5 pricing',
+    pattern: /(?:Founding Member|Founding|founder)[^\n]{0,80}\$5\/mo|\$5\/mo[^\n]{0,80}(?:Founding Member|Founding|founder)|Price:\s*\$5\/mo recurring/i,
+  },
+  {
+    label: 'retired $10 Pro pricing',
+    pattern: /(?:\*\*Pro\*\*|\bPro\b|price reverts|paying users)[^\n]{0,80}\$10\/mo|\$10\/mo[^\n]{0,80}(?:\*\*Pro\*\*|\bPro\b|price reverts|paying users)/i,
+  },
+  {
+    label: 'retired $29 Team pricing',
+    pattern: /(?:\*\*Team\*\*|Team)[^\n]{0,80}\$29\/mo|\$29\/mo[^\n]{0,80}(?:\*\*Team\*\*|Team)/i,
+  },
+  {
+    label: 'retired $19 starter-pack positioning',
+    pattern: /Mistake-Free Starter Pack|Mistake-Free Starter Pack[^\n]{0,80}\$19\/mo|\$19\/mo[^\n]{0,80}subscriptions/i,
+  },
+  {
+    label: 'retired $49 founder lifetime pricing',
+    pattern: /(?:Founding Member|Founder|Founding Member Deal)[^\n]{0,100}\$49|\$49[^\n]{0,100}(?:Pro forever|Founding Member|Founder)/i,
+  },
+  {
+    label: 'retired founder-license positioning',
+    pattern: /founder[- ]license/i,
+  },
+];
 
 function read(rel) {
   const full = path.join(ROOT, rel);
@@ -95,9 +126,15 @@ async function main() {
   const teamSeatPrice = `$${TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`;
   const teamSeatPricePattern = new RegExp(`\\$${TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`, 'i');
   const pricingSurfaceFiles = PRICING_SURFACE_ROOTS.flatMap(listTextFiles);
-  const legacyTeamPricingHits = pricingSurfaceFiles.filter((rel) => (
-    LEGACY_TEAM_PRICE_PATTERN.test(read(rel) || '')
-  ));
+  const legacyPricingHits = [];
+  for (const rel of pricingSurfaceFiles) {
+    const text = read(rel) || '';
+    for (const { label, pattern } of LEGACY_THUMBGATE_PRICING_PATTERNS) {
+      if (pattern.test(text)) {
+        legacyPricingHits.push(`${rel} (${label})`);
+      }
+    }
+  }
 
   check(
     landingHtml.includes(`v${version}`),
@@ -190,8 +227,8 @@ async function main() {
     'scripts/commercial-offer.js Team label must match the canonical Team seat price'
   );
   check(
-    legacyTeamPricingHits.length === 0,
-    `Legacy $12 Team pricing found in public pricing surfaces: ${legacyTeamPricingHits.join(', ')}`
+    legacyPricingHits.length === 0,
+    `Legacy ThumbGate pricing found in public pricing surfaces: ${legacyPricingHits.join(', ')}`
   );
   check(
     teamSeatPricePattern.test(guideHtml),

--- a/scripts/commercial-offer.js
+++ b/scripts/commercial-offer.js
@@ -2,7 +2,6 @@
 
 const PRO_MONTHLY_PAYMENT_LINK = 'https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06';
 const PRO_ANNUAL_PAYMENT_LINK = 'https://buy.stripe.com/3cI8wPfCYaPs2dzdKz3sI07';
-const PRO_FOUNDER_PAYMENT_LINK = 'https://buy.stripe.com/aFa4gz1M84r419v7mb3sI05';
 
 const PRO_MONTHLY_PRICE_ID = 'price_1THQY7GGBpd520QYHoS7RG0J';
 const PRO_ANNUAL_PRICE_ID = 'price_1THQZ7GGBpd520QYxzDRnxhB';
@@ -39,7 +38,6 @@ function normalizeSeatCount(value, fallback = TEAM_MIN_SEATS) {
 module.exports = {
   PRO_MONTHLY_PAYMENT_LINK,
   PRO_ANNUAL_PAYMENT_LINK,
-  PRO_FOUNDER_PAYMENT_LINK,
   PRO_MONTHLY_PRICE_ID,
   PRO_ANNUAL_PRICE_ID,
   TEAM_MONTHLY_PRICE_ID,

--- a/scripts/org-dashboard.js
+++ b/scripts/org-dashboard.js
@@ -19,6 +19,11 @@ const path = require('path');
 const { resolveFeedbackDir } = require('./feedback-paths');
 const { readAuditLog, auditStats, skillAdherence } = require('./audit-trail');
 const { isProTier } = require('./rate-limiter');
+const {
+  PRO_MONTHLY_PAYMENT_LINK,
+  PRO_PRICE_LABEL,
+  TEAM_PRICE_LABEL,
+} = require('./commercial-offer');
 
 // ---------------------------------------------------------------------------
 // Agent Registry
@@ -181,7 +186,7 @@ function generateOrgDashboard(opts = {}) {
   };
 
   if (!pro) {
-    summary.upgradeMessage = 'Founding Member: $49 once, Pro forever — https://buy.stripe.com/aFa4gz1M84r419v7mb3sI05 | Or $19/mo: https://thumbgate-production.up.railway.app/checkout/pro';
+    summary.upgradeMessage = `Pro checkout: ${PRO_PRICE_LABEL} — ${PRO_MONTHLY_PAYMENT_LINK} | Team: ${TEAM_PRICE_LABEL} after workflow qualification.`;
   }
 
   return summary;

--- a/scripts/pro-features.js
+++ b/scripts/pro-features.js
@@ -2,12 +2,11 @@
 const { isProLicensed } = require('./license');
 const {
   PRO_MONTHLY_PAYMENT_LINK,
-  PRO_FOUNDER_PAYMENT_LINK,
   PRO_PRICE_LABEL,
+  TEAM_PRICE_LABEL,
 } = require('./commercial-offer');
 
 const PRO_URL = PRO_MONTHLY_PAYMENT_LINK;
-const FOUNDER_URL = PRO_FOUNDER_PAYMENT_LINK;
 
 function requirePro(
   featureName,
@@ -32,8 +31,8 @@ function requirePro(
   const desc = descriptions[featureName] || featureName;
   write(
     `\n  🔒 Pro Feature Required: ${desc}\n` +
-    `     Founding Member: $49 once, Pro forever — ${FOUNDER_URL}\n` +
-    `     Or subscribe: ${PRO_PRICE_LABEL} — ${PRO_URL}\n` +
+    `     Pro: ${PRO_PRICE_LABEL} — ${PRO_URL}\n` +
+    `     Team: ${TEAM_PRICE_LABEL} after workflow qualification\n` +
     `     Or run: npx thumbgate pro\n\n`
   );
   return false;

--- a/scripts/rate-limiter.js
+++ b/scripts/rate-limiter.js
@@ -5,7 +5,8 @@ const fs = require('fs');
 const path = require('path');
 const {
   PRO_MONTHLY_PAYMENT_LINK,
-  PRO_FOUNDER_PAYMENT_LINK,
+  PRO_PRICE_LABEL,
+  TEAM_PRICE_LABEL,
 } = require('./commercial-offer');
 
 const USAGE_FILE = path.join(process.env.HOME || '/tmp', '.thumbgate', 'usage-limits.json');
@@ -21,7 +22,7 @@ const FREE_TIER_LIMITS = {
 
 const FREE_TIER_MAX_GATES = 5;
 
-const UPGRADE_MESSAGE = `Founding Member deal: $49 once, Pro forever — includes dashboard and DPO export: ${PRO_FOUNDER_PAYMENT_LINK}\n  Or subscribe: $19/mo — ${PRO_MONTHLY_PAYMENT_LINK}`;
+const UPGRADE_MESSAGE = `Pro: ${PRO_PRICE_LABEL} — dashboard and DPO export: ${PRO_MONTHLY_PAYMENT_LINK}\n  Team: ${TEAM_PRICE_LABEL} after workflow qualification.`;
 
 function isProTier(authContext) {
   if (authContext && authContext.tier === 'pro') return true;

--- a/tests/seo-guides.test.js
+++ b/tests/seo-guides.test.js
@@ -65,11 +65,11 @@ describe('SEO guide and comparison pages', () => {
         assert.ok(html.includes('ThumbGate'), `${file} does not mention ThumbGate`);
       });
 
-      it('mentions the founding member deal', () => {
+      it('mentions the current Pro and Team pricing', () => {
         html = html || fs.readFileSync(path.join(PUBLIC_DIR, file), 'utf-8');
         assert.ok(
-          html.includes('$49') || html.includes('Founding Member'),
-          `${file} missing founding member deal`
+          html.includes('$19/mo') && html.includes('$149/yr') && html.includes('$99/seat/mo'),
+          `${file} missing current Pro and Team pricing`
         );
       });
     });

--- a/tests/thumbgate-skill.test.js
+++ b/tests/thumbgate-skill.test.js
@@ -56,7 +56,9 @@ describe('thumbgate-skill', () => {
     assert.ok(content.includes('Multi-hop recall'), 'mentions multi-hop recall');
     assert.ok(content.includes('Synthetic DPO'), 'mentions synthetic DPO');
     assert.match(content, /https:\/\/buy\.stripe\.com\/[^\s)]+/, 'has Stripe checkout link');
-    assert.ok(content.includes('founder license'), 'mentions founder license');
+    assert.ok(content.includes('$19/mo or $149/yr'), 'mentions current Pro pricing');
+    assert.ok(content.includes('$99/seat/mo'), 'mentions current Team pricing');
+    assert.doesNotMatch(content, /founder[- ]license/i, 'does not mention retired founder-license positioning');
   });
 
   test('SKILL.md links to reference files that exist', () => {


### PR DESCRIPTION
## Summary
- Align README, landing page, public SEO guides, compare pages, skill docs, Commercial Truth, and marketing/support docs on the current offer: Pro at $19/mo or $149/yr, Team at $99/seat/mo with a 3-seat minimum after intake.
- Remove active retired founder/starter-pack pricing surfaces and disable the hidden one-time starter checkout pack.
- Harden `scripts/check-congruence.js` so stale pricing and founder-license positioning fail CI across README, docs, public pages, and tracked skill bundles.

## Verification
- `npm ci`
- `npm test`
- `npm run test:coverage` (84.69% statements, 71.69% branches, 87.55% functions)
- `npm run prove:adapters` (48/48 pass)
- `npm run prove:automation` (55/55 pass)
- `npm run self-heal:check` (Overall HEALTHY, 6/6 checks)
- `node scripts/check-congruence.js`
- `node --test tests/check-congruence.test.js tests/public-landing.test.js tests/seo-guides.test.js tests/thumbgate-skill.test.js tests/funnel-invariants.test.js tests/billing.test.js tests/api-server.test.js tests/cli.test.js` (269/269 pass after rebase onto `d733437c`)
- `git diff --check`
