### PR TITLE
docs: tighten PR hygiene session directives

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -3,11 +3,6 @@ name: Changeset Check
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - '.github/workflows/daily-*.yml'
-      - '.github/workflows/marketing-*.yml'
 
 jobs:
   changeset-check:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,10 @@ On explicit user preference signals (`up/down`, `correct/wrong`, or subjective "
 ## Session Directive: PR Management & System Hygiene
 
 ### CTO Protocol
-1. **Research:** Read directives and local ThumbGate memory first.
-2. **PRs:** Inspect all open PRs with `npm run pr:manage`. Merge green, non-blocking ones.
-3. **Orphans:** Delete branches/worktrees without PRs after evaluation.
-4. **Integrity:** `main` must be 100% green. Fix regressions on sight.
-5. **Hygiene:** Remove stale logs and temporary files.
-6. **Ready:** Say: **"Done merging PRs. CI passing. System hygiene complete. Ready for next session."**
+1. **Research:** Read `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, then query local ThumbGate memory before acting.
+2. **PRs:** Inspect all open PRs with `npm run pr:manage`. Merge only when critical checks have terminal success and no actionable review blockers remain. If a PR is blocked, report the exact failing check or merge-state reason.
+3. **Orphans:** Classify non-PR branches/worktrees as merge candidate, archive-delete candidate, or protected dirty lane. Archive unique local commits before deletion.
+4. **Integrity:** `main` must be green on the exact merge commit before any completion claim. If `develop` does not exist, state that explicitly instead of implying coverage.
+5. **Hygiene:** Remove stale logs and temporary files. Report before/after branch and worktree counts for cleanup actions.
+6. **Secrets:** Never persist secrets, PATs, or copied credentials into directives, memory logs, commits, or PR bodies.
+7. **Ready:** Say: **"Done merging PRs. CI passing. System hygiene complete. Ready for next session."** only after evidence is in hand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,13 @@ curl -s https://thumbgate-production.up.railway.app/dashboard | grep 'ThumbGate 
 3. Wait for CI (runs on push to `main` and `feat/**` branches).
 4. After push, run: `gh pr view --json reviewDecision,comments,reviewThreads`
 5. If unresolved threads > 0 → fix them → push again → re-check.
+6. If a PR is not mergeable, report the exact blocker (`REVIEW_REQUIRED`, pending checks, failing checks, behind base, merge conflicts).
 6. Merge only when: CI green AND 0 unresolved threads.
    - Never use raw `gh pr merge --auto`; use `npm run pr:manage` after all critical quality checks have terminal success.
-7. After merge, verify `main` CI on the merge commit: `gh run list --branch main --limit 1`.
-8. Delete the feature branch after merge.
+7. After merge, verify `main` CI on the exact merge commit, not just the latest branch run.
+8. Delete the feature branch after merge. Archive unique orphan branches before deleting them.
 9. For `main`, merge submission is Trunk-managed: request `/trunk merge` and let the queue finish asynchronously. Do not build helper workflows that poll their own required check or block on the final merge commit.
+10. Never persist secrets, PATs, or copied credentials into tracked repo files, PR bodies, or local memory notes.
 
 **NEVER say "done" or "pushed" without showing `gh pr view` output first.**
 
@@ -179,10 +181,14 @@ node bin/cli.js cfo --today
 ## Session Startup
 
 ```bash
-# 1. Read primer to recover context
+# 1. Read directives and primer to recover context
+cat AGENTS.md
+cat CLAUDE.md
+cat GEMINI.md
 cat primer.md
 
-# 2. Check for open PRs
+# 2. Check local ThumbGate memory and open PRs
+npm run feedback:summary
 npm run pr:manage
 
 # 3. Verify main is green

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -92,9 +92,10 @@ Use feedback-derived prevention rules as constraints to reduce repeated failures
 ## Session Directive: PR Management & System Hygiene
 
 ### CTO Protocol
-1. **Research & Recall:** Read directives and local ThumbGate memory for lessons before tasks.
-2. **PR Inspection:** Review all open PRs using `npm run pr:manage`. No PR should remain open if mergeable.
-3. **Orphan Cleanup:** List branches without PRs. Evaluate and delete stale/regressive ones.
-4. **Main Integrity:** Ensure CI passes on `main` after all merges. Fix regressions immediately.
-5. **Dry Run:** Confirm operational readiness for the next session.
-6. **Confirmation:** Say: **"Done merging PRs. CI passing. System hygiene complete. Ready for next session."**
+1. **Research & Recall:** Read `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, then query only local ThumbGate memory for lessons before tasks.
+2. **PR Inspection:** Review all open PRs using `npm run pr:manage`. No PR should remain open if mergeable; blocked PRs must include an exact blocker report.
+3. **Orphan Cleanup:** List branches without PRs. Archive unique local commits before deleting clean stale lanes, and preserve dirty rescue lanes until they are intentionally resolved.
+4. **Main Integrity:** Ensure CI passes on the exact merge commit on `main` after all merges. If `develop` is absent, say so explicitly.
+5. **Dry Run:** Confirm operational readiness for the next session and report before/after branch-worktree cleanup counts.
+6. **Secrets:** Never persist secrets, PATs, or copied credentials into directives, memory, commits, or PR text.
+7. **Confirmation:** Say: **"Done merging PRs. CI passing. System hygiene complete. Ready for next session."** only after evidence is verified.


### PR DESCRIPTION
## Summary
- tighten the PR hygiene session directive language in AGENTS.md, CLAUDE.md, and GEMINI.md
- require local-memory-first startup, explicit blocker reporting, archive-before-delete cleanup, and before/after cleanup counts
- add a hard reminder to never persist secrets or PATs into repo directives, memory, or PR text

## Test plan
- [x] Docs-only directive update reviewed locally
- [x] Rebased onto latest main after PR #726 merged
