### PR TITLE
feat: promote Codex plugin install path

### DIFF
--- a/.changeset/codex-plugin-promotion.md
+++ b/.changeset/codex-plugin-promotion.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Promote the published Codex plugin bundle more clearly from the landing page and README.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Make your AI coding agent self-improving — and authentically yours. ThumbGate 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Start Sprint](https://img.shields.io/badge/Workflow%20Hardening%20Sprint-Start%20Intake%20→-16a34a?style=for-the-badge)](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=badge_cta#workflow-sprint-intake)
 
-**[Workflow Hardening Sprint](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake)** · **[Live Dashboard](https://thumbgate-production.up.railway.app/dashboard?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[Setup Guide](https://thumbgate-production.up.railway.app/guide?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[Pro Page](https://thumbgate-production.up.railway.app/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page)**
+**[Workflow Hardening Sprint](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake)** · **[Live Dashboard](https://thumbgate-production.up.railway.app/dashboard?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[Setup Guide](https://thumbgate-production.up.railway.app/guide?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[Install Codex Plugin](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)** · **[Pro Page](https://thumbgate-production.up.railway.app/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page)**
 
 **Popular buyer questions:** **[How to stop repeated AI agent mistakes](https://thumbgate-production.up.railway.app/guides/stop-repeated-ai-agent-mistakes?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Cursor guardrails](https://thumbgate-production.up.railway.app/guides/cursor-agent-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Codex CLI guardrails](https://thumbgate-production.up.railway.app/guides/codex-cli-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Gemini CLI memory + enforcement](https://thumbgate-production.up.railway.app/guides/gemini-cli-feedback-memory?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)**
+
+**Running Codex?** **[Download the standalone Codex plugin bundle](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)** · **[Open the Codex install guide](plugins/codex-profile/INSTALL.md)**
 
 ### Get Started
 
@@ -20,6 +22,11 @@ Make your AI coding agent self-improving — and authentically yours. ThumbGate 
 One workflow. One owner. One proof review. That is the fastest path to a paid team engagement because it qualifies a real blocker before anyone tries to sell a full rollout.
 
 **Best first technical motion:** install the local CLI and let `init` wire the hooks and MCP transport for the agent you already use.
+
+**Best first Codex motion:** install the published Codex plugin bundle if you want ThumbGate to show up as a first-class Codex plugin instead of wiring MCP by hand.
+
+- Standalone download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip`
+- Install guide: `plugins/codex-profile/INSTALL.md`
 
 Free stays for individual developers. The commercial path is enterprise-first: Team pricing anchors at **$99/seat/mo with a 3-seat minimum**, and the public paid motion starts with the Workflow Hardening Sprint so one blocker gets qualified before a wider rollout. [See pricing →](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=pricing_link#pricing)
 
@@ -146,6 +153,8 @@ Or wire MCP directly: `claude mcp add thumbgate -- npx -y thumbgate serve`
 Works with **Claude Code, Cursor, Codex, Gemini, Amp, OpenCode**, and any MCP-compatible agent.
 
 Codex standalone plugin bundle: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip`
+
+Codex install guide: `plugins/codex-profile/INSTALL.md`
 
 > **Need shared enforcement, auditability, approval boundaries, and rollout proof for a team workflow?** [Start with the Workflow Hardening Sprint →](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=quickstart_cta#workflow-sprint-intake)
 >

--- a/public/index.html
+++ b/public/index.html
@@ -463,9 +463,11 @@ __GA_BOOTSTRAP__
     <p><strong>Best first paid motion:</strong> start with one repo, one workflow, and one repeat failure. ThumbGate turns the blocker into enforcement, routes risky runs toward isolated execution, and gives the buyer a proof-ready story around shared memory, approval boundaries, release confidence, and auditability.</p>
     <div class="hero-actions">
       <a href="#workflow-sprint-intake" class="btn-team">Start Workflow Hardening Sprint</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" class="btn-install-link" target="_blank" rel="noopener">Install Codex plugin</a>
       <a href="/guide?utm_source=website&utm_medium=homepage_hero&utm_campaign=install_free" class="btn-pro-page btn-install-link">Install Free CLI</a>
       <a href="/dashboard?utm_source=website&utm_medium=homepage_hero&utm_campaign=demo" class="btn-demo-link">Open dashboard demo</a>
     </div>
+    <p class="hero-paid-note"><strong>Running Codex?</strong> Download the published plugin bundle or open the <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/INSTALL.md" target="_blank" rel="noopener">Codex install guide</a> for the repo-local profile and MCP path.</p>
     <p class="hero-paid-note"><strong>Start free as an individual.</strong> Pro stays the self-serve lane for personal dashboard and DPO export. Team pricing anchors at <strong>$99/seat/mo with a 3-seat minimum</strong>, but the team path starts intake-first with the Workflow Hardening Sprint so buyers see proof before a wider rollout.</p>
     <div class="hero-install" onclick="copyInstall(this)" title="Click to copy">
       <span class="prompt">$</span>
@@ -474,6 +476,8 @@ __GA_BOOTSTRAP__
     </div>
     <div class="proof-bar">
       <a href="/guide" rel="noopener">CLI-first setup guide →</a>
+      <span class="dot"></span>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">Codex plugin download →</a>
       <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence →</a>
       <span class="dot"></span>
@@ -505,6 +509,11 @@ __GA_BOOTSTRAP__
         <h3>🤖 AI CLIs</h3>
         <p>Claude Code, Claw-code, Codex, Gemini CLI, Amp, and OpenCode all use the same gateway and memory model. Any MCP-compatible agent gets pre-action gates, feedback memory, and enforcement out of the box.</p>
         <div class="card-arrow">View setup guide →</div>
+      </a>
+      <a class="compat-card" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/INSTALL.md" target="_blank" rel="noopener">
+        <h3>🧩 Codex plugin</h3>
+        <p>Codex ships with a published standalone ThumbGate plugin bundle plus a repo-local plugin profile. Download the zip, extract it, and install without wiring MCP by hand.</p>
+        <div class="card-arrow">Get the Codex plugin →</div>
       </a>
       <a class="compat-card" href="/guides/claude-desktop">
         <h3>🧩 Claude Desktop plugin</h3>
@@ -830,7 +839,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What AI agents and editors does this work with?</div>
-        <div class="faq-a">ThumbGate works with Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, and any other MCP-compatible agent. Cursor ships with a plugin bundle in this repo. Codex now ships both a standalone plugin bundle and a repo-local app plugin profile. VS Code works when you run an MCP-compatible agent inside it, but this repo does not ship a standalone VS Code extension today.</div>
+        <div class="faq-a">ThumbGate works with Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, and any other MCP-compatible agent. Cursor ships with a plugin bundle in this repo. Codex now ships both a standalone plugin bundle and a repo-local app plugin profile, and the published download is linked directly from this page. VS Code works when you run an MCP-compatible agent inside it, but this repo does not ship a standalone VS Code extension today.</div>
       </div>
       <div class="faq-item">
         <button class="faq-q" type="button" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How do we keep high-risk autonomous runs off the host?</button>

--- a/tests/codex-plugin.test.js
+++ b/tests/codex-plugin.test.js
@@ -58,6 +58,15 @@ test('codex plugin manifest uses ThumbGate branding and local MCP config', () =>
   assert.match(install, /marketplace catalog points at `\.\/`/i);
 });
 
+test('root README promotes the Codex plugin as a first-class install path', () => {
+  const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf-8');
+
+  assert.match(readme, /Install Codex Plugin/);
+  assert.match(readme, /Download the standalone Codex plugin bundle/i);
+  assert.match(readme, /plugins\/codex-profile\/INSTALL\.md/);
+  assert.match(readme, new RegExp(getCodexPluginLatestDownloadUrl(root).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
 test('codex plugin staging writes a standalone bundle with self-contained marketplace metadata', () => {
   const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-plugin-stage-'));
 

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -281,6 +281,16 @@ test('public landing page internally links to comparison and guide pages without
   assert.doesNotMatch(landingPage, /convert.*search.*demand/i);
 });
 
+test('public landing page advertises the Codex standalone plugin install path', () => {
+  const landingPage = readLandingPage();
+
+  assert.match(landingPage, /Install Codex plugin/);
+  assert.match(landingPage, /Codex plugin download →/);
+  assert.match(landingPage, /Get the Codex plugin →/);
+  assert.match(landingPage, /plugins\/codex-profile\/INSTALL\.md/);
+  assert.match(landingPage, /thumbgate-codex-plugin\.zip/);
+});
+
 test('public landing page FAQ defaults first item open for credibility', () => {
   const landingPage = readLandingPage();
 


### PR DESCRIPTION
## Summary
- make the published Codex plugin bundle a first-class CTA on the landing page hero and proof bar
- add a dedicated Codex plugin compatibility card and strengthen the README install path
- extend landing page and Codex plugin tests to keep the promo surface in place

## Test plan
- [x] node --test tests/codex-plugin.test.js tests/public-landing.test.js
