### PR TITLE
feat: Claude plugin marketplace spec compliance

### DIFF
--- a/.changeset/claude-plugin-marketplace.md
+++ b/.changeset/claude-plugin-marketplace.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Update Claude plugin manifests to current marketplace spec for directory listing

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,23 +1,42 @@
 {
-  "name": "thumbgate",
+  "name": "thumbgate-marketplace",
   "version": "1.3.0",
+  "owner": {
+    "name": "Igor Ganapolsky",
+    "email": "ig5973700@gmail.com"
+  },
   "plugins": [
     {
       "name": "thumbgate",
       "description": "Pre-action gates that block AI coding agents from repeating known mistakes. Captures feedback, auto-promotes failures into prevention rules, and enforces them via PreToolUse hooks.",
-      "type": "mcp",
       "source": {
-        "type": "npm",
-        "package": "thumbgate",
-        "command": "npx",
-        "args": [
-          "--yes",
-          "--package",
-          "thumbgate",
-          "thumbgate",
-          "serve"
-        ]
+        "source": "npm",
+        "package": "thumbgate"
       },
+      "version": "1.3.0",
+      "author": {
+        "name": "Igor Ganapolsky"
+      },
+      "homepage": "https://thumbgate-production.up.railway.app",
+      "repository": "https://github.com/IgorGanapolsky/ThumbGate",
+      "license": "MIT",
+      "category": "developer-tools",
+      "tags": [
+        "pre-action-gates",
+        "ai-agent-safety",
+        "mcp",
+        "memory",
+        "workflow-hardening"
+      ],
+      "keywords": [
+        "claude-desktop",
+        "desktop-extension",
+        "pre-action-gates",
+        "ai-agent-safety",
+        "mcp",
+        "memory",
+        "workflow-hardening"
+      ],
       "metadata": {
         "author": "Igor Ganapolsky",
         "homepage": "https://thumbgate-production.up.railway.app",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,5 +17,12 @@
     "memory",
     "guardrails",
     "workflow-hardening"
-  ]
+  ],
+  "skills": "skills",
+  "mcpServers": {
+    "thumbgate": {
+      "command": "npx",
+      "args": ["--yes", "--package", "thumbgate", "thumbgate", "serve"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Updates `.claude-plugin/marketplace.json` to current Claude Code plugin directory spec (adds `owner`, `source.source: npm`, flat metadata fields)
- Adds `skills` and `mcpServers` declarations to `.claude-plugin/plugin.json`
- Plugin is now installable via: `/plugin marketplace add IgorGanapolsky/ThumbGate`
- Then: `/plugin install thumbgate@thumbgate-marketplace`

## Install Instructions
```
/plugin marketplace add IgorGanapolsky/ThumbGate
/plugin install thumbgate@thumbgate-marketplace
```

## Next: Official Submission
Submit to Anthropic's official marketplace at:
- claude.ai/settings/plugins/submit
- platform.claude.com/plugins/submit

## Test plan
- [x] Version sync check passes (30/30 targets)
- [x] Congruence check passes
- [x] Plugin metadata alignment test passes
- [x] Existing tests unbroken (dual metadata format preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)