### PR TITLE
feat: harden Claude plugin listing readiness

### DIFF
--- a/.changeset/claude-listing-readiness.md
+++ b/.changeset/claude-listing-readiness.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Strengthen Claude plugin listing readiness docs, release assets, and submission packaging

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -38,11 +38,22 @@ https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-c
 
 That bundle is built from the same `.claude-plugin` metadata in this repo and is meant for people who want a ready-to-install artifact instead of building locally.
 
+### Review packet zip
+
+Anthropic's submission flow may ask for a GitHub link or a zip that preserves the plugin folder structure. The review-ready source zip lives on GitHub Releases:
+
+https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip
+
 ### Anthropic directory path
 
 If Anthropic approves the listing, install from Claude Desktop via `Settings -> Extensions`.
 
 Directory inclusion is an external review process. Do not claim listing or approval before it is real.
+
+Submission forms:
+
+- https://claude.ai/settings/plugins/submit
+- https://platform.claude.com/plugins/submit
 
 ### MCPB bundle build
 
@@ -131,4 +142,5 @@ For complete privacy information, see: https://thumbgate-production.up.railway.a
 
 - Local Claude metadata lives in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
 - The MCPB bundle is built with `npm run build:claude-mcpb`.
+- The review packet zip is built with `npm run build:claude-review-zip`.
 - Anthropic directory requirements and the internal publish checklist live in `docs/CLAUDE_DESKTOP_EXTENSION.md`.

--- a/.github/workflows/publish-claude-plugin.yml
+++ b/.github/workflows/publish-claude-plugin.yml
@@ -40,33 +40,42 @@ jobs:
       - run: npm run prove:runtime
 
       - run: npm run build:claude-mcpb
+      - run: npm run build:claude-review-zip
 
       - name: Resolve Claude plugin asset names
         id: assets
         run: |
           version=$(node -p "require('./package.json').version")
-          versioned_asset=$(node -e "const { getClaudePluginVersionedAssetName } = require('./scripts/distribution-surfaces'); process.stdout.write(getClaudePluginVersionedAssetName())")
-          channel_asset=$(node -e "const { getClaudePluginChannelAssetName } = require('./scripts/distribution-surfaces'); process.stdout.write(getClaudePluginChannelAssetName())")
+          versioned_bundle=$(node -e "const { getClaudePluginVersionedAssetName } = require('./scripts/distribution-surfaces'); process.stdout.write(getClaudePluginVersionedAssetName())")
+          channel_bundle=$(node -e "const { getClaudePluginChannelAssetName } = require('./scripts/distribution-surfaces'); process.stdout.write(getClaudePluginChannelAssetName())")
+          versioned_review=$(node -e "const { getClaudePluginReviewVersionedAssetName } = require('./scripts/distribution-surfaces'); process.stdout.write(getClaudePluginReviewVersionedAssetName())")
+          channel_review=$(node -e "const { getClaudePluginReviewChannelAssetName } = require('./scripts/distribution-surfaces'); process.stdout.write(getClaudePluginReviewChannelAssetName())")
           is_prerelease=$(node -e "const { isPrereleaseVersion } = require('./scripts/distribution-surfaces'); process.stdout.write(String(isPrereleaseVersion()))")
           {
             echo "version=$version"
-            echo "versioned_asset=$versioned_asset"
-            echo "channel_asset=$channel_asset"
+            echo "versioned_bundle=$versioned_bundle"
+            echo "channel_bundle=$channel_bundle"
+            echo "versioned_review=$versioned_review"
+            echo "channel_review=$channel_review"
             echo "is_prerelease=$is_prerelease"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create channel asset alias
+      - name: Create release asset aliases
         run: |
-          cp ".artifacts/claude-desktop/${{ steps.assets.outputs.versioned_asset }}" \
-            ".artifacts/claude-desktop/${{ steps.assets.outputs.channel_asset }}"
+          cp ".artifacts/claude-desktop/${{ steps.assets.outputs.versioned_bundle }}" \
+            ".artifacts/claude-desktop/${{ steps.assets.outputs.channel_bundle }}"
+          cp ".artifacts/claude-desktop/${{ steps.assets.outputs.versioned_review }}" \
+            ".artifacts/claude-desktop/${{ steps.assets.outputs.channel_review }}"
 
       - name: Upload Claude plugin artifact
         uses: actions/upload-artifact@v7
         with:
-          name: claude-plugin-mcpb
+          name: claude-plugin-assets
           path: |
-            .artifacts/claude-desktop/${{ steps.assets.outputs.versioned_asset }}
-            .artifacts/claude-desktop/${{ steps.assets.outputs.channel_asset }}
+            .artifacts/claude-desktop/${{ steps.assets.outputs.versioned_bundle }}
+            .artifacts/claude-desktop/${{ steps.assets.outputs.channel_bundle }}
+            .artifacts/claude-desktop/${{ steps.assets.outputs.versioned_review }}
+            .artifacts/claude-desktop/${{ steps.assets.outputs.channel_review }}
 
       - name: Ensure GitHub Release exists
         env:
@@ -88,22 +97,34 @@ jobs:
           VERSION: ${{ steps.assets.outputs.version }}
         run: |
           gh release upload "v${VERSION}" \
-            ".artifacts/claude-desktop/${{ steps.assets.outputs.versioned_asset }}" \
-            ".artifacts/claude-desktop/${{ steps.assets.outputs.channel_asset }}" \
+            ".artifacts/claude-desktop/${{ steps.assets.outputs.versioned_bundle }}" \
+            ".artifacts/claude-desktop/${{ steps.assets.outputs.channel_bundle }}" \
+            ".artifacts/claude-desktop/${{ steps.assets.outputs.versioned_review }}" \
+            ".artifacts/claude-desktop/${{ steps.assets.outputs.channel_review }}" \
             --clobber
 
       - name: Verify Claude plugin release assets
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.assets.outputs.version }}
-          VERSIONED_ASSET: ${{ steps.assets.outputs.versioned_asset }}
-          CHANNEL_ASSET: ${{ steps.assets.outputs.channel_asset }}
+          VERSIONED_BUNDLE: ${{ steps.assets.outputs.versioned_bundle }}
+          CHANNEL_BUNDLE: ${{ steps.assets.outputs.channel_bundle }}
+          VERSIONED_REVIEW: ${{ steps.assets.outputs.versioned_review }}
+          CHANNEL_REVIEW: ${{ steps.assets.outputs.channel_review }}
         run: |
           release_json="$(gh release view "v${VERSION}" --json assets)"
-          echo "$release_json" | jq -e --arg versioned "$VERSIONED_ASSET" --arg channel "$CHANNEL_ASSET" '
+          echo "$release_json" | jq -e \
+            --arg versioned_bundle "$VERSIONED_BUNDLE" \
+            --arg channel_bundle "$CHANNEL_BUNDLE" \
+            --arg versioned_review "$VERSIONED_REVIEW" \
+            --arg channel_review "$CHANNEL_REVIEW" '
             [.assets[].name] as $names
-            | ($names | index($versioned))
+            | ($names | index($versioned_bundle))
             | select(. != null)
-            | ($names | index($channel))
+            | ($names | index($channel_bundle))
+            | select(. != null)
+            | ($names | index($versioned_review))
+            | select(. != null)
+            | ($names | index($channel_review))
             | select(. != null)
           ' >/dev/null

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Make your AI coding agent self-improving — and authentically yours. ThumbGate 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Start Sprint](https://img.shields.io/badge/Workflow%20Hardening%20Sprint-Start%20Intake%20→-16a34a?style=for-the-badge)](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=badge_cta#workflow-sprint-intake)
 
-**[Workflow Hardening Sprint](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake)** · **[Live Dashboard](https://thumbgate-production.up.railway.app/dashboard?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[Setup Guide](https://thumbgate-production.up.railway.app/guide?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[Install Codex Plugin](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)** · **[Pro Page](https://thumbgate-production.up.railway.app/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page)**
+**[Workflow Hardening Sprint](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake)** · **[Install Claude Desktop Extension](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb)** · **[Claude Plugin Guide](docs/CLAUDE_DESKTOP_EXTENSION.md)** · **[Install Codex Plugin](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)** · **[Live Dashboard](https://thumbgate-production.up.railway.app/dashboard?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[Pro Page](https://thumbgate-production.up.railway.app/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page)**
 
 **Popular buyer questions:** **[How to stop repeated AI agent mistakes](https://thumbgate-production.up.railway.app/guides/stop-repeated-ai-agent-mistakes?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Cursor guardrails](https://thumbgate-production.up.railway.app/guides/cursor-agent-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Codex CLI guardrails](https://thumbgate-production.up.railway.app/guides/codex-cli-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Gemini CLI memory + enforcement](https://thumbgate-production.up.railway.app/guides/gemini-cli-feedback-memory?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)**
+
+**Running Claude Desktop?** **[Download the packaged Claude bundle](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb)** · **[Open the Claude install + submission guide](docs/CLAUDE_DESKTOP_EXTENSION.md)** · **[Review packet zip](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip)**
 
 **Running Codex?** **[Download the standalone Codex plugin bundle](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)** · **[Open the Codex install guide](plugins/codex-profile/INSTALL.md)**
 
@@ -22,6 +24,12 @@ Make your AI coding agent self-improving — and authentically yours. ThumbGate 
 One workflow. One owner. One proof review. That is the fastest path to a paid team engagement because it qualifies a real blocker before anyone tries to sell a full rollout.
 
 **Best first technical motion:** install the local CLI and let `init` wire the hooks and MCP transport for the agent you already use.
+
+**Best first Claude motion:** install the published Claude Desktop bundle if you want a one-click extension path today, then keep the review packet zip ready for Anthropic's official directory submission flow.
+
+- Bundle download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
+- Submission guide: `docs/CLAUDE_DESKTOP_EXTENSION.md`
+- Review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
 
 **Best first Codex motion:** install the published Codex plugin bundle if you want ThumbGate to show up as a first-class Codex plugin instead of wiring MCP by hand.
 
@@ -118,7 +126,7 @@ No. ThumbGate doesn't update model weights. It works by capturing feedback into 
 CLAUDE.md files are suggestions that agents can ignore. ThumbGate gates are enforcement — they physically block the action before it executes via PreToolUse hooks. Gates also auto-generate from feedback instead of requiring manual rule-writing.
 
 **Does it work with my agent?**
-Yes. ThumbGate is MCP-compatible and works with Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, and any agent that supports PreToolUse hooks or MCP. Codex now has a standalone plugin bundle at `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip` in addition to the repo-local profile.
+Yes. ThumbGate is MCP-compatible and works with Claude Code, Claude Desktop, Cursor, Codex, Gemini CLI, Amp, OpenCode, and any agent that supports PreToolUse hooks or MCP. Claude Desktop has a published bundle at `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`, and Codex has a standalone plugin bundle at `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip`.
 
 **What's the self-distillation mode?**
 ThumbGate can auto-evaluate agent action outcomes (test failures, reverted edits, error patterns) and generate prevention rules without any human feedback. Your agent gets smarter every session automatically.
@@ -151,6 +159,10 @@ npx thumbgate dashboard                               # local dashboard
 Or wire MCP directly: `claude mcp add thumbgate -- npx -y thumbgate serve`
 
 Works with **Claude Code, Cursor, Codex, Gemini, Amp, OpenCode**, and any MCP-compatible agent.
+
+Claude Desktop bundle: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
+
+Claude review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
 
 Codex standalone plugin bundle: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip`
 
@@ -208,6 +220,10 @@ Add to your `claude_desktop_config.json`:
   }
 }
 ```
+
+Or install the packaged extension bundle directly:
+
+`https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 
 ## Built-in Gates
 

--- a/docs/CLAUDE_DESKTOP_EXTENSION.md
+++ b/docs/CLAUDE_DESKTOP_EXTENSION.md
@@ -156,9 +156,10 @@ That command:
 The repo now publishes a user-consumable Claude Desktop bundle on GitHub Releases:
 
 - Latest direct download: https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb
+- Latest review packet zip: https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip
 - Release notes: https://github.com/IgorGanapolsky/ThumbGate/releases
 
-This is the clean public install lane for buyers who do not want to build the bundle locally.
+This is the clean public install lane for buyers who do not want to build the bundle locally. The review packet zip is the backup lane when Anthropic asks for a source zip instead of a GitHub repository link.
 
 ## Promotion lanes
 
@@ -168,6 +169,7 @@ Call out the Claude Desktop extension path as:
 
 - install locally today
 - download the packaged `.mcpb` from GitHub Releases
+- keep a review-ready source zip handy for submission forms
 - review proof and privacy before rollout
 - treat directory inclusion as discoverability, not traction proof
 
@@ -200,7 +202,8 @@ Keep the generated MCPB manifest aligned with:
 2. Keep Claude plugin metadata version-aligned with `package.json`.
 3. Run `npm run build:claude-mcpb`.
 4. Confirm the GitHub Release asset exists at `releases/latest/download/thumbgate-claude-desktop.mcpb`.
-5. Confirm privacy, support, and proof links resolve.
-6. Inspect the resulting `.mcpb` with `mcpb info`.
-7. Submit through Anthropic's official directory process.
-8. Do not market the directory listing until approval is real.
+5. Confirm the GitHub Release asset exists at `releases/latest/download/thumbgate-claude-plugin-review.zip`.
+6. Confirm privacy, support, and proof links resolve.
+7. Inspect the resulting `.mcpb` with `mcpb info`.
+8. Submit through Anthropic's official directory process using the GitHub repository link or the review packet zip.
+9. Do not market the directory listing until approval is real.

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -49,8 +49,10 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Claude Desktop bundle icon: `.claude-plugin/bundle/icon.png`
 - Internal submission packet: `docs/CLAUDE_DESKTOP_EXTENSION.md`
 - Bundle build command: `npm run build:claude-mcpb`
+- Review packet build command: `npm run build:claude-review-zip`
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
+- Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
 - Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.3.0 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
@@ -58,6 +60,12 @@ Build the `.mcpb` for Claude Desktop review or direct installation with:
 
 ```bash
 npm run build:claude-mcpb
+```
+
+Build the review-ready source zip for Anthropic submission backup with:
+
+```bash
+npm run build:claude-review-zip
 ```
 
 ## Claude Code repo-local plugin

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -747,10 +747,10 @@
           </div>
           <div class='card'>
             <h3>Build, then pitch honestly</h3>
-            <p>Use <code>npm run build:claude-mcpb</code> to package the real bundle, then market Claude workflow hardening, Pre-Action Gates, and proof-backed reliability without claiming approval before it exists.</p>
+            <p>Use <code>npm run build:claude-mcpb</code> plus the review-ready source zip to package the real bundle, then market Claude workflow hardening, Pre-Action Gates, and proof-backed reliability without claiming approval before it exists.</p>
           </div>
         </div>
-        <p class='note'><a href='__GITHUB_URL__/blob/main/.claude-plugin/README.md'>Claude extension guide</a> • <a href='__GITHUB_URL__/blob/main/docs/CLAUDE_DESKTOP_EXTENSION.md'>Submission packet</a> • <a href='https://thumbgate-production.up.railway.app/privacy'>Privacy policy</a></p>
+        <p class='note'><a href='__GITHUB_URL__/blob/main/.claude-plugin/README.md'>Claude extension guide</a> • <a href='__GITHUB_URL__/blob/main/docs/CLAUDE_DESKTOP_EXTENSION.md'>Submission packet</a> • <a href='__GITHUB_URL__/releases/latest/download/thumbgate-claude-desktop.mcpb'>Bundle download</a> • <a href='__GITHUB_URL__/releases/latest/download/thumbgate-claude-plugin-review.zip'>Review packet zip</a> • <a href='https://thumbgate-production.up.railway.app/privacy'>Privacy policy</a></p>
       </div>
     </section>
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "changeset:status": "changeset status",
     "changeset:check": "node scripts/changeset-check.js",
     "build:claude-mcpb": "node scripts/build-claude-mcpb.js",
+    "build:claude-review-zip": "node scripts/build-claude-mcpb.js --review-zip",
     "build:codex-plugin": "node scripts/build-codex-plugin.js",
     "verify:quick": "node scripts/verify-run.js quick",
     "verify:full": "node scripts/verify-run.js full",

--- a/public/index.html
+++ b/public/index.html
@@ -477,6 +477,10 @@ __GA_BOOTSTRAP__
     <div class="proof-bar">
       <a href="/guide" rel="noopener">CLI-first setup guide →</a>
       <span class="dot"></span>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener">Claude plugin bundle →</a>
+      <span class="dot"></span>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/CLAUDE_DESKTOP_EXTENSION.md" target="_blank" rel="noopener">Claude submission packet →</a>
+      <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">Codex plugin download →</a>
       <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence →</a>
@@ -517,7 +521,7 @@ __GA_BOOTSTRAP__
       </a>
       <a class="compat-card" href="/guides/claude-desktop">
         <h3>🧩 Claude Desktop plugin</h3>
-        <p>One command install. No build step, no cloud account. Grab the <code>.mcpb</code> bundle or run <code>npx thumbgate init --claude-desktop</code>.</p>
+        <p>Install the published <code>.mcpb</code> bundle today, point buyers at the submission packet, and keep the official directory story honest until Anthropic review is real.</p>
         <div class="card-arrow">Get the Claude plugin →</div>
       </a>
       <a class="compat-card" href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/plugins" target="_blank" rel="noopener">

--- a/scripts/build-claude-mcpb.js
+++ b/scripts/build-claude-mcpb.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const {
+  getClaudePluginReviewVersionedAssetName,
   getClaudePluginVersionedAssetName,
 } = require('./distribution-surfaces');
 
@@ -22,6 +23,14 @@ const RUNTIME_COPY_PATHS = [
   'public',
   '.well-known',
   '.claude-plugin',
+  'README.md',
+  'LICENSE',
+  'SECURITY.md',
+  'server.json',
+];
+const REVIEW_PACKET_COPY_PATHS = [
+  '.claude-plugin',
+  'docs/CLAUDE_DESKTOP_EXTENSION.md',
   'README.md',
   'LICENSE',
   'SECURITY.md',
@@ -173,17 +182,59 @@ function buildClaudeMcpb(outputDir = DEFAULT_OUTPUT_DIR) {
   };
 }
 
+function buildClaudeReviewZip(outputDir = DEFAULT_OUTPUT_DIR) {
+  const packageJson = readJson('package.json');
+  const reviewRoot = path.join(outputDir, 'review');
+  const reviewDirName = 'thumbgate-claude-plugin-review';
+  const stageDir = path.join(reviewRoot, reviewDirName);
+  const outputFile = path.join(outputDir, getClaudePluginReviewVersionedAssetName(packageJson.version));
+
+  fs.rmSync(reviewRoot, { recursive: true, force: true });
+  fs.mkdirSync(stageDir, { recursive: true });
+
+  for (const relativePath of REVIEW_PACKET_COPY_PATHS) {
+    copyEntry(relativePath, stageDir);
+  }
+
+  fs.rmSync(outputFile, { force: true });
+  exec('zip', ['-qr', outputFile, reviewDirName], { cwd: reviewRoot });
+
+  return {
+    stageDir,
+    outputFile,
+  };
+}
+
 if (require.main === module) {
-  const outputDir = process.argv[2]
-    ? path.resolve(process.cwd(), process.argv[2])
+  const args = process.argv.slice(2);
+  const mode = args.includes('--review-zip')
+    ? 'review-zip'
+    : args.includes('--all')
+      ? 'all'
+      : 'mcpb';
+  const outputArg = args.find((arg) => !arg.startsWith('--'));
+  const outputDir = outputArg
+    ? path.resolve(process.cwd(), outputArg)
     : DEFAULT_OUTPUT_DIR;
-  const { outputFile } = buildClaudeMcpb(outputDir);
-  console.log(`Built Claude Desktop bundle: ${outputFile}`);
+
+  if (mode === 'review-zip') {
+    const { outputFile } = buildClaudeReviewZip(outputDir);
+    console.log(`Built Claude plugin review zip: ${outputFile}`);
+  } else if (mode === 'all') {
+    const { outputFile } = buildClaudeMcpb(outputDir);
+    const { outputFile: reviewOutputFile } = buildClaudeReviewZip(outputDir);
+    console.log(`Built Claude Desktop bundle: ${outputFile}`);
+    console.log(`Built Claude plugin review zip: ${reviewOutputFile}`);
+  } else {
+    const { outputFile } = buildClaudeMcpb(outputDir);
+    console.log(`Built Claude Desktop bundle: ${outputFile}`);
+  }
 }
 
 module.exports = {
   DEFAULT_OUTPUT_DIR,
   buildClaudeMcpbManifest,
+  buildClaudeReviewZip,
   stageClaudeMcpbBundle,
   buildClaudeMcpb,
 };

--- a/scripts/build-claude-mcpb.js
+++ b/scripts/build-claude-mcpb.js
@@ -205,8 +205,7 @@ function buildClaudeReviewZip(outputDir = DEFAULT_OUTPUT_DIR) {
   };
 }
 
-if (require.main === module) {
-  const args = process.argv.slice(2);
+function resolveBuildRequest(args = [], cwd = process.cwd()) {
   const mode = args.includes('--review-zip')
     ? 'review-zip'
     : args.includes('--all')
@@ -214,20 +213,34 @@ if (require.main === module) {
       : 'mcpb';
   const outputArg = args.find((arg) => !arg.startsWith('--'));
   const outputDir = outputArg
-    ? path.resolve(process.cwd(), outputArg)
+    ? path.resolve(cwd, outputArg)
     : DEFAULT_OUTPUT_DIR;
 
+  return { mode, outputDir };
+}
+
+function runBuildRequest({ mode, outputDir }, deps = { buildClaudeMcpb, buildClaudeReviewZip }) {
   if (mode === 'review-zip') {
-    const { outputFile } = buildClaudeReviewZip(outputDir);
-    console.log(`Built Claude plugin review zip: ${outputFile}`);
-  } else if (mode === 'all') {
-    const { outputFile } = buildClaudeMcpb(outputDir);
-    const { outputFile: reviewOutputFile } = buildClaudeReviewZip(outputDir);
-    console.log(`Built Claude Desktop bundle: ${outputFile}`);
-    console.log(`Built Claude plugin review zip: ${reviewOutputFile}`);
-  } else {
-    const { outputFile } = buildClaudeMcpb(outputDir);
-    console.log(`Built Claude Desktop bundle: ${outputFile}`);
+    const { outputFile } = deps.buildClaudeReviewZip(outputDir);
+    return [`Built Claude plugin review zip: ${outputFile}`];
+  }
+
+  if (mode === 'all') {
+    const { outputFile } = deps.buildClaudeMcpb(outputDir);
+    const { outputFile: reviewOutputFile } = deps.buildClaudeReviewZip(outputDir);
+    return [
+      `Built Claude Desktop bundle: ${outputFile}`,
+      `Built Claude plugin review zip: ${reviewOutputFile}`,
+    ];
+  }
+
+  const { outputFile } = deps.buildClaudeMcpb(outputDir);
+  return [`Built Claude Desktop bundle: ${outputFile}`];
+}
+
+if (require.main === module) {
+  for (const line of runBuildRequest(resolveBuildRequest(process.argv.slice(2)))) {
+    console.log(line);
   }
 }
 
@@ -237,4 +250,6 @@ module.exports = {
   buildClaudeReviewZip,
   stageClaudeMcpbBundle,
   buildClaudeMcpb,
+  resolveBuildRequest,
+  runBuildRequest,
 };

--- a/scripts/distribution-surfaces.js
+++ b/scripts/distribution-surfaces.js
@@ -7,6 +7,8 @@ const ROOT = path.join(__dirname, '..');
 const PRODUCTHUNT_URL = 'https://www.producthunt.com/products/thumbgate';
 const CLAUDE_PLUGIN_LATEST_ASSET_NAME = 'thumbgate-claude-desktop.mcpb';
 const CLAUDE_PLUGIN_NEXT_ASSET_NAME = 'thumbgate-claude-desktop-next.mcpb';
+const CLAUDE_PLUGIN_REVIEW_LATEST_ASSET_NAME = 'thumbgate-claude-plugin-review.zip';
+const CLAUDE_PLUGIN_REVIEW_NEXT_ASSET_NAME = 'thumbgate-claude-plugin-review-next.zip';
 const CODEX_PLUGIN_LATEST_ASSET_NAME = 'thumbgate-codex-plugin.zip';
 const CODEX_PLUGIN_NEXT_ASSET_NAME = 'thumbgate-codex-plugin-next.zip';
 
@@ -27,12 +29,23 @@ function getClaudePluginVersionedAssetName(version = getPackageVersion(ROOT)) {
   return `thumbgate-claude-desktop-v${normalized}.mcpb`;
 }
 
+function getClaudePluginReviewVersionedAssetName(version = getPackageVersion(ROOT)) {
+  const normalized = String(version || '').replace(/^v/, '');
+  return `thumbgate-claude-plugin-review-v${normalized}.zip`;
+}
+
 function isPrereleaseVersion(version = getPackageVersion(ROOT)) {
   return /^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(String(version || '').trim());
 }
 
 function getClaudePluginChannelAssetName(version = getPackageVersion(ROOT)) {
   return isPrereleaseVersion(version) ? CLAUDE_PLUGIN_NEXT_ASSET_NAME : CLAUDE_PLUGIN_LATEST_ASSET_NAME;
+}
+
+function getClaudePluginReviewChannelAssetName(version = getPackageVersion(ROOT)) {
+  return isPrereleaseVersion(version)
+    ? CLAUDE_PLUGIN_REVIEW_NEXT_ASSET_NAME
+    : CLAUDE_PLUGIN_REVIEW_LATEST_ASSET_NAME;
 }
 
 function getClaudePluginLatestDownloadUrl(root = ROOT) {
@@ -42,6 +55,15 @@ function getClaudePluginLatestDownloadUrl(root = ROOT) {
 function getClaudePluginVersionedDownloadUrl(root = ROOT, version = getPackageVersion(root)) {
   const normalized = String(version || '').replace(/^v/, '');
   return `${getRepositoryUrl(root)}/releases/download/v${normalized}/${getClaudePluginVersionedAssetName(normalized)}`;
+}
+
+function getClaudePluginReviewLatestDownloadUrl(root = ROOT) {
+  return `${getRepositoryUrl(root)}/releases/latest/download/${CLAUDE_PLUGIN_REVIEW_LATEST_ASSET_NAME}`;
+}
+
+function getClaudePluginReviewVersionedDownloadUrl(root = ROOT, version = getPackageVersion(root)) {
+  const normalized = String(version || '').replace(/^v/, '');
+  return `${getRepositoryUrl(root)}/releases/download/v${normalized}/${getClaudePluginReviewVersionedAssetName(normalized)}`;
 }
 
 function getCodexPluginVersionedAssetName(version = getPackageVersion(ROOT)) {
@@ -65,11 +87,17 @@ function getCodexPluginVersionedDownloadUrl(root = ROOT, version = getPackageVer
 module.exports = {
   CLAUDE_PLUGIN_LATEST_ASSET_NAME,
   CLAUDE_PLUGIN_NEXT_ASSET_NAME,
+  CLAUDE_PLUGIN_REVIEW_LATEST_ASSET_NAME,
+  CLAUDE_PLUGIN_REVIEW_NEXT_ASSET_NAME,
   CODEX_PLUGIN_LATEST_ASSET_NAME,
   CODEX_PLUGIN_NEXT_ASSET_NAME,
   PRODUCTHUNT_URL,
   getClaudePluginChannelAssetName,
   getClaudePluginLatestDownloadUrl,
+  getClaudePluginReviewChannelAssetName,
+  getClaudePluginReviewLatestDownloadUrl,
+  getClaudePluginReviewVersionedAssetName,
+  getClaudePluginReviewVersionedDownloadUrl,
   getClaudePluginVersionedAssetName,
   getClaudePluginVersionedDownloadUrl,
   getCodexPluginChannelAssetName,

--- a/tests/claude-mcpb.test.js
+++ b/tests/claude-mcpb.test.js
@@ -7,10 +7,27 @@ const path = require('node:path');
 const packageJson = require('../package.json');
 const { TOOLS } = require('../scripts/tool-registry');
 const {
+  getClaudePluginChannelAssetName,
+  getClaudePluginLatestDownloadUrl,
+  CLAUDE_PLUGIN_REVIEW_NEXT_ASSET_NAME,
+  getCodexPluginChannelAssetName,
+  getCodexPluginLatestDownloadUrl,
+  getCodexPluginVersionedAssetName,
+  getCodexPluginVersionedDownloadUrl,
+  getPackageVersion,
+  getClaudePluginReviewChannelAssetName,
+  getClaudePluginReviewLatestDownloadUrl,
+  getClaudePluginReviewVersionedAssetName,
+  getClaudePluginReviewVersionedDownloadUrl,
+  getClaudePluginVersionedDownloadUrl,
+  getRepositoryUrl,
   getClaudePluginVersionedAssetName,
 } = require('../scripts/distribution-surfaces');
 const {
   buildClaudeMcpbManifest,
+  buildClaudeReviewZip,
+  resolveBuildRequest,
+  runBuildRequest,
   stageClaudeMcpbBundle,
 } = require('../scripts/build-claude-mcpb');
 
@@ -71,6 +88,120 @@ test('claude mcpb staging writes a submission-ready bundle directory', () => {
   } finally {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }
+});
+
+test('claude review zip staging writes a review-ready packet and zip', () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-review-stage-'));
+
+  try {
+    const { stageDir, outputFile } = buildClaudeReviewZip(outputDir);
+
+    assert.equal(fs.existsSync(path.join(stageDir, '.claude-plugin', 'plugin.json')), true);
+    assert.equal(fs.existsSync(path.join(stageDir, 'docs', 'CLAUDE_DESKTOP_EXTENSION.md')), true);
+    assert.equal(fs.existsSync(path.join(stageDir, 'README.md')), true);
+    assert.equal(fs.existsSync(path.join(stageDir, 'LICENSE')), true);
+    assert.equal(fs.existsSync(path.join(stageDir, 'server.json')), true);
+    assert.equal(fs.existsSync(outputFile), true);
+    assert.equal(path.basename(outputFile), getClaudePluginReviewVersionedAssetName(packageJson.version));
+    assert.ok(fs.statSync(outputFile).size > 0);
+  } finally {
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test('review zip distribution surfaces stay canonical for stable and prerelease channels', () => {
+  const repoRoot = path.join(__dirname, '..');
+
+  assert.equal(getPackageVersion(repoRoot), packageJson.version);
+  assert.equal(getRepositoryUrl(repoRoot), 'https://github.com/IgorGanapolsky/ThumbGate');
+  assert.equal(getClaudePluginChannelAssetName('1.2.3'), 'thumbgate-claude-desktop.mcpb');
+  assert.equal(getClaudePluginChannelAssetName('1.2.3-beta.1'), 'thumbgate-claude-desktop-next.mcpb');
+  assert.equal(
+    getClaudePluginReviewVersionedAssetName('1.2.3'),
+    'thumbgate-claude-plugin-review-v1.2.3.zip'
+  );
+  assert.equal(
+    getClaudePluginReviewChannelAssetName('1.2.3'),
+    'thumbgate-claude-plugin-review.zip'
+  );
+  assert.equal(
+    getClaudePluginReviewChannelAssetName('1.2.3-beta.1'),
+    CLAUDE_PLUGIN_REVIEW_NEXT_ASSET_NAME
+  );
+  assert.match(
+    getClaudePluginLatestDownloadUrl(repoRoot),
+    /releases\/latest\/download\/thumbgate-claude-desktop\.mcpb$/
+  );
+  assert.match(
+    getClaudePluginVersionedDownloadUrl(repoRoot, '1.2.3'),
+    /releases\/download\/v1\.2\.3\/thumbgate-claude-desktop-v1\.2\.3\.mcpb$/
+  );
+  assert.match(
+    getClaudePluginReviewLatestDownloadUrl(repoRoot),
+    /releases\/latest\/download\/thumbgate-claude-plugin-review\.zip$/
+  );
+  assert.match(
+    getClaudePluginReviewVersionedDownloadUrl(repoRoot, '1.2.3'),
+    /releases\/download\/v1\.2\.3\/thumbgate-claude-plugin-review-v1\.2\.3\.zip$/
+  );
+  assert.equal(getCodexPluginVersionedAssetName('1.2.3'), 'thumbgate-codex-plugin-v1.2.3.zip');
+  assert.equal(getCodexPluginChannelAssetName('1.2.3'), 'thumbgate-codex-plugin.zip');
+  assert.equal(getCodexPluginChannelAssetName('1.2.3-beta.1'), 'thumbgate-codex-plugin-next.zip');
+  assert.match(
+    getCodexPluginLatestDownloadUrl(repoRoot),
+    /releases\/latest\/download\/thumbgate-codex-plugin\.zip$/
+  );
+  assert.match(
+    getCodexPluginVersionedDownloadUrl(repoRoot, '1.2.3'),
+    /releases\/download\/v1\.2\.3\/thumbgate-codex-plugin-v1\.2\.3\.zip$/
+  );
+});
+
+test('build request helpers route Claude bundle modes without invoking packaging in tests', () => {
+  const stableRequest = resolveBuildRequest([], '/tmp/thumbgate');
+  const reviewRequest = resolveBuildRequest(['--review-zip', 'dist/review'], '/tmp/thumbgate');
+  const allRequest = resolveBuildRequest(['--all'], '/tmp/thumbgate');
+  const calls = [];
+  const deps = {
+    buildClaudeMcpb(outputDir) {
+      calls.push(['mcpb', outputDir]);
+      return { outputFile: path.join(outputDir, 'bundle.mcpb') };
+    },
+    buildClaudeReviewZip(outputDir) {
+      calls.push(['review', outputDir]);
+      return { outputFile: path.join(outputDir, 'review.zip') };
+    },
+  };
+
+  assert.deepEqual(stableRequest, {
+    mode: 'mcpb',
+    outputDir: path.join(__dirname, '..', '.artifacts', 'claude-desktop'),
+  });
+  assert.deepEqual(reviewRequest, {
+    mode: 'review-zip',
+    outputDir: path.resolve('/tmp/thumbgate', 'dist/review'),
+  });
+  assert.deepEqual(allRequest, {
+    mode: 'all',
+    outputDir: path.join(__dirname, '..', '.artifacts', 'claude-desktop'),
+  });
+
+  assert.deepEqual(runBuildRequest(stableRequest, deps), [
+    `Built Claude Desktop bundle: ${path.join(stableRequest.outputDir, 'bundle.mcpb')}`,
+  ]);
+  assert.deepEqual(runBuildRequest(reviewRequest, deps), [
+    `Built Claude plugin review zip: ${path.resolve('/tmp/thumbgate', 'dist/review', 'review.zip')}`,
+  ]);
+  assert.deepEqual(runBuildRequest(allRequest, deps), [
+    `Built Claude Desktop bundle: ${path.join(allRequest.outputDir, 'bundle.mcpb')}`,
+    `Built Claude plugin review zip: ${path.join(allRequest.outputDir, 'review.zip')}`,
+  ]);
+  assert.deepEqual(calls, [
+    ['mcpb', stableRequest.outputDir],
+    ['review', reviewRequest.outputDir],
+    ['mcpb', allRequest.outputDir],
+    ['review', allRequest.outputDir],
+  ]);
 });
 
 test('claude desktop submission doc covers history-aware lesson distillation', () => {

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -550,7 +550,7 @@ test('Dependabot auto-merge trusts the pull request author instead of the trigge
   assert.doesNotMatch(workflow, /gh pr checks "\$PR_URL"/);
 });
 
-test('Publish Claude Plugin workflow builds the MCPB and uploads channel-safe release assets', () => {
+test('Publish Claude Plugin workflow builds the MCPB and review zip and uploads channel-safe release assets', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'publish-claude-plugin.yml'), 'utf8');
 
   assert.match(workflow, /name: Publish Claude Plugin/);
@@ -559,18 +559,22 @@ test('Publish Claude Plugin workflow builds the MCPB and uploads channel-safe re
   assert.match(workflow, /cancel-in-progress:\s*true/);
   assert.match(workflow, /npm ci --onnxruntime-node-install-cuda=skip/);
   assert.match(workflow, /npm run build:claude-mcpb/);
+  assert.match(workflow, /npm run build:claude-review-zip/);
   assert.match(workflow, /scripts\/distribution-surfaces/);
   assert.match(workflow, /version=\$\(node -p "require\('\.\/package\.json'\)\.version"\)/);
-  assert.match(workflow, /versioned_asset=\$\(node -e "const \{ getClaudePluginVersionedAssetName \} = require\('\.\/scripts\/distribution-surfaces'\); process\.stdout\.write\(getClaudePluginVersionedAssetName\(\)\)"\)/);
-  assert.match(workflow, /channel_asset=\$\(node -e "const \{ getClaudePluginChannelAssetName \} = require\('\.\/scripts\/distribution-surfaces'\); process\.stdout\.write\(getClaudePluginChannelAssetName\(\)\)"\)/);
+  assert.match(workflow, /versioned_bundle=\$\(node -e "const \{ getClaudePluginVersionedAssetName \} = require\('\.\/scripts\/distribution-surfaces'\); process\.stdout\.write\(getClaudePluginVersionedAssetName\(\)\)"\)/);
+  assert.match(workflow, /channel_bundle=\$\(node -e "const \{ getClaudePluginChannelAssetName \} = require\('\.\/scripts\/distribution-surfaces'\); process\.stdout\.write\(getClaudePluginChannelAssetName\(\)\)"\)/);
+  assert.match(workflow, /versioned_review=\$\(node -e "const \{ getClaudePluginReviewVersionedAssetName \} = require\('\.\/scripts\/distribution-surfaces'\); process\.stdout\.write\(getClaudePluginReviewVersionedAssetName\(\)\)"\)/);
+  assert.match(workflow, /channel_review=\$\(node -e "const \{ getClaudePluginReviewChannelAssetName \} = require\('\.\/scripts\/distribution-surfaces'\); process\.stdout\.write\(getClaudePluginReviewChannelAssetName\(\)\)"\)/);
   assert.match(workflow, /is_prerelease=\$\(node -e "const \{ isPrereleaseVersion \} = require\('\.\/scripts\/distribution-surfaces'\); process\.stdout\.write\(String\(isPrereleaseVersion\(\)\)\)"\)/);
   assert.doesNotMatch(workflow, /require\\+"/);
-  assert.match(workflow, /claude-plugin-mcpb/);
+  assert.match(workflow, /claude-plugin-assets/);
   assert.match(workflow, /gh release create/);
   assert.match(workflow, /gh release upload/);
   assert.match(workflow, /--clobber/);
-  assert.match(workflow, /Create channel asset alias/);
-  assert.match(workflow, /steps\.assets\.outputs\.channel_asset/);
+  assert.match(workflow, /Create release asset aliases/);
+  assert.match(workflow, /steps\.assets\.outputs\.channel_bundle/);
+  assert.match(workflow, /steps\.assets\.outputs\.channel_review/);
   assert.match(workflow, /--prerelease/);
 });
 

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -9,10 +9,13 @@ const {
 } = require('../scripts/hosted-config');
 const {
   CLAUDE_PLUGIN_NEXT_ASSET_NAME,
+  CLAUDE_PLUGIN_REVIEW_NEXT_ASSET_NAME,
   CODEX_PLUGIN_NEXT_ASSET_NAME,
   PRODUCTHUNT_URL,
   getClaudePluginChannelAssetName,
   getClaudePluginLatestDownloadUrl,
+  getClaudePluginReviewChannelAssetName,
+  getClaudePluginReviewLatestDownloadUrl,
   getCodexPluginChannelAssetName,
   getCodexPluginLatestDownloadUrl,
 } = require('../scripts/distribution-surfaces');
@@ -84,7 +87,9 @@ test('public docs render the current package version', () => {
   assert.match(claudePluginReadme, /Support/i);
   assert.match(claudePluginReadme, /claude mcp add thumbgate -- npx --yes --package thumbgate thumbgate serve/i);
   assert.match(claudePluginReadme, /npm run build:claude-mcpb/i);
+  assert.match(claudePluginReadme, /npm run build:claude-review-zip/i);
   assert.match(claudePluginReadme, new RegExp(getClaudePluginLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(claudePluginReadme, new RegExp(getClaudePluginReviewLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.match(claudeCodexBridgeReadme, /claude --plugin-dir/i);
   assert.match(claudeCodexBridgeReadme, /claude plugin validate/i);
   assert.match(claudeCodexBridgeInstall, /\/codex-bridge:review/);
@@ -97,11 +102,14 @@ test('public docs render the current package version', () => {
   assert.match(distributionDoc, /publish-codex-plugin\.yml/);
   assert.match(distributionDoc, /thumbgate-codex-plugin\.zip/);
   assert.match(distributionDoc, new RegExp(getCodexPluginLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(distributionDoc, /build:claude-review-zip/);
+  assert.match(distributionDoc, new RegExp(getClaudePluginReviewLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.match(claudeDesktopPacket, /Anthropic Local MCP Server Submission Guide/i);
   assert.match(claudeDesktopPacket, /Build the MCPB/i);
   assert.match(claudeDesktopPacket, /privacy_policies/i);
   assert.match(claudeDesktopPacket, /npm run build:claude-mcpb/i);
   assert.match(claudeDesktopPacket, new RegExp(getClaudePluginLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(claudeDesktopPacket, new RegExp(getClaudePluginReviewLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.match(claudeDesktopPacket, /Tool safety annotations/i);
   assert.match(claudeDesktopPacket, /Do not claim directory approval/i);
   assert.ok(productHuntKit.includes(PRODUCTHUNT_URL));
@@ -114,6 +122,8 @@ test('public docs render the current package version', () => {
 test('distribution surfaces reserve a separate prerelease Claude asset alias', () => {
   assert.equal(getClaudePluginChannelAssetName('1.0.0'), 'thumbgate-claude-desktop.mcpb');
   assert.equal(getClaudePluginChannelAssetName('1.1.0-beta.1'), CLAUDE_PLUGIN_NEXT_ASSET_NAME);
+  assert.equal(getClaudePluginReviewChannelAssetName('1.0.0'), 'thumbgate-claude-plugin-review.zip');
+  assert.equal(getClaudePluginReviewChannelAssetName('1.1.0-beta.1'), CLAUDE_PLUGIN_REVIEW_NEXT_ASSET_NAME);
   assert.equal(getCodexPluginChannelAssetName('1.0.0'), 'thumbgate-codex-plugin.zip');
   assert.equal(getCodexPluginChannelAssetName('1.1.0-beta.1'), CODEX_PLUGIN_NEXT_ASSET_NAME);
 });


### PR DESCRIPTION
## Summary\n- make the top-level README and public landing surfaces more Claude-first\n- publish a review-ready Claude plugin source zip alongside the  bundle\n- document the Anthropic submission lane without claiming directory approval\n\n## Verification\n- node --test tests/version-metadata.test.js tests/public-landing.test.js\n- node --test tests/claude-mcpb.test.js\n- node scripts/build-claude-mcpb.js --review-zip .artifacts/claude-desktop-smoke\n- node scripts/build-claude-mcpb.js .artifacts/claude-desktop-mcpb-smoke\n