### PR TITLE
fix: isolate test fixtures from environment signing and learned policy state

### DIFF
--- a/.changeset/fix-test-isolation-signing-learned-policy.md
+++ b/.changeset/fix-test-isolation-signing-learned-policy.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix test fixture isolation: disable commit signing in temp git repos and use empty feedback dir in workflow-sentinel unit tests so CI environments with signing servers and accumulated learned-policy data don't cause false failures.

--- a/tests/operational-integrity.test.js
+++ b/tests/operational-integrity.test.js
@@ -35,6 +35,7 @@ function createTempGitRepo() {
   execFileSync('git', ['init', '--initial-branch=main'], { cwd: repoDir, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.name', 'ThumbGate Test'], { cwd: repoDir, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'thumbgate@example.com'], { cwd: repoDir, stdio: 'ignore' });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: repoDir, stdio: 'ignore' });
   fs.writeFileSync(path.join(repoDir, 'package.json'), JSON.stringify({ name: 'thumbgate-temp', version: '1.0.0' }, null, 2));
   execFileSync('git', ['add', 'package.json'], { cwd: repoDir, stdio: 'ignore' });
   execFileSync('git', ['commit', '-m', 'init'], { cwd: repoDir, stdio: 'ignore' });

--- a/tests/workflow-sentinel.test.js
+++ b/tests/workflow-sentinel.test.js
@@ -33,6 +33,9 @@ function makeTempPath(name) {
 }
 
 test('workflow sentinel warns on multi-surface release-sensitive blast radius', () => {
+  // Use an isolated empty feedbackDir so local learned policy data does not
+  // inflate the risk score beyond the warn threshold in this deterministic test.
+  const isolatedFeedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-sentinel-fb-'));
   const report = evaluateWorkflowSentinel('Bash', {
     command: 'node scripts/deploy-policy.js --dry-run',
     changed_files: [
@@ -43,6 +46,8 @@ test('workflow sentinel warns on multi-surface release-sensitive blast radius', 
     ],
   }, {
     repoPath: process.cwd(),
+    feedbackDir: isolatedFeedbackDir,
+    feedbackOptions: { feedbackDir: isolatedFeedbackDir },
     governanceState: {
       taskScope: {
         summary: 'sentinel dry run',


### PR DESCRIPTION
## Summary

- **`tests/operational-integrity.test.js`**: add `commit.gpgsign false` to `createTempGitRepo()` — temp-repo tests were failing when the CI environment has a commit-signing server that requires a `source` header not present in throwaway repos (exit 128 on every `git commit -m init`)

- **`tests/workflow-sentinel.test.js`**: pass an empty `isolatedFeedbackDir` to the multi-surface warn test — local learned-policy data (trained on real feedback) was pushing the risk score from ~0.64 to 0.8756, crossing the deny threshold and breaking a deterministic unit test that expected `warn`

Both failures were environment-coupling bugs in the test fixtures, not regressions in production scripts.

## Test plan
- [x] `npm test` — 3412 tests, 0 failures (was 8 failures on main before this fix)
- [x] `npm run test:operational-integrity` — all temp-repo tests pass
- [x] `npm run test:gates` — workflow-sentinel warn test passes (decision = warn)

https://claude.ai/code/session_01D3yuBU4odVjeKWNNmwqdvt