### PR TITLE
[codex] feat: add Ralph Loop audience engagement CI

### DIFF
--- a/.changeset/ralph-loop-audience-ci.md
+++ b/.changeset/ralph-loop-audience-ci.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Add Ralph Loop CI for always-on audience engagement, with hourly analytics polling, stateful reply monitoring, launch asset sync, and Reliability Gateway evidence artifacts.

--- a/.github/workflows/ralph-loop.yml
+++ b/.github/workflows/ralph-loop.yml
@@ -1,0 +1,134 @@
+name: Ralph Loop Audience Engagement
+
+# Ralph Mode is the always-on acquisition loop:
+# - hourly audience sensing and reply monitoring
+# - cache-backed state so CI does not forget handled replies
+# - Reddit remains draft-only; X replies still pass the social quality gate
+# - outbound campaign posts stay in the separate Ralph Mode workflow
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Ralph mode to run'
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - engage
+          - poll
+          - audit
+          - post
+      dry_run:
+        description: 'Detect and draft without live replies/posts'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ralph-loop-audience-state
+  cancel-in-progress: true
+
+jobs:
+  ralph-loop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
+      ZERNIO_INSTAGRAM_ACCOUNT_ID: ${{ secrets.ZERNIO_INSTAGRAM_ACCOUNT_ID }}
+      ZERNIO_LINKEDIN_ACCOUNT_ID: ${{ secrets.ZERNIO_LINKEDIN_ACCOUNT_ID }}
+      ZERNIO_PROFILE_ID: ${{ secrets.ZERNIO_PROFILE_ID }}
+      ZERNIO_REDDIT_ACCOUNT_ID: ${{ secrets.ZERNIO_REDDIT_ACCOUNT_ID }}
+      ZERNIO_TIKTOK_ACCOUNT_ID: ${{ secrets.ZERNIO_TIKTOK_ACCOUNT_ID }}
+      ZERNIO_YOUTUBE_ACCOUNT_ID: ${{ secrets.ZERNIO_YOUTUBE_ACCOUNT_ID }}
+      X_API_KEY: ${{ secrets.X_API_KEY }}
+      X_API_SECRET: ${{ secrets.X_API_SECRET }}
+      X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+      X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+      X_BEARER_TOKEN: ${{ secrets.X_BEARER_TOKEN }}
+      X_USER_ID: ${{ secrets.X_USER_ID }}
+      X_USERNAME: ${{ secrets.X_USERNAME }}
+      TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+      TWITTER_API_SECRET: ${{ secrets.TWITTER_API_SECRET }}
+      TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
+      TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+      TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
+      REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+      REDDIT_USERNAME: ${{ secrets.REDDIT_USERNAME }}
+      REDDIT_PASSWORD: ${{ secrets.REDDIT_PASSWORD }}
+      LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+      LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
+      PLAUSIBLE_API_KEY: ${{ secrets.PLAUSIBLE_API_KEY }}
+      PLAUSIBLE_SITE_ID: ${{ secrets.PLAUSIBLE_SITE_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --onnxruntime-node-install-cuda=skip
+
+      - name: Prepare Ralph state directories
+        run: mkdir -p .thumbgate .artifacts/ralph-loop
+
+      - name: Restore Ralph state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .thumbgate/reply-monitor-state.json
+            .thumbgate/reply-drafts.jsonl
+            .thumbgate/social-launch-assets.json
+          key: ralph-loop-state-${{ github.run_id }}
+          restore-keys: |
+            ralph-loop-state-
+
+      - name: Run Ralph Loop
+        run: |
+          MODE="${{ github.event.inputs.mode }}"
+          if [ -z "$MODE" ]; then
+            MODE="all"
+          fi
+
+          DRY_RUN_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+
+          node scripts/ralph-loop.js --mode="$MODE" $DRY_RUN_FLAG --artifact-dir=.artifacts/ralph-loop
+
+      - name: Upload Ralph evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ralph-loop-${{ github.run_id }}
+          path: |
+            .artifacts/ralph-loop/
+            .thumbgate/reply-drafts.jsonl
+            .thumbgate/social-launch-assets.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Save Ralph state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .thumbgate/reply-monitor-state.json
+            .thumbgate/reply-drafts.jsonl
+            .thumbgate/social-launch-assets.json
+          key: ralph-loop-state-${{ github.run_id }}

--- a/.github/workflows/ralph-mode.yml
+++ b/.github/workflows/ralph-mode.yml
@@ -1,9 +1,21 @@
 name: Ralph Mode - 24/7 Engagement Loop
 
+# Ralph Mode handles outbound campaign posts and GitHub/dev.to outreach.
+# Ralph Loop Audience Engagement handles hourly reply sensing, analytics, and
+# draft-safe audience replies. Keep both lanes stateful so CI does not repeat
+# the same contact or forget previous engagement.
+
 on:
   schedule:
     - cron: '0 */2 * * *'  # Every 2 hours
   workflow_dispatch: {}      # Manual trigger
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ralph-mode-outbound-state
+  cancel-in-progress: true
 
 jobs:
   ralph-mode:
@@ -15,6 +27,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Prepare Ralph Mode state
+        run: mkdir -p .thumbgate .artifacts/ralph-mode
+
+      - name: Restore Ralph Mode state
+        uses: actions/cache/restore@v4
+        with:
+          path: .thumbgate/ralph-state.json
+          key: ralph-mode-state-${{ github.run_id }}
+          restore-keys: |
+            ralph-mode-state-
 
       - name: Ralph Mode - X + LinkedIn + GitHub + dev.to
         env:
@@ -30,3 +53,19 @@ jobs:
           ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
         run: |
           node scripts/ralph-mode-ci.js
+
+      - name: Upload Ralph Mode evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ralph-mode-state-${{ github.run_id }}
+          path: .thumbgate/ralph-state.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Save Ralph Mode state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .thumbgate/ralph-state.json
+          key: ralph-mode-state-${{ github.run_id }}

--- a/.github/workflows/reply-monitor.yml
+++ b/.github/workflows/reply-monitor.yml
@@ -1,15 +1,14 @@
 name: Social Reply Monitor
 
 # Monitors Reddit, X.com, and LinkedIn for replies to ThumbGate posts and
-# generates contextual responses. Runs every 6 hours to stay within API rate
-# limits while keeping reply latency acceptable.
+# generates contextual responses. Scheduled audience engagement now lives in
+# Ralph Loop Audience Engagement, which restores cache-backed state between CI
+# runs. Keep this workflow as an explicit manual fallback only.
 #
 # Reddit replies are NEVER auto-posted — they are saved to
 # .thumbgate/reply-drafts.jsonl for human review (per script policy).
 
 on:
-  schedule:
-    - cron: '0 */6 * * *'   # Every 6 hours (00:00, 06:00, 12:00, 18:00 UTC)
   workflow_dispatch:
     inputs:
       platform:

--- a/.github/workflows/social-engagement-hourly.yml
+++ b/.github/workflows/social-engagement-hourly.yml
@@ -2,8 +2,7 @@ name: Social Engagement (Smart Schedule)
 
 # Strategy based on research of Linear, Vercel, Supabase, PostHog, Cursor, Raycast, Cal.com:
 # - 1 quality post/day (not 24 spam posts)
-# - Reply monitoring 4x/day (engagement in first hour is critical for algorithms)
-# - Analytics poll 2x/day
+# - Reply monitoring and analytics polling are owned by Ralph Loop Audience Engagement
 # - Content rotates: horror stories, hot takes, tips, product demos
 # - No Dev.to auto-posting (counterproductive at high volume)
 # - Reddit: reply-only, no auto-posting (ban risk)
@@ -12,8 +11,6 @@ on:
   schedule:
     # Post once daily at 2pm UTC (10am EST — peak dev engagement)
     - cron: '0 14 * * *'
-    # Reply monitor: 4x/day (9am, 1pm, 5pm, 9pm UTC)
-    - cron: '0 9,13,17,21 * * *'
   workflow_dispatch:
     inputs:
       action:
@@ -74,9 +71,8 @@ jobs:
           node scripts/social-post-hourly.js $DRY_RUN
 
   reply-to-comments:
-    # Runs 4x/day on reply-monitor schedule, or on manual trigger
+    # Manual fallback only. Scheduled reply engagement is owned by Ralph Loop.
     if: >-
-      github.event.schedule == '0 9,13,17,21 * * *' ||
       github.event.inputs.action == 'all' ||
       github.event.inputs.action == 'reply'
     runs-on: ubuntu-latest
@@ -120,9 +116,8 @@ jobs:
           node scripts/social-reply-monitor.js $DRY_RUN
 
   poll-analytics:
-    # Runs 2x/day: at 9am and 9pm UTC
+    # Manual fallback only. Scheduled analytics polling is owned by Ralph Loop.
     if: >-
-      github.event.schedule == '0 9,13,17,21 * * *' ||
       github.event.inputs.action == 'all' ||
       github.event.inputs.action == 'poll'
     runs-on: ubuntu-latest

--- a/docs/marketing/social-automation.md
+++ b/docs/marketing/social-automation.md
@@ -14,6 +14,34 @@ It exists so we can ship founder-style IG and TikTok content without filming, ma
 6. Blocks duplicate live publishes via `.thumbgate/social-post-history.jsonl` unless `--force` is supplied.
 7. Publishes through the already-authenticated Chrome session for Instagram and TikTok.
 
+## Ralph Mode CI
+
+Ralph Mode is the always-on acquisition loop for audience engagement. Two GitHub Actions workflows
+share the lane:
+
+- `.github/workflows/ralph-mode.yml` runs every two hours for outbound campaign posts, GitHub issue
+  monitoring, repo discovery, and dev.to outreach through `scripts/ralph-mode-ci.js`. It restores
+  and saves `.thumbgate/ralph-state.json` so CI does not re-contact the same audience.
+- `.github/workflows/ralph-loop.yml` runs hourly for audience sensing, reply monitoring, analytics
+  polling, launch asset sync, and machine-readable evidence from `scripts/ralph-loop.js`.
+
+The guardrails are intentional:
+
+- Reddit stays draft-only. Suggested replies go to `.thumbgate/reply-drafts.jsonl`.
+- X replies pass the contextual social quality gate before posting.
+- LinkedIn comment intake remains limited until the required API approval is available.
+- Ralph Mode outbound state and Ralph Loop reply state are cache-backed so CI does not spam the audience.
+- Ralph reports link back to [VERIFICATION_EVIDENCE.md](../VERIFICATION_EVIDENCE.md) for authority evidence.
+
+Run the same loop locally:
+
+```bash
+node scripts/ralph-loop.js --mode=all --dry-run
+```
+
+Manual CI modes are `all`, `engage`, `poll`, `audit`, and `post`. The scheduled hourly mode uses
+`all`, which senses, engages, and audits without invoking the manual-post lane.
+
 ## Canonical Source
 
 - Carousel HTML: [assets/pre-action-gates-instagram-carousel.html](./assets/pre-action-gates-instagram-carousel.html)

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "test:training-export": "node --test tests/training-export.test.js tests/databricks-export.test.js",
     "test:deployment": "node --test tests/deployment.test.js tests/deploy-policy.test.js tests/publish-decision.test.js tests/changeset-check.test.js tests/sonarcloud-workflow.test.js",
     "test:operational-integrity": "node --test tests/operational-integrity.test.js tests/sync-branch-protection.test.js",
-    "test:workflow": "node --test tests/workflow-contract.test.js tests/social-marketing-assets.test.js tests/social-pipeline.test.js tests/positioning-contract.test.js tests/docs-claim-hygiene.test.js tests/workflow-runs.test.js tests/workflow-sprint-intake.test.js tests/gtm-revenue-loop.test.js tests/enterprise-story.test.js",
+    "test:workflow": "node --test tests/workflow-contract.test.js tests/social-marketing-assets.test.js tests/social-pipeline.test.js tests/positioning-contract.test.js tests/docs-claim-hygiene.test.js tests/workflow-runs.test.js tests/workflow-sprint-intake.test.js tests/gtm-revenue-loop.test.js tests/enterprise-story.test.js tests/ralph-loop.test.js",
     "test:billing": "node --test tests/billing.test.js",
     "test:cli": "node --test tests/analytics-report.test.js tests/creator-campaigns.test.js tests/cli.test.js tests/codex-bridge-script.test.js tests/dispatch-brief.test.js tests/feedback-normalize.test.js tests/install-mcp.test.js tests/pr-manager.test.js tests/pro-local-dashboard.test.js tests/published-cli.test.js tests/revenue-status.test.js",
     "test:evolution": "node --test tests/workspace-evolver.test.js",

--- a/scripts/ralph-loop.js
+++ b/scripts/ralph-loop.js
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const {
+  buildEngagementAudit,
+  DEFAULT_DRAFTS_PATH,
+  DEFAULT_LAUNCH_ASSETS_PATH,
+  DEFAULT_REPLY_STATE_PATH,
+  DEFAULT_TIMEZONE,
+} = require('./social-analytics/engagement-audit');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_ARTIFACT_DIR = path.join(REPO_ROOT, '.artifacts', 'ralph-loop');
+const VALID_MODES = new Set(['all', 'engage', 'poll', 'audit', 'post']);
+const RALPH_STATE_PATHS = [
+  path.relative(REPO_ROOT, DEFAULT_REPLY_STATE_PATH),
+  path.relative(REPO_ROOT, DEFAULT_DRAFTS_PATH),
+  path.relative(REPO_ROOT, DEFAULT_LAUNCH_ASSETS_PATH),
+];
+const VALUE_OPTIONS = new Map([
+  ['--artifact-dir', 'artifactDir'],
+  ['--date', 'date'],
+  ['--mode', 'mode'],
+  ['--timezone', 'timezone'],
+]);
+
+function parseArgs(argv = []) {
+  const options = {
+    artifactDir: DEFAULT_ARTIFACT_DIR,
+    date: '',
+    dryRun: false,
+    mode: 'all',
+    timezone: DEFAULT_TIMEZONE,
+    replyStatePath: DEFAULT_REPLY_STATE_PATH,
+    draftsPath: DEFAULT_DRAFTS_PATH,
+    launchAssetsPath: DEFAULT_LAUNCH_ASSETS_PATH,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    index = consumeArg(options, argv, index);
+  }
+
+  options.mode = normalizeMode(options.mode);
+  return options;
+}
+
+function consumeArg(options, argv, index) {
+  const token = String(argv[index] || '').trim();
+  if (token === '--dry-run') {
+    options.dryRun = true;
+    return index;
+  }
+
+  const inline = token.match(/^(--[^=]+)=(.*)$/);
+  if (inline && VALUE_OPTIONS.has(inline[1])) {
+    setOption(options, VALUE_OPTIONS.get(inline[1]), inline[2]);
+    return index;
+  }
+
+  if (VALUE_OPTIONS.has(token) && argv[index + 1]) {
+    setOption(options, VALUE_OPTIONS.get(token), argv[index + 1]);
+    return index + 1;
+  }
+
+  return index;
+}
+
+function setOption(options, name, value) {
+  const trimmed = String(value || '').trim();
+  if (name === 'artifactDir') {
+    options.artifactDir = path.resolve(trimmed || DEFAULT_ARTIFACT_DIR);
+    return;
+  }
+  if (name === 'timezone') {
+    options.timezone = trimmed || DEFAULT_TIMEZONE;
+    return;
+  }
+  options[name] = trimmed || options[name];
+}
+
+function normalizeMode(mode) {
+  const normalized = String(mode || 'all').trim().toLowerCase();
+  if (!VALID_MODES.has(normalized)) {
+    throw new Error(`Invalid Ralph mode: ${mode}. Expected one of: ${[...VALID_MODES].join(', ')}`);
+  }
+  return normalized;
+}
+
+function hasAnyEnv(env, keys = []) {
+  return keys.some((key) => Boolean(env[key]));
+}
+
+function hasAllEnv(env, keys = []) {
+  return keys.every((key) => Boolean(env[key]));
+}
+
+function makeNodeStep(id, scriptPath, args = [], extra = {}) {
+  return {
+    id,
+    command: process.execPath,
+    args: [path.join(REPO_ROOT, scriptPath), ...args],
+    scriptPath,
+    type: 'node',
+    ...extra,
+  };
+}
+
+function withSkipReason(step, env) {
+  if (step.requiredEnvAll && !hasAllEnv(env, step.requiredEnvAll)) {
+    return {
+      ...step,
+      skipReason: `missing env: ${step.requiredEnvAll.filter((key) => !env[key]).join(', ')}`,
+    };
+  }
+  if (step.requiredEnvAny && !hasAnyEnv(env, step.requiredEnvAny)) {
+    return {
+      ...step,
+      skipReason: `missing one of: ${step.requiredEnvAny.join(', ')}`,
+    };
+  }
+  return step;
+}
+
+function wants(mode, names) {
+  return mode === 'all' || names.includes(mode);
+}
+
+function buildRalphSteps(options = {}, env = process.env) {
+  const mode = normalizeMode(options.mode || 'all');
+  const dryRun = Boolean(options.dryRun);
+  const steps = [];
+
+  if (wants(mode, ['poll'])) {
+    steps.push(makeNodeStep(
+      'poll-analytics',
+      'scripts/social-analytics/poll-all.js',
+      [],
+      {
+        stage: 'sense',
+        description: 'Polls configured social analytics for audience and attribution signals.',
+      }
+    ));
+  }
+
+  if (wants(mode, ['engage'])) {
+    steps.push(withSkipReason(makeNodeStep(
+      'sync-launch-assets',
+      'scripts/social-analytics/sync-launch-assets.js',
+      ['--limit=50', `--state-path=${options.launchAssetsPath || DEFAULT_LAUNCH_ASSETS_PATH}`],
+      {
+        stage: 'sense',
+        description: 'Syncs owned Zernio launch assets so reply monitoring anchors on current campaign posts.',
+        requiredEnvAll: ['ZERNIO_API_KEY'],
+      }
+    ), env));
+
+    const replyArgs = [];
+    if (dryRun) {
+      replyArgs.push('--dry-run');
+    }
+    steps.push(makeNodeStep(
+      'reply-monitor',
+      'scripts/social-reply-monitor.js',
+      replyArgs,
+      {
+        stage: 'engage',
+        description: 'Checks Reddit, X, and LinkedIn reply surfaces with platform-safe posting and draft rules.',
+      }
+    ));
+  }
+
+  if (mode === 'post') {
+    const postArgs = [];
+    if (dryRun) {
+      postArgs.push('--dry-run');
+    }
+    steps.push(makeNodeStep(
+      'daily-social-post',
+      'scripts/social-post-hourly.js',
+      postArgs,
+      {
+        stage: 'publish',
+        description: 'Runs the one-quality-post lane on demand. Ralph hourly mode does not call this step.',
+        requiredEnvAll: ['ZERNIO_API_KEY'],
+      }
+    ));
+  }
+
+  steps.push({
+    id: 'engagement-audit',
+    stage: 'prove',
+    type: 'internal',
+    description: 'Builds a machine-readable Ralph Loop audit from reply state, drafts, and launch assets.',
+  });
+
+  return steps.map((step) => withSkipReason(step, env));
+}
+
+function runExternalStep(step, env = process.env) {
+  const result = spawnSync(step.command, step.args, {
+    cwd: REPO_ROOT,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+  });
+
+  return {
+    exitCode: typeof result.status === 'number' ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error ? result.error.message : '',
+  };
+}
+
+function runAuditStep(options = {}) {
+  return buildEngagementAudit({
+    date: options.date,
+    timezone: options.timezone || DEFAULT_TIMEZONE,
+    replyStatePath: options.replyStatePath || DEFAULT_REPLY_STATE_PATH,
+    draftsPath: options.draftsPath || DEFAULT_DRAFTS_PATH,
+    launchAssetsPath: options.launchAssetsPath || DEFAULT_LAUNCH_ASSETS_PATH,
+  });
+}
+
+function runStep(step, options = {}, deps = {}) {
+  const startedAt = new Date().toISOString();
+
+  if (step.skipReason) {
+    return {
+      id: step.id,
+      stage: step.stage,
+      status: 'skipped',
+      skipReason: step.skipReason,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+    };
+  }
+
+  if (step.type === 'internal') {
+    const audit = runAuditStep(options);
+    return {
+      id: step.id,
+      stage: step.stage,
+      status: 'passed',
+      audit,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+    };
+  }
+
+  const runner = deps.runner || runExternalStep;
+  const result = runner(step, deps.env || process.env);
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  return {
+    id: step.id,
+    stage: step.stage,
+    status: result.exitCode === 0 ? 'passed' : 'failed',
+    exitCode: result.exitCode,
+    error: result.error || '',
+    stdoutTail: tail(result.stdout),
+    stderrTail: tail(result.stderr),
+    startedAt,
+    finishedAt: new Date().toISOString(),
+  };
+}
+
+function tail(text, maxChars = 4000) {
+  const value = String(text || '');
+  return value.length <= maxChars ? value : value.slice(value.length - maxChars);
+}
+
+function renderMarkdownReport(report) {
+  const lines = [
+    '# Ralph Loop Audience Engagement Report',
+    '',
+    `Generated: ${report.generatedAt}`,
+    `Mode: ${report.mode}`,
+    `Dry run: ${report.dryRun ? 'yes' : 'no'}`,
+    '',
+    'Ralph Mode keeps the Reliability Gateway pointed at acquisition: sense audience signals, engage safely, and preserve proof for Pre-Action Gates, DPO, and Thompson Sampling review.',
+    '',
+    '## Steps',
+    '',
+    '| Step | Stage | Status | Evidence |',
+    '|------|-------|--------|----------|',
+  ];
+
+  for (const step of report.steps) {
+    const evidence = step.skipReason || step.error || `exit ${step.exitCode ?? 0}`;
+    lines.push(`| ${step.id} | ${step.stage} | ${step.status} | ${String(evidence).replaceAll('|', '/')} |`);
+  }
+
+  lines.push(
+    '',
+    '## Audit',
+    '',
+    `- Checked: ${report.audit.totals.checked}`,
+    `- Replied: ${report.audit.totals.replied}`,
+    `- Drafted: ${report.audit.totals.drafted}`,
+    `- Skipped: ${report.audit.totals.skipped}`,
+    '',
+    'Authority evidence: docs/VERIFICATION_EVIDENCE.md',
+    ''
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function writeReports(report, artifactDir = DEFAULT_ARTIFACT_DIR) {
+  fs.mkdirSync(artifactDir, { recursive: true });
+  const jsonPath = path.join(artifactDir, 'ralph-loop-report.json');
+  const markdownPath = path.join(artifactDir, 'ralph-loop-report.md');
+  fs.writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(markdownPath, renderMarkdownReport(report), 'utf8');
+  return { jsonPath, markdownPath };
+}
+
+function runRalphLoop(options = {}, deps = {}) {
+  const normalized = {
+    ...parseArgs([]),
+    ...options,
+    mode: normalizeMode(options.mode || 'all'),
+  };
+  const env = deps.env || process.env;
+  const steps = buildRalphSteps(normalized, env);
+  const results = steps.map((step) => runStep(step, normalized, { ...deps, env }));
+  const auditStep = results.find((step) => step.id === 'engagement-audit');
+  const audit = auditStep?.audit ? auditStep.audit : runAuditStep(normalized);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    mode: normalized.mode,
+    dryRun: Boolean(normalized.dryRun),
+    cadence: 'hourly_ci',
+    statePaths: RALPH_STATE_PATHS,
+    steps: results,
+    audit,
+  };
+  report.artifacts = writeReports(report, normalized.artifactDir || DEFAULT_ARTIFACT_DIR);
+  return report;
+}
+
+function isCliEntrypoint(argv = process.argv) {
+  return Boolean(argv[1] && path.resolve(argv[1]) === __filename);
+}
+
+if (isCliEntrypoint()) {
+  try {
+    const report = runRalphLoop(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`\n[ralph-loop] Report: ${report.artifacts.jsonPath}\n`);
+    if (report.steps.some((step) => step.status === 'failed')) {
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    console.error(`[ralph-loop] Fatal: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  DEFAULT_ARTIFACT_DIR,
+  RALPH_STATE_PATHS,
+  VALID_MODES,
+  buildRalphSteps,
+  isCliEntrypoint,
+  normalizeMode,
+  parseArgs,
+  renderMarkdownReport,
+  runRalphLoop,
+  runStep,
+  writeReports,
+};

--- a/tests/ralph-loop.test.js
+++ b/tests/ralph-loop.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const {
+  RALPH_STATE_PATHS,
+  buildRalphSteps,
+  isCliEntrypoint,
+  normalizeMode,
+  parseArgs,
+  renderMarkdownReport,
+  runRalphLoop,
+  runStep,
+} = require('../scripts/ralph-loop');
+
+test('parseArgs supports Ralph modes, dry runs, and artifact directories', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ralph-args-'));
+  const options = parseArgs([
+    '--mode',
+    'engage',
+    '--dry-run',
+    '--artifact-dir',
+    tmp,
+    '--timezone=UTC',
+    '--date',
+    '2026-04-13',
+  ]);
+
+  assert.equal(options.mode, 'engage');
+  assert.equal(options.dryRun, true);
+  assert.equal(options.artifactDir, tmp);
+  assert.equal(options.timezone, 'UTC');
+  assert.equal(options.date, '2026-04-13');
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('normalizeMode rejects unknown Ralph modes', () => {
+  assert.throws(() => normalizeMode('spray-and-pray'), /Invalid Ralph mode/);
+});
+
+test('buildRalphSteps keeps hourly all mode focused on sensing, replying, and audit proof', () => {
+  const steps = buildRalphSteps({ mode: 'all', dryRun: true }, {});
+  const ids = steps.map((step) => step.id);
+
+  assert.deepEqual(ids, [
+    'poll-analytics',
+    'sync-launch-assets',
+    'reply-monitor',
+    'engagement-audit',
+  ]);
+  assert.match(steps.find((step) => step.id === 'sync-launch-assets').skipReason, /ZERNIO_API_KEY/);
+  assert.deepEqual(steps.find((step) => step.id === 'reply-monitor').args.slice(-1), ['--dry-run']);
+  assert.equal(ids.includes('daily-social-post'), false);
+});
+
+test('buildRalphSteps supports manual post mode with skip evidence', () => {
+  const steps = buildRalphSteps({ mode: 'post', dryRun: true }, {});
+  const post = steps.find((step) => step.id === 'daily-social-post');
+
+  assert.deepEqual(steps.map((step) => step.id), ['daily-social-post', 'engagement-audit']);
+  assert.deepEqual(post.args.slice(-1), ['--dry-run']);
+  assert.match(post.skipReason, /ZERNIO_API_KEY/);
+});
+
+test('runStep records skipped, external, and failed step evidence', () => {
+  const skipped = runStep({
+    id: 'sync-launch-assets',
+    stage: 'sense',
+    skipReason: 'missing env: ZERNIO_API_KEY',
+  });
+  assert.equal(skipped.status, 'skipped');
+  assert.match(skipped.skipReason, /ZERNIO_API_KEY/);
+
+  const passed = runStep({
+    id: 'node-ok',
+    stage: 'prove',
+    type: 'node',
+    command: process.execPath,
+    args: ['-e', 'process.stdout.write("ok")'],
+  });
+  assert.equal(passed.status, 'passed');
+  assert.equal(passed.exitCode, 0);
+  assert.equal(passed.stdoutTail, 'ok');
+
+  const failed = runStep({
+    id: 'node-fail',
+    stage: 'prove',
+    type: 'node',
+    command: process.execPath,
+    args: ['-e', 'process.stderr.write("bad"); process.exit(2)'],
+  });
+  assert.equal(failed.status, 'failed');
+  assert.equal(failed.exitCode, 2);
+  assert.equal(failed.stderrTail, 'bad');
+});
+
+test('renderMarkdownReport escapes table separators and CLI entrypoint detection is path based', () => {
+  const markdown = renderMarkdownReport({
+    generatedAt: '2026-04-13T00:00:00.000Z',
+    mode: 'audit',
+    dryRun: false,
+    steps: [{
+      id: 'reply-monitor',
+      stage: 'engage',
+      status: 'skipped',
+      skipReason: 'missing A|B',
+    }],
+    audit: {
+      totals: {
+        checked: 1,
+        replied: 0,
+        drafted: 1,
+        skipped: 0,
+      },
+    },
+  });
+
+  assert.match(markdown, /missing A\/B/);
+  assert.equal(isCliEntrypoint(['node', path.join(PROJECT_ROOT, 'scripts', 'ralph-loop.js')]), true);
+  assert.equal(isCliEntrypoint(['node', path.join(PROJECT_ROOT, 'tests', 'ralph-loop.test.js')]), false);
+});
+
+test('runRalphLoop writes machine-readable evidence and keeps state paths explicit', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ralph-loop-'));
+  const calls = [];
+  const report = runRalphLoop({
+    mode: 'engage',
+    dryRun: true,
+    artifactDir: tmp,
+    replyStatePath: path.join(tmp, 'reply-monitor-state.json'),
+    draftsPath: path.join(tmp, 'reply-drafts.jsonl'),
+    launchAssetsPath: path.join(tmp, 'social-launch-assets.json'),
+  }, {
+    env: { ZERNIO_API_KEY: 'zernio_test_key' },
+    runner: (step) => {
+      calls.push(step.id);
+      return {
+        exitCode: 0,
+        stdout: `${step.id} ok\n`,
+        stderr: '',
+      };
+    },
+  });
+
+  assert.deepEqual(calls, ['sync-launch-assets', 'reply-monitor']);
+  assert.equal(report.mode, 'engage');
+  assert.equal(report.dryRun, true);
+  assert.deepEqual(report.statePaths, RALPH_STATE_PATHS);
+  assert.equal(fs.existsSync(path.join(tmp, 'ralph-loop-report.json')), true);
+  assert.equal(fs.existsSync(path.join(tmp, 'ralph-loop-report.md')), true);
+
+  const rendered = fs.readFileSync(path.join(tmp, 'ralph-loop-report.md'), 'utf8');
+  assert.match(rendered, /Reliability Gateway/);
+  assert.match(rendered, /VERIFICATION_EVIDENCE\.md/);
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('Ralph workflows are scheduled, stateful, and split outbound from reply engagement', () => {
+  const workflowsDir = path.join(PROJECT_ROOT, '.github', 'workflows');
+  const ralph = fs.readFileSync(path.join(workflowsDir, 'ralph-loop.yml'), 'utf8');
+  const ralphMode = fs.readFileSync(path.join(workflowsDir, 'ralph-mode.yml'), 'utf8');
+  const replyMonitor = fs.readFileSync(path.join(workflowsDir, 'reply-monitor.yml'), 'utf8');
+  const socialEngagement = fs.readFileSync(path.join(workflowsDir, 'social-engagement-hourly.yml'), 'utf8');
+
+  assert.match(ralph, /name: Ralph Loop Audience Engagement/);
+  assert.match(ralph, /cron: '17 \* \* \* \*'/);
+  assert.match(ralph, /actions\/cache\/restore@v4/);
+  assert.match(ralph, /actions\/cache\/save@v4/);
+  assert.match(ralph, /node scripts\/ralph-loop\.js --mode="\$MODE"/);
+  assert.match(ralph, /\.thumbgate\/reply-monitor-state\.json/);
+  assert.match(ralph, /\.thumbgate\/reply-drafts\.jsonl/);
+  assert.match(ralph, /\.thumbgate\/social-launch-assets\.json/);
+  assert.match(ralphMode, /name: Ralph Mode - 24\/7 Engagement Loop/);
+  assert.match(ralphMode, /cron: '0 \*\/2 \* \* \*'/);
+  assert.match(ralphMode, /actions\/cache\/restore@v4/);
+  assert.match(ralphMode, /actions\/cache\/save@v4/);
+  assert.match(ralphMode, /\.thumbgate\/ralph-state\.json/);
+  assert.match(ralphMode, /node scripts\/ralph-mode-ci\.js/);
+  assert.doesNotMatch(replyMonitor, /^\s*schedule:/m);
+  assert.doesNotMatch(socialEngagement, /0 9,13,17,21 \* \* \*/);
+});


### PR DESCRIPTION
## Summary
- Add an hourly Ralph Loop GitHub Actions workflow for stateful audience sensing, reply engagement, analytics polling, and evidence artifacts.
- Persist reply monitor state, drafts, and launch assets across CI runs so the loop does not forget handled audience signals.
- Keep daily posting separate from hourly engagement, with Reddit draft-only and X quality-gated safeguards documented.

## Verification
- npm ci --onnxruntime-node-install-cuda=skip
- node --check scripts/ralph-loop.js
- node --test tests/ralph-loop.test.js
- npm run test:workflow
- npm run test:social-reply-monitor
- npm run test:engagement-audit
- node scripts/ralph-loop.js --mode=audit --dry-run --artifact-dir=/tmp/thumbgate-ralph-loop-audit-proof-2
- npm run test:deployment
- node --test tests/ralph-loop.test.js tests/social-reply-monitor.test.js tests/engagement-audit.test.js
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check

## Authority Evidence
- docs/VERIFICATION_EVIDENCE.md
- Ralph Loop workflow artifact: ralph-loop-report.json and ralph-loop-report.md