### PR TITLE
fix: make statusbar lesson text readable and strip localhost links

### DIFF
--- a/.changeset/fix-statusline-readability.md
+++ b/.changeset/fix-statusline-readability.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Make statusbar lesson text readable: prefer structured rule actions over raw feedback, increase truncation to 60 chars, strip localhost links from display.

--- a/scripts/lesson-inference.js
+++ b/scripts/lesson-inference.js
@@ -303,7 +303,26 @@ function getStatusbarLessonData() {
   if (!recent) return { hasLesson: false, text: null, link: null };
 
   const normalizedLesson = stripLessonPrefix(recent.lesson || '');
-  const truncated = normalizedLesson.length > 48 ? normalizedLesson.slice(0, 45) + '...' : normalizedLesson;
+
+  // Distill to actionable insight: prefer structured rule action, then
+  // whatToChange, then the lesson text itself. Raw user feedback
+  // ("are you sure?", "is this working?") is not useful in a statusbar.
+  let displayText = normalizedLesson;
+  if (recent.structuredRule && recent.structuredRule.action && recent.structuredRule.action.description) {
+    displayText = recent.structuredRule.action.description;
+  } else if (recent.whatToChange || recent.what_to_change) {
+    displayText = String(recent.whatToChange || recent.what_to_change);
+  }
+
+  // Clean up: strip noise prefixes, collapse whitespace
+  displayText = displayText
+    .replace(/^CRITICAL ERROR - User frustrated:\s*/i, '')
+    .replace(/^thumbs?\s*(up|down)\s*:?\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // Truncate to 60 chars (enough to be readable, short enough for statusbar)
+  const truncated = displayText.length > 60 ? displayText.slice(0, 57) + '...' : displayText;
 
   return {
     hasLesson: true,

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -162,10 +162,15 @@ DASHBOARD_LINK="$DASHBOARD_LABEL"
 LESSONS_LINK="$LESSONS_LABEL"
 LATEST_LESSON_LINK=""
 if [ -n "$LESSON_LABEL" ]; then
+  # Only include link if it's a real URL (not localhost)
+  _DISPLAY_LINK="$LESSON_LINK"
+  case "$_DISPLAY_LINK" in
+    *localhost*|*127.0.0.1*) _DISPLAY_LINK="" ;;
+  esac
   if [ -n "$LESSON_TEXT" ]; then
-    LATEST_LESSON_LINK="$(inline_link "$LESSON_LINK" "${LESSON_LABEL}: ${LESSON_TEXT}")"
+    LATEST_LESSON_LINK="$(inline_link "$_DISPLAY_LINK" "${LESSON_LABEL}: ${LESSON_TEXT}")"
   else
-    LATEST_LESSON_LINK="$(inline_link "$LESSON_LINK" "$LESSON_LABEL")"
+    LATEST_LESSON_LINK="$(inline_link "$_DISPLAY_LINK" "$LESSON_LABEL")"
   fi
 fi
 

--- a/tests/statusline.test.js
+++ b/tests/statusline.test.js
@@ -375,7 +375,8 @@ test('statusline preserves dashboard links under a tight width budget', () => {
     assert.match(plain, /Dashboard/, 'should preserve the dashboard link label');
     assert.match(plain, /Lessons/, 'should preserve the lessons link label');
     assert.match(plain, /Latest mistake \d{4}-\d{2}-\d{2} \d{2}:\d{2}Z:/, 'should clarify that the snippet is the latest mistake');
-    assert.match(plain, /http:\/\/localhost:3456\/lessons#lesson_/, 'should include a deep link to the latest lesson');
+    // localhost links are intentionally stripped from statusbar display — only real URLs shown
+    assert.doesNotMatch(plain, /http:\/\/localhost/, 'should NOT include localhost links in statusbar');
   } finally {
     if (previousFeedbackDir === undefined) {
       delete process.env.THUMBGATE_FEEDBACK_DIR;


### PR DESCRIPTION
## Summary
- Statusbar showed raw user feedback as "latest mistake" — now prefers structured rule actions > whatToChange > lesson text
- Localhost URLs cluttered the statusbar — now stripped, only real URLs shown
- Truncation increased from 48 to 60 chars for readability

## Test plan
- [ ] CI passes (8 required checks)
- [ ] `test:statusline` passes with updated assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)