### PR TITLE
ci: skip Railway deploy for adapter docs

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -46,7 +46,7 @@ jobs:
           BEFORE_SHA='${{ github.event.before }}'
           CHANGED_FILES=''
           SHOULD_DEPLOY=true
-          DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/|public/|\.well-known/|openapi/|workers/|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
+          DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml)$|public/|\.well-known/|openapi/|workers/|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
             CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" | sed '/^$/d')"

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -330,8 +330,16 @@ test('Deploy to Railway workflow skips non-runtime pushes and only deploys when 
     'workflow should only treat runtime JS script modules as deployable',
   );
   assert.ok(
+    workflow.includes('adapters/.*\\.(js|mjs|cjs|json|ya?ml)$'),
+    'workflow should only treat adapter runtime/spec files as deployable',
+  );
+  assert.ok(
     !workflow.includes("DEPLOYABLE_PATTERN='^(src/|scripts/|"),
     'workflow should not treat every scripts/ path as deployable',
+  );
+  assert.ok(
+    !workflow.includes('|adapters/|'),
+    'workflow should not treat adapter markdown guides as deployable',
   );
   assert.match(workflow, /! printf '%s\\n' "\$CHANGED_FILES" \| grep -Eq "\$DEPLOYABLE_PATTERN"/);
   assert.match(workflow, /should_deploy=\$SHOULD_DEPLOY/);


### PR DESCRIPTION
## Summary
- narrow Railway deploy scope so adapter Markdown guides do not trigger runtime deploys
- keep adapter JS/JSON/YAML/OpenAPI specs deployable
- add deployment workflow regression coverage for adapter docs

## Why
Main deploy failed on #777 because `adapters/chatgpt/INSTALL.md` matched the broad `adapters/` deploy pattern and Railway env var writes failed with `Cannot redeploy without a snapshot` before deployment.

## Verification
- `node --test tests/deployment.test.js`
- `npm run test:deployment`

## Evidence
- Failed main deploy run: https://github.com/IgorGanapolsky/ThumbGate/actions/runs/24364981468
- GPT instructions fix PR: https://github.com/IgorGanapolsky/ThumbGate/pull/777