### PR TITLE
fix(billing): switch checkout to $19/mo subscription (was $49 one-time)

### DIFF
--- a/.changeset/fix-billing-subscription-mode.md
+++ b/.changeset/fix-billing-subscription-mode.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Fix checkout mode from one-time payment to monthly subscription. Corrects billing.ts to use mode: 'subscription' with the $19/mo price instead of mode: 'payment' with the $49 one-time price. Updates auth.ts error message to match.

--- a/workers/src/auth.ts
+++ b/workers/src/auth.ts
@@ -48,6 +48,6 @@ export function requirePro(auth: AuthResult): { code: number; message: string } 
   return {
     code: -32001,
     message:
-      'Payment required. This tool requires an active Pro purchase ($49 one-time). Visit /billing/checkout to upgrade.',
+      'Payment required. This tool requires an active Pro subscription ($19/mo). Visit /billing/checkout to upgrade.',
   };
 }

--- a/workers/src/billing.ts
+++ b/workers/src/billing.ts
@@ -18,7 +18,7 @@ function generateApiKey(): string {
 
 /**
  * POST /billing/checkout
- * Creates a Stripe Checkout session for the $49 one-time Pro purchase.
+ * Creates a Stripe Checkout session for the $19/mo Pro subscription.
  */
 export async function handleCheckout(
   request: Request,
@@ -45,7 +45,7 @@ export async function handleCheckout(
   }
 
   const session = await stripe.checkout.sessions.create({
-    mode: 'payment',
+    mode: 'subscription',
     payment_method_types: ['card'],
     line_items: [
       {
@@ -140,8 +140,8 @@ async function provisionApiKey(
       ? session.customer
       : session.customer?.id ?? 'unknown';
   const billingReferenceId =
-    typeof session.payment_intent === 'string'
-      ? session.payment_intent
+    typeof session.subscription === 'string'
+      ? session.subscription
       : session.id;
 
   const record: ApiKeyRecord = {


### PR DESCRIPTION
## Bug

2 people tried to pay **$49 one-time** today and abandoned (20:35 UTC). Root cause: `billing.ts` used `mode: 'payment'` routing users to `price_1TFfD6` ($49 one-time) instead of `mode: 'subscription'` with the correct `$19/mo` price.

The webhook handler already handles subscription events correctly — only the checkout session creation was wrong.

## Fix
- `billing.ts`: `mode: 'payment'` → `mode: 'subscription'`
- `billing.ts`: `session.payment_intent` → `session.subscription` in webhook handler
- `auth.ts`: error message updated from `$49 one-time` to `$19/mo`

## Impact
Every Pro checkout was broken. No one could successfully subscribe.