### PR TITLE
fix(wire-hooks): clean up stale project-level hooks referencing missing files

### DIFF
--- a/.changeset/fix-stale-hooks.md
+++ b/.changeset/fix-stale-hooks.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix wire-hooks to clean stale project-level Claude Code hooks referencing missing files. Previously only cleaned user-level settings, leaving broken hooks in .claude/settings.json that caused "UserPromptSubmit hook error".

--- a/scripts/auto-wire-hooks.js
+++ b/scripts/auto-wire-hooks.js
@@ -94,6 +94,64 @@ function hookAlreadyPresent(hookArray, command) {
   );
 }
 
+/**
+ * pruneStaleFileHooks — Remove hook entries whose command references a shell
+ * script path that no longer exists on disk.
+ *
+ * Only paths that look like file references (contain a `/` or `\`, or end with
+ * `.sh`) are checked.  Pure command strings (node calls, npx invocations, etc.)
+ * are left untouched.
+ *
+ * @param {Array}  hookArray  - The array of hook-entry objects for one lifecycle.
+ * @param {string} [baseDir]  - Directory used to resolve relative paths
+ *                              (defaults to process.cwd()).
+ * @returns {{ hooks: Array, removedPaths: string[] }}
+ */
+function pruneStaleFileHooks(hookArray, baseDir) {
+  if (!Array.isArray(hookArray)) {
+    return { hooks: [], removedPaths: [] };
+  }
+
+  const resolveBase = baseDir || process.cwd();
+  const removedPaths = [];
+
+  const hooks = hookArray.filter((entry) => {
+    const entryHooks = Array.isArray(entry && entry.hooks) ? entry.hooks : [];
+    let shouldRemove = false;
+
+    for (const hook of entryHooks) {
+      const command = hook && typeof hook.command === 'string' ? hook.command : '';
+      if (!command) continue;
+
+      // Extract the first token as the potential script path.
+      const firstToken = command.split(/\s+/)[0];
+
+      // Only treat it as a file reference if it looks like a path.
+      const looksLikePath =
+        firstToken.includes('/') ||
+        firstToken.includes('\\') ||
+        firstToken.endsWith('.sh');
+
+      if (!looksLikePath) continue;
+
+      // Resolve the path (absolute or relative to baseDir).
+      const resolved = path.isAbsolute(firstToken)
+        ? firstToken
+        : path.resolve(resolveBase, firstToken);
+
+      if (!fs.existsSync(resolved)) {
+        removedPaths.push(firstToken);
+        shouldRemove = true;
+        break;
+      }
+    }
+
+    return !shouldRemove;
+  });
+
+  return { hooks, removedPaths };
+}
+
 function pruneLegacyHookEntries(hookArray, expectedCommand, legacyPattern) {
   if (!Array.isArray(hookArray)) {
     return { hooks: [], removed: false };
@@ -131,11 +189,77 @@ function syncClaudeStatusLine(settingsPath, desiredStatusLine, dryRun) {
   return true;
 }
 
+/**
+ * claudeProjectSettingsPath — returns the project-level .claude/settings.json
+ * path relative to the given base directory (defaults to CWD).
+ */
+function claudeProjectSettingsPath(baseDir) {
+  return path.join(baseDir || process.cwd(), '.claude', 'settings.json');
+}
+
+/**
+ * pruneStaleHooksInFile — reads a settings file, removes any hook entries that
+ * reference missing shell script files, and writes the file back if changed.
+ *
+ * @param {string}  filePath - Absolute path to the settings JSON file.
+ * @param {string}  baseDir  - Base directory for resolving relative script paths.
+ * @param {boolean} dryRun   - When true, changes are computed but not persisted.
+ * @returns {{ changed: boolean, removedPaths: string[] }}
+ */
+function pruneStaleHooksInFile(filePath, baseDir, dryRun) {
+  const settings = loadJsonFile(filePath);
+  if (!settings || !settings.hooks || typeof settings.hooks !== 'object') {
+    return { changed: false, removedPaths: [] };
+  }
+
+  const allRemovedPaths = [];
+  let changed = false;
+
+  for (const lifecycle of Object.keys(settings.hooks)) {
+    const { hooks, removedPaths } = pruneStaleFileHooks(settings.hooks[lifecycle], baseDir);
+    if (removedPaths.length > 0) {
+      settings.hooks[lifecycle] = hooks;
+      allRemovedPaths.push(...removedPaths);
+      changed = true;
+    }
+  }
+
+  if (changed && !dryRun) {
+    fs.writeFileSync(filePath, JSON.stringify(settings, null, 2) + '\n');
+  }
+
+  return { changed, removedPaths: allRemovedPaths };
+}
+
 function wireClaudeHooks(options) {
   const settingsPath = options.settingsPath || claudeSettingsPath();
   const sharedSettingsPath = options.sharedSettingsPath || claudeSharedSettingsPath();
+  const projectSettingsPath =
+    options.projectSettingsPath || claudeProjectSettingsPath(options.projectDir);
   const dryRun = options.dryRun || false;
+  const projectDir = options.projectDir || process.cwd();
   const desiredStatusLine = statuslineCommand();
+
+  // --- Step 0: clean up stale hooks from BOTH settings locations ---
+  const staleWarnings = [];
+
+  // User-level: ~/.claude/settings.local.json
+  const userStale = pruneStaleHooksInFile(settingsPath, projectDir, dryRun);
+  for (const p of userStale.removedPaths) {
+    const msg = `Removed stale hook referencing missing file: ${p}`;
+    console.warn(msg);
+    staleWarnings.push({ file: settingsPath, path: p });
+  }
+
+  // Project-level: $CWD/.claude/settings.json (takes precedence for some events)
+  if (fs.existsSync(projectSettingsPath)) {
+    const projStale = pruneStaleHooksInFile(projectSettingsPath, projectDir, dryRun);
+    for (const p of projStale.removedPaths) {
+      const msg = `Removed stale hook referencing missing file: ${p}`;
+      console.warn(msg);
+      staleWarnings.push({ file: projectSettingsPath, path: p });
+    }
+  }
 
   let settings = loadJsonFile(settingsPath) || {};
   settings.hooks = settings.hooks || {};
@@ -426,10 +550,13 @@ module.exports = {
   parseFlags,
   claudeSettingsPath,
   claudeSharedSettingsPath,
+  claudeProjectSettingsPath,
   codexConfigPath,
   geminiSettingsPath,
   syncClaudeStatusLine,
   forgeConfigPath,
+  pruneStaleFileHooks,
+  pruneStaleHooksInFile,
   CLAUDE_HOOKS,
   preToolHookCommand,
   userPromptHookCommand,

--- a/tests/auto-wire-hooks.test.js
+++ b/tests/auto-wire-hooks.test.js
@@ -34,6 +34,9 @@ const {
   preToolHookCommand,
   userPromptHookCommand,
   sessionStartHookCommand,
+  pruneStaleFileHooks,
+  pruneStaleHooksInFile,
+  claudeProjectSettingsPath,
 } = require('../scripts/auto-wire-hooks');
 
 function makeTmpDir() {
@@ -498,6 +501,292 @@ describe('auto-wire-hooks', () => {
         process.chdir(origCwd);
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
+    });
+  });
+
+  // --- pruneStaleFileHooks ---
+
+  describe('pruneStaleFileHooks', () => {
+    test('returns empty result for non-array input', () => {
+      const result = pruneStaleFileHooks(null);
+      assert.deepStrictEqual(result.hooks, []);
+      assert.deepStrictEqual(result.removedPaths, []);
+    });
+
+    test('keeps hooks whose command does not reference a file path', () => {
+      const hookArray = [
+        { hooks: [{ type: 'command', command: 'npx thumbgate gate-check' }] },
+        { hooks: [{ type: 'command', command: 'node /dev/null' }] },
+      ];
+      // /dev/null always exists, so only the npx entry (no path) should survive
+      const result = pruneStaleFileHooks(hookArray, '/tmp');
+      assert.equal(result.removedPaths.length, 0);
+      assert.equal(result.hooks.length, 2);
+    });
+
+    test('removes hook entry whose script path does not exist', () => {
+      const tmpDir = makeTmpDir();
+      try {
+        const missingScript = path.join(tmpDir, '.claude', 'hooks', 'user-prompt-submit.sh');
+        const hookArray = [
+          {
+            hooks: [{ type: 'command', command: `${missingScript} --capture` }],
+          },
+          {
+            hooks: [{ type: 'command', command: 'npx thumbgate capture' }],
+          },
+        ];
+        const result = pruneStaleFileHooks(hookArray, tmpDir);
+        assert.equal(result.removedPaths.length, 1);
+        assert.equal(result.removedPaths[0], missingScript);
+        // The npx entry is preserved; the missing-script entry is gone
+        assert.equal(result.hooks.length, 1);
+        assert.equal(result.hooks[0].hooks[0].command, 'npx thumbgate capture');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('keeps hook entry whose script path exists on disk', () => {
+      const tmpDir = makeTmpDir();
+      try {
+        const existingScript = path.join(tmpDir, 'my-hook.sh');
+        fs.writeFileSync(existingScript, '#!/bin/sh\necho ok\n');
+        const hookArray = [
+          { hooks: [{ type: 'command', command: existingScript }] },
+        ];
+        const result = pruneStaleFileHooks(hookArray, tmpDir);
+        assert.equal(result.removedPaths.length, 0);
+        assert.equal(result.hooks.length, 1);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('removes hook with relative path to missing script', () => {
+      const tmpDir = makeTmpDir();
+      try {
+        const relPath = '.claude/hooks/user-prompt-submit.sh';
+        const hookArray = [
+          { hooks: [{ type: 'command', command: relPath }] },
+        ];
+        // The script does not exist under tmpDir
+        const result = pruneStaleFileHooks(hookArray, tmpDir);
+        assert.equal(result.removedPaths.length, 1);
+        assert.equal(result.removedPaths[0], relPath);
+        assert.equal(result.hooks.length, 0);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // --- pruneStaleHooksInFile ---
+
+  describe('pruneStaleHooksInFile', () => {
+    test('returns unchanged when file does not exist', () => {
+      const result = pruneStaleHooksInFile('/tmp/nonexistent-thumbgate-test.json', '/tmp', false);
+      assert.equal(result.changed, false);
+      assert.deepStrictEqual(result.removedPaths, []);
+    });
+
+    test('removes stale hooks and rewrites the file', () => {
+      const tmpDir = makeTmpDir();
+      try {
+        const settingsPath = path.join(tmpDir, 'settings.json');
+        const missingScript = path.join(tmpDir, '.claude', 'hooks', 'user-prompt-submit.sh');
+
+        const settings = {
+          hooks: {
+            UserPromptSubmit: [
+              { hooks: [{ type: 'command', command: missingScript }] },
+              { hooks: [{ type: 'command', command: 'npx thumbgate capture' }] },
+            ],
+          },
+        };
+        fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+        const result = pruneStaleHooksInFile(settingsPath, tmpDir, false);
+        assert.equal(result.changed, true);
+        assert.equal(result.removedPaths.length, 1);
+        assert.equal(result.removedPaths[0], missingScript);
+
+        // Verify the file was rewritten without the stale entry
+        const written = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        assert.equal(written.hooks.UserPromptSubmit.length, 1);
+        assert.equal(
+          written.hooks.UserPromptSubmit[0].hooks[0].command,
+          'npx thumbgate capture'
+        );
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('dry-run does not rewrite the file', () => {
+      const tmpDir = makeTmpDir();
+      try {
+        const settingsPath = path.join(tmpDir, 'settings.json');
+        const missingScript = path.join(tmpDir, '.claude', 'hooks', 'user-prompt-submit.sh');
+
+        const settings = {
+          hooks: {
+            UserPromptSubmit: [
+              { hooks: [{ type: 'command', command: missingScript }] },
+            ],
+          },
+        };
+        const original = JSON.stringify(settings, null, 2);
+        fs.writeFileSync(settingsPath, original);
+
+        const result = pruneStaleHooksInFile(settingsPath, tmpDir, true);
+        assert.equal(result.changed, true);
+        assert.equal(result.removedPaths.length, 1);
+        // File must not have been modified
+        assert.equal(fs.readFileSync(settingsPath, 'utf8'), original);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // --- wireClaudeHooks + project-level stale cleanup ---
+
+  describe('wireClaudeHooks — project-level stale hook cleanup', () => {
+    test('removes stale hooks from project-level .claude/settings.json during wiring', () => {
+      const tmpDir = makeTmpDir();
+      const userSettingsDir = path.join(tmpDir, 'home', '.claude');
+      const userSettingsPath = path.join(userSettingsDir, 'settings.local.json');
+      const userSharedPath = path.join(userSettingsDir, 'settings.json');
+
+      // Project directory contains a stale .claude/settings.json
+      const projectDir = path.join(tmpDir, 'project');
+      const projectClaudeDir = path.join(projectDir, '.claude');
+      const projectSettingsPath = path.join(projectClaudeDir, 'settings.json');
+
+      fs.mkdirSync(userSettingsDir, { recursive: true });
+      fs.mkdirSync(projectClaudeDir, { recursive: true });
+
+      // Simulate a stale hook: the shell script is referenced but does NOT exist
+      const staleScript = path.join(projectClaudeDir, 'hooks', 'user-prompt-submit.sh');
+      const projectSettings = {
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: staleScript }] },
+            { hooks: [{ type: 'command', command: 'npx thumbgate capture' }] },
+          ],
+        },
+      };
+      fs.writeFileSync(projectSettingsPath, JSON.stringify(projectSettings, null, 2));
+
+      try {
+        const result = wireClaudeHooks({
+          settingsPath: userSettingsPath,
+          sharedSettingsPath: userSharedPath,
+          projectSettingsPath,
+          projectDir,
+        });
+
+        // The wiring itself should succeed
+        assert.equal(result.changed, true);
+
+        // Project-level file must have had the stale entry removed
+        const written = JSON.parse(fs.readFileSync(projectSettingsPath, 'utf8'));
+        const submitHooks = written.hooks.UserPromptSubmit;
+        assert.ok(Array.isArray(submitHooks), 'UserPromptSubmit should still be an array');
+        // Only the non-stale entry should remain
+        assert.equal(submitHooks.length, 1);
+        assert.equal(submitHooks[0].hooks[0].command, 'npx thumbgate capture');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('removes stale hooks from user-level settings.local.json during wiring', () => {
+      const tmpDir = makeTmpDir();
+      const userSettingsDir = path.join(tmpDir, 'home', '.claude');
+      const userSettingsPath = path.join(userSettingsDir, 'settings.local.json');
+      const userSharedPath = path.join(userSettingsDir, 'settings.json');
+      const projectDir = path.join(tmpDir, 'project');
+
+      fs.mkdirSync(userSettingsDir, { recursive: true });
+      fs.mkdirSync(projectDir, { recursive: true });
+
+      // Stale entry in the user-level settings (script doesn't exist)
+      const staleScript = path.join(projectDir, '.claude', 'hooks', 'user-prompt-submit.sh');
+      const userSettings = {
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: staleScript }] },
+          ],
+        },
+      };
+      fs.writeFileSync(userSettingsPath, JSON.stringify(userSettings, null, 2));
+
+      try {
+        wireClaudeHooks({
+          settingsPath: userSettingsPath,
+          sharedSettingsPath: userSharedPath,
+          projectDir,
+        });
+
+        // The stale entry should have been removed before the new hook was added
+        const written = JSON.parse(fs.readFileSync(userSettingsPath, 'utf8'));
+        const submitHooks = written.hooks.UserPromptSubmit;
+        assert.ok(Array.isArray(submitHooks));
+        const staleStillPresent = submitHooks.some((e) =>
+          e.hooks && e.hooks.some((h) => h.command === staleScript)
+        );
+        assert.equal(staleStillPresent, false, 'Stale hook should have been removed');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('does not touch project-level file when it has no stale hooks', () => {
+      const tmpDir = makeTmpDir();
+      const userSettingsDir = path.join(tmpDir, 'home', '.claude');
+      const userSettingsPath = path.join(userSettingsDir, 'settings.local.json');
+      const userSharedPath = path.join(userSettingsDir, 'settings.json');
+
+      const projectDir = path.join(tmpDir, 'project');
+      const projectClaudeDir = path.join(projectDir, '.claude');
+      const projectSettingsPath = path.join(projectClaudeDir, 'settings.json');
+
+      fs.mkdirSync(userSettingsDir, { recursive: true });
+      fs.mkdirSync(projectClaudeDir, { recursive: true });
+
+      // All hooks are valid (npx commands, no missing files)
+      const projectSettings = {
+        hooks: {
+          PreToolUse: [
+            { hooks: [{ type: 'command', command: 'npx thumbgate gate-check' }] },
+          ],
+        },
+        someOtherKey: 'preserved',
+      };
+      const originalJson = JSON.stringify(projectSettings, null, 2);
+      fs.writeFileSync(projectSettingsPath, originalJson);
+
+      try {
+        wireClaudeHooks({
+          settingsPath: userSettingsPath,
+          sharedSettingsPath: userSharedPath,
+          projectSettingsPath,
+          projectDir,
+        });
+
+        // Project settings should be unchanged (no stale entries to remove)
+        const written = fs.readFileSync(projectSettingsPath, 'utf8');
+        assert.equal(written, originalJson);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('claudeProjectSettingsPath returns CWD-relative path by default', () => {
+      const result = claudeProjectSettingsPath('/some/project/dir');
+      assert.equal(result, path.join('/some/project/dir', '.claude', 'settings.json'));
     });
   });
 


### PR DESCRIPTION
## Summary

- `thumbgate init --wire-hooks --agent=claude-code` previously only operated on `~/.claude/settings.local.json` (user-level). It never checked the project-level `.claude/settings.json`, which takes precedence for some hook events in Claude Code.
- This left stale hook entries (e.g., `.claude/hooks/user-prompt-submit.sh`) pointing to shell scripts that no longer exist, causing **"UserPromptSubmit hook error"** at runtime.
- This fix adds a stale-hook pruning pass to `wireClaudeHooks` that runs **before** the new hooks are injected, covering both settings files.

## Changes

**`scripts/auto-wire-hooks.js`**
- New `pruneStaleFileHooks(hookArray, baseDir)` — filters out hook entries whose command begins with a path (absolute or relative) that does not exist on disk; emits a `console.warn` for each removal: `"Removed stale hook referencing missing file: <path>"`
- New `pruneStaleHooksInFile(filePath, baseDir, dryRun)` — applies `pruneStaleFileHooks` to every lifecycle in a JSON settings file and rewrites it if changed (respects `dryRun`)
- New `claudeProjectSettingsPath(baseDir)` — resolves `$baseDir/.claude/settings.json`
- `wireClaudeHooks` now accepts `projectSettingsPath` / `projectDir` options and calls `pruneStaleHooksInFile` on both the user-level and project-level files before wiring new hooks
- All three helpers are exported

**`tests/auto-wire-hooks.test.js`**
- Imports new exports
- 12 new test cases across 4 new `describe` blocks:
  - `pruneStaleFileHooks` (5 cases)
  - `pruneStaleHooksInFile` (3 cases)
  - `wireClaudeHooks — project-level stale hook cleanup` (4 cases)
- All 51 tests pass

## Test plan

- [x] `node --test tests/auto-wire-hooks.test.js` — 51 tests, 0 failures
- [x] Stale hook in project-level `.claude/settings.json` is removed and warning is printed
- [x] Stale hook in user-level `settings.local.json` is removed
- [x] Non-file-path commands (`npx`, `node`) are never removed
- [x] Existing hook entries pointing to real files are preserved
- [x] `dryRun: true` computes removals but does not write the file
- [x] File with no stale hooks is left untouched (no spurious writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)