### PR TITLE
ci: speed up SonarCloud gating

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,37 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect Sonar-relevant changes
+        id: sonar-scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "scan=true" >> "$GITHUB_OUTPUT"
+            echo "reason=full-analysis-event" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/sonar-changed-files.txt
+          if grep -E '^(src/|scripts/|bin/|tests/|package(-lock)?\.json$|sonar-project\.properties$|\.github/workflows/sonarcloud\.yml$)' /tmp/sonar-changed-files.txt > /dev/null; then
+            echo "scan=true" >> "$GITHUB_OUTPUT"
+            echo "reason=sonar-surface-changed" >> "$GITHUB_OUTPUT"
+          else
+            echo "scan=false" >> "$GITHUB_OUTPUT"
+            echo "reason=non-sonar-surface-only" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip SonarCloud scan for non-Sonar PR
+        if: steps.sonar-scope.outputs.scan == 'false'
+        run: |
+          echo "No files in Sonar-scanned surfaces changed; required SonarCloud job exits successfully without scanner startup."
+
       - name: Setup Node
+        if: steps.sonar-scope.outputs.scan == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: '20'
@@ -39,10 +69,20 @@ jobs:
             package-lock.json
             workers/package-lock.json
 
+      - name: Cache SonarCloud packages
+        if: steps.sonar-scope.outputs.scan == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Install deps
+        if: steps.sonar-scope.outputs.scan == 'true'
         run: npm ci --onnxruntime-node-install-cuda=skip
 
       - name: Generate LCOV coverage report
+        if: steps.sonar-scope.outputs.scan == 'true'
         run: |
           rm -rf .coverage coverage
           mkdir -p .coverage/raw
@@ -63,18 +103,20 @@ jobs:
 
       - name: Read package version
         id: package-version
+        if: steps.sonar-scope.outputs.scan == 'true'
         run: |
           VERSION=$(node -p 'require("./package.json").version')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build Sonar mainline analysis version
         id: sonar-mainline-version
+        if: steps.sonar-scope.outputs.scan == 'true'
         run: |
           SHORT_SHA=$(printf '%s' "$GITHUB_SHA" | cut -c1-12)
           echo "value=${{ steps.package-version.outputs.version }}+sha.$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Run SonarCloud scan (quality gate)
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: steps.sonar-scope.outputs.scan == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         uses: SonarSource/sonarqube-scan-action@v7.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -85,7 +127,7 @@ jobs:
             -Dsonar.qualitygate.timeout=600
 
       - name: Run SonarCloud scan (default branch refresh)
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: steps.sonar-scope.outputs.scan == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: SonarSource/sonarqube-scan-action@v7.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/tests/sonarcloud-workflow.test.js
+++ b/tests/sonarcloud-workflow.test.js
@@ -27,12 +27,39 @@ test('SonarCloud workflow waits on quality gates only for PR and merge-queue sca
   const gatedSection = workflow.slice(gatedStart, refreshStart);
   const refreshSection = workflow.slice(refreshStart);
 
-  assert.match(gatedSection, /if:\s*github\.event_name == 'pull_request' \|\| github\.event_name == 'merge_group'/);
+  assert.match(gatedSection, /if:\s*steps\.sonar-scope\.outputs\.scan == 'true' && \(github\.event_name == 'pull_request' \|\| github\.event_name == 'merge_group'\)/);
   assert.match(gatedSection, /-Dsonar\.qualitygate\.wait=true/);
   assert.match(gatedSection, /-Dsonar\.qualitygate\.timeout=600/);
   assert.match(gatedSection, /-Dsonar\.projectVersion=\$\{\{\s*steps\.package-version\.outputs\.version\s*\}\}/);
-  assert.match(refreshSection, /if:\s*github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch'/);
+  assert.match(refreshSection, /if:\s*steps\.sonar-scope\.outputs\.scan == 'true' && \(github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch'\)/);
   assert.match(refreshSection, /-Dsonar\.projectVersion=\$\{\{\s*steps\.sonar-mainline-version\.outputs\.value\s*\}\}/);
   assert.doesNotMatch(refreshSection, /-Dsonar\.qualitygate\.wait=true/);
   assert.doesNotMatch(refreshSection, /-Dsonar\.qualitygate\.timeout=600/);
+});
+
+test('SonarCloud workflow skips scanner startup for PRs outside scanned surfaces', () => {
+  assert.match(workflow, /name: Detect Sonar-relevant changes/);
+  assert.match(workflow, /id: sonar-scope/);
+  assert.match(workflow, /git diff --name-only "\$BASE_SHA" "\$HEAD_SHA" > \/tmp\/sonar-changed-files\.txt/);
+  assert.match(workflow, /\^\(src\/\|scripts\/\|bin\/\|tests\/\|package\(-lock\)\?\\\.json\$\|sonar-project\\\.properties\$\|\\\.github\/workflows\/sonarcloud\\\.yml\$\)/);
+  assert.match(workflow, /name: Skip SonarCloud scan for non-Sonar PR/);
+  assert.match(workflow, /if: steps\.sonar-scope\.outputs\.scan == 'false'/);
+  assert.match(workflow, /required SonarCloud job exits successfully without scanner startup/);
+});
+
+test('SonarCloud workflow caches scanner packages for real scans', () => {
+  const cacheStart = workflow.indexOf('name: Cache SonarCloud packages');
+  const installStart = workflow.indexOf('name: Install deps');
+
+  assert.notEqual(cacheStart, -1, 'SonarCloud cache step should exist');
+  assert.notEqual(installStart, -1, 'dependency install step should exist');
+  assert.ok(cacheStart < installStart, 'Sonar cache should restore before dependency install and scanner startup');
+
+  const cacheSection = workflow.slice(cacheStart, installStart);
+
+  assert.match(cacheSection, /if: steps\.sonar-scope\.outputs\.scan == 'true'/);
+  assert.match(cacheSection, /uses: actions\/cache@v4/);
+  assert.match(cacheSection, /path: ~\/\.sonar\/cache/);
+  assert.match(cacheSection, /key: \$\{\{\s*runner\.os\s*\}\}-sonar/);
+  assert.match(cacheSection, /restore-keys: \$\{\{\s*runner\.os\s*\}\}-sonar/);
 });


### PR DESCRIPTION
## Summary
- add a SonarCloud package cache for real scans
- skip scanner startup for PRs that only touch files outside Sonar-scanned surfaces
- keep quality-gate waiting enabled for PR and merge-queue scans that do touch Sonar-scanned surfaces
- cover the workflow contract with tests

## Evidence
- node --test tests/sonarcloud-workflow.test.js: 4 pass, 0 fail
- npm run test:deployment: 80 pass, 0 fail
- npm run changeset:check: exit 0 (skipped outside PR/merge-group context)
- git diff --check: exit 0

## Notes
This keeps branch protection tied to the existing required `SonarCloud Code Analysis` job while avoiding the 6-9 minute scanner path for docs-only/non-Sonar PRs.