### PR TITLE
chore: harden package boundaries

### DIFF
--- a/.changeset/package-boundary-hygiene.md
+++ b/.changeset/package-boundary-hygiene.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Harden package and Claude plugin boundaries so generated runtime state cannot leak into npm tarballs and Claude plugin skill paths remain spec-compliant.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,7 +18,7 @@
     "guardrails",
     "workflow-hardening"
   ],
-  "skills": "skills",
+  "skills": "./skills/",
   "mcpServers": {
     "thumbgate": {
       "command": "npx",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "test:quality": "node --test tests/validate-feedback.test.js",
     "test:intelligence": "node --test tests/intelligence.test.js",
     "test:training-export": "node --test tests/training-export.test.js tests/databricks-export.test.js",
-    "test:deployment": "node --test tests/deployment.test.js tests/deploy-policy.test.js tests/publish-decision.test.js tests/changeset-check.test.js tests/sonarcloud-workflow.test.js",
+    "test:deployment": "node --test tests/deployment.test.js tests/deploy-policy.test.js tests/publish-decision.test.js tests/changeset-check.test.js tests/sonarcloud-workflow.test.js tests/package-boundary.test.js",
     "test:operational-integrity": "node --test tests/operational-integrity.test.js tests/sync-branch-protection.test.js",
     "test:workflow": "node --test tests/workflow-contract.test.js tests/social-marketing-assets.test.js tests/social-pipeline.test.js tests/positioning-contract.test.js tests/docs-claim-hygiene.test.js tests/workflow-runs.test.js tests/workflow-sprint-intake.test.js tests/gtm-revenue-loop.test.js tests/enterprise-story.test.js tests/ralph-loop.test.js tests/ralph-mode-ci.test.js",
     "test:billing": "node --test tests/billing.test.js",

--- a/scripts/.npmignore
+++ b/scripts/.npmignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+social-analytics/db/*.db
+social-analytics/db/*.sqlite
+social-analytics/db/*.sqlite3
+social-analytics/db/*.sqlite-*
+social-analytics/db/*.sqlite3-*

--- a/tests/adapters.test.js
+++ b/tests/adapters.test.js
@@ -244,6 +244,7 @@ test('claude plugin metadata stays aligned with the released package and install
   assert.equal(pluginManifest.version, packageVersion);
   assert.equal(marketplace.version, packageVersion);
   assert.equal(marketplaceEntry.name, pluginManifest.name);
+  assert.equal(pluginManifest.skills, './skills/');
   assert.match(pluginManifest.description, /Pre-Action Gates|pre-action gates|prevention rules/i);
   assert.match(marketplaceEntry.description, /Pre-Action Gates|pre-action gates|prevention rules/i);
   assert.ok(pluginManifest.keywords.includes('pre-action-gates'));

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const root = path.join(__dirname, '..');
+
+function npmPackFiles() {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return JSON.parse(output)[0].files.map((file) => file.path);
+}
+
+test('npm package excludes generated runtime state from included directories', () => {
+  const runtimeDb = path.join(root, 'scripts', 'social-analytics', 'db', 'package-leak-test.sqlite');
+  const pycacheDir = path.join(root, 'scripts', '__pycache__');
+  const pycacheFile = path.join(pycacheDir, 'package_leak_test.cpython-314.pyc');
+
+  fs.mkdirSync(path.dirname(runtimeDb), { recursive: true });
+  fs.mkdirSync(pycacheDir, { recursive: true });
+  fs.writeFileSync(runtimeDb, 'local sqlite state must not ship\n');
+  fs.writeFileSync(pycacheFile, 'compiled bytecode must not ship\n');
+
+  try {
+    const files = npmPackFiles();
+    assert.equal(files.includes('scripts/social-analytics/db/package-leak-test.sqlite'), false);
+    assert.equal(files.includes('scripts/__pycache__/package_leak_test.cpython-314.pyc'), false);
+  } finally {
+    fs.rmSync(runtimeDb, { force: true });
+    fs.rmSync(pycacheFile, { force: true });
+    try {
+      fs.rmdirSync(pycacheDir);
+    } catch {
+      // Keep the directory if a developer has other local bytecode files.
+    }
+  }
+});


### PR DESCRIPTION
## Summary\n- make the Claude plugin skills path spec-compliant with a relative ./skills/ component path\n- add a scripts/.npmignore guard so generated SQLite DBs and Python bytecode cannot leak into npm tarballs\n- add package-boundary coverage to deployment tests\n\n## Research basis\n- Claude plugin reference requires component paths to be relative to the plugin root and start with ./\n- npm package files include allow-listed directories, so directory-local npm ignore rules are needed to block generated files inside included folders\n\n## Verification\n- node --test tests/adapters.test.js tests/package-boundary.test.js tests/thumbgate-skill.test.js\n- npm run test:deployment\n- npm run changeset:check\n- git diff --check\n- npm pack --dry-run --json --ignore-scripts => fileCount 445, bad []