### PR TITLE
fix(statusline): restore OSC 8 clickable hyperlinks for Dashboard/Lessons

### DIFF
--- a/.changeset/osc8-links.md
+++ b/.changeset/osc8-links.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Restore OSC 8 clickable hyperlinks for Dashboard/Lessons in Claude Code statusbar. Links are now clickable in WezTerm, iTerm2, and other terminals supporting OSC 8.

--- a/scripts/prove-packaged-runtime.js
+++ b/scripts/prove-packaged-runtime.js
@@ -269,10 +269,13 @@ async function runPackagedRuntimeSmoke(options = {}) {
     if (!/(Lessons|Lessons…)/.test(readyStatusline)) {
       throw new Error(`Ready statusline missing lessons label: ${readyStatusline.trim()}`);
     }
-    if (readyStatusline.includes(`${origin}/dashboard`)) {
+    // OSC 8 hyperlinks embed URLs in escape sequences (\033]8;;URL\033\\) — that's expected.
+    // Only reject raw plaintext URLs (not wrapped in OSC 8).
+    const stripOsc8 = (s) => s.replace(/\033\]8;;[^\033]*\033\\/g, '');
+    if (stripOsc8(readyStatusline).includes(`${origin}/dashboard`)) {
       throw new Error(`Ready statusline leaked dashboard URL: ${readyStatusline.trim()}`);
     }
-    if (readyStatusline.includes(`${origin}/lessons`)) {
+    if (stripOsc8(readyStatusline).includes(`${origin}/lessons`)) {
       throw new Error(`Ready statusline leaked lessons URL: ${readyStatusline.trim()}`);
     }
     // Thumbs-up/down icons stay inline while dashboard + lessons remain compact

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -150,7 +150,8 @@ inline_link() {
   local url="$1"
   local label="$2"
   if [ -n "$url" ]; then
-    printf '%s (%s)' "$label" "$url"
+    # OSC 8 terminal hyperlink: clickable in WezTerm, iTerm2, etc.
+    printf '\033]8;;%s\033\\%s\033]8;;\033\\' "$url" "$label"
   else
     printf '%s' "$label"
   fi
@@ -158,15 +159,14 @@ inline_link() {
 
 UP_ICON="👍"
 DOWN_ICON="👎"
-DASHBOARD_LINK="$DASHBOARD_LABEL"
-LESSONS_LINK="$LESSONS_LABEL"
+# Wire up clickable links for Dashboard and Lessons.
+# Use whatever URL statusline-links.js returned (localhost when local server
+# is running, production URL otherwise).
+DASHBOARD_LINK="$(inline_link "$DASHBOARD_URL" "$DASHBOARD_LABEL")"
+LESSONS_LINK="$(inline_link "$LESSONS_URL" "$LESSONS_LABEL")"
 LATEST_LESSON_LINK=""
 if [ -n "$LESSON_LABEL" ]; then
-  # Only include link if it's a real URL (not localhost)
   _DISPLAY_LINK="$LESSON_LINK"
-  case "$_DISPLAY_LINK" in
-    *localhost*|*127.0.0.1*) _DISPLAY_LINK="" ;;
-  esac
   if [ -n "$LESSON_TEXT" ]; then
     LATEST_LESSON_LINK="$(inline_link "$_DISPLAY_LINK" "${LESSON_LABEL}: ${LESSON_TEXT}")"
   else

--- a/tests/statusline.test.js
+++ b/tests/statusline.test.js
@@ -92,8 +92,7 @@ test('statusline script reads jq input and outputs ThumbGate line', () => {
   assert.ok(out.includes('3'), 'should show lesson count');
   assert.match(out, /Dashboard/);
   assert.match(out, /Lessons/);
-  assert.doesNotMatch(out, /Dashboard \(http:\/\/localhost:3456\/dashboard\)/);
-  assert.doesNotMatch(out, /Lessons \(http:\/\/localhost:3456\/lessons\)/);
+  assert.match(out, /localhost:3456/, 'should include local dashboard URLs');
 });
 
 test('statusline shows "no feedback yet" when cache has zeros', () => {
@@ -428,8 +427,7 @@ test('statusline preserves dashboard links under a tight width budget', () => {
     assert.match(plain, /Dashboard/, 'should preserve the dashboard link label');
     assert.match(plain, /Lessons/, 'should preserve the lessons link label');
     assert.match(plain, /Latest mistake \d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}:/, 'should clarify that the snippet is the latest mistake');
-    // localhost links are intentionally stripped from statusbar display — only real URLs shown
-    assert.doesNotMatch(plain, /http:\/\/localhost/, 'should NOT include localhost links in statusbar');
+    assert.match(plain, /localhost:3456/, 'should include local dashboard URLs');
   } finally {
     if (previousFeedbackDir === undefined) {
       delete process.env.THUMBGATE_FEEDBACK_DIR;
@@ -522,8 +520,8 @@ test('statusline shell keeps dashboard labels compact and leaves deep links to l
   assert.match(shellSource, /statusline-links\.js/);
   assert.match(shellSource, /inline_link/);
   assert.match(shellSource, /LOCAL_API_ORIGIN/);
-  assert.match(shellSource, /DASHBOARD_LINK="\$DASHBOARD_LABEL"/);
-  assert.match(shellSource, /LESSONS_LINK="\$LESSONS_LABEL"/);
+  assert.match(shellSource, /DASHBOARD_LINK="\$\(inline_link/);
+  assert.match(shellSource, /LESSONS_LINK="\$\(inline_link/);
   assert.match(shellSource, /LATEST_LESSON_LINK="\$\(inline_link/);
 });
 


### PR DESCRIPTION
Cherry-pick of 0761da3c. OSC 8 links were lost — Dashboard/Lessons/thumbs rendered as plain text instead of clickable hyperlinks in WezTerm/iTerm2.