### PR TITLE
fix: make statusbar Dashboard/Lessons links clickable (OSC 8)

### DIFF
--- a/.changeset/fix-statusline-clickable-links.md
+++ b/.changeset/fix-statusline-clickable-links.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+fix: make Dashboard and Lessons links clickable in Claude Code statusbar using OSC 8 terminal hyperlinks

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.4.1",
+      "version": "1.4.3",
       "author": {
         "name": "Igor Ganapolsky"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action gates, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.4.1"
+    "version": "1.4.3"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://github.com/IgorGanapolsky/thumbgate",
   "transport": "stdio",

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,7 +3,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.4.1 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.4.3 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.4.1", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.4.3", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.4.1", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.4.3", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -1,9 +1,9 @@
 # Codex MCP profile (copy into ~/.codex/config.toml or merge section)
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.4.1", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.4.3", "thumbgate", "serve"]
 
 # Hard PreToolUse hook for Codex
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.4.1", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.4.3", "thumbgate", "gate-check"]

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -124,7 +124,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.4.1' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.4.3' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.4.1",
+        "thumbgate@1.4.3",
         "thumbgate",
         "serve"
       ],

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.4.1 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.4.3 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.4.1 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.4.3 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:
@@ -95,7 +95,7 @@ This lane is for Claude Code users who want Codex review, adversarial review, an
 - Repo-local Codex plugin manifest: `plugins/codex-profile/.codex-plugin/plugin.json`
 - Repo-local Codex MCP config: `plugins/codex-profile/.mcp.json`
 - Repo-local Codex marketplace: `.agents/plugins/marketplace.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.4.1 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.4.3 serve`
 
 The standalone Codex bundle ships `.codex-plugin/plugin.json`, `.mcp.json`, `.agents/plugins/marketplace.json`, `config.toml`, and install docs in one zip. Stable releases publish `thumbgate-codex-plugin.zip`; prereleases publish `thumbgate-codex-plugin-next.zip`.
 

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1515,7 +1515,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.4.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.4.3 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2732,7 +2732,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.4.1 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.4.3 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.4.1`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.4.3`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.4.1 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.4.3 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.4.1", "serve"],
+      "args": ["-y", "thumbgate@1.4.3", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.4.1", "serve"],
+      "args": ["-y", "thumbgate@1.4.3", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.4.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.4.3 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.4.1
+1.4.3
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.4.1"
+version: "1.4.3"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "Self-improving agent governance: type thumbs-up or thumbs-down on any AI agent action. ThumbGate turns every mistake into a prevention rule and blocks the pattern from repeating. One thumbs-down, never again. 33 pre-action gates, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.4.1",
+        "thumbgate@1.4.3",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/codex-profile/.mcp.json
+++ b/plugins/codex-profile/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.4.1",
+        "thumbgate@1.4.3",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/INSTALL.md
+++ b/plugins/codex-profile/INSTALL.md
@@ -54,7 +54,7 @@ The following block is appended to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.4.1", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.4.3", "thumbgate", "serve"]
 ```
 
 The repo-local Codex app plugin ships the same runtime path through `plugins/codex-profile/.mcp.json`, so the manual config and plugin metadata stay aligned.

--- a/plugins/codex-profile/README.md
+++ b/plugins/codex-profile/README.md
@@ -45,7 +45,7 @@ That profile launches:
 ```toml
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.4.1", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.4.3", "thumbgate", "serve"]
 ```
 
 ### Build from source

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.4.1",
+  "version": "1.4.3",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.4.1", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.4.3", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -1054,7 +1054,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.4.1</span>
+    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.4.3</span>
   </div>
 </footer>
 

--- a/public/index.html
+++ b/public/index.html
@@ -718,7 +718,7 @@ __GA_BOOTSTRAP__
 <!-- HOW IT WORKS -->
 <section class="how-it-works" id="how-it-works">
   <div class="container">
-    <div class="section-label">New in v1.4.1</div>
+    <div class="section-label">New in v1.4.3</div>
     <h2 class="section-title">Three steps to stop repeated AI failures</h2>
     <div class="steps">
       <div class="step">

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -146,20 +146,21 @@ case "${TREND}" in
   improving) ARROW="↗" ;; degrading) ARROW="↘" ;; stable) ARROW="→" ;; *) ARROW="?" ;;
 esac
 
-inline_link() {
+# OSC 8 hyperlink: \e]8;;URL\a LABEL \e]8;;\a
+# Falls back to plain label when URL is empty or localhost.
+osc_link() {
   local url="$1"
   local label="$2"
-  if [ -n "$url" ]; then
-    printf '%s (%s)' "$label" "$url"
-  else
-    printf '%s' "$label"
-  fi
+  case "$url" in
+    *localhost*|*127.0.0.1*|"") printf '%s' "$label" ;;
+    *) printf '\033]8;;%s\007%s\033]8;;\007' "$url" "$label" ;;
+  esac
 }
 
 UP_ICON="👍"
 DOWN_ICON="👎"
-DASHBOARD_LINK="$DASHBOARD_LABEL"
-LESSONS_LINK="$LESSONS_LABEL"
+DASHBOARD_LINK="$(osc_link "$DASHBOARD_URL" "$DASHBOARD_LABEL")"
+LESSONS_LINK="$(osc_link "$LESSONS_URL" "$LESSONS_LABEL")"
 LATEST_LESSON_LINK=""
 if [ -n "$LESSON_LABEL" ]; then
   _DISPLAY_LINK="$LESSON_LINK"
@@ -167,9 +168,9 @@ if [ -n "$LESSON_LABEL" ]; then
     *localhost*|*127.0.0.1*) _DISPLAY_LINK="" ;;
   esac
   if [ -n "$LESSON_TEXT" ]; then
-    LATEST_LESSON_LINK="$(inline_link "$_DISPLAY_LINK" "${LESSON_LABEL}: ${LESSON_TEXT}")"
+    LATEST_LESSON_LINK="$(osc_link "$_DISPLAY_LINK" "${LESSON_LABEL}: ${LESSON_TEXT}")"
   else
-    LATEST_LESSON_LINK="$(inline_link "$_DISPLAY_LINK" "$LESSON_LABEL")"
+    LATEST_LESSON_LINK="$(osc_link "$_DISPLAY_LINK" "$LESSON_LABEL")"
   fi
 fi
 

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.4.1",
+  "version": "1.4.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "transport": {
         "type": "stdio"
       }

--- a/tests/statusline.test.js
+++ b/tests/statusline.test.js
@@ -389,6 +389,52 @@ test('statusline shows booting labels while the local dashboard is coming online
   assert.doesNotMatch(out, /\u001b]8;;http:\/\/localhost:3456\/dashboard/);
 });
 
+test('statusline emits OSC 8 hyperlinks for production (non-localhost) URLs', () => {
+  const PROD = 'https://thumbgate-production.up.railway.app';
+  const out = runStatusline({
+    thumbs_up: '6', thumbs_down: '2', lessons: '1', trend: 'stable'
+  }, {
+    _TEST_THUMBGATE_STATUSLINE_LINKS_JSON: JSON.stringify(linkFixture({
+      state: 'unavailable',
+      dashboardLabel: 'Dashboard',
+      lessonsLabel: 'Lessons',
+      dashboardUrl: `${PROD}/dashboard`,
+      lessonsUrl: `${PROD}/lessons`,
+      upUrl: '',
+      downUrl: '',
+    })),
+  });
+  // OSC 8 opening: \e]8;;URL\a
+  assert.match(out, /\u001b]8;;https:\/\/thumbgate-production\.up\.railway\.app\/dashboard\u0007Dashboard\u001b]8;;\u0007/,
+    'Dashboard should be wrapped in an OSC 8 hyperlink');
+  assert.match(out, /\u001b]8;;https:\/\/thumbgate-production\.up\.railway\.app\/lessons\u0007Lessons\u001b]8;;\u0007/,
+    'Lessons should be wrapped in an OSC 8 hyperlink');
+
+  // Verify plain text after stripping still shows labels
+  const plain = stripStatuslineFormatting(out);
+  assert.match(plain, /Dashboard/);
+  assert.match(plain, /Lessons/);
+  assert.doesNotMatch(plain, /https:\/\/thumbgate-production/, 'URLs should be in escape sequences, not visible text');
+});
+
+test('statusline does NOT emit OSC 8 hyperlinks for localhost URLs', () => {
+  const out = runStatusline({
+    thumbs_up: '3', thumbs_down: '1', lessons: '0', trend: 'stable'
+  }, {
+    _TEST_THUMBGATE_STATUSLINE_LINKS_JSON: JSON.stringify(linkFixture({
+      state: 'ready',
+      dashboardLabel: 'Dashboard',
+      lessonsLabel: 'Lessons',
+      dashboardUrl: 'http://localhost:3456/dashboard',
+      lessonsUrl: 'http://localhost:3456/lessons',
+    })),
+  });
+  assert.doesNotMatch(out, /\u001b]8;;http:\/\/localhost/,
+    'localhost URLs should not produce OSC 8 hyperlinks');
+  assert.match(out, /Dashboard/);
+  assert.match(out, /Lessons/);
+});
+
 test('statusline preserves dashboard links under a tight width budget', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-statusline-budget-'));
   const homeDir = path.join(tmpDir, 'home');
@@ -517,14 +563,14 @@ test('setupClaude uses portable ThumbGate commands for status line and cache upd
   );
 });
 
-test('statusline shell keeps dashboard labels compact and leaves deep links to lesson chips', () => {
+test('statusline shell wires dashboard and lesson links through osc_link', () => {
   const shellSource = fs.readFileSync(STATUSLINE_PATH, 'utf8');
   assert.match(shellSource, /statusline-links\.js/);
-  assert.match(shellSource, /inline_link/);
+  assert.match(shellSource, /osc_link/);
   assert.match(shellSource, /LOCAL_API_ORIGIN/);
-  assert.match(shellSource, /DASHBOARD_LINK="\$DASHBOARD_LABEL"/);
-  assert.match(shellSource, /LESSONS_LINK="\$LESSONS_LABEL"/);
-  assert.match(shellSource, /LATEST_LESSON_LINK="\$\(inline_link/);
+  assert.match(shellSource, /DASHBOARD_LINK="\$\(osc_link "\$DASHBOARD_URL" "\$DASHBOARD_LABEL"\)"/);
+  assert.match(shellSource, /LESSONS_LINK="\$\(osc_link "\$LESSONS_URL" "\$LESSONS_LABEL"\)"/);
+  assert.match(shellSource, /LATEST_LESSON_LINK="\$\(osc_link/);
 });
 
 test('statusline output ends with Dashboard and Lessons links (regression guard)', () => {


### PR DESCRIPTION
## Summary
- Statusline computed Dashboard/Lessons URLs via `statusline-links.js` but never wired them into the rendered output — `DASHBOARD_LINK` and `LESSONS_LINK` were set to plain label text
- Replace `inline_link()` with `osc_link()` that emits [OSC 8 terminal hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) for non-localhost URLs
- Localhost URLs remain plain text (existing policy preserved)
- Adds 2 new tests verifying OSC 8 emission for production URLs and suppression for localhost
- Bumps version to 1.4.3

## Test plan
- [x] `npm run test:statusline` — all 28 tests pass
- [x] New test: OSC 8 hyperlinks emitted for production URLs
- [x] New test: OSC 8 NOT emitted for localhost URLs
- [x] Existing regression tests pass (no-feedback, booting, budget, etc.)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>