### PR TITLE
feat(marketing): lead with costly mistake prevention

### DIFF
--- a/.changeset/costly-agent-mistakes.md
+++ b/.changeset/costly-agent-mistakes.md
@@ -1,0 +1,8 @@
+---
+"thumbgate": patch
+---
+
+Lead public marketing, README, LLM context, and ChatGPT GPT instructions with
+costly AI mistake prevention outcomes while clarifying that the GPT provides
+advice/checkpointing and hard enforcement runs through the local ThumbGate
+Reliability Gateway.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,15 +1,17 @@
-# ThumbGate — Type 👍 or 👎 on any AI agent action. Blocks the pattern from repeating. One thumbs-down, never again.
+# ThumbGate — Stop AI agents before they make costly mistakes.
 # https://thumbgate-production.up.railway.app
 # https://github.com/IgorGanapolsky/ThumbGate
 # https://www.npmjs.com/package/thumbgate
 
-> ThumbGate makes AI coding agents self-improving. Every mistake becomes
-> a prevention rule that physically blocks the agent from repeating it.
-> Feedback-driven enforcement via PreToolUse hooks.
+> ThumbGate prevents expensive AI mistakes before they happen. It checks
+> risky commands, file edits, deploys, payments, API calls, and other agent
+> actions before execution. 👎 Thumbs down becomes a history-aware lesson and
+> a Pre-Action Gate; 👍 thumbs up reinforces safe patterns.
 
 ## What ThumbGate solves
 
-- AI coding agents repeat the same mistakes across sessions
+- AI coding agents repeat costly mistakes across sessions
+- Bad commands, destructive SQL, risky deploys, unsafe publishes, and API mistakes are expensive after execution
 - CLAUDE.md and .cursorrules files are suggestions agents can ignore
 - No memory between sessions means no learning from corrections
 - Teams have no shared safety rules across developers
@@ -27,6 +29,7 @@
 - Developers using Claude Code, Cursor, Codex, Gemini CLI, or any MCP-compatible agent
 - Engineering teams that need shared agent safety rules
 - Anyone tired of re-correcting their AI coding assistant
+- Solo operators who want Pro dashboard proof for blocked mistakes and DPO exports
 
 ## Install
 
@@ -36,9 +39,10 @@ npx thumbgate init --agent claude-code
 
 ## Pricing
 
-- Free: 3 feedback captures/day, 5 lesson searches/day, 5 built-in gates
-- Pro: $19/mo or $149/yr — unlimited everything, auto-gate promotion, multi-repo sync
-- Founding Member: $49 one-time, Pro forever
+- Free GPT: advice, checkpointing, and setup help in ChatGPT
+- Free local CLI: 3 feedback captures/day, 5 lesson searches/day, recall, and local Pre-Action Gates after install
+- Pro: $19/mo or $149/yr — personal enforcement proof, local dashboard, gate debugger, DPO export, and review-ready exports
+- Team: $99/seat/mo, 3-seat minimum after intake — shared lessons, org visibility, approval boundaries, and rollout proof
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ThumbGate
 
-**Thumbs up or thumbs down — and your AI coding agent never makes the same mistake twice.**
+**Stop AI agents before they make costly mistakes.**
+
+ThumbGate checks risky commands, file edits, deploys, API calls, and other agent actions before they run. Thumbs-up/down feedback becomes remembered lessons, repeated failures become Pre-Action Gates, and the next bad action gets blocked instead of becoming another cleanup bill.
 
 [![CI](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/thumbgate)](https://www.npmjs.com/package/thumbgate)
@@ -18,7 +20,7 @@
 
 ## ThumbGate GPT: start here
 
-**Use ThumbGate in ChatGPT now:** **[Open the live ThumbGate GPT](https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate)**, paste the action your AI agent wants to run, and ask whether to allow, block, or checkpoint it.
+**Use ThumbGate in ChatGPT now:** **[Open the live ThumbGate GPT](https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate)**, paste the action your AI agent wants to run, and ask whether to allow, block, or checkpoint it before the mistake becomes expensive.
 
 Try this first prompt:
 
@@ -26,7 +28,7 @@ Try this first prompt:
 Check this agent action before it runs: git push --force --tags
 ```
 
-**No, users do not have to keep chatting inside the ThumbGate GPT to use ThumbGate.** The GPT is the fast demo, guided setup path, and thumbs-up/down memory surface for ChatGPT users. The hard enforcement layer still runs where the work happens: your local coding agent, CI workflow, or MCP-compatible runtime after `npx thumbgate init`.
+**No, users do not have to keep chatting inside the ThumbGate GPT to use ThumbGate.** The GPT is the fast demo, guided setup path, and thumbs-up/down memory surface for ChatGPT users. Think of the GPT as advice and checkpointing; the hard enforcement layer still runs where the work happens: your local coding agent, CI workflow, or MCP-compatible runtime after `npx thumbgate init`.
 
 Developers can import the prepared **[GPT Actions OpenAPI spec](adapters/chatgpt/openapi.yaml)** with the **[ChatGPT Actions setup guide](adapters/chatgpt/INSTALL.md)**. Regular ChatGPT users should just open the GPT and type what happened.
 
@@ -46,7 +48,13 @@ It scores deterministic GitHub, npm, database, Railway, shell, and filesystem sc
 
 ## What problem does this solve?
 
-AI agents repeat mistakes. You fix the same problem in session after session — force-push to main, broken migrations, unauthorized file edits — because the agent has no memory of your feedback.
+AI agents repeat expensive mistakes. You fix the same problem in session after session — force-push to main, broken migrations, unauthorized file edits, risky deploys — because the agent has no durable memory of your feedback and no gate before execution.
+
+ThumbGate sells three concrete outcomes:
+
+- **Prevent expensive AI mistakes** — catch bad commands, destructive database actions, unsafe publishes, and risky API calls before they run.
+- **Make AI stop repeating mistakes** — fix it once, turn the lesson into a rule, and block the repeat before the next tool call lands.
+- **Turn AI into a reliable operator** — move from a smart assistant that apologizes after damage to a production-ready operator with checkpoints, proof, and enforcement.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -64,7 +72,7 @@ AI agents repeat mistakes. You fix the same problem in session after session —
 └─────────────────────────────────────────────────────────────┘
 ```
 
-ThumbGate is the **control plane** for AI coding agents — turning your feedback into **enforced rules**, not suggestions.
+ThumbGate is the **Reliability Gateway** for AI coding agents — turning your feedback into **enforced rules**, not suggestions.
 
 ---
 
@@ -129,6 +137,8 @@ Session 3:                     │  Session 3+:
 **Best first technical motion:** install the CLI-first and let `init` wire hooks for the agent you already use.
 
 **Paid path for individual operators:** [ThumbGate Pro](https://thumbgate-production.up.railway.app/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page) is the self-serve side lane for a personal dashboard and export-ready evidence.
+
+**Plain product line:** GPT preview = advice and checkpointing. Free local CLI (3 daily feedback captures, 5 daily lesson searches) = basic enforcement on one machine. Pro ($19/mo or $149/yr) = personal enforcement proof, dashboard, and exports. Team = shared hosted lesson DB, org dashboard, and shared enforcement so one correction protects every seat.
 
 ---
 
@@ -265,9 +275,9 @@ Free and self-hosted users can invoke `search_lessons` directly through MCP, and
 **[Start Workflow Hardening Sprint](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake)** · **[Live Dashboard](https://thumbgate-production.up.railway.app/dashboard?utm_source=github&utm_medium=readme&utm_campaign=top_cta)** · **[See Pro](https://thumbgate-production.up.railway.app/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page)**
 
 **Where to start:**
-- **Teams:** Begin with the Workflow Hardening Sprint — qualify one real repeated failure before committing to a full rollout
-- **Solo operators:** ThumbGate Pro adds a personal dashboard and export-ready evidence
-- **Individuals & open source:** Free CLI tier, self-hosted
+- **Teams:** Begin with the Workflow Hardening Sprint — prove one costly repeat failure can be blocked before committing to a full rollout
+- **Solo operators:** ThumbGate Pro adds personal enforcement proof, a gate debugger, and export-ready evidence
+- **Individuals & open source:** Free CLI tier, self-hosted, with local Pre-Action Gates after install
 
 ---
 

--- a/adapters/chatgpt/INSTALL.md
+++ b/adapters/chatgpt/INSTALL.md
@@ -4,9 +4,11 @@ Open the published ThumbGate GPT directly:
 
 https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate
 
-Use the GPT as the public front door: paste an AI action to check, save a thumbs-up/down lesson, write a Pre-Action Gate, install ThumbGate for an agent, or export proof.
+Use the GPT as the public front door: paste a risky AI action to check, prevent an expensive mistake before it runs, save a thumbs-up/down lesson, write a Pre-Action Gate, install ThumbGate for an agent, or export proof.
 
-Users do **not** have to keep chatting inside the ThumbGate GPT for enforcement. The GPT is the fast demo, guided setup path, and ChatGPT memory surface. Real enforcement for coding agents still runs locally through ThumbGate hooks after `npx thumbgate init`.
+Users do **not** have to keep chatting inside the ThumbGate GPT for enforcement. The GPT is advice, checkpointing, guided setup, and ChatGPT memory capture. Real enforcement for coding agents still runs locally through ThumbGate hooks after `npx thumbgate init`.
+
+Use the term **Reliability Gateway** only after the user understands the outcome: ThumbGate is the gate between AI intent and costly execution.
 
 Marketing rule: every landing page, README, social post, and plugin listing should point to the live GPT before asking a cold user to read OpenAPI docs.
 
@@ -25,22 +27,22 @@ Marketing rule: every landing page, README, social post, and plugin listing shou
 4. ThumbGate saves the lesson, refreshes prevention rules when patterns repeat, and can show what it remembers.
 5. When the user is ready to enforce outside ChatGPT, send them to `npx thumbgate init` for Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, or another MCP-compatible agent.
 
-Regular users should never need to know MCP, OpenAPI, Actions, DPO, Thompson Sampling, or schema validation. The GPT should explain the loop as: "One signal becomes one remembered rule."
+Regular users should never need to know MCP, OpenAPI, Actions, DPO, Thompson Sampling, or schema validation. The GPT should explain the loop as: "One signal becomes one remembered rule. Fix it once; block the repeat before the next tool call."
 
 ## GPT profile card
 
-Use this copy in GPT Builder instead of the generic "AI safety gate" framing:
+Use this copy in GPT Builder instead of the generic "AI safety gate" or "reliability layer" framing:
 
 Short description:
 
 ```text
-Turn thumbs-down into prevention gates
+Stop costly AI mistakes before they run
 ```
 
 Full description:
 
 ```text
-Paste a proposed AI action or reply thumbs up/down after an answer. ThumbGate captures the lesson, searches prior mistakes, writes Pre-Action Gates, and tells you when to allow, block, or checkpoint. Built for developers using AI agents and proof-backed Reliability Gateway workflows.
+Paste a risky AI action before it runs. ThumbGate tells you whether to allow, block, or checkpoint it, then turns thumbs-up/down feedback into Pre-Action Gates so repeated mistakes stop coming back.
 ```
 
 Conversation starters:
@@ -68,7 +70,7 @@ Plain thumbs-up/down feedback is the memory loop. The decision endpoint is the g
 Use this as the first response:
 
 ```text
-Paste an AI action to check, or tell me what went right/wrong. I can block risky actions, save the lesson, write a prevention gate, or show what ThumbGate already remembers.
+Paste the risky AI action before it runs, or tell me what went right/wrong. I can prevent costly mistakes, save the lesson, write a prevention gate, or show what ThumbGate already remembers.
 ```
 
 ## Prerequisites
@@ -78,7 +80,7 @@ Paste an AI action to check, or tell me what went right/wrong. I can block risky
 - Privacy policy URL: `https://thumbgate-production.up.railway.app/privacy`
 - Owner-managed `THUMBGATE_API_KEY` for one-time GPT Builder Actions auth
 
-Regular GPT users should not need an API key, JSON payload, OpenAPI knowledge, or developer setup. They should only see the thumbs-up/down memory loop.
+Regular GPT users should not need an API key, JSON payload, OpenAPI knowledge, or developer setup. They should only see the action-checking path, the thumbs-up/down memory loop, and the handoff to local enforcement when they need hard blocking.
 
 ## Step 1 — Open GPT Builder
 

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -2,8 +2,8 @@
   "repo": "IgorGanapolsky/ThumbGate",
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
   "homepageUrl": "https://thumbgate-production.up.railway.app",
-  "githubDescription": "CLI-first agent governance for AI coding workflows: pre-action gates, shared lessons, and team safeguards that stop repeated agent mistakes.",
-  "metaDescription": "CLI-first agent governance for teams shipping AI-generated changes. \ud83d\udc4e Thumbs down distills history-aware lessons from up to 8 prior entries and stays linked to a 60-second feedback session. \ud83d\udc4d Thumbs up reinforces safe patterns. Pre-action gates, workflow governance, shared lessons and org visibility, release confidence, and isolated execution guidance turn vibe coding mistakes into shared enforcement and proof-ready rollout.",
+  "githubDescription": "Agent governance that stops costly AI mistakes before they run: pre-action gates, shared lessons, and team safeguards for AI coding workflows.",
+  "metaDescription": "Stop expensive AI agent mistakes before they happen. \ud83d\udc4e Thumbs down becomes history-aware lessons and Pre-Action Gates; \ud83d\udc4d thumbs up reinforces safe patterns. ThumbGate checks risky commands, deploys, API calls, and file edits across ChatGPT, Claude Code, Cursor, Codex, Gemini, Amp, and OpenCode with workflow governance, shared lessons and org visibility for safer vibe coding.",
   "topics": [
     "thumbgate",
     "pre-action-gates",

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -2,7 +2,7 @@
 
 ## Core Identity
 **Product Name:** ThumbGate
-**Primary Value Proposition:** Pre-Action Gates
+**Primary Value Proposition:** Stop AI agents before they make costly mistakes
 
 ## Surface Descriptions
 
@@ -10,14 +10,14 @@
 > Pre-action gates that block AI agents from repeating known mistakes. Captures feedback, auto-generates prevention rules, and enforces them via PreToolUse hooks.
 
 ### Public Landing Page (thumbgate-production.up.railway.app)
-> CLI-first agent governance for teams shipping AI-generated changes. 👎 Thumbs down distills history-aware lessons from up to 8 prior entries and stays linked to a 60-second feedback session. 👍 Thumbs up reinforces safe patterns. Pre-action gates, workflow governance, shared lessons and org visibility, release confidence, and isolated execution guidance turn vibe coding mistakes into shared enforcement and proof-ready rollout.
+> Stop expensive AI agent mistakes before they happen. 👎 Thumbs down becomes history-aware lessons and Pre-Action Gates; 👍 thumbs up reinforces safe patterns. ThumbGate checks risky commands, deploys, API calls, and file edits across ChatGPT, Claude Code, Cursor, Codex, Gemini, Amp, and OpenCode with workflow governance, shared lessons and org visibility for safer vibe coding.
 
 ### NPM package.json
 > Pre-action gates that block AI coding agents from repeating known mistakes. Captures feedback, auto-promotes failures into prevention rules, and enforces them via PreToolUse hooks.
 
 ### GitHub Repo About
 **Canonical source:** `config/github-about.json`
-> CLI-first agent governance for AI coding workflows: pre-action gates, shared lessons, and team safeguards that stop repeated agent mistakes.
+> Agent governance that stops costly AI mistakes before they run: pre-action gates, shared lessons, and team safeguards for AI coding workflows.
 
 **Canonical topics:** `thumbgate`, `pre-action-gates`, `mcp`, `mcp-server`, `ai-agents`, `agent-reliability`, `guardrails`, `ai-safety`, `developer-tools`, `feedback-loop`, `claude-code`, `cursor`, `codex`, `gemini`, `amp`, `opencode`, `thompson-sampling`
 
@@ -32,6 +32,9 @@
 
 | Old Term | New Term (Lead with this) |
 |---|---|
+| AI reliability layer | stop costly AI agent mistakes |
+| Global enforcement | enforcement for actions routed through ThumbGate |
+| Behavior control system | Pre-Action Gates that block risky actions before execution |
 | ThumbGate feedback loop | feedback-to-enforcement pipeline |
 | Veto Layer | Pre-Action Gates |
 | Agentic Feedback Studio | [DROP] |
@@ -48,6 +51,10 @@
 **ThumbGate's answer**: ThumbGate is the authenticity enforcement layer for AI agents. The thumbs-up/down mechanism is a hard gate between AI intent and execution — not a soft suggestion. Every thumbs-down becomes a prevention rule specific to your team's actual standards.
 
 **Key messages to use on this angle:**
+- "Stop AI agents before they make costly mistakes."
+- "Prevent expensive AI mistakes before they happen."
+- "Fix it once. Block the repeat before the next tool call."
+- "Turn a smart assistant into a reliable operator."
 - "Your AI's outputs should reflect your standards, not generic patterns."
 - "Human judgment leads. ThumbGate enforces it."
 - "Stop AI slop before it ships — at the tool-call level."

--- a/docs/chatgpt-gpt-instructions.md
+++ b/docs/chatgpt-gpt-instructions.md
@@ -7,7 +7,7 @@ Use these instructions for the published ThumbGate GPT and any Custom GPT clone 
 Published GPT URL: https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate
 
 ```text
-You are ThumbGate: the Reliability Gateway for AI agents. Your job is to turn user feedback and proposed agent actions into concrete lessons, Pre-Action Gates, and proof the user can reuse.
+You are ThumbGate: the Reliability Gateway for AI agents. Your job is to prevent costly AI mistakes before they happen, then turn user feedback and proposed agent actions into concrete lessons, Pre-Action Gates, and proof the user can reuse.
 
 You are also the public front door for ThumbGate. Make the product easy to try immediately, then route serious users into local enforcement with `npx thumbgate init`. Do not trap users inside ChatGPT when they need hard blocking in Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, CI, or another MCP-compatible runtime.
 
@@ -20,7 +20,7 @@ Lead with jobs, not explanations. When the user is not specific, offer these six
 6. Export evidence: feedback summary, prevention rules, DPO pairs, or verification links.
 
 Default first response:
-"Paste an AI action to check, or tell me what went right/wrong. I can block risky actions, save the lesson, write a prevention gate, or show what ThumbGate already remembers."
+"Paste the risky AI action before it runs, or tell me what went right/wrong. I can prevent costly mistakes, save the lesson, write a prevention gate, or show what ThumbGate already remembers."
 
 When users ask whether they must use ThumbGate from this GPT, answer directly:
 "No. This GPT is the fastest demo, guided setup path, and memory surface. Hard enforcement runs locally after `npx thumbgate init` where your agent actually executes."
@@ -36,6 +36,8 @@ User experience rules:
 - Never make regular users write JSON, API payloads, or schemas.
 - Do not mention MCP, OpenAPI, Actions, DPO, Thompson Sampling, or schema validation unless the user asks as a developer.
 - Do not make the GPT feel like a documentation kiosk. Lead with "paste the risky action" and "install local enforcement" before explaining architecture.
+- Sell outcomes before infrastructure: prevent expensive AI mistakes, make AI stop repeating mistakes, and turn a smart assistant into a reliable operator.
+- Be precise about scope: this GPT provides advice, checkpointing, and memory capture; hard blocking applies to actions routed through ThumbGate locally, in CI, or through the decision endpoint.
 - Do not imply ChatGPT's native rating buttons automatically save ThumbGate lessons. The reliable capture path is a typed message such as "thumbs up: this worked" or "thumbs down: this missed the point."
 - Do not claim hard enforcement from plain feedback alone. Hard enforcement requires an applied saved lesson, generated prevention rule, or decision evaluation.
 - Confirm every saved lesson with the exact future behavior it changes.
@@ -65,13 +67,13 @@ ThumbGate
 ## Short Description
 
 ```text
-Turn thumbs-down into prevention gates
+Stop costly AI mistakes before they run
 ```
 
 ## Full Description
 
 ```text
-Paste a proposed AI action or reply thumbs up/down after an answer. ThumbGate captures the lesson, searches prior mistakes, writes Pre-Action Gates, and tells you when to allow, block, or checkpoint. Built for developers using AI agents and proof-backed Reliability Gateway workflows.
+Paste a risky AI action before it runs. ThumbGate tells you whether to allow, block, or checkpoint it, then turns thumbs-up/down feedback into Pre-Action Gates so repeated mistakes stop coming back.
 ```
 
 ## Conversation Starters

--- a/docs/gpt-store-submission.md
+++ b/docs/gpt-store-submission.md
@@ -24,7 +24,7 @@ ThumbGate
 ## Short Description (max 50 characters)
 
 ```
-Turn thumbs-down into prevention gates
+Stop costly AI mistakes before they run
 ```
 
 ---
@@ -32,7 +32,7 @@ Turn thumbs-down into prevention gates
 ## Full Description (max 300 characters)
 
 ```
-Paste a proposed AI action or reply thumbs up/down after an answer. ThumbGate captures the lesson, searches prior mistakes, writes Pre-Action Gates, and tells you when to allow, block, or checkpoint. Built for developers using AI agents and proof-backed Reliability Gateway workflows.
+Paste a risky AI action before it runs. ThumbGate tells you whether to allow, block, or checkpoint it, then turns thumbs-up/down feedback into Pre-Action Gates so repeated mistakes stop coming back.
 ```
 
 ---
@@ -40,7 +40,7 @@ Paste a proposed AI action or reply thumbs up/down after an answer. ThumbGate ca
 ## Instructions (paste into the "Instructions" field)
 
 ```
-You are ThumbGate: the Reliability Gateway for AI agents. Your job is to turn user feedback and proposed agent actions into concrete lessons, Pre-Action Gates, and proof the user can reuse.
+You are ThumbGate: the Reliability Gateway for AI agents. Your job is to prevent costly AI mistakes before they happen, then turn user feedback and proposed agent actions into concrete lessons, Pre-Action Gates, and proof the user can reuse.
 
 Lead with jobs, not explanations. When the user is not specific, offer these six paths:
 1. Check an AI action before it runs.
@@ -51,7 +51,7 @@ Lead with jobs, not explanations. When the user is not specific, offer these six
 6. Export evidence: feedback summary, prevention rules, DPO pairs, or verification links.
 
 Default first response:
-"Paste an AI action to check, or tell me what went right/wrong. I can block risky actions, save the lesson, write a prevention gate, or show what ThumbGate already remembers."
+"Paste the risky AI action before it runs, or tell me what went right/wrong. I can prevent costly mistakes, save the lesson, write a prevention gate, or show what ThumbGate already remembers."
 
 Mode routing:
 - Action check mode: if the user asks whether an agent should run a command, file edit, merge, deploy, payment, API call, email, or publish step, call `evaluateDecision` (`POST /v1/decisions/evaluate`) before giving approval. If `decisionControl.executionMode` is `blocked`, say it is blocked and why. If it is `checkpoint_required`, ask for explicit confirmation. If it is `auto_execute`, say it is allowed and summarize the evidence.
@@ -65,6 +65,8 @@ User experience rules:
 - Do not mention MCP, OpenAPI, Actions, DPO, Thompson Sampling, or schema validation unless the user asks as a developer.
 - Do not imply ChatGPT's native rating buttons automatically save ThumbGate lessons. The reliable capture path is a typed message such as "thumbs up: this worked" or "thumbs down: this missed the point."
 - Do not claim hard enforcement from plain feedback alone. Hard enforcement requires an applied saved lesson, generated prevention rule, or decision evaluation.
+- Sell outcomes before infrastructure: prevent expensive AI mistakes, make AI stop repeating mistakes, and turn a smart assistant into a reliable operator.
+- Be precise about scope: this GPT provides advice, checkpointing, and memory capture; hard blocking applies to actions routed through ThumbGate locally, in CI, or through the decision endpoint.
 - Confirm every saved lesson with the exact future behavior it changes.
 - Only show feedback IDs when the user asks for technical details or is configuring developer Actions.
 - Keep confirmations short. The product feeling is: one signal becomes one remembered rule.

--- a/public/index.html
+++ b/public/index.html
@@ -19,10 +19,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 __GOOGLE_SITE_VERIFICATION_META__
-<title>ThumbGate — Your AI agent just made that mistake again. One thumbs-down. It never happens again.</title>
-<meta name="description" content="CLI-first agent governance for teams shipping AI-generated changes. 👎 Thumbs down distills history-aware lessons from up to 8 prior entries and stays linked to a 60-second feedback session. 👍 Thumbs up reinforces safe patterns. Pre-action gates, workflow governance, shared lessons and org visibility, release confidence, and isolated execution guidance turn vibe coding mistakes into shared enforcement and proof-ready rollout.">
-<meta property="og:title" content="ThumbGate — Your AI agent just made that mistake again. One thumbs-down. It never happens again.">
-<meta property="og:description" content="CLI-first agent governance for teams shipping AI-generated changes. 👎 Thumbs down distills history-aware lessons from up to 8 prior entries and stays linked to a 60-second feedback session. 👍 Thumbs up reinforces safe patterns. Pre-action gates, workflow governance, shared lessons and org visibility, release confidence, and isolated execution guidance turn vibe coding mistakes into shared enforcement and proof-ready rollout.">
+<title>ThumbGate — Stop AI agents before they make costly mistakes</title>
+<meta name="description" content="Stop expensive AI agent mistakes before they happen. 👎 Thumbs down becomes history-aware lessons and Pre-Action Gates; 👍 thumbs up reinforces safe patterns. ThumbGate checks risky commands, deploys, API calls, and file edits across ChatGPT, Claude Code, Cursor, Codex, Gemini, Amp, and OpenCode with workflow governance, shared lessons and org visibility for safer vibe coding.">
+<meta property="og:title" content="ThumbGate — Stop AI agents before they make costly mistakes">
+<meta property="og:description" content="Stop expensive AI agent mistakes before they happen. 👎 Thumbs down becomes history-aware lessons and Pre-Action Gates; 👍 thumbs up reinforces safe patterns. ThumbGate checks risky commands, deploys, API calls, and file edits across ChatGPT, Claude Code, Cursor, Codex, Gemini, Amp, and OpenCode with workflow governance, shared lessons and org visibility for safer vibe coding.">
 <meta property="og:type" content="website">
 <meta name="keywords" content="ThumbGate, thumbgate, agent governance, AI coding workflow governance, workflow hardening sprint, pre-action gates, CLI-first agent safety, Claude Code, Cursor, Codex, Gemini, Amp, OpenCode, approval policies, audit trail, release confidence, Docker Sandboxes, feedback enforcement, context engineering, AI authenticity, prevent AI slop, human-led AI, AI agent standards enforcement, brand authenticity AI">
 
@@ -44,7 +44,7 @@ __GA_BOOTSTRAP__
   "@type": "SoftwareApplication",
   "name": "ThumbGate",
   "alternateName": "thumbgate",
-  "description": "ThumbGate is a CLI-first agent governance control plane for AI coding workflows. Every repeated failure can become shared enforcement, every risky rollout can carry approval and audit boundaries, and high-risk local autonomy can be routed toward isolated execution instead of running directly on the host.",
+  "description": "ThumbGate stops costly AI agent mistakes before they happen. It checks risky commands, file edits, deploys, API calls, and other agent actions before execution, then turns thumbs-up/down feedback into Pre-Action Gates, workflow governance, shared lessons, org visibility, release confidence, and isolated execution guidance.",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
   "license": "https://opensource.org/licenses/MIT",
@@ -58,7 +58,9 @@ __GA_BOOTSTRAP__
     "url": "https://github.com/IgorGanapolsky"
   },
   "featureList": [
-    "Pre-Action Gates — block known-bad tool calls before execution",
+    "Prevent expensive AI mistakes — catch bad commands, destructive database actions, unsafe publishes, and risky API calls before execution",
+    "Make AI stop repeating mistakes — thumbs-down feedback becomes history-aware lessons and Pre-Action Gates",
+    "Turn AI into a reliable operator — checkpoint risky actions, enforce safe patterns, and keep proof of what changed",
     "ThumbGate GPT for ChatGPT — check proposed agent actions, capture thumbs-up/down lessons, and route users into local enforcement",
     "Workflow Sentinel — score blast radius before PR, merge, release, and publish actions fire",
     "Docker Sandboxes routing — move high-risk local runs into isolated microVM-backed execution",
@@ -81,7 +83,7 @@ __GA_BOOTSTRAP__
       "name": "Free",
       "price": "0",
       "priceCurrency": "USD",
-      "description": "Local enforcement — captures, recalls, gates, and PreToolUse hook blocking for solo devs"
+      "description": "Free local CLI enforcement for one developer — captures, recalls, gates, and PreToolUse hook blocking after install"
     },
     {
       "@type": "Offer",
@@ -96,7 +98,7 @@ __GA_BOOTSTRAP__
       "name": "Pro Monthly",
       "price": "19",
       "priceCurrency": "USD",
-      "description": "Self-serve side lane for solo operators who want a personal local dashboard, DPO export, and proof-ready exports",
+      "description": "Self-serve side lane for solo operators who want personal enforcement proof, a local dashboard, DPO export, and proof-ready exports",
       "url": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&landing_path=%2F"
     },
     {
@@ -104,7 +106,7 @@ __GA_BOOTSTRAP__
       "name": "Pro Annual",
       "price": "149",
       "priceCurrency": "USD",
-      "description": "Annual Pro for individual operators who want the personal local dashboard and proof-ready exports",
+      "description": "Annual Pro for individual operators who want personal enforcement proof, the local dashboard, and proof-ready exports",
       "url": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&billing_cycle=annual&landing_path=%2F"
     }
   ]
@@ -190,7 +192,7 @@ __GA_BOOTSTRAP__
       "name": "Do I have to chat inside the ThumbGate GPT for enforcement?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "No. The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions, capturing thumbs-up/down lessons, and getting setup help. Hard enforcement still runs locally where the agent executes after npx thumbgate init."
+        "text": "No. The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions, capturing thumbs-up/down lessons, and getting setup help. Use it for advice and checkpointing; hard enforcement still runs locally where the agent executes after npx thumbgate init."
       }
     },
     {
@@ -494,13 +496,13 @@ __GA_BOOTSTRAP__
 <section class="hero">
   <div class="container">
     <div class="hero-thumbs">👍👎</div>
-    <div class="hero-badge">● Live ThumbGate GPT for ChatGPT</div>
-    <h1>Your AI agent just made<br>that mistake again.<br><span style="color:var(--cyan)">One thumbs-down.<br>It never happens again.</span></h1>
-    <p style="font-size:18px;color:var(--text-muted);max-width:620px;margin:0 auto 20px;line-height:1.6;">Start in ChatGPT: paste the proposed action into the live ThumbGate GPT and get allow, block, or checkpoint guidance.<br><strong style="color:var(--text)">Then enforce locally with <code>npx thumbgate init</code> where your agent actually runs.</strong></p>
+    <div class="hero-badge">● Stop costly AI mistakes before they run</div>
+    <h1>Stop AI agents before<br>they make costly mistakes.</h1>
+    <p style="font-size:18px;color:var(--text-muted);max-width:640px;margin:0 auto 20px;line-height:1.6;">Paste a risky command, file edit, deploy, payment, API call, or email into the live ThumbGate GPT for allow, block, or checkpoint guidance.<br><strong style="color:var(--text)">Then enforce locally with <code>npx thumbgate init</code> where your agent actually executes.</strong></p>
     <div class="hero-signals">
-      <div class="signal-pill signal-down">👎 Repeated failure becomes enforcement before the next run</div>
-      <div class="signal-pill signal-up">✅ Safe pattern reinforced across the shared workflow</div>
-      <div class="signal-pill">🔁 Works with Claude Code · Cursor · Codex · Gemini · Amp</div>
+      <div class="signal-pill signal-down">👎 Prevent expensive mistakes: force-pushes, destructive SQL, bad deploys</div>
+      <div class="signal-pill signal-up">✅ Fix it once, then block the repeat before the next tool call</div>
+      <div class="signal-pill">🔁 Turn a smart assistant into a reliable operator</div>
     </div>
     <p class="hero-persona" style="display:none">For consultancies, platform teams, and AI product teams with one workflow owner, one repeated failure, and one buyer who needs proof before a wider rollout.</p>
     <div class="hero-actions" style="margin-top:32px;">
@@ -514,8 +516,8 @@ __GA_BOOTSTRAP__
       <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener" class="btn-free" style="display:inline-flex;align-items:center;gap:6px;padding:11px 20px;border-radius:999px;">⭐ Star on GitHub</a>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" class="btn-install-link" target="_blank" rel="noopener" style="font-size:13px;color:var(--text-muted);text-decoration:none;padding:8px 14px;">Install Codex plugin →</a>
     </div>
-    <p style="font-size:13px;color:var(--text-muted);margin:16px auto 0;max-width:620px;">No, you do not have to chat inside the GPT forever. The GPT is the fastest demo and setup path; local hooks do the hard blocking for Claude Code, Cursor, Codex, Gemini, Amp, OpenCode, and MCP-compatible agents.</p>
-    <p style="font-size:13px;color:var(--text-muted);margin:8px auto 28px;max-width:480px;">Team plan is intake-first — one workflow, one repeat failure, proof before wider rollout. Pro stays the solo side lane for gate debugger, DPO export, and personal dashboard. <a href="#pricing" style="color:var(--cyan);text-decoration:none;">See all plans →</a></p>
+    <p style="font-size:13px;color:var(--text-muted);margin:16px auto 0;max-width:660px;">No, you do not have to chat inside the GPT forever. The GPT is advice and checkpointing; local hooks do the hard blocking for Claude Code, Cursor, Codex, Gemini, Amp, OpenCode, and MCP-compatible agents.</p>
+    <p style="font-size:13px;color:var(--text-muted);margin:8px auto 28px;max-width:560px;">Free local CLI proves the enforcement loop on one machine. Pro adds personal enforcement proof, the gate debugger, DPO export, and a dashboard. Team shares the gates across seats. <a href="#pricing" style="color:var(--cyan);text-decoration:none;">See all plans →</a></p>
     <div class="proof-bar">
       <a href="/guide" rel="noopener">CLI-first setup guide →</a>
       <span class="dot"></span>
@@ -559,13 +561,13 @@ __GA_BOOTSTRAP__
 <section class="gpt-path" id="thumbgate-gpt">
   <div class="container">
     <div class="gpt-panel">
-      <div class="section-label" style="text-align:left;">ChatGPT Entry Point</div>
+      <div class="section-label" style="text-align:left;">ChatGPT Entry Point · Live ThumbGate GPT for ChatGPT</div>
       <h2>Open the GPT. Check the action. Turn the lesson into a gate.</h2>
-      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to understand the product before installing anything.</p>
+      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to prevent an expensive AI mistake before installing anything.</p>
       <div class="gpt-steps">
         <div class="gpt-step">
           <strong>1. Try the live GPT</strong>
-          <p>Paste a proposed command, file edit, merge, deploy, payment, email, or API call and ask what should happen next.</p>
+          <p>Paste a proposed command, file edit, merge, deploy, payment, email, or API call and ask whether to allow, block, or checkpoint it.</p>
         </div>
         <div class="gpt-step">
           <strong>2. Save the signal</strong>
@@ -580,7 +582,7 @@ __GA_BOOTSTRAP__
         <a href="https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('gpt_path_cta_click',{cta:'open_gpt'})">Open ThumbGate GPT</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/adapters/chatgpt/INSTALL.md" class="btn-free" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">ChatGPT Actions setup</a>
       </div>
-      <p class="gpt-note"><strong>Plain English rule:</strong> ChatGPT is the discovery and memory surface. The hard Reliability Gateway still runs in the local agent or CI lane.</p>
+      <p class="gpt-note"><strong>Plain English rule:</strong> ChatGPT is the discovery and memory surface for advice, checkpointing, and typed feedback capture. The hard Reliability Gateway still runs in the local agent or CI lane.</p>
     </div>
   </div>
 </section>
@@ -861,13 +863,13 @@ __GA_BOOTSTRAP__
 <section class="pricing" id="pricing">
   <div class="container">
     <div class="section-label">Pricing</div>
-    <h2 class="section-title">Install free. Buy with the workflow hardening sprint. Keep Pro as the solo side lane.</h2>
+    <h2 class="section-title">Install free. Pro adds enforcement proof. Team shares it across seats.</h2>
     <div class="pricing-grid">
       <div class="price-card">
         <div class="tier">Free</div>
         <div class="price">$0</div>
         <div class="price-sub">Forever free · CLI-first local enforcement for one developer</div>
-        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">For solo developers who want to stop the same agent mistake from showing up twice and prove value before a team rollout conversation exists.</p>
+        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">For solo developers who want to stop the same agent mistake from showing up twice and prove local value before a team rollout conversation exists.</p>
         <ul>
           <li>3 feedback captures/day · 5 lesson searches/day · unlimited recall</li>
           <li>5 auto-promoted gates plus the core safety policy</li>
@@ -882,10 +884,10 @@ __GA_BOOTSTRAP__
       <div class="price-card pro" data-price-dollars="__PRO_PRICE_DOLLARS__">
         <div class="tier">Solo Pro</div>
         <div class="price">$19<span style="font-size:16px;color:var(--text-dim)">/mo</span></div>
-        <div class="price-sub">or $149/yr (save 35%) · Personal dashboard + exports</div>
-        <p style="font-size:13px;color:var(--cyan);margin-bottom:16px;font-weight:500;">For an individual operator who wants a personal dashboard and proof-ready exports without starting the team rollout motion.</p>
+        <div class="price-sub">or $149/yr (save 35%) · Personal dashboard + enforcement proof</div>
+        <p style="font-size:13px;color:var(--cyan);margin-bottom:16px;font-weight:500;">For an individual operator who wants the gate debugger, personal dashboard, proof-ready exports, and export-ready evidence without starting the team rollout motion.</p>
         <div class="pro-upgrade-triggers" style="font-size:12px;color:#aaa;margin-bottom:12px;">
-          <strong style="color:#fff;">Choose Pro when:</strong> you want review-ready evidence, need your own dashboard, or are still operating solo.
+          <strong style="color:#fff;">Choose Pro when:</strong> you want review-ready evidence, need your own dashboard, or need to show which mistakes were blocked.
         </div>
         <div class="dashboard-preview" style="margin-bottom:16px;border:1px solid #333;border-radius:8px;overflow:hidden;">
           <div style="background:linear-gradient(135deg,#1a1a2e 0%,#16213e 100%);padding:16px;text-align:center;">
@@ -910,7 +912,7 @@ __GA_BOOTSTRAP__
         </ul>
         <div class="trial-badge" style="background:var(--cyan);color:#000;display:inline-block;padding:4px 12px;border-radius:12px;font-size:12px;font-weight:700;margin-bottom:12px;">7-DAY FREE TRIAL</div>
         <a href="/checkout/pro?utm_source=website&utm_medium=pricing_card&utm_campaign=pro_trial&cta_id=pricing_pro_trial&cta_placement=pricing&plan_id=pro&landing_path=%2F" class="btn-pro" onclick="posthog.capture('pricing_cta_click',{cta:'pro_trial',plan:'pro'})" style="display:block;width:100%;text-align:center;padding:12px;font-size:15px;">Start 7-Day Free Trial — $19/mo</a>
-        <p style="font-size:11px;color:#666;margin-top:8px;">Solo Pro stays available for operators who want a personal dashboard and export-ready evidence without the team rollout motion.</p>
+        <p style="font-size:11px;color:#666;margin-top:8px;">Solo Pro stays available for operators who want personal enforcement proof without the team rollout motion.</p>
       </div>
       <div class="price-card team">
         <div class="tier">Team</div>
@@ -985,7 +987,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">Do I have to chat inside the ThumbGate GPT for enforcement?</div>
-        <div class="faq-a">No. The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions, capturing thumbs-up/down lessons, and getting setup help. Hard enforcement still runs locally where the agent executes after <code>npx thumbgate init</code>.</div>
+        <div class="faq-a">No. The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions, capturing thumbs-up/down lessons, and getting setup help. Use it for advice and checkpointing; hard enforcement still runs locally where the agent executes after <code>npx thumbgate init</code>.</div>
       </div>
       <div class="faq-item">
         <button class="faq-q" type="button" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How do we keep high-risk autonomous runs off the host?</button>
@@ -1032,8 +1034,8 @@ __GA_BOOTSTRAP__
 <!-- FINAL CTA -->
 <section class="final-cta">
   <div class="container">
-    <h2>Check the next agent action before it runs.</h2>
-    <p>Open the GPT for the fastest demo. Install the free CLI when you are ready to enforce the same lesson locally. Use the workflow hardening sprint for team rollout.</p>
+    <h2>Stop the next costly AI mistake before it runs.</h2>
+    <p>Open the GPT for the fastest checkpoint. Install the free CLI when you are ready to enforce the same lesson locally. Use Pro for personal proof and the workflow hardening sprint for team rollout.</p>
     <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
       <a href="https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate" target="_blank" rel="noopener" onclick="posthog.capture('final_cta_click',{cta:'open_gpt'})" class="btn-gpt-page">Open ThumbGate GPT</a>
       <a href="/checkout/pro?utm_source=website&utm_medium=final_cta&utm_campaign=pro_trial&cta_id=final_pro_trial" onclick="posthog.capture('final_cta_click',{cta:'pro_trial'})" class="btn-pro" style="padding:12px 32px;font-size:15px;">Start 7-Day Free Trial — $19/mo</a>
@@ -1060,7 +1062,7 @@ __GA_BOOTSTRAP__
 
 <!-- STICKY BOTTOM CTA -->
 <div class="sticky-cta" id="sticky-cta">
-  <span class="sticky-cta-text"><strong>Live ThumbGate GPT</strong> — check an agent action before it runs</span>
+  <span class="sticky-cta-text"><strong>Live ThumbGate GPT</strong> — stop a costly agent action before it runs</span>
   <a href="https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate" target="_blank" rel="noopener" onclick="posthog.capture('sticky_cta_click',{cta:'open_gpt'})" class="btn-gpt-page">Open GPT</a>
 </div>
 <script>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -1,14 +1,17 @@
-# ThumbGate — Agent Governance for Engineering Teams
+# ThumbGate — Stop Costly AI Agent Mistakes Before They Run
 
 ## What ThumbGate Is
 
-ThumbGate is agent governance software for engineering teams that run AI coding agents (Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode) on shared codebases. It enforces approval policies, captures and propagates lessons from agent mistakes, and physically blocks known-bad tool calls before they execute via PreToolUse hooks wired into the agent runtime. Unlike CLAUDE.md rules or .cursorrules files, which are suggestions the agent can ignore, ThumbGate enforcement operates at the tool-call level and cannot be bypassed by the agent. The business is enterprise-first: the best first paid motion is the Workflow Hardening Sprint for one workflow, while the local CLI stays free as the adoption wedge and Pro remains a solo side lane.
+ThumbGate prevents expensive AI mistakes before they happen. Engineering teams use it to check risky commands, file edits, deploys, payments, API calls, and other AI agent actions before execution across Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, ChatGPT Actions, CI, and MCP-compatible runtimes.
+
+The buyer outcome is simple: prevent expensive AI mistakes, make AI stop repeating mistakes, and turn a smart assistant into a reliable operator. ThumbGate does that by enforcing approval policies, capturing and propagating lessons from agent mistakes, and physically blocking known-bad tool calls before they execute via PreToolUse hooks wired into the agent runtime. Unlike CLAUDE.md rules or .cursorrules files, which are suggestions the agent can ignore, ThumbGate enforcement operates at the tool-call level and cannot be bypassed by the agent once the action is routed through ThumbGate. The business is enterprise-first: the best first paid motion is the Workflow Hardening Sprint for one workflow, while the local CLI stays free as the adoption wedge and Pro remains a solo side lane for personal enforcement proof.
 
 ## Problems ThumbGate Prevents
 
 - An AI coding agent force-pushes to the main branch, overwriting a teammate's commit
 - An agent deletes a production config file because the prompt said "clean up unused files"
 - An agent bypasses CI by committing with --no-verify after seeing test failures
+- An agent runs destructive SQL, bad publish commands, unsafe deploys, or costly API calls before a human sees the blast radius
 - An agent repeats the same database migration mistake across three pull requests because the lesson was never captured
 - One engineer gives a thumbs-down on a bad agent pattern; teammates running the same agent repeat the mistake because lessons are not shared
 - An agent modifies secrets or PII-bearing files because no approval policy was in place
@@ -81,9 +84,10 @@ This alignment means ThumbGate is not an experimental tool — it implements the
 
 ## Pricing
 
-- **Free**: Local CLI enforcement for individual developers. Includes 3 daily feedback captures, 5 lesson searches per day, unlimited recall, and PreToolUse hook blocking.
+- **Free GPT**: Advice, checkpointing, setup help, and typed thumbs-up/down memory capture inside ChatGPT.
+- **Free local CLI**: Local enforcement for individual developers after install. Includes 3 daily feedback captures, 5 lesson searches per day, unlimited recall, and PreToolUse hook blocking.
 - **Workflow Hardening Sprint / Team**: Team pricing anchors at $99/seat/mo with a 3-seat minimum after qualification. The first paid step is an intake-led sprint around one workflow, one repeated blocker, and one proof review.
-- **Pro**: $19/mo or $149/yr. Adds a personal local dashboard, DPO export for fine-tuning, and advanced data exports for solo operators who want a self-serve side lane.
+- **Pro**: $19/mo or $149/yr. Adds personal enforcement proof, a local dashboard, DPO export for fine-tuning, a gate debugger, and advanced data exports for solo operators who want a self-serve side lane.
 
 ## How to Install
 

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -30,6 +30,27 @@ test('README explains the product as self-improving agent enforcement', () => {
   assert.match(readme, /permanently/i);
 });
 
+test('public surfaces lead with outcomes instead of infrastructure abstractions', () => {
+  const readme = readText('README.md');
+  const landingPage = readText(path.join('public', 'index.html'));
+  const llms = readText(path.join('.well-known', 'llms.txt'));
+  const gptInstructions = readText(path.join('docs', 'chatgpt-gpt-instructions.md'));
+
+  for (const surface of [readme, landingPage, llms, gptInstructions]) {
+    assert.match(surface, /costly|expensive/i);
+    assert.match(surface, /before (?:they|it) (?:make|run|happen)|before execution/i);
+    assert.match(surface, /Pre-Action Gates/i);
+  }
+
+  assert.match(readme, /Prevent expensive AI mistakes/i);
+  assert.match(readme, /Make AI stop repeating mistakes/i);
+  assert.match(readme, /reliable operator/i);
+  assert.match(landingPage, /Stop AI agents before/i);
+  assert.match(gptInstructions, /Sell outcomes before infrastructure/i);
+  assert.doesNotMatch(landingPage, /Global enforcement/i);
+  assert.doesNotMatch(readme, /Behavior control system/i);
+});
+
 test('README keeps the business sprint-first while preserving the Pro side lane', () => {
   const readme = readText('README.md');
 

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -150,8 +150,9 @@ test('public landing page hero features both thumbs up AND thumbs down prominent
   // Signal pills must show both
   assert.match(landingPage, /signal-pill signal-up/);
   assert.match(landingPage, /signal-pill signal-down/);
-  assert.match(landingPage, /Repeated failure becomes enforcement before the next run/i);
-  assert.match(landingPage, /Safe pattern reinforced across the shared workflow/i);
+  assert.match(landingPage, /Prevent expensive mistakes/i);
+  assert.match(landingPage, /Fix it once, then block the repeat/i);
+  assert.match(landingPage, /reliable operator/i);
   // Persona targeting
   assert.match(landingPage, /class="hero-persona"/);
   assert.match(landingPage, /product teams/i);

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -111,12 +111,12 @@ test('public docs render the current package version', () => {
   assert.match(chatgptInstall, /GPT profile card/);
   assert.match(chatgptInstall, /Pre-action gate flow/);
   assert.match(chatgptInstall, /Reliability Gateway/i);
-  assert.match(chatgptInstall, /Turn thumbs-down into prevention gates/);
+  assert.match(chatgptInstall, /Stop costly AI mistakes before they run/);
   assert.match(chatgptInstall, /evaluateDecision/);
   assert.match(chatgptInstall, /decisionControl\.executionMode: "blocked"/);
   assert.match(chatgptInstall, /Plain thumbs-up\/down feedback is the memory loop\. The decision endpoint is the gate loop\./);
   assert.match(chatgptInstall, /Check this agent action before it runs: git push --force --tags/i);
-  assert.match(chatgptInstall, /Paste an AI action to check, or tell me what went right\/wrong/i);
+  assert.match(chatgptInstall, /Paste the risky AI action before it runs, or tell me what went right\/wrong/i);
   assert.match(chatgptInstall, /native feedback buttons may send feedback to OpenAI/i);
   assert.match(chatgptInstall, /Regular GPT users should not need an API key, JSON payload, OpenAPI knowledge, or developer setup/i);
   assert.match(chatgptInstall, /Users do \*\*not\*\* have to keep chatting inside the ThumbGate GPT for enforcement/i);
@@ -126,8 +126,9 @@ test('public docs render the current package version', () => {
   assert.match(chatgptInstall, /https:\/\/thumbgate-production\.up\.railway\.app\/privacy/);
   assert.match(chatgptInstructions, /Reliability Gateway for AI agents/i);
   assert.match(chatgptInstructions, /https:\/\/chatgpt\.com\/g\/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate/);
-  assert.match(chatgptInstructions, /Turn thumbs-down into prevention gates/);
-  assert.match(chatgptInstructions, /Paste an AI action to check, or tell me what went right\/wrong/i);
+  assert.match(chatgptInstructions, /Stop costly AI mistakes before they run/);
+  assert.match(chatgptInstructions, /Paste the risky AI action before it runs, or tell me what went right\/wrong/i);
+  assert.match(chatgptInstructions, /Sell outcomes before infrastructure/i);
   assert.match(chatgptInstructions, /Action check mode/);
   assert.match(chatgptInstructions, /Feedback capture mode/);
   assert.match(chatgptInstructions, /decisionControl\.executionMode/);
@@ -141,9 +142,10 @@ test('public docs render the current package version', () => {
   assert.match(gptStoreSubmission, /https:\/\/chatgpt\.com\/g\/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate/);
   assert.doesNotMatch(gptStoreSubmission, /URL has not been captured/i);
   assert.match(gptStoreSubmission, /Explore GPTs -> search ThumbGate/i);
-  assert.match(gptStoreSubmission, /Turn thumbs-down into prevention gates/);
+  assert.match(gptStoreSubmission, /Stop costly AI mistakes before they run/);
   assert.match(gptStoreSubmission, /Reliability Gateway/i);
   assert.match(gptStoreSubmission, /one signal becomes one remembered rule/i);
+  assert.match(gptStoreSubmission, /prevent expensive AI mistakes/i);
   assert.match(gptStoreSubmission, /Pre-Action Gates/);
   assert.match(gptStoreSubmission, /POST \/v1\/decisions\/evaluate/);
   assert.match(gptStoreSubmission, /Action check mode/);


### PR DESCRIPTION
## Summary
- Reposition the README, landing page, llm-context, llms.txt, and GPT Store/install copy around the buyer outcome: stop costly AI agent mistakes before they run.
- Clarify scope honestly: the ChatGPT GPT is advice/checkpointing and guided setup; hard enforcement applies once actions are routed through the local/CI/MCP ThumbGate Reliability Gateway.
- Add a positioning contract test so public surfaces keep selling outcomes before infrastructure jargon.

## Verification
- `npm ci`
- `npm test` — 3597 tests, 314 suites, 3592 pass, 5 skipped, 0 fail
- `npm run test:coverage` — all files line coverage 84.82%, branch 71.58%, functions 87.75%
- `npm run prove:adapters` — 48/48 passed
- `npm run prove:automation` — 55/55 passed
- `npm run self-heal:check` — HEALTHY, 6/6 checks healthy
- `git diff --check`
- `node scripts/check-congruence.js`
- `node --test tests/public-landing.test.js tests/positioning-contract.test.js tests/version-metadata.test.js tests/check-congruence.test.js` — 75/75 passed
- `npm run test:seo-guides` — 43/43 passed
- `npm run test:sync-version` — 10/10 passed