### PR TITLE
fix: publish full changeset release notes

### DIFF
--- a/.changeset/release-notes-email.md
+++ b/.changeset/release-notes-email.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Generate full Changeset-backed release notes during the npm publish workflow, write them into the GitHub Release, upload them as a release asset, and copy them into the GitHub Actions summary linked from npm's publish email.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           # npm provenance on GitHub Actions is most reliable on current LTS.
@@ -85,6 +87,19 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
+      - name: Build full changeset release notes
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.ensure_release == 'true'
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          notes_file="thumbgate-${VERSION}-release-notes.md"
+          node scripts/release-notes.js \
+            --version="${VERSION}" \
+            --current-ref="${GITHUB_SHA}" \
+            --github-run-url="${GITHUB_RUN_URL}" \
+            --output="${notes_file}"
+          cat "${notes_file}" >> "$GITHUB_STEP_SUMMARY"
       - name: Publish npm package
         if: ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.publish_npm == 'true') || (github.event_name == 'release' && steps.npm.outputs.published == 'false')
         run: npm publish --tag "${{ steps.plan.outputs.npm_tag || 'latest' }}" --provenance
@@ -101,6 +116,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.package.outputs.version }}
         run: |
+          notes_file="thumbgate-${VERSION}-release-notes.md"
           if ! gh release view "v${VERSION}" >/dev/null 2>&1; then
-            gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes
+            gh release create "v${VERSION}" --title "thumbgate@${VERSION}" --notes-file "${notes_file}"
+          else
+            gh release edit "v${VERSION}" --title "thumbgate@${VERSION}" --notes-file "${notes_file}"
           fi
+          gh release upload "v${VERSION}" "${notes_file}" --clobber

--- a/docs/CHANGESET_STRATEGY.md
+++ b/docs/CHANGESET_STRATEGY.md
@@ -59,3 +59,17 @@ That command updates the root version, generates or updates `CHANGELOG.md`, and 
 - release coverage is enforced in CI before merge, not requested after a release goes sideways.
 
 This is the release narrative layer that sits on top of CI, proof artifacts, and publish gating. For the full trust chain, see [Release Confidence](RELEASE_CONFIDENCE.md).
+
+## Publish Email Follow-Through
+
+npm's native "Successfully published" email is controlled by npm and cannot be customized by this repository. ThumbGate compensates by making the email's linked GitHub Actions run and matching GitHub Release carry the complete customer-readable Changeset record.
+
+On publish, `.github/workflows/publish-npm.yml` runs `node scripts/release-notes.js` to:
+
+- collect the `.changeset/*.md` files changed since the previous release tag.
+- render the full Changeset summaries by SemVer impact.
+- write the same release note into the GitHub Actions summary linked from the npm email.
+- create or update the `vX.Y.Z` GitHub Release with those notes.
+- upload `thumbgate-X.Y.Z-release-notes.md` as a release asset for audit trails.
+
+The npm email remains short, but the first-party release artifact it points to now contains the full release notes.

--- a/docs/RELEASE_CONFIDENCE.md
+++ b/docs/RELEASE_CONFIDENCE.md
@@ -16,6 +16,7 @@ Customers, investors, and internal reviewers should be able to inspect why a ver
    - `npm run prove:automation`
    - `npm run self-heal:check`
 5. **Exact merge proof:** the work is not considered complete until the exact `main` merge commit is verified and its evidence is cited.
+6. **Release-note delivery:** the npm publish workflow renders full Changeset-backed release notes into the GitHub Actions summary, the `vX.Y.Z` GitHub Release body, and a downloadable `thumbgate-X.Y.Z-release-notes.md` release asset.
 
 ## What buyers can inspect
 
@@ -24,6 +25,7 @@ Customers, investors, and internal reviewers should be able to inspect why a ver
 - [Verification Evidence](VERIFICATION_EVIDENCE.md)
 - [CHANGELOG.md](../CHANGELOG.md)
 - [CI workflow](../.github/workflows/ci.yml)
+- [Publish to NPM workflow](../.github/workflows/publish-npm.yml)
 
 These are the public surfaces that explain what changed, why it changed, and what was verified.
 
@@ -33,6 +35,7 @@ These are the public surfaces that explain what changed, why it changed, and wha
 - An investor can see that package releases are governed by durable process, not ad hoc pushes.
 - A platform team can map a release note to its proof artifacts and merge checks.
 - A future incident review can reconstruct the decision path from PR, to version, to proof, to publish.
+- The npm "Successfully published" email links to a GitHub Actions run whose summary contains the full release notes, even though npm's own email template is not customizable.
 
 ## Operating rule
 

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "test:quality": "node --test tests/validate-feedback.test.js",
     "test:intelligence": "node --test tests/intelligence.test.js",
     "test:training-export": "node --test tests/training-export.test.js tests/databricks-export.test.js",
-    "test:deployment": "node --test tests/deployment.test.js tests/deploy-policy.test.js tests/publish-decision.test.js tests/changeset-check.test.js tests/sonarcloud-workflow.test.js tests/package-boundary.test.js",
+    "test:deployment": "node --test tests/deployment.test.js tests/deploy-policy.test.js tests/publish-decision.test.js tests/changeset-check.test.js tests/release-notes.test.js tests/sonarcloud-workflow.test.js tests/package-boundary.test.js",
     "test:operational-integrity": "node --test tests/operational-integrity.test.js tests/sync-branch-protection.test.js",
     "test:workflow": "node --test tests/workflow-contract.test.js tests/social-marketing-assets.test.js tests/social-pipeline.test.js tests/positioning-contract.test.js tests/docs-claim-hygiene.test.js tests/workflow-runs.test.js tests/workflow-sprint-intake.test.js tests/gtm-revenue-loop.test.js tests/enterprise-story.test.js tests/ralph-loop.test.js tests/ralph-mode-ci.test.js",
     "test:billing": "node --test tests/billing.test.js",

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { parseChangesetMarkdown } = require('./changeset-check');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+const DEFAULT_PACKAGE_NAME = 'thumbgate';
+const REPO_FULL_NAME = 'IgorGanapolsky/ThumbGate';
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {};
+  for (const arg of argv) {
+    if (arg.startsWith('--version=')) options.version = arg.slice('--version='.length);
+    else if (arg.startsWith('--package=')) options.packageName = arg.slice('--package='.length);
+    else if (arg.startsWith('--current-ref=')) options.currentRef = arg.slice('--current-ref='.length);
+    else if (arg.startsWith('--previous-tag=')) options.previousTag = arg.slice('--previous-tag='.length);
+    else if (arg.startsWith('--output=')) options.outputPath = arg.slice('--output='.length);
+    else if (arg.startsWith('--github-run-url=')) options.githubRunUrl = arg.slice('--github-run-url='.length);
+    else if (arg.startsWith('--repo=')) options.repoFullName = arg.slice('--repo='.length);
+  }
+  return options;
+}
+
+function runGit(args, { cwd = PROJECT_ROOT, runner = execFileSync } = {}) {
+  return String(runner('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }) || '').trim();
+}
+
+function readPackageVersion({ cwd = PROJECT_ROOT } = {}) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+  return String(pkg.version || '').trim();
+}
+
+function semverTagValue(tag) {
+  const match = /^v(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(String(tag || '').trim());
+  if (!match) return null;
+  return match.slice(1, 4).map((value) => Number(value));
+}
+
+function compareSemverTagsDescending(a, b) {
+  const aParts = semverTagValue(a);
+  const bParts = semverTagValue(b);
+  if (!aParts && !bParts) return String(b).localeCompare(String(a));
+  if (!aParts) return 1;
+  if (!bParts) return -1;
+  for (let index = 0; index < aParts.length; index += 1) {
+    if (aParts[index] !== bParts[index]) return bParts[index] - aParts[index];
+  }
+  return String(b).localeCompare(String(a));
+}
+
+function listTags({ cwd = PROJECT_ROOT, runner = execFileSync } = {}) {
+  const output = runGit(['tag', '--list', 'v*'], { cwd, runner });
+  return output ? output.split('\n').map((line) => line.trim()).filter(Boolean) : [];
+}
+
+function detectPreviousTag({
+  version,
+  currentTag = `v${version}`,
+  cwd = PROJECT_ROOT,
+  runner = execFileSync,
+} = {}) {
+  const tags = listTags({ cwd, runner })
+    .filter((tag) => semverTagValue(tag))
+    .filter((tag) => tag !== currentTag)
+    .sort(compareSemverTagsDescending);
+  return tags[0] || '';
+}
+
+function getChangedChangesetFiles({
+  previousTag,
+  currentRef = 'HEAD',
+  cwd = PROJECT_ROOT,
+  runner = execFileSync,
+} = {}) {
+  if (!previousTag) return [];
+  const output = runGit([
+    'diff',
+    '--name-only',
+    '--diff-filter=ACMR',
+    `${previousTag}...${currentRef}`,
+    '--',
+    '.changeset/*.md',
+  ], { cwd, runner });
+
+  return output
+    ? output.split('\n')
+      .map((line) => line.trim())
+      .filter((file) => file && path.basename(file) !== 'README.md')
+    : [];
+}
+
+function readChangesetEntries({
+  files = [],
+  packageName = DEFAULT_PACKAGE_NAME,
+  cwd = PROJECT_ROOT,
+} = {}) {
+  return files.map((file) => {
+    const content = fs.readFileSync(path.join(cwd, file), 'utf8');
+    const parsed = parseChangesetMarkdown(content);
+    return {
+      file,
+      releaseType: parsed.releases[packageName] || null,
+      summary: parsed.summary,
+      errors: parsed.errors,
+    };
+  }).filter((entry) => entry.releaseType);
+}
+
+function extractChangelogEntry(changelog, version) {
+  const lines = String(changelog || '').replaceAll('\r\n', '\n').split('\n');
+  const headingPattern = new RegExp(`^##\\s+(?:\\[)?${String(version).replaceAll('.', '\\.')}(?:\\])?(?:\\s|$)`);
+  const start = lines.findIndex((line) => headingPattern.test(line.trim()));
+  if (start === -1) return '';
+
+  const next = lines.findIndex((line, index) => index > start && /^##\s+/.test(line.trim()));
+  return lines.slice(start, next === -1 ? undefined : next).join('\n').trim();
+}
+
+function groupChangesets(entries) {
+  const groups = {
+    major: [],
+    minor: [],
+    patch: [],
+  };
+  for (const entry of entries) {
+    if (groups[entry.releaseType]) groups[entry.releaseType].push(entry);
+  }
+  return groups;
+}
+
+function renderChangesetGroup(title, entries) {
+  if (entries.length === 0) return '';
+  const lines = [`### ${title}`, ''];
+  for (const entry of entries) {
+    lines.push(`#### ${entry.file}`);
+    lines.push('');
+    lines.push(entry.summary.trim());
+    lines.push('');
+  }
+  return lines.join('\n').trim();
+}
+
+function formatReleaseNotes({
+  packageName = DEFAULT_PACKAGE_NAME,
+  repoFullName = REPO_FULL_NAME,
+  version,
+  previousTag,
+  currentTag = `v${version}`,
+  currentRef = 'HEAD',
+  githubRunUrl = '',
+  changesets = [],
+  changelogEntry = '',
+} = {}) {
+  const releaseUrl = `https://github.com/${repoFullName}/releases/tag/${currentTag}`;
+  const npmUrl = `https://www.npmjs.com/package/${packageName}/v/${version}`;
+  const compareUrl = previousTag
+    ? `https://github.com/${repoFullName}/compare/${previousTag}...${currentTag}`
+    : `https://github.com/${repoFullName}/releases/tag/${currentTag}`;
+  const groups = groupChangesets(changesets);
+  const sections = [
+    `# ${packageName}@${version}`,
+    '',
+    '## Release Links',
+    '',
+    `- npm: ${npmUrl}`,
+    `- GitHub Release: ${releaseUrl}`,
+    `- Compare: ${compareUrl}`,
+    githubRunUrl ? `- Publish workflow: ${githubRunUrl}` : '',
+    `- Release ref: ${currentRef}`,
+    '',
+    '## Full Changeset Release Notes',
+    '',
+  ].filter((line) => line !== '');
+
+  const renderedGroups = [
+    renderChangesetGroup('Major Changes', groups.major),
+    renderChangesetGroup('Minor Changes', groups.minor),
+    renderChangesetGroup('Patch Changes', groups.patch),
+  ].filter(Boolean);
+
+  if (renderedGroups.length > 0) {
+    sections.push(renderedGroups.join('\n\n'));
+  } else {
+    sections.push('No changed `.changeset/*.md` entries were detected for this release range.');
+  }
+
+  sections.push('');
+  sections.push('## CHANGELOG.md Entry');
+  sections.push('');
+  sections.push(changelogEntry || `No \`CHANGELOG.md\` section was found for ${version}; the release notes above were generated from the changed Changeset files.`);
+  sections.push('');
+  sections.push('## Verification Standard');
+  sections.push('');
+  sections.push('- Publish only runs from `main` after version sync, tests, and runtime proof pass.');
+  sections.push('- The npm package is smoke-tested after publish by installing `thumbgate@VERSION` in a clean runtime.');
+  sections.push('- GitHub Release notes are generated from Changesets, not only GitHub auto-generated PR titles.');
+
+  return `${sections.join('\n')}\n`;
+}
+
+function buildReleaseNotes({
+  version,
+  packageName = DEFAULT_PACKAGE_NAME,
+  repoFullName = REPO_FULL_NAME,
+  currentRef = 'HEAD',
+  previousTag,
+  githubRunUrl = '',
+  cwd = PROJECT_ROOT,
+  runner = execFileSync,
+} = {}) {
+  const resolvedVersion = String(version || readPackageVersion({ cwd })).trim();
+  const currentTag = `v${resolvedVersion}`;
+  const resolvedPreviousTag = previousTag || detectPreviousTag({
+    version: resolvedVersion,
+    currentTag,
+    cwd,
+    runner,
+  });
+  const changedChangesetFiles = getChangedChangesetFiles({
+    previousTag: resolvedPreviousTag,
+    currentRef,
+    cwd,
+    runner,
+  });
+  const changesets = readChangesetEntries({
+    files: changedChangesetFiles,
+    packageName,
+    cwd,
+  });
+  const changelogPath = path.join(cwd, 'CHANGELOG.md');
+  const changelogEntry = fs.existsSync(changelogPath)
+    ? extractChangelogEntry(fs.readFileSync(changelogPath, 'utf8'), resolvedVersion)
+    : '';
+
+  return {
+    markdown: formatReleaseNotes({
+      packageName,
+      repoFullName,
+      version: resolvedVersion,
+      previousTag: resolvedPreviousTag,
+      currentTag,
+      currentRef,
+      githubRunUrl,
+      changesets,
+      changelogEntry,
+    }),
+    version: resolvedVersion,
+    previousTag: resolvedPreviousTag,
+    changedChangesetFiles,
+    changesets,
+  };
+}
+
+function runCli({
+  argv = process.argv.slice(2),
+  cwd = PROJECT_ROOT,
+  env = process.env,
+  runner = execFileSync,
+} = {}) {
+  const options = parseArgs(argv);
+  const result = buildReleaseNotes({
+    version: options.version || env.VERSION,
+    packageName: options.packageName || DEFAULT_PACKAGE_NAME,
+    repoFullName: options.repoFullName || env.GITHUB_REPOSITORY || REPO_FULL_NAME,
+    currentRef: options.currentRef || env.GITHUB_SHA || 'HEAD',
+    previousTag: options.previousTag,
+    githubRunUrl: options.githubRunUrl || env.GITHUB_RUN_URL || '',
+    cwd,
+    runner,
+  });
+
+  if (options.outputPath) {
+    fs.writeFileSync(path.resolve(cwd, options.outputPath), result.markdown);
+  }
+  process.stdout.write(result.markdown);
+  return result;
+}
+
+if (require.main === module) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  buildReleaseNotes,
+  compareSemverTagsDescending,
+  detectPreviousTag,
+  extractChangelogEntry,
+  formatReleaseNotes,
+  getChangedChangesetFiles,
+  parseArgs,
+  readChangesetEntries,
+  runCli,
+  semverTagValue,
+};

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -37,6 +37,29 @@ function readPackageVersion({ cwd = PROJECT_ROOT } = {}) {
   return String(pkg.version || '').trim();
 }
 
+function resolveInside(baseDir, requestedPath, label = 'path') {
+  const root = path.resolve(baseDir);
+  const resolved = path.resolve(root, requestedPath);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`${label} must stay inside ${root}`);
+  }
+  return resolved;
+}
+
+function normalizeChangesetPath(file) {
+  return String(file || '').trim().replaceAll('\\', '/');
+}
+
+function isSafeChangesetPath(file) {
+  const normalized = normalizeChangesetPath(file);
+  return normalized.startsWith('.changeset/')
+    && normalized.endsWith('.md')
+    && path.posix.basename(normalized) !== 'README.md'
+    && !normalized.split('/').includes('..')
+    && !path.posix.isAbsolute(normalized);
+}
+
 function semverTagValue(tag) {
   const match = /^v(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(String(tag || '').trim());
   if (!match) return null;
@@ -92,7 +115,7 @@ function getChangedChangesetFiles({
   return output
     ? output.split('\n')
       .map((line) => line.trim())
-      .filter((file) => file && path.basename(file) !== 'README.md')
+      .filter(isSafeChangesetPath)
     : [];
 }
 
@@ -102,10 +125,14 @@ function readChangesetEntries({
   cwd = PROJECT_ROOT,
 } = {}) {
   return files.map((file) => {
-    const content = fs.readFileSync(path.join(cwd, file), 'utf8');
+    if (!isSafeChangesetPath(file)) {
+      throw new Error(`Unsafe changeset path: ${file}`);
+    }
+    const safeFile = normalizeChangesetPath(file);
+    const content = fs.readFileSync(resolveInside(cwd, safeFile, 'changeset file'), 'utf8');
     const parsed = parseChangesetMarkdown(content);
     return {
-      file,
+      file: safeFile,
       releaseType: parsed.releases[packageName] || null,
       summary: parsed.summary,
       errors: parsed.errors,
@@ -113,13 +140,24 @@ function readChangesetEntries({
   }).filter((entry) => entry.releaseType);
 }
 
+function changelogHeadingVersion(line) {
+  const trimmed = String(line || '').trim();
+  if (!trimmed.startsWith('##') || trimmed.startsWith('###')) return '';
+  const heading = trimmed.slice(2).trim();
+  if (!heading) return '';
+  const token = heading.split(/\s+/)[0];
+  return token.startsWith('[') && token.endsWith(']')
+    ? token.slice(1, -1)
+    : token;
+}
+
 function extractChangelogEntry(changelog, version) {
   const lines = String(changelog || '').replaceAll('\r\n', '\n').split('\n');
-  const headingPattern = new RegExp(`^##\\s+(?:\\[)?${String(version).replaceAll('.', '\\.')}(?:\\])?(?:\\s|$)`);
-  const start = lines.findIndex((line) => headingPattern.test(line.trim()));
+  const targetVersion = String(version || '').trim();
+  const start = lines.findIndex((line) => changelogHeadingVersion(line) === targetVersion);
   if (start === -1) return '';
 
-  const next = lines.findIndex((line, index) => index > start && /^##\s+/.test(line.trim()));
+  const next = lines.findIndex((line, index) => index > start && changelogHeadingVersion(line));
   return lines.slice(start, next === -1 ? undefined : next).join('\n').trim();
 }
 
@@ -277,7 +315,7 @@ function runCli({
   });
 
   if (options.outputPath) {
-    fs.writeFileSync(path.resolve(cwd, options.outputPath), result.markdown);
+    fs.writeFileSync(resolveInside(cwd, options.outputPath, 'output path'), result.markdown);
   }
   process.stdout.write(result.markdown);
   return result;
@@ -299,8 +337,10 @@ module.exports = {
   extractChangelogEntry,
   formatReleaseNotes,
   getChangedChangesetFiles,
+  isSafeChangesetPath,
   parseArgs,
   readChangesetEntries,
+  resolveInside,
   runCli,
   semverTagValue,
 };

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -63,7 +63,7 @@ function isSafeChangesetPath(file) {
 function semverTagValue(tag) {
   const match = /^v(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(String(tag || '').trim());
   if (!match) return null;
-  return match.slice(1, 4).map((value) => Number(value));
+  return match.slice(1, 4).map(Number);
 }
 
 function compareSemverTagsDescending(a, b) {
@@ -158,7 +158,8 @@ function extractChangelogEntry(changelog, version) {
   if (start === -1) return '';
 
   const next = lines.findIndex((line, index) => index > start && changelogHeadingVersion(line));
-  return lines.slice(start, next === -1 ? undefined : next).join('\n').trim();
+  const end = next === -1 ? lines.length : next;
+  return lines.slice(start, end).join('\n').trim();
 }
 
 function groupChangesets(entries) {
@@ -175,14 +176,17 @@ function groupChangesets(entries) {
 
 function renderChangesetGroup(title, entries) {
   if (entries.length === 0) return '';
-  const lines = [`### ${title}`, ''];
-  for (const entry of entries) {
-    lines.push(`#### ${entry.file}`);
-    lines.push('');
-    lines.push(entry.summary.trim());
-    lines.push('');
-  }
-  return lines.join('\n').trim();
+  const renderedEntries = entries.map((entry) => [
+    `#### ${entry.file}`,
+    '',
+    entry.summary.trim(),
+  ].join('\n'));
+
+  return [
+    `### ${title}`,
+    '',
+    renderedEntries.join('\n\n'),
+  ].join('\n').trim();
 }
 
 function formatReleaseNotes({
@@ -202,7 +206,18 @@ function formatReleaseNotes({
     ? `https://github.com/${repoFullName}/compare/${previousTag}...${currentTag}`
     : `https://github.com/${repoFullName}/releases/tag/${currentTag}`;
   const groups = groupChangesets(changesets);
-  const sections = [
+  const renderedGroups = [
+    renderChangesetGroup('Major Changes', groups.major),
+    renderChangesetGroup('Minor Changes', groups.minor),
+    renderChangesetGroup('Patch Changes', groups.patch),
+  ].filter(Boolean);
+  const changesetBody = renderedGroups.length > 0
+    ? renderedGroups.join('\n\n')
+    : 'No changed `.changeset/*.md` entries were detected for this release range.';
+  const changelogBody = changelogEntry
+    || `No \`CHANGELOG.md\` section was found for ${version}; the release notes above were generated from the changed Changeset files.`;
+
+  return `${[
     `# ${packageName}@${version}`,
     '',
     '## Release Links',
@@ -210,37 +225,23 @@ function formatReleaseNotes({
     `- npm: ${npmUrl}`,
     `- GitHub Release: ${releaseUrl}`,
     `- Compare: ${compareUrl}`,
-    githubRunUrl ? `- Publish workflow: ${githubRunUrl}` : '',
+    githubRunUrl ? `- Publish workflow: ${githubRunUrl}` : null,
     `- Release ref: ${currentRef}`,
     '',
     '## Full Changeset Release Notes',
     '',
-  ].filter((line) => line !== '');
-
-  const renderedGroups = [
-    renderChangesetGroup('Major Changes', groups.major),
-    renderChangesetGroup('Minor Changes', groups.minor),
-    renderChangesetGroup('Patch Changes', groups.patch),
-  ].filter(Boolean);
-
-  if (renderedGroups.length > 0) {
-    sections.push(renderedGroups.join('\n\n'));
-  } else {
-    sections.push('No changed `.changeset/*.md` entries were detected for this release range.');
-  }
-
-  sections.push('');
-  sections.push('## CHANGELOG.md Entry');
-  sections.push('');
-  sections.push(changelogEntry || `No \`CHANGELOG.md\` section was found for ${version}; the release notes above were generated from the changed Changeset files.`);
-  sections.push('');
-  sections.push('## Verification Standard');
-  sections.push('');
-  sections.push('- Publish only runs from `main` after version sync, tests, and runtime proof pass.');
-  sections.push('- The npm package is smoke-tested after publish by installing `thumbgate@VERSION` in a clean runtime.');
-  sections.push('- GitHub Release notes are generated from Changesets, not only GitHub auto-generated PR titles.');
-
-  return `${sections.join('\n')}\n`;
+    changesetBody,
+    '',
+    '## CHANGELOG.md Entry',
+    '',
+    changelogBody,
+    '',
+    '## Verification Standard',
+    '',
+    '- Publish only runs from `main` after version sync, tests, and runtime proof pass.',
+    '- The npm package is smoke-tested after publish by installing `thumbgate@VERSION` in a clean runtime.',
+    '- GitHub Release notes are generated from Changesets, not only GitHub auto-generated PR titles.',
+  ].filter((line) => line !== null).join('\n')}\n`;
 }
 
 function buildReleaseNotes({
@@ -321,7 +322,7 @@ function runCli({
   return result;
 }
 
-if (require.main === module) {
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
   try {
     runCli();
   } catch (error) {

--- a/tests/release-notes.test.js
+++ b/tests/release-notes.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildReleaseNotes,
+  extractChangelogEntry,
+  formatReleaseNotes,
+} = require('../scripts/release-notes');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+
+test('extractChangelogEntry returns the exact version section', () => {
+  const entry = extractChangelogEntry([
+    '# Changelog',
+    '',
+    '## 1.4.4',
+    '',
+    '### Patch Changes',
+    '',
+    '- Slim package boundary.',
+    '',
+    '## 1.4.3',
+    '',
+    '- Previous release.',
+  ].join('\n'), '1.4.4');
+
+  assert.match(entry, /## 1\.4\.4/);
+  assert.match(entry, /Slim package boundary/);
+  assert.doesNotMatch(entry, /Previous release/);
+});
+
+test('formatReleaseNotes includes full changeset summaries and verification links', () => {
+  const markdown = formatReleaseNotes({
+    version: '1.4.4',
+    previousTag: 'v1.4.3',
+    currentTag: 'v1.4.4',
+    currentRef: 'abc123',
+    githubRunUrl: 'https://github.com/IgorGanapolsky/ThumbGate/actions/runs/1',
+    changesets: [{
+      file: '.changeset/slim-npm-package-boundary.md',
+      releaseType: 'patch',
+      summary: 'Harden npm package boundaries so generated runtime state cannot leak into published tarballs.',
+    }],
+    changelogEntry: '## 1.4.4\n\n- Changelog copy.',
+  });
+
+  assert.match(markdown, /^# thumbgate@1\.4\.4/m);
+  assert.match(markdown, /Full Changeset Release Notes/);
+  assert.match(markdown, /slim-npm-package-boundary\.md/);
+  assert.match(markdown, /generated runtime state cannot leak/);
+  assert.match(markdown, /actions\/runs\/1/);
+  assert.match(markdown, /CHANGELOG\.md Entry/);
+  assert.match(markdown, /Changelog copy/);
+});
+
+test('buildReleaseNotes uses changed changeset files from the previous release tag', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-release-notes-'));
+  fs.mkdirSync(path.join(tempDir, '.changeset'));
+  fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ version: '1.4.4' }));
+  fs.writeFileSync(path.join(tempDir, 'CHANGELOG.md'), '# Changelog\n');
+  fs.writeFileSync(path.join(tempDir, '.changeset', 'slim-npm-package-boundary.md'), [
+    '---',
+    '"thumbgate": patch',
+    '---',
+    '',
+    'Slim the npm package boundary and keep release emails traceable to full Changeset notes.',
+  ].join('\n'));
+
+  const runner = (command, args) => {
+    assert.equal(command, 'git');
+    if (args[0] === 'tag') return 'v1.4.4\nv1.4.3\n';
+    if (args[0] === 'diff') return '.changeset/slim-npm-package-boundary.md\n';
+    throw new Error(`unexpected git command: ${args.join(' ')}`);
+  };
+
+  try {
+    const result = buildReleaseNotes({
+      cwd: tempDir,
+      currentRef: 'abc123',
+      runner,
+    });
+
+    assert.equal(result.version, '1.4.4');
+    assert.equal(result.previousTag, 'v1.4.3');
+    assert.deepEqual(result.changedChangesetFiles, ['.changeset/slim-npm-package-boundary.md']);
+    assert.match(result.markdown, /Slim the npm package boundary/);
+    assert.match(result.markdown, /No `CHANGELOG\.md` section was found for 1\.4\.4/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('publish workflow writes full release notes instead of GitHub generated notes only', () => {
+  const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'publish-npm.yml'), 'utf8');
+
+  assert.match(workflow, /fetch-depth: 0/);
+  assert.match(workflow, /Build full changeset release notes/);
+  assert.match(workflow, /scripts\/release-notes\.js/);
+  assert.match(workflow, /GITHUB_STEP_SUMMARY/);
+  assert.match(workflow, /gh release create "v\$\{VERSION\}" --title "thumbgate@\$\{VERSION\}" --notes-file "\$\{notes_file\}"/);
+  assert.match(workflow, /gh release edit "v\$\{VERSION\}" --title "thumbgate@\$\{VERSION\}" --notes-file "\$\{notes_file\}"/);
+  assert.match(workflow, /gh release upload "v\$\{VERSION\}" "\$\{notes_file\}" --clobber/);
+  assert.doesNotMatch(workflow, /gh release create "v\$\{VERSION\}".*--generate-notes/);
+});

--- a/tests/release-notes.test.js
+++ b/tests/release-notes.test.js
@@ -10,6 +10,8 @@ const {
   buildReleaseNotes,
   extractChangelogEntry,
   formatReleaseNotes,
+  isSafeChangesetPath,
+  resolveInside,
 } = require('../scripts/release-notes');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
@@ -32,6 +34,45 @@ test('extractChangelogEntry returns the exact version section', () => {
   assert.match(entry, /## 1\.4\.4/);
   assert.match(entry, /Slim package boundary/);
   assert.doesNotMatch(entry, /Previous release/);
+
+  const bracketedEntry = extractChangelogEntry('## [1.4.5]\n\n- Bracketed release.\n', '1.4.5');
+  assert.match(bracketedEntry, /Bracketed release/);
+});
+
+test('extractChangelogEntry treats version input as a literal heading value', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '## 1.4.4|1.4.3',
+    '',
+    '- Literal version text.',
+    '',
+    '## 1.4.3',
+    '',
+    '- Previous release.',
+  ].join('\n');
+
+  const entry = extractChangelogEntry(changelog, '1.4.4|1.4.3');
+
+  assert.match(entry, /Literal version text/);
+  assert.doesNotMatch(entry, /Previous release/);
+  assert.equal(extractChangelogEntry(changelog, '1.4.4.*'), '');
+});
+
+test('release note file paths stay inside the expected project boundaries', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-release-notes-paths-'));
+
+  try {
+    assert.equal(isSafeChangesetPath('.changeset/release-notes-email.md'), true);
+    assert.equal(isSafeChangesetPath('.changeset/../release-notes-email.md'), false);
+    assert.equal(isSafeChangesetPath('scripts/release-notes-email.md'), false);
+    assert.throws(
+      () => resolveInside(tempDir, '../outside.md', 'output path'),
+      /output path must stay inside/,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('formatReleaseNotes includes full changeset summaries and verification links', () => {


### PR DESCRIPTION
## Summary
- Add `scripts/release-notes.js` to render release notes from changed `.changeset/*.md` files since the previous release tag.
- Update Publish to NPM to fetch tags/history, write full notes into the Actions summary, create/edit the GitHub Release with `--notes-file`, and upload `thumbgate-X.Y.Z-release-notes.md`.
- Document that npm publish emails are not customizable, so the controlled release artifact must carry the full changeset.

## Evidence
- `pdftotext /Users/igorganapolsky/Downloads/Gmail - Successfully published thumbgate@1.4.4.pdf -`: npm email contains only package/version/time/run/shasum.
- `node --test tests/release-notes.test.js tests/changeset-check.test.js tests/publish-decision.test.js`: 24 pass.
- `npm run test:deployment`: 87 pass.
- `node scripts/sync-version.js --check`: 30 targets in sync at v1.4.4.
- `npm run changeset:check`: skipped locally outside PR; PR CI is source of truth.
- `git diff --check`: clean.

## Backfill
- Updated `v1.4.4` release title/body and uploaded `thumbgate-1.4.4-release-notes.md` with the full `.changeset/slim-npm-package-boundary.md` note.