### PR TITLE
fix(billing): remove card requirement from 7-day trial checkout

### DIFF
--- a/.changeset/no-card-trial.md
+++ b/.changeset/no-card-trial.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Remove credit card requirement from 7-day free trial checkout — 100 sessions, 0 completions proved card-required trials kill conversion for developer tools.

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -2068,8 +2068,11 @@ function buildCheckoutSessionPayload({ successUrl, cancelUrl, customerEmail, che
       packId: pack ? pack.id : null,
       credits: pack ? pack.credits : null,
     }),
-    // 7-day free trial for subscriptions — reduces checkout abandonment
-    ...(pack ? {} : { subscription_data: { trial_period_days: 7 } }),
+    // 7-day free trial for subscriptions — don't require card upfront
+    ...(pack ? {} : {
+      subscription_data: { trial_period_days: 7 },
+      payment_method_collection: 'if_required',
+    }),
   };
 
   const normalizedCustomerEmail = normalizeText(customerEmail);

--- a/tests/billing.test.js
+++ b/tests/billing.test.js
@@ -194,6 +194,7 @@ describe('billing.js — funnel ledger', () => {
     });
     assert.equal(withEmail.customer_email, 'buyer@example.com');
     assert.equal(withoutEmail.mode, 'subscription');
+    assert.equal(withoutEmail.payment_method_collection, 'if_required');
     assert.equal(withoutEmail.line_items[0].price, billing.CONFIG.STRIPE_PRICE_ID_PRO_MONTHLY);
     assert.equal(withoutEmail.line_items[0].quantity, 1);
   });
@@ -212,6 +213,7 @@ describe('billing.js — funnel ledger', () => {
     });
     assert.equal(annual.line_items[0].price, billing.CONFIG.STRIPE_PRICE_ID_PRO_ANNUAL);
     assert.equal(annual.line_items[0].quantity, 1);
+    assert.equal(annual.payment_method_collection, 'if_required');
     assert.equal(annual.metadata.billingCycle, 'annual');
 
     const team = billing._buildCheckoutSessionPayload({
@@ -226,6 +228,7 @@ describe('billing.js — funnel ledger', () => {
     });
     assert.equal(team.line_items[0].price, billing.CONFIG.STRIPE_PRICE_ID_TEAM_MONTHLY);
     assert.equal(team.line_items[0].quantity, 3);
+    assert.equal(team.payment_method_collection, 'if_required');
     assert.equal(team.metadata.planId, 'team');
     assert.equal(team.metadata.seatCount, '3');
   });


### PR DESCRIPTION
## Summary
- Add `payment_method_collection: 'if_required'` to subscription checkout sessions so users can start the 7-day free trial without entering a credit card
- 100 checkout sessions with 0 completions proved that requiring a card upfront kills conversion for developer tools
- Credit pack (one-time payment) checkouts are unaffected — they still require payment

## Test plan
- [x] All 29 billing tests pass, including new assertions for `payment_method_collection: 'if_required'` on subscription payloads (monthly, annual, team)
- [x] Verified credit pack payloads do not include `payment_method_collection`
- [ ] Verify in Stripe dashboard that new checkout sessions show "Trial" without card collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)