### PR TITLE
fix(billing): switch CLI upgrade link to no-card 7-day trial

### DIFF
--- a/.agents/skills/thumbgate/SKILL.md
+++ b/.agents/skills/thumbgate/SKILL.md
@@ -118,7 +118,7 @@ Pro users ($19/mo or $149/yr) unlock:
 Team rollout ($99/seat/mo, 3-seat minimum after intake) adds the shared hosted lesson DB,
 org dashboard, approval boundaries, and proof-backed workflow hardening sprint.
 
-Upgrade: https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06
+Upgrade: https://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a
 
 ## Detailed Reference
 

--- a/.changeset/no-card-trial.md
+++ b/.changeset/no-card-trial.md
@@ -2,4 +2,4 @@
 "thumbgate": patch
 ---
 
-Remove credit card requirement from 7-day free trial checkout — 100 sessions, 0 completions proved card-required trials kill conversion for developer tools.
+Switch CLI upgrade link to no-card 7-day trial — 2,478 cloners seeing card-required checkout was killing conversion.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -207,7 +207,7 @@
 
   <div class="demo-banner" id="demoBanner" style="display:none;">
     <span>📊 <strong>Demo Mode</strong> — sample data. Pro unlocks your personal dashboard with search, DPO export, and gate analytics.</span>
-    <a href="https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06" target="_blank" rel="noopener" style="background:#b85c2d;color:#fff;padding:6px 14px;border-radius:8px;text-decoration:none;font-weight:700;white-space:nowrap;">Upgrade to Pro — $19/mo</a>
+    <a href="https://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a" target="_blank" rel="noopener" style="background:#b85c2d;color:#fff;padding:6px 14px;border-radius:8px;text-decoration:none;font-weight:700;white-space:nowrap;">Start 7-day free trial</a>
   </div>
 
   <!-- STATS -->
@@ -956,8 +956,8 @@ function loadDemo() {
     '<div style="text-align:center;background:rgba(10,10,15,0.92);border:1px solid #333;border-radius:12px;padding:28px 36px;">' +
     '<div style="font-size:20px;font-weight:700;color:#fff;margin-bottom:8px;">Unlock your full dashboard</div>' +
     '<div style="color:#aaa;margin-bottom:16px;">Pro shows your real feedback, gates, and lessons — not sample data.</div>' +
-    '<a href="https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06" target="_blank" rel="noopener" ' +
-    'style="display:inline-block;background:#b85c2d;color:#fff;padding:10px 24px;border-radius:8px;text-decoration:none;font-weight:700;">Upgrade to Pro — $19/mo</a>' +
+    '<a href="https://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a" target="_blank" rel="noopener" ' +
+    'style="display:inline-block;background:#b85c2d;color:#fff;padding:10px 24px;border-radius:8px;text-decoration:none;font-weight:700;">Start 7-day free trial</a>' +
     '<div style="color:#666;font-size:12px;margin-top:10px;">npx thumbgate pro --activate --key=YOUR_KEY</div>' +
     '</div></div></div>';
   document.getElementById('searchResults').innerHTML = teaserHtml + upgradeWall;

--- a/public/lessons.html
+++ b/public/lessons.html
@@ -817,8 +817,8 @@ function renderUpgradeWall(containerId) {
     '<div style="text-align:center;background:rgba(10,10,15,0.92);border:1px solid #333;border-radius:12px;padding:28px 36px;">' +
     '<div style="font-size:20px;font-weight:700;color:#fff;margin-bottom:8px;">Unlock your full lessons</div>' +
     '<div style="color:#aaa;margin-bottom:16px;">Pro shows your real prevention rules, timeline, and insights.</div>' +
-    '<a href="https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06" target="_blank" rel="noopener" ' +
-    'style="display:inline-block;background:#b85c2d;color:#fff;padding:10px 24px;border-radius:8px;text-decoration:none;font-weight:700;">Upgrade to Pro — $19/mo</a>' +
+    '<a href="https://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a" target="_blank" rel="noopener" ' +
+    'style="display:inline-block;background:#b85c2d;color:#fff;padding:10px 24px;border-radius:8px;text-decoration:none;font-weight:700;">Start 7-day free trial</a>' +
     '<div style="color:#666;font-size:12px;margin-top:10px;">npx thumbgate pro --activate --key=YOUR_KEY</div>' +
     '</div></div>';
   el.appendChild(wall);

--- a/scripts/commercial-offer.js
+++ b/scripts/commercial-offer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const PRO_MONTHLY_PAYMENT_LINK = 'https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06';
+const PRO_MONTHLY_PAYMENT_LINK = 'https://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a';
 const PRO_ANNUAL_PAYMENT_LINK = 'https://buy.stripe.com/3cI8wPfCYaPs2dzdKz3sI07';
 
 const PRO_MONTHLY_PRICE_ID = 'price_1THQY7GGBpd520QYHoS7RG0J';

--- a/scripts/ralph-mode-ci.js
+++ b/scripts/ralph-mode-ci.js
@@ -178,7 +178,7 @@ const TWEET_ANGLES = [
   'Thompson Sampling for AI agent gates:\n\nEach gate: Beta(alpha, beta)\nCorrect block → alpha++ → tighter\nFalse positive → beta++ → relaxes\n\nNo thresholds. Gates converge on their own.\n\nhttps://github.com/IgorGanapolsky/ThumbGate',
   'Google DeepMind: hidden prompt injections commandeer AI agents 86% of the time.\n\nThumbGate gates the action, not the prompt. PreToolUse hooks are the last defense.\n\nhttps://github.com/IgorGanapolsky/ThumbGate',
   'Every AI agent framework ships memory. None ship enforcement.\n\nMemory: "Don\'t force-push to main"\nEnforcement: *physically blocked*\n\nThumbGate is the enforcement layer.\n\nhttps://github.com/IgorGanapolsky/ThumbGate',
-  'ThumbGate Pro is $19/mo or $149/yr for solo AI agent operators.\n\nLocal dashboard, DPO export, self-distillation, SQL MCP gates, Thompson Sampling, and pre-action enforcement.\n\nTeam rollout starts with intake: $99/seat/mo.\n\nhttps://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06',
+  'ThumbGate Pro is $19/mo or $149/yr for solo AI agent operators.\n\nLocal dashboard, DPO export, self-distillation, SQL MCP gates, Thompson Sampling, and pre-action enforcement.\n\nTeam rollout starts with intake: $99/seat/mo.\n\nhttps://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a',
   'Context-stuffing: skip RAG entirely.\n\nDump ALL prevention rules into agent context at session start. 20-200 rules = 1K-10K tokens.\n\nInspired by Karpathy. Simpler. Faster.\n\nhttps://github.com/IgorGanapolsky/ThumbGate',
   'The AI agent safety stack:\n\nGovernance: Paperclip\nOrchestration: iloom\nContext: RepoWise\nEnforcement: ThumbGate\n\nAll open source. All necessary.\n\nhttps://github.com/IgorGanapolsky/ThumbGate',
 ];

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -318,13 +318,13 @@ test('runtime hosted billing config defaults to the live pro price label', () =>
 
 test('runtime hosted billing config preserves absolute fallback checkout urls', () => {
   const previousFallback = process.env.THUMBGATE_CHECKOUT_FALLBACK_URL;
-  process.env.THUMBGATE_CHECKOUT_FALLBACK_URL = 'https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06?utm_source=website&utm_medium=cta_button';
+  process.env.THUMBGATE_CHECKOUT_FALLBACK_URL = 'https://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a?utm_source=website&utm_medium=cta_button';
 
   try {
     const runtimeConfig = resolveHostedBillingConfig();
     assert.equal(
       runtimeConfig.checkoutFallbackUrl,
-      'https://buy.stripe.com/5kQ4gzbmI9Lo6tPayn3sI06?utm_source=website&utm_medium=cta_button'
+      'https://buy.stripe.com/7sYcN5bmIf5IcSd8qf3sI0a?utm_source=website&utm_medium=cta_button'
     );
   } finally {
     if (previousFallback === undefined) {


### PR DESCRIPTION
## Summary
- Replaced card-required Stripe payment link (`5kQ4gzbmI9Lo6tPayn3sI06`) with trial-enabled link (`7sYcN5bmIf5IcSd8qf3sI0a`) across all user-facing surfaces
- New link config: `payment_method_collection: if_required`, 7-day trial, auto-cancel if no card added
- Updated CTA text from "Upgrade to Pro — $19/mo" to "Start 7-day free trial" in dashboard and lessons HTML
- 2,478 unique cloners in 14 days with 0 conversions due to card-required checkout

### Files changed
- `scripts/commercial-offer.js` — canonical payment link constant
- `scripts/ralph-mode-ci.js` — social/marketing copy
- `public/dashboard.html` — demo banner + upgrade wall CTAs
- `public/lessons.html` — lessons upgrade wall CTA
- `.agents/skills/thumbgate/SKILL.md` — skill doc upgrade link
- `tests/version-metadata.test.js` — test fixtures for fallback URL
- `.changeset/no-card-trial.md` — changeset description

## Test plan
- [x] `npm run test:billing` — 117 tests pass
- [x] `npm run test:api` (includes version-metadata, commerce-quality, dashboard tests) — all pass
- [x] Dashboard/landing page tests — 89 tests pass
- [x] Grep confirms no remaining references to old link ID `5kQ4gzbmI9Lo6tPayn3sI06` in source files (only `.claude/skills/thumbgate/SKILL.md` which is permission-restricted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)