### PR TITLE
feat: activate first-dollar release confidence

### DIFF
--- a/.changeset/first-dollar-activation.md
+++ b/.changeset/first-dollar-activation.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Clarify the first-dollar activation path across the landing page, README, and ChatGPT GPT docs so cold users start by proving one blocked repeated mistake before upgrading to Pro or entering the Workflow Hardening Sprint.

--- a/.changeset/release-email-companion.md
+++ b/.changeset/release-email-companion.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add npm publish receipt metadata and a downloadable full release-notes artifact to the publish workflow, so npm's bare "Successfully published" email can be reconciled with complete Changeset-backed release notes, tarball URL, shasum, and verification evidence.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -87,19 +87,6 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
-      - name: Build full changeset release notes
-        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.ensure_release == 'true'
-        env:
-          VERSION: ${{ steps.package.outputs.version }}
-          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          notes_file="thumbgate-${VERSION}-release-notes.md"
-          node scripts/release-notes.js \
-            --version="${VERSION}" \
-            --current-ref="${GITHUB_SHA}" \
-            --github-run-url="${GITHUB_RUN_URL}" \
-            --output="${notes_file}"
-          cat "${notes_file}" >> "$GITHUB_STEP_SUMMARY"
       - name: Publish npm package
         if: ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.publish_npm == 'true') || (github.event_name == 'release' && steps.npm.outputs.published == 'false')
         run: npm publish --tag "${{ steps.plan.outputs.npm_tag || 'latest' }}" --provenance
@@ -110,6 +97,60 @@ jobs:
         env:
           VERSION: ${{ steps.package.outputs.version }}
         run: node scripts/prove-packaged-runtime.js --package-spec "thumbgate@${VERSION}" --expected-version "${VERSION}"
+      - name: Resolve npm publish receipt
+        id: receipt
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.ensure_release == 'true'
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const { execFileSync } = require('node:child_process');
+
+          const version = process.env.VERSION;
+          const metadata = JSON.parse(execFileSync('npm', [
+            'view',
+            `thumbgate@${version}`,
+            'dist',
+            'time',
+            '--json',
+          ], { encoding: 'utf8' }));
+          const dist = metadata.dist || {};
+          const time = metadata.time || {};
+          const lines = [
+            `shasum=${dist.shasum || ''}`,
+            `tarball=${dist.tarball || ''}`,
+            `published_at=${time[version] || ''}`,
+          ];
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+          NODE
+      - name: Build full changeset release notes
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.ensure_release == 'true'
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NPM_SHASUM: ${{ steps.receipt.outputs.shasum }}
+          NPM_TARBALL_URL: ${{ steps.receipt.outputs.tarball }}
+          NPM_PUBLISHED_AT: ${{ steps.receipt.outputs.published_at }}
+        run: |
+          notes_file="thumbgate-${VERSION}-release-notes.md"
+          node scripts/release-notes.js \
+            --version="${VERSION}" \
+            --current-ref="${GITHUB_SHA}" \
+            --github-run-url="${GITHUB_RUN_URL}" \
+            --npm-shasum="${NPM_SHASUM}" \
+            --npm-tarball-url="${NPM_TARBALL_URL}" \
+            --npm-published-at="${NPM_PUBLISHED_AT}" \
+            --output="${notes_file}"
+          cat "${notes_file}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload full release notes artifact
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.ensure_release == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: thumbgate-${{ steps.package.outputs.version }}-release-notes
+          path: thumbgate-${{ steps.package.outputs.version }}-release-notes.md
+          if-no-files-found: error
       - name: Ensure GitHub Release exists
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.ensure_release == 'true'
         env:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ ThumbGate checks risky commands, file edits, deploys, API calls, and other agent
 
 **Running Codex?** **[Download the standalone Codex plugin bundle](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)** · **[Codex install guide](plugins/codex-profile/INSTALL.md)**
 
+## First-dollar activation path
+
+If someone is not already bought into ThumbGate, do not lead with architecture. Lead with one repeated mistake.
+
+1. **Show the pain:** open the **[ThumbGate GPT](https://thumbgate-production.up.railway.app/go/gpt?utm_source=github&utm_medium=readme&utm_campaign=first_dollar_activation&cta_id=readme_first_dollar_open_gpt&cta_placement=readme_first_dollar)** and paste the bad answer, risky command, deploy, PR action, or agent plan before it runs again.
+2. **Capture the lesson:** type `thumbs down:` or `thumbs up:` with one concrete sentence. Native ChatGPT rating buttons are not the ThumbGate capture path; typed feedback is.
+3. **Enforce the repeat:** run `npx thumbgate init` where the agent executes so the lesson can become a Pre-Action Gate instead of another reminder.
+4. **Upgrade only after proof:** Solo Pro is for the dashboard, DPO export, proof-ready evidence, and higher capture limits after one real blocked repeat. Team starts with the Workflow Hardening Sprint around one repeated failure, one owner, and one proof review.
+
+The buying question is simple: **what repeated AI mistake would be worth blocking before the next tool call?**
+
 ## ThumbGate GPT: start here
 
 **Use ThumbGate in ChatGPT now:** **[Open the live ThumbGate GPT](https://thumbgate-production.up.railway.app/go/gpt?utm_source=github&utm_medium=readme&utm_campaign=gpt_intro&cta_id=readme_intro_open_gpt&cta_placement=readme_intro)**, paste the action your AI agent wants to run, and ask whether to allow, block, or checkpoint it before the mistake becomes expensive.

--- a/adapters/chatgpt/INSTALL.md
+++ b/adapters/chatgpt/INSTALL.md
@@ -12,6 +12,17 @@ Use the term **Reliability Gateway** only after the user understands the outcome
 
 Marketing rule: every landing page, README, social post, and plugin listing should point to the live GPT before asking a cold user to read OpenAPI docs.
 
+## Regular-user promise
+
+The GPT should feel like a feedback button that remembers.
+
+- Users paste the answer, plan, or action they want checked.
+- Users type `thumbs down:` when the answer was wrong and one sentence about what should change.
+- Users type `thumbs up:` when the answer was useful and one sentence about what should be repeated.
+- ThumbGate confirms the future behavior it saved, then routes users to `npx thumbgate init` when they need hard blocking outside ChatGPT.
+
+Do not imply ChatGPT's built-in thumbs buttons save ThumbGate lessons. The reliable public capture path is a typed message inside the GPT.
+
 ## GPT Store path
 
 1. Open the direct GPT URL: https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate
@@ -48,9 +59,9 @@ Paste a risky AI action before it runs. ThumbGate tells you whether to allow, bl
 Conversation starters:
 
 1. `Check this agent action before it runs: git push --force --tags`
-2. `Turn this mistake into a ThumbGate rule: the agent edited generated files again.`
-3. `Install ThumbGate for Claude Code or Codex in this repo.`
-4. `Search my saved lessons before you answer.`
+2. `Thumbs down: that answer ignored my request for exact commands. Remember that.`
+3. `Thumbs up: this answer gave file paths, commands, and tests. Do that again.`
+4. `Turn this mistake into a ThumbGate rule: the agent edited generated files again.`
 
 Use typed chat replies. ChatGPT's native feedback buttons may send feedback to OpenAI, but they should not be described as the ThumbGate capture path unless OpenAI exposes them to GPT Actions.
 

--- a/docs/CHANGESET_STRATEGY.md
+++ b/docs/CHANGESET_STRATEGY.md
@@ -68,8 +68,10 @@ On publish, `.github/workflows/publish-npm.yml` runs `node scripts/release-notes
 
 - collect the `.changeset/*.md` files changed since the previous release tag.
 - render the full Changeset summaries by SemVer impact.
+- fetch npm publish receipt metadata, including published timestamp, tarball URL, and shasum when available.
 - write the same release note into the GitHub Actions summary linked from the npm email.
+- upload `thumbgate-X.Y.Z-release-notes` as a GitHub Actions artifact on the linked publish run.
 - create or update the `vX.Y.Z` GitHub Release with those notes.
 - upload `thumbgate-X.Y.Z-release-notes.md` as a release asset for audit trails.
 
-The npm email remains short, but the first-party release artifact it points to now contains the full release notes.
+The npm email remains short, but the first-party release artifact it points to now contains the full release notes and publish receipt metadata needed for audit review.

--- a/docs/FIRST_DOLLAR_PLAYBOOK.md
+++ b/docs/FIRST_DOLLAR_PLAYBOOK.md
@@ -1,7 +1,7 @@
 # First Dollar Playbook
 
 Status: current  
-Updated: April 9, 2026
+Updated: April 14, 2026
 
 Use [COMMERCIAL_TRUTH.md](COMMERCIAL_TRUTH.md) for live pricing and traction claims. Use [VERIFICATION_EVIDENCE.md](VERIFICATION_EVIDENCE.md) and [RELEASE_CONFIDENCE.md](RELEASE_CONFIDENCE.md) for engineering and package-publish proof.
 
@@ -15,6 +15,25 @@ The shortest honest path is:
 2. sell the **Workflow Hardening Sprint**
 3. attach the proof pack
 4. expand into Team rollout only after the first workflow proves out
+
+## Why broad launch activity did not create paying customers
+
+The failure mode is not missing infrastructure. It is weak demand capture:
+
+- Low-audience social posts create impressions, not buyer conversations.
+- Generic "agent memory" copy sounds replaceable by `CLAUDE.md`, `.cursorrules`, or another prompt file.
+- A GPT, plugin, npm package, and docs page are distribution surfaces, not revenue by themselves.
+- Revenue starts when one buyer names one repeated failure they already care about and agrees that blocking it before the next tool call is valuable.
+
+The first-dollar motion therefore has one job: move a cold user from curiosity to one blocked repeat.
+
+## First-dollar activation ladder
+
+1. **GPT proof:** send the user to the live ThumbGate GPT and ask for one bad answer, risky command, deploy, PR action, or agent plan they do not want repeated.
+2. **Typed feedback:** have them type `thumbs down:` or `thumbs up:` with one concrete sentence. Do not claim ChatGPT's native rating buttons feed ThumbGate.
+3. **Local enforcement:** install with `npx thumbgate init` where the agent executes, then show the saved lesson, generated rule, or blocked repeat.
+4. **Solo Pro trigger:** upgrade only after a real blocked repeat when the buyer needs more captures, the dashboard, DPO export, or proof-ready evidence.
+5. **Team trigger:** if there is a shared repo, review queue, deploy workflow, migration process, or release approval problem, convert to the Workflow Hardening Sprint.
 
 ## Operating thesis
 

--- a/docs/RELEASE_CONFIDENCE.md
+++ b/docs/RELEASE_CONFIDENCE.md
@@ -16,7 +16,8 @@ Customers, investors, and internal reviewers should be able to inspect why a ver
    - `npm run prove:automation`
    - `npm run self-heal:check`
 5. **Exact merge proof:** the work is not considered complete until the exact `main` merge commit is verified and its evidence is cited.
-6. **Release-note delivery:** the npm publish workflow renders full Changeset-backed release notes into the GitHub Actions summary, the `vX.Y.Z` GitHub Release body, and a downloadable `thumbgate-X.Y.Z-release-notes.md` release asset.
+6. **Release-note delivery:** the npm publish workflow renders full Changeset-backed release notes into the GitHub Actions summary, the `vX.Y.Z` GitHub Release body, a downloadable Actions artifact, and a downloadable `thumbgate-X.Y.Z-release-notes.md` release asset.
+7. **Publish receipt metadata:** after npm publish or no-op recovery, the workflow fetches npm's published timestamp, tarball URL, and shasum so the generated release note can be matched back to the bare npm "Successfully published" email.
 
 ## What buyers can inspect
 
@@ -35,7 +36,8 @@ These are the public surfaces that explain what changed, why it changed, and wha
 - An investor can see that package releases are governed by durable process, not ad hoc pushes.
 - A platform team can map a release note to its proof artifacts and merge checks.
 - A future incident review can reconstruct the decision path from PR, to version, to proof, to publish.
-- The npm "Successfully published" email links to a GitHub Actions run whose summary contains the full release notes, even though npm's own email template is not customizable.
+- The npm "Successfully published" email links to a GitHub Actions run whose summary and `thumbgate-X.Y.Z-release-notes` artifact contain the full release notes, even though npm's own email template is not customizable.
+- The generated release note includes npm shasum and tarball metadata when npm exposes them, so the email receipt can be reconciled with the customer-readable Changeset record.
 
 ## Operating rule
 

--- a/docs/chatgpt-gpt-instructions.md
+++ b/docs/chatgpt-gpt-instructions.md
@@ -36,6 +36,7 @@ User experience rules:
 - Never make regular users write JSON, API payloads, or schemas.
 - Do not mention MCP, OpenAPI, Actions, DPO, Thompson Sampling, or schema validation unless the user asks as a developer.
 - Do not make the GPT feel like a documentation kiosk. Lead with "paste the risky action" and "install local enforcement" before explaining architecture.
+- Make the GPT feel like a feedback button that remembers: users can paste a bad answer, type `thumbs down:`, and get a saved future behavior without learning the product internals.
 - Sell outcomes before infrastructure: prevent expensive AI mistakes, make AI stop repeating mistakes, and turn a smart assistant into a reliable operator.
 - Be precise about scope: this GPT provides advice, checkpointing, and memory capture; hard blocking applies to actions routed through ThumbGate locally, in CI, or through the decision endpoint.
 - Do not imply ChatGPT's native rating buttons automatically save ThumbGate lessons. The reliable capture path is a typed message such as "thumbs up: this worked" or "thumbs down: this missed the point."
@@ -79,9 +80,9 @@ Paste a risky AI action before it runs. ThumbGate tells you whether to allow, bl
 ## Conversation Starters
 
 1. `Check this agent action before it runs: git push --force --tags`
-2. `Turn this mistake into a ThumbGate rule: the agent edited generated files again.`
-3. `Install ThumbGate for Claude Code or Codex in this repo.`
-4. `Search my saved lessons before you answer.`
+2. `Thumbs down: that answer ignored my request for exact commands. Remember that.`
+3. `Thumbs up: this answer gave file paths, commands, and tests. Do that again.`
+4. `Turn this mistake into a ThumbGate rule: the agent edited generated files again.`
 
 ## Actions
 

--- a/public/index.html
+++ b/public/index.html
@@ -298,6 +298,14 @@ __GA_BOOTSTRAP__
   .hero-install .cmd { color: var(--cyan); }
   .hero-install .copy-hint { font-size: 11px; color: var(--text-muted); font-family: var(--font); margin-left: 8px; }
   .hero-install .copied { color: var(--green); }
+  .first-gate-card { max-width: 820px; margin: 0 auto 28px; text-align: left; border: 1px solid rgba(34,211,238,0.28); background: linear-gradient(135deg, rgba(34,211,238,0.08) 0%, rgba(74,222,128,0.06) 100%); border-radius: 14px; padding: 22px; box-shadow: 0 18px 60px rgba(0,0,0,0.22); }
+  .first-gate-card h2 { font-size: clamp(22px, 3vw, 30px); line-height: 1.15; margin-bottom: 8px; letter-spacing: -0.025em; }
+  .first-gate-card p { max-width: none; margin: 0 0 16px; color: var(--text-muted); font-size: 15px; }
+  .first-gate-steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 16px; }
+  .first-gate-step { border: 1px solid var(--border); border-radius: 10px; background: rgba(10,10,11,0.62); padding: 14px; }
+  .first-gate-step strong { display: block; color: var(--cyan); margin-bottom: 6px; }
+  .first-gate-step p { font-size: 13px; line-height: 1.5; margin: 0; }
+  .first-gate-example { font-family: var(--mono); color: var(--green); background: rgba(74,222,128,0.08); border: 1px solid rgba(74,222,128,0.24); border-radius: 8px; padding: 10px 12px; font-size: 12px; margin-top: 12px; overflow-x: auto; }
 
   /* SOCIAL PROOF BAR */
   .proof-bar { display: flex; justify-content: center; flex-wrap: wrap; gap: 24px; font-size: 13px; color: var(--text-muted); padding: 0 0 8px; }
@@ -447,6 +455,7 @@ __GA_BOOTSTRAP__
   @media (max-width: 700px) {
     .steps { grid-template-columns: 1fr; }
     .compatibility-grid { grid-template-columns: 1fr; }
+    .first-gate-steps { grid-template-columns: 1fr; }
     .gpt-steps { grid-template-columns: 1fr; }
     .seo-grid { grid-template-columns: 1fr; }
     .pricing-grid { grid-template-columns: 1fr; }
@@ -497,9 +506,9 @@ __GA_BOOTSTRAP__
 <section class="hero">
   <div class="container">
     <div class="hero-thumbs">👍👎</div>
-    <div class="hero-badge">● Stop costly AI mistakes before they run</div>
-    <h1>Stop AI agents before<br>they make costly mistakes.</h1>
-    <p style="font-size:18px;color:var(--text-muted);max-width:640px;margin:0 auto 20px;line-height:1.6;">Paste a risky command, file edit, deploy, payment, API call, or email into the live ThumbGate GPT for allow, block, or checkpoint guidance.<br><strong style="color:var(--text)">Then enforce locally with <code>npx thumbgate init</code> where your agent actually executes.</strong></p>
+    <div class="hero-badge">● Block your first repeated AI mistake in 5 minutes</div>
+    <h1>Stop the same AI mistake<br>before it runs again.</h1>
+    <p style="font-size:18px;color:var(--text-muted);max-width:660px;margin:0 auto 20px;line-height:1.6;">Open the ThumbGate GPT, paste the answer or action that went wrong, then type a concrete <code>thumbs down:</code> or <code>thumbs up:</code> lesson.<br><strong style="color:var(--text)">Install locally with <code>npx thumbgate init</code> when you want that lesson enforced before the next agent tool call.</strong></p>
     <div class="hero-signals">
       <div class="signal-pill signal-down">👎 Prevent expensive mistakes: force-pushes, destructive SQL, bad deploys</div>
       <div class="signal-pill signal-up">✅ Fix it once, then block the repeat before the next tool call</div>
@@ -520,6 +529,26 @@ __GA_BOOTSTRAP__
     </div>
     <p style="font-size:13px;color:var(--text-muted);margin:16px auto 0;max-width:660px;">No, you do not have to chat inside the GPT forever. The GPT is advice and checkpointing; local hooks do the hard blocking for Claude Code, Cursor, Codex, Gemini, Amp, OpenCode, and MCP-compatible agents.</p>
     <p style="font-size:13px;color:var(--text-muted);margin:8px auto 28px;max-width:560px;">Free local CLI proves the enforcement loop on one machine. Pro adds personal enforcement proof, the gate debugger, DPO export, and a dashboard. Team shares the gates across seats. <a href="#pricing" style="color:var(--cyan);text-decoration:none;">See all plans →</a></p>
+    <div class="first-gate-card" id="first-gate">
+      <div class="section-label" style="text-align:left;margin-bottom:8px;">First-Dollar Activation Path</div>
+      <h2>Prove one blocked repeat before asking anyone to buy.</h2>
+      <p>The fastest path to revenue is not another feature. It is one person proving ThumbGate prevents one repeated mistake they already care about.</p>
+      <div class="first-gate-steps">
+        <div class="first-gate-step">
+          <strong>1. Open the GPT</strong>
+          <p>Paste the bad answer, command, deploy, PR action, or agent plan before it runs again.</p>
+        </div>
+        <div class="first-gate-step">
+          <strong>2. Type the signal</strong>
+          <p>Use <code>thumbs down:</code> for the mistake or <code>thumbs up:</code> for the pattern worth repeating. Native ChatGPT rating buttons are not the ThumbGate capture path.</p>
+        </div>
+        <div class="first-gate-step">
+          <strong>3. Enforce the lesson</strong>
+          <p>Run <code>npx thumbgate init</code>. Upgrade to Pro when you need the dashboard, proof, exports, or more captures.</p>
+        </div>
+      </div>
+      <div class="first-gate-example">thumbs down: the answer ignored my request for exact files and tests; next time include file paths, commands, and verification evidence.</div>
+    </div>
     <div class="proof-bar">
       <a href="/guide" rel="noopener">CLI-first setup guide →</a>
       <span class="dot"></span>
@@ -564,8 +593,8 @@ __GA_BOOTSTRAP__
   <div class="container">
     <div class="gpt-panel">
       <div class="section-label" style="text-align:left;">ChatGPT Entry Point · Live ThumbGate GPT for ChatGPT</div>
-      <h2>Open the GPT. Check the action. Turn the lesson into a gate.</h2>
-      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to prevent an expensive AI mistake before installing anything.</p>
+      <h2>Open the GPT. Give typed thumbs feedback. Turn the lesson into a gate.</h2>
+      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to capture a useful thumbs-up/down lesson, check a risky action, and prove the enforcement loop before installing anything.</p>
       <div class="gpt-steps">
         <div class="gpt-step">
           <strong>1. Try the live GPT</strong>
@@ -573,7 +602,7 @@ __GA_BOOTSTRAP__
         </div>
         <div class="gpt-step">
           <strong>2. Save the signal</strong>
-          <p>Reply with <code>thumbs up:</code> or <code>thumbs down:</code> plus one concrete sentence. One signal becomes one remembered rule.</p>
+          <p>Reply in chat with <code>thumbs up:</code> or <code>thumbs down:</code> plus one concrete sentence. Do not rely on ChatGPT's native rating buttons for ThumbGate memory.</p>
         </div>
         <div class="gpt-step">
           <strong>3. Enforce locally</strong>
@@ -584,7 +613,7 @@ __GA_BOOTSTRAP__
         <a href="/go/gpt?utm_source=website&utm_medium=gpt_section&utm_campaign=chatgpt_gpt&cta_id=gpt_path_open_gpt&cta_placement=gpt_section" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('gpt_path_cta_click',{cta:'open_gpt'})">Open ThumbGate GPT</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/adapters/chatgpt/INSTALL.md" class="btn-free" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">ChatGPT Actions setup</a>
       </div>
-      <p class="gpt-note"><strong>Plain English rule:</strong> ChatGPT is the discovery and memory surface for advice, checkpointing, and typed feedback capture. The hard Reliability Gateway still runs in the local agent or CI lane.</p>
+      <p class="gpt-note"><strong>Plain English rule:</strong> ChatGPT is the discovery and memory surface for advice, checkpointing, and typed feedback capture. One typed signal becomes one remembered rule. The hard Reliability Gateway still runs in the local agent or CI lane.</p>
     </div>
   </div>
 </section>
@@ -872,7 +901,7 @@ __GA_BOOTSTRAP__
         <div class="tier" style="color:var(--cyan);">Free</div>
         <div class="price">$0</div>
         <div class="price-sub">Forever free · CLI-first local enforcement for one developer</div>
-        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">For solo developers who want to stop the same agent mistake from showing up twice and prove local value before a team rollout conversation exists.</p>
+        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">For solo developers who want to stop the same agent mistake from showing up twice and prove one blocked repeat before a team rollout conversation exists.</p>
         <ul>
           <li>3 feedback captures/day · 5 lesson searches/day · unlimited recall</li>
           <li>5 auto-promoted gates plus the core safety policy</li>
@@ -920,7 +949,7 @@ __GA_BOOTSTRAP__
         </ul>
         <div class="trial-badge" style="background:var(--cyan);color:#000;display:inline-block;padding:4px 12px;border-radius:12px;font-size:12px;font-weight:700;margin-bottom:12px;">7-DAY FREE TRIAL</div>
         <a href="/go/pro?utm_source=website&utm_medium=pricing_card&utm_campaign=pro_upgrade&cta_id=pricing_pro_upgrade&cta_placement=pricing&plan_id=pro&landing_path=%2F" class="btn-pro" onclick="posthog.capture('pricing_cta_click',{cta:'pro_upgrade',plan:'pro'})" style="display:block;width:100%;text-align:center;padding:12px;font-size:15px;">Upgrade to Pro — $19/mo</a>
-        <p style="font-size:11px;color:#666;margin-top:8px;">Start with the free CLI. Upgrade when you hit the 3 captures/day limit and need the dashboard, DPO export, and export-ready evidence.</p>
+        <p style="font-size:11px;color:#666;margin-top:8px;">Start with the free CLI. Upgrade after one real blocked repeat when you hit the 3 captures/day limit or need dashboard proof, DPO export, and export-ready evidence.</p>
       </div>
       <div class="price-card team">
         <div class="tier">Team</div>

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -20,6 +20,9 @@ function parseArgs(argv = process.argv.slice(2)) {
     else if (arg.startsWith('--output=')) options.outputPath = arg.slice('--output='.length);
     else if (arg.startsWith('--github-run-url=')) options.githubRunUrl = arg.slice('--github-run-url='.length);
     else if (arg.startsWith('--repo=')) options.repoFullName = arg.slice('--repo='.length);
+    else if (arg.startsWith('--npm-shasum=')) options.npmShasum = arg.slice('--npm-shasum='.length);
+    else if (arg.startsWith('--npm-tarball-url=')) options.npmTarballUrl = arg.slice('--npm-tarball-url='.length);
+    else if (arg.startsWith('--npm-published-at=')) options.npmPublishedAt = arg.slice('--npm-published-at='.length);
   }
   return options;
 }
@@ -197,6 +200,9 @@ function formatReleaseNotes({
   currentTag = `v${version}`,
   currentRef = 'HEAD',
   githubRunUrl = '',
+  npmShasum = '',
+  npmTarballUrl = '',
+  npmPublishedAt = '',
   changesets = [],
   changelogEntry = '',
 } = {}) {
@@ -226,7 +232,14 @@ function formatReleaseNotes({
     `- GitHub Release: ${releaseUrl}`,
     `- Compare: ${compareUrl}`,
     githubRunUrl ? `- Publish workflow: ${githubRunUrl}` : null,
+    npmPublishedAt ? `- npm published at: ${npmPublishedAt}` : null,
+    npmShasum ? `- npm shasum: \`${npmShasum}\`` : null,
+    npmTarballUrl ? `- npm tarball: ${npmTarballUrl}` : null,
     `- Release ref: ${currentRef}`,
+    '',
+    '## npm Email Companion',
+    '',
+    'npm controls the native "Successfully published" email template, so the email itself stays short. Treat this generated artifact as the full release-note companion for that email: it carries the Changeset summaries, CHANGELOG entry, publish workflow, npm tarball, and shasum when available.',
     '',
     '## Full Changeset Release Notes',
     '',
@@ -251,6 +264,9 @@ function buildReleaseNotes({
   currentRef = 'HEAD',
   previousTag,
   githubRunUrl = '',
+  npmShasum = '',
+  npmTarballUrl = '',
+  npmPublishedAt = '',
   cwd = PROJECT_ROOT,
   runner = execFileSync,
 } = {}) {
@@ -287,6 +303,9 @@ function buildReleaseNotes({
       currentTag,
       currentRef,
       githubRunUrl,
+      npmShasum,
+      npmTarballUrl,
+      npmPublishedAt,
       changesets,
       changelogEntry,
     }),
@@ -311,6 +330,9 @@ function runCli({
     currentRef: options.currentRef || env.GITHUB_SHA || 'HEAD',
     previousTag: options.previousTag,
     githubRunUrl: options.githubRunUrl || env.GITHUB_RUN_URL || '',
+    npmShasum: options.npmShasum || env.NPM_SHASUM || '',
+    npmTarballUrl: options.npmTarballUrl || env.NPM_TARBALL_URL || '',
+    npmPublishedAt: options.npmPublishedAt || env.NPM_PUBLISHED_AT || '',
     cwd,
     runner,
   });

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -56,6 +56,9 @@ test('README keeps the business sprint-first while preserving the Pro side lane'
 
   assert.match(readme, /Best first paid motion for teams/i);
   assert.match(readme, /Best first technical motion/i);
+  assert.match(readme, /First-dollar activation path/i);
+  assert.match(readme, /what repeated AI mistake would be worth blocking before the next tool call/i);
+  assert.match(readme, /Native ChatGPT rating buttons are not the ThumbGate capture path/i);
   assert.match(readme, /CLI-first/i);
   assert.match(readme, /Workflow Hardening Sprint/i);
   assert.match(readme, /Paid path for individual operators/i);
@@ -205,6 +208,9 @@ test('first dollar playbook keeps the sales motion sprint-first and proof-backed
 
   assert.match(playbook, /Status: current/i);
   assert.match(playbook, /next repeatable dollar/i);
+  assert.match(playbook, /First-dollar activation ladder/i);
+  assert.match(playbook, /move a cold user from curiosity to one blocked repeat/i);
+  assert.match(playbook, /Do not claim ChatGPT's native rating buttons feed ThumbGate/i);
   assert.match(playbook, /Workflow Hardening Sprint/i);
   assert.match(playbook, /proof pack/i);
   assert.match(playbook, /named pilot agreement/i);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -169,6 +169,17 @@ test('public landing page exposes the free CLI wedge above the fold and keeps Pr
   assert.match(landingPage, /solo side lane/i);
 });
 
+test('public landing page gives cold users a first-dollar activation path', () => {
+  const landingPage = readLandingPage();
+
+  assert.match(landingPage, /Block your first repeated AI mistake in 5 minutes/i);
+  assert.match(landingPage, /First-Dollar Activation Path/i);
+  assert.match(landingPage, /Prove one blocked repeat before asking anyone to buy/i);
+  assert.match(landingPage, /Native ChatGPT rating buttons are not the ThumbGate capture path/i);
+  assert.match(landingPage, /thumbs down: the answer ignored my request/i);
+  assert.match(landingPage, /Upgrade after one real blocked repeat/i);
+});
+
 test('public landing page Pro tier uses outcome-framed bullets that justify upgrade', () => {
   const landingPage = readLandingPage();
 
@@ -250,9 +261,10 @@ test('public landing page includes compatibility section for AI agent surfaces',
   assert.match(landingPage, /Open ThumbGate GPT/);
   assert.match(landingPage, /Live ThumbGate GPT for ChatGPT/);
   assert.match(landingPage, /ChatGPT Entry Point/);
-  assert.match(landingPage, /Open the GPT\. Check the action\. Turn the lesson into a gate\./);
+  assert.match(landingPage, /Open the GPT\. Give typed thumbs feedback\. Turn the lesson into a gate\./);
   assert.match(landingPage, /No, you do not have to chat inside the GPT forever/);
   assert.match(landingPage, /ChatGPT is the discovery and memory surface/);
+  assert.match(landingPage, /Do not rely on ChatGPT's native rating buttons for ThumbGate memory/);
   assert.match(landingPage, /Do I have to chat inside the ThumbGate GPT for enforcement\?/);
   assert.match(landingPage, /capture thumbs-up\/down lessons/i);
   assert.match(landingPage, /Real blocking for coding agents still runs locally/);

--- a/tests/release-notes.test.js
+++ b/tests/release-notes.test.js
@@ -82,6 +82,9 @@ test('formatReleaseNotes includes full changeset summaries and verification link
     currentTag: 'v1.4.4',
     currentRef: 'abc123',
     githubRunUrl: 'https://github.com/IgorGanapolsky/ThumbGate/actions/runs/1',
+    npmShasum: '118f7abfbaba942195bc2d62219a9fd28cd52ffd',
+    npmTarballUrl: 'https://registry.npmjs.org/thumbgate/-/thumbgate-1.4.4.tgz',
+    npmPublishedAt: '2026-04-14T16:20:49.754Z',
     changesets: [{
       file: '.changeset/slim-npm-package-boundary.md',
       releaseType: 'patch',
@@ -95,6 +98,11 @@ test('formatReleaseNotes includes full changeset summaries and verification link
   assert.match(markdown, /slim-npm-package-boundary\.md/);
   assert.match(markdown, /generated runtime state cannot leak/);
   assert.match(markdown, /actions\/runs\/1/);
+  assert.match(markdown, /npm Email Companion/);
+  assert.match(markdown, /Successfully published/);
+  assert.match(markdown, /118f7abfbaba942195bc2d62219a9fd28cd52ffd/);
+  assert.match(markdown, /thumbgate-1\.4\.4\.tgz/);
+  assert.match(markdown, /2026-04-14T16:20:49\.754Z/);
   assert.match(markdown, /CHANGELOG\.md Entry/);
   assert.match(markdown, /Changelog copy/);
 });
@@ -142,7 +150,15 @@ test('publish workflow writes full release notes instead of GitHub generated not
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /Build full changeset release notes/);
   assert.match(workflow, /scripts\/release-notes\.js/);
+  assert.match(workflow, /Resolve npm publish receipt/);
+  assert.match(workflow, /npm'\s*,\s*\[\s*'view'/);
+  assert.match(workflow, /--npm-shasum="\$\{NPM_SHASUM\}"/);
+  assert.match(workflow, /--npm-tarball-url="\$\{NPM_TARBALL_URL\}"/);
+  assert.match(workflow, /--npm-published-at="\$\{NPM_PUBLISHED_AT\}"/);
   assert.match(workflow, /GITHUB_STEP_SUMMARY/);
+  assert.match(workflow, /Upload full release notes artifact/);
+  assert.match(workflow, /actions\/upload-artifact@v7/);
+  assert.match(workflow, /if-no-files-found:\s*error/);
   assert.match(workflow, /gh release create "v\$\{VERSION\}" --title "thumbgate@\$\{VERSION\}" --notes-file "\$\{notes_file\}"/);
   assert.match(workflow, /gh release edit "v\$\{VERSION\}" --title "thumbgate@\$\{VERSION\}" --notes-file "\$\{notes_file\}"/);
   assert.match(workflow, /gh release upload "v\$\{VERSION\}" "\$\{notes_file\}" --clobber/);

--- a/tests/release-notes.test.js
+++ b/tests/release-notes.test.js
@@ -11,7 +11,9 @@ const {
   extractChangelogEntry,
   formatReleaseNotes,
   isSafeChangesetPath,
+  parseArgs,
   resolveInside,
+  runCli,
 } = require('../scripts/release-notes');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
@@ -75,6 +77,20 @@ test('release note file paths stay inside the expected project boundaries', () =
   }
 });
 
+test('parseArgs accepts npm publish receipt metadata flags', () => {
+  const options = parseArgs([
+    '--version=1.4.6',
+    '--npm-shasum=118f7abfbaba942195bc2d62219a9fd28cd52ffd',
+    '--npm-tarball-url=https://registry.npmjs.org/thumbgate/-/thumbgate-1.4.6.tgz',
+    '--npm-published-at=2026-04-14T16:20:49.754Z',
+  ]);
+
+  assert.equal(options.version, '1.4.6');
+  assert.equal(options.npmShasum, '118f7abfbaba942195bc2d62219a9fd28cd52ffd');
+  assert.equal(options.npmTarballUrl, 'https://registry.npmjs.org/thumbgate/-/thumbgate-1.4.6.tgz');
+  assert.equal(options.npmPublishedAt, '2026-04-14T16:20:49.754Z');
+});
+
 test('formatReleaseNotes includes full changeset summaries and verification links', () => {
   const markdown = formatReleaseNotes({
     version: '1.4.4',
@@ -131,6 +147,9 @@ test('buildReleaseNotes uses changed changeset files from the previous release t
     const result = buildReleaseNotes({
       cwd: tempDir,
       currentRef: 'abc123',
+      npmShasum: '118f7abfbaba942195bc2d62219a9fd28cd52ffd',
+      npmTarballUrl: 'https://registry.npmjs.org/thumbgate/-/thumbgate-1.4.4.tgz',
+      npmPublishedAt: '2026-04-14T16:20:49.754Z',
       runner,
     });
 
@@ -138,8 +157,67 @@ test('buildReleaseNotes uses changed changeset files from the previous release t
     assert.equal(result.previousTag, 'v1.4.3');
     assert.deepEqual(result.changedChangesetFiles, ['.changeset/slim-npm-package-boundary.md']);
     assert.match(result.markdown, /Slim the npm package boundary/);
+    assert.match(result.markdown, /118f7abfbaba942195bc2d62219a9fd28cd52ffd/);
+    assert.match(result.markdown, /thumbgate-1\.4\.4\.tgz/);
+    assert.match(result.markdown, /2026-04-14T16:20:49\.754Z/);
     assert.match(result.markdown, /No `CHANGELOG\.md` section was found for 1\.4\.4/);
   } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('runCli writes npm email companion notes from environment metadata', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-release-notes-cli-'));
+  fs.mkdirSync(path.join(tempDir, '.changeset'));
+  fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ version: '1.4.6' }));
+  fs.writeFileSync(path.join(tempDir, 'CHANGELOG.md'), '# Changelog\n');
+  fs.writeFileSync(path.join(tempDir, '.changeset', 'release-email-companion.md'), [
+    '---',
+    '"thumbgate": patch',
+    '---',
+    '',
+    'Publish full release notes beside npm email receipts.',
+  ].join('\n'));
+
+  const runner = (command, args) => {
+    assert.equal(command, 'git');
+    if (args[0] === 'tag') return 'v1.4.6\nv1.4.5\n';
+    if (args[0] === 'diff') return '.changeset/release-email-companion.md\n';
+    throw new Error(`unexpected git command: ${args.join(' ')}`);
+  };
+
+  const originalWrite = process.stdout.write;
+  let stdout = '';
+
+  try {
+    process.stdout.write = (chunk, encoding, callback) => {
+      stdout += String(chunk);
+      if (typeof callback === 'function') callback();
+      return true;
+    };
+    const result = runCli({
+      argv: ['--output=release-notes.md'],
+      cwd: tempDir,
+      env: {
+        VERSION: '1.4.6',
+        GITHUB_SHA: 'abc123',
+        GITHUB_RUN_URL: 'https://github.com/IgorGanapolsky/ThumbGate/actions/runs/24410268228',
+        NPM_SHASUM: '118f7abfbaba942195bc2d62219a9fd28cd52ffd',
+        NPM_TARBALL_URL: 'https://registry.npmjs.org/thumbgate/-/thumbgate-1.4.6.tgz',
+        NPM_PUBLISHED_AT: '2026-04-14T16:20:49.754Z',
+      },
+      runner,
+    });
+    const written = fs.readFileSync(path.join(tempDir, 'release-notes.md'), 'utf8');
+
+    assert.match(result.markdown, /npm Email Companion/);
+    assert.equal(stdout, result.markdown);
+    assert.match(written, /Publish full release notes beside npm email receipts/);
+    assert.match(written, /actions\/runs\/24410268228/);
+    assert.match(written, /118f7abfbaba942195bc2d62219a9fd28cd52ffd/);
+    assert.match(written, /thumbgate-1\.4\.6\.tgz/);
+  } finally {
+    process.stdout.write = originalWrite;
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -116,6 +116,9 @@ test('public docs render the current package version', () => {
   assert.match(chatgptInstall, /decisionControl\.executionMode: "blocked"/);
   assert.match(chatgptInstall, /Plain thumbs-up\/down feedback is the memory loop\. The decision endpoint is the gate loop\./);
   assert.match(chatgptInstall, /Check this agent action before it runs: git push --force --tags/i);
+  assert.match(chatgptInstall, /The GPT should feel like a feedback button that remembers/i);
+  assert.match(chatgptInstall, /Thumbs down: that answer ignored my request for exact commands/i);
+  assert.match(chatgptInstall, /Thumbs up: this answer gave file paths, commands, and tests/i);
   assert.match(chatgptInstall, /Paste the risky AI action before it runs, or tell me what went right\/wrong/i);
   assert.match(chatgptInstall, /native feedback buttons may send feedback to OpenAI/i);
   assert.match(chatgptInstall, /Regular GPT users should not need an API key, JSON payload, OpenAPI knowledge, or developer setup/i);
@@ -133,6 +136,9 @@ test('public docs render the current package version', () => {
   assert.match(chatgptInstructions, /Feedback capture mode/);
   assert.match(chatgptInstructions, /decisionControl\.executionMode/);
   assert.match(chatgptInstructions, /one signal becomes one remembered rule/i);
+  assert.match(chatgptInstructions, /feedback button that remembers/i);
+  assert.match(chatgptInstructions, /Thumbs down: that answer ignored my request for exact commands/i);
+  assert.match(chatgptInstructions, /Thumbs up: this answer gave file paths, commands, and tests/i);
   assert.match(chatgptInstructions, /public front door for ThumbGate/i);
   assert.match(chatgptInstructions, /Hard enforcement runs locally after `npx thumbgate init` where your agent actually executes/i);
   assert.match(chatgptInstructions, /Regular users should never need an API key, JSON payload, OpenAPI knowledge, or developer setup/i);


### PR DESCRIPTION
## Summary
- clarify the first-dollar activation path across README, landing page, GPT install docs, and GPT instructions
- make typed thumbs-up/down feedback explicit because native ChatGPT rating buttons are not ThumbGate capture
- upgrade npm publish release notes with npm receipt metadata, Actions summary output, and a downloadable full release-notes artifact

## Verification
- npm ci
- npm test
- node --test tests/release-notes.test.js tests/changeset-check.test.js tests/deployment.test.js
- npm run test:deployment
- node --test tests/public-landing.test.js tests/positioning-contract.test.js tests/version-metadata.test.js tests/release-notes.test.js tests/changeset-check.test.js tests/deployment.test.js
- git diff --check