### PR TITLE
chore(release): fix public version sync writes

### DIFF
--- a/.changeset/public-version-sync.md
+++ b/.changeset/public-version-sync.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Fix public landing page version synchronization so multiple release markers update in one pass.

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -373,15 +373,14 @@ function syncVersion(opts) {
   const publicIndexPath = 'public/index.html';
   if (fs.existsSync(path.join(PROJECT_ROOT, publicIndexPath))) {
     const publicIndexFile = path.join(PROJECT_ROOT, publicIndexPath);
-    const publicContent = fs.readFileSync(publicIndexFile, 'utf-8');
+    let publicContent = fs.readFileSync(publicIndexFile, 'utf-8');
+    let publicContentChanged = false;
     const heroVersionMatch = publicContent.match(new RegExp(`New in v(${VERSION_PATTERN}):?`));
     if (heroVersionMatch && heroVersionMatch[1] !== version) {
       drifted.push({ file: publicIndexPath, field: 'hero-release-note', current: heroVersionMatch[1] });
       if (!checkOnly) {
-        fs.writeFileSync(
-          publicIndexFile,
-          publicContent.replace(new RegExp(`New in v${VERSION_PATTERN}:?`), `New in v${version}`)
-        );
+        publicContent = publicContent.replace(new RegExp(`New in v${VERSION_PATTERN}:?`), `New in v${version}`);
+        publicContentChanged = true;
       }
     }
 
@@ -389,7 +388,8 @@ function syncVersion(opts) {
     if (proofMatch && proofMatch[1] !== version) {
       drifted.push({ file: publicIndexPath, field: 'proof-pill', current: proofMatch[1] });
       if (!checkOnly) {
-        replaceInFile(publicIndexPath, `Versioned proof: v${proofMatch[1]}`, `Versioned proof: v${version}`);
+        publicContent = publicContent.replace(`Versioned proof: v${proofMatch[1]}`, `Versioned proof: v${version}`);
+        publicContentChanged = true;
       }
     }
 
@@ -397,14 +397,15 @@ function syncVersion(opts) {
     if (footerMatch && footerMatch[1] !== version) {
       drifted.push({ file: publicIndexPath, field: 'footer-version', current: footerMatch[1] });
       if (!checkOnly) {
-        fs.writeFileSync(
-          publicIndexFile,
-          publicContent.replace(
-            new RegExp(`((?:Context Gateway|MIT License) [•·] )v${VERSION_PATTERN}`),
-            `$1v${version}`
-          )
+        publicContent = publicContent.replace(
+          new RegExp(`((?:Context Gateway|MIT License) [•·] )v${VERSION_PATTERN}`),
+          `$1v${version}`
         );
+        publicContentChanged = true;
       }
+    }
+    if (publicContentChanged) {
+      fs.writeFileSync(publicIndexFile, publicContent);
     }
     targets.push(publicIndexPath);
   }

--- a/tests/sync-version.test.js
+++ b/tests/sync-version.test.js
@@ -128,3 +128,32 @@ test('sync-version detects public landing footer drift', serial, () => {
     fs.writeFileSync(publicIndexPath, original);
   }
 });
+
+test('sync-version updates multiple public landing markers in one pass', serial, () => {
+  const { syncVersion } = require('../scripts/sync-version');
+  const { version } = require('../package.json');
+  const publicIndexPath = path.join(ROOT, 'public', 'index.html');
+  const original = fs.readFileSync(publicIndexPath, 'utf8');
+  const drifted = original
+    .replace(/New in v\d+\.\d+\.\d+:?/, 'New in v0.0.1')
+    .replace(/MIT License · v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/, 'MIT License · v0.0.1');
+
+  try {
+    fs.writeFileSync(publicIndexPath, drifted);
+    const result = syncVersion({ checkOnly: false });
+    assert.ok(
+      result.drifted.some((entry) => entry.file === 'public/index.html' && entry.field === 'hero-release-note'),
+      `expected hero drift, found: ${JSON.stringify(result.drifted)}`
+    );
+    assert.ok(
+      result.drifted.some((entry) => entry.file === 'public/index.html' && entry.field === 'footer-version'),
+      `expected footer drift, found: ${JSON.stringify(result.drifted)}`
+    );
+
+    const synced = fs.readFileSync(publicIndexPath, 'utf8');
+    assert.ok(synced.includes(`New in v${version}`), 'hero marker should be synced');
+    assert.ok(synced.includes(`MIT License · v${version}`), 'footer marker should be synced');
+  } finally {
+    fs.writeFileSync(publicIndexPath, original);
+  }
+});


### PR DESCRIPTION
## Summary
- Make `scripts/sync-version.js` mutate one `public/index.html` buffer and write once so multiple drifting public version markers cannot overwrite each other.
- Add a regression test that drifts both the landing hero version and footer version, then verifies both are restored in a single sync pass.

## Verification
- `npm ci --onnxruntime-node-install-cuda=skip`
- `npm run test:sync-version`
- `node scripts/sync-version.js --check`
- `npm test`
- `npm run test:coverage` (all files: 84.95 lines / 71.65 branches / 87.85 functions)
- `npm run self-heal:check` (HEALTHY, 6/6)

## Release Hygiene
- `thumbgate@1.5.0` is already published as `latest` on npm from release PR #856.
- This PR is chore/tooling-only and does not require a package version bump.