### PR TITLE
Fix ChatGPT Actions OpenAPI YAML import

### DIFF
--- a/.changeset/chatgpt-actions-openapi-yaml.md
+++ b/.changeset/chatgpt-actions-openapi-yaml.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Expose the ChatGPT Actions OpenAPI YAML import before bearer auth and document the GPT Builder bearer key setup.

--- a/.changeset/chatgpt-openapi-yaml.md
+++ b/.changeset/chatgpt-openapi-yaml.md
@@ -1,5 +1,0 @@
----
-thumbgate: patch
----
-
-Expose the public ChatGPT Actions OpenAPI YAML route and document bearer-key import verification.

--- a/.changeset/chatgpt-openapi-yaml.md
+++ b/.changeset/chatgpt-openapi-yaml.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Expose the public ChatGPT Actions OpenAPI YAML route and document bearer-key import verification.

--- a/adapters/chatgpt/INSTALL.md
+++ b/adapters/chatgpt/INSTALL.md
@@ -118,7 +118,13 @@ In the Actions panel:
 
 1. Select **Authentication type: API Key**
 2. **Auth type**: Bearer
-3. **API Key**: paste your `THUMBGATE_API_KEY` value
+3. **API Key**: paste the raw `THUMBGATE_API_KEY` value only, without a `Bearer ` prefix
+
+Expected outbound header:
+
+```text
+Authorization: Bearer <THUMBGATE_API_KEY>
+```
 
 This is an owner setup field. Do not ask regular GPT users to provide an API key.
 
@@ -149,6 +155,14 @@ Expected response: `200 OK` with `{ "accepted": true, "status": "promoted" }`.
 
 If you only send a bare `thumbs up/down` style payload, expect `422` with `status: "clarification_required"` and a follow-up `prompt`.
 
+Before publishing or re-publishing the GPT, keep it private and verify these three private flows in GPT Builder:
+
+1. `Thumbs up: this answer gave exact commands, file paths, and tests`
+2. `Thumbs down: that answer ignored the requested auth setup`
+3. `Check this: git push --force`
+
+All three should call the action layer without a `401 Unauthorized` response. If any action test returns `401`, the GPT Builder secret is missing, stale, pasted with an extra `Bearer ` prefix, or pointed at a different backend key than Railway's `THUMBGATE_API_KEY`.
+
 ## Available Actions
 
 | Action | Method | Path | Description |
@@ -166,6 +180,7 @@ Full spec: `adapters/chatgpt/openapi.yaml`
 
 ## Troubleshooting
 
-- **401 Unauthorized**: Verify `THUMBGATE_API_KEY` is set and matches the Bearer token
+- **401 Unauthorized on action calls**: Verify the GPT Builder action uses **Authentication type: API Key**, **Auth type: Bearer**, and the raw `THUMBGATE_API_KEY` value. The backend must receive `Authorization: Bearer <key>`.
+- **401 Unauthorized when importing the schema**: Use `https://thumbgate-production.up.railway.app/openapi.yaml` after the public spec route is deployed, or fall back to `https://thumbgate-production.up.railway.app/openapi.json`.
 - **Connection refused**: Confirm Railway deployment is live (`curl https://<domain>/health`)
 - **Schema errors**: Ensure you are using the latest `openapi.yaml` (version 1.1.0+)

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1211,6 +1211,13 @@ function getPublicOrigin(req) {
   return `${proto}://${host}`;
 }
 
+function renderOpenApiYamlForRequest(yaml, req) {
+  return yaml.replace(
+    /servers:\n\s+- url: .+/m,
+    `servers:\n  - url: ${getPublicOrigin(req)}`
+  );
+}
+
 function getRequestHostHeader(req) {
   const forwardedHost = req.headers['x-forwarded-host'];
   if (Array.isArray(forwardedHost)) {
@@ -3956,18 +3963,23 @@ async function addContext(){
     }
 
     // Public OpenAPI spec — no auth required (needed for ChatGPT GPT Store import)
-    if (isGetLikeRequest && pathname === '/openapi.json') {
+    if (isGetLikeRequest && (pathname === '/openapi.json' || pathname === '/openapi.yaml')) {
       const specPath = path.join(__dirname, '../../adapters/chatgpt/openapi.yaml');
       try {
-        const yaml = fs.readFileSync(specPath, 'utf8');
+        const yaml = renderOpenApiYamlForRequest(fs.readFileSync(specPath, 'utf8'), req);
+        if (pathname === '/openapi.yaml') {
+          sendText(res, 200, yaml, {
+            'Content-Type': 'text/yaml; charset=utf-8',
+            'Access-Control-Allow-Origin': '*',
+          }, {
+            headOnly: isHeadRequest,
+          });
+          return;
+        }
         // Convert YAML to JSON inline (simple key:value conversion via js-yaml if available, else serve as-is)
         try {
           const jsYaml = require('js-yaml');
           const spec = jsYaml.load(yaml);
-          // Override server URL to current deployment
-          if (spec.servers && spec.servers[0]) {
-            spec.servers[0].url = `${req.headers['x-forwarded-proto'] || 'https'}://${req.headers.host}`;
-          }
           sendJson(res, 200, spec, {
             'Access-Control-Allow-Origin': '*',
           }, {

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -507,6 +507,11 @@ test('public HEAD routes stay unauthenticated and side-effect free', async () =>
   assert.match(String(openapiRes.headers.get('content-type')), /(application\/json|text\/yaml)/);
   assert.equal(await openapiRes.text(), '');
 
+  const openapiYamlRes = await fetch(apiUrl('/openapi.yaml'), { method: 'HEAD' });
+  assert.equal(openapiYamlRes.status, 200);
+  assert.match(String(openapiYamlRes.headers.get('content-type')), /text\/yaml/);
+  assert.equal(await openapiYamlRes.text(), '');
+
   const checkoutRes = await fetch(apiUrl('/checkout/pro'), { method: 'HEAD' });
   assert.equal(checkoutRes.status, 200);
   assert.equal(await checkoutRes.text(), '');
@@ -521,6 +526,30 @@ test('public HEAD routes stay unauthenticated and side-effect free', async () =>
     : 0;
   assert.equal(telemetryCountAfter, telemetryCountBefore);
   assert.equal(checkoutSessionsAfter, checkoutSessionsBefore);
+});
+
+test('public openapi yaml stays reachable before bearer auth for GPT Actions import', async () => {
+  const res = await fetch(apiUrl('/openapi.yaml'));
+  assert.equal(res.status, 200);
+  assert.match(String(res.headers.get('content-type')), /text\/yaml/);
+
+  const body = await res.text();
+  assert.match(body, /^openapi: 3\.1\.0/m);
+  assert.match(body, new RegExp(`servers:\\n  - url: ${apiOrigin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  assert.doesNotMatch(body, /test-api-key/);
+});
+
+test('public openapi yaml advertises forwarded https origin for hosted imports', async () => {
+  const res = await fetch(apiUrl('/openapi.yaml'), {
+    headers: {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'thumbgate-production.up.railway.app',
+    },
+  });
+  assert.equal(res.status, 200);
+
+  const body = await res.text();
+  assert.match(body, /servers:\n  - url: https:\/\/thumbgate-production\.up\.railway\.app/);
 });
 
 test('public server card exposes MCP tool schemas for directory scanners', async () => {


### PR DESCRIPTION
## Summary
- Expose `/openapi.yaml` as an unauthenticated GPT Actions schema endpoint alongside `/openapi.json`.
- Rewrite the OpenAPI `servers` URL from forwarded host/proto headers so hosted imports advertise the production origin.
- Clarify GPT Builder bearer auth setup and private pre-publish validation flows in the ChatGPT adapter install guide.

## Root Cause
The ChatGPT adapter docs point GPT Builder at `/openapi.yaml`, but the API only exempted `/openapi.json` from bearer auth. GPT Builder schema import could therefore receive a 401 before action authentication was even relevant.

## Verification
- `npm ci`
- `npm test`
- `npm run test:coverage` (all files: 84.98% lines; `src/api/server.js`: 88.69% lines)
- `npm run prove:adapters` (48/48 passed, including `adapter.chatgpt.openapi.parity`)
- `npm run prove:automation` (55/55 passed)
- `npm run self-heal:check` (6/6 healthy: budget, tests, adapters, automation, data pipeline, Tessl)

## Deployment Note
This repo change fixes the public schema import path and documents the expected GPT Builder auth mode. The GPT Builder secret remains an external configuration value and should stay out of git, PR bodies, logs, and memory.
