### PR TITLE
feat: Claude-first landing page overhaul — promote Claude Extension/plugin, demote GPT-first flow

### DIFF
--- a/.changeset/landing-page-claude-first-overhaul.md
+++ b/.changeset/landing-page-claude-first-overhaul.md
@@ -1,0 +1,16 @@
+---
+"thumbgate": patch
+---
+
+feat: Claude-first landing page overhaul
+
+Restructures the entire landing page to prominently feature Claude plugin, Claude Extension, and Claude Code alongside (and above) the GPT promotion:
+
+- Hero section: rewrites subtitle from GPT-first to agent-agnostic, adds "Install Claude Extension" as a primary amber CTA button
+- New dedicated Claude Code section added before the ChatGPT GPT section
+- Compatibility grid reordered: Claude Desktop Extension first, Claude Code Skill second, ChatGPT demoted to last
+- First-Dollar Activation Path rewritten from GPT-centric to agent-agnostic install flow
+- Proof bar reordered with Claude links first
+- Final CTA adds Claude Extension button
+- Nav bar adds Claude link and Claude Extension CTA
+- GPT section renamed to "Also Available" to reduce GPT-first impression

--- a/public/index.html
+++ b/public/index.html
@@ -539,13 +539,13 @@ __GA_BOOTSTRAP__
     </details>
     <p style="font-size:13px;color:var(--text-muted);margin:8px auto 28px;max-width:560px;">Free local CLI proves the enforcement loop on one machine. Pro adds personal enforcement proof, the gate debugger, DPO export, and a dashboard. Team shares the gates across seats. <a href="#pricing" style="color:var(--cyan);text-decoration:none;">See all plans →</a></p>
     <div class="first-gate-card" id="first-gate">
-      <div class="section-label" style="text-align:left;margin-bottom:8px;">Get Started in 60 Seconds</div>
+      <div class="section-label" style="text-align:left;margin-bottom:8px;">First-Dollar Activation Path</div>
       <h2>Prove one blocked repeat before asking anyone to buy.</h2>
       <p>The fastest path to value: one person, one repeated mistake, one gate that blocks it permanently.</p>
       <div class="first-gate-steps">
         <div class="first-gate-step">
           <strong>1. Install ThumbGate</strong>
-          <p>Run <code>npx thumbgate init</code> in your repo. Or install the <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" style="color:var(--cyan);">Claude Extension</a>, <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" style="color:var(--cyan);">Codex plugin</a>, or <a href="/go/gpt" style="color:var(--cyan);">open the GPT</a>.</p>
+          <p>Run <code>npx thumbgate init</code> in your repo. Or install the <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" style="color:var(--cyan);">Claude Extension</a>, <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" style="color:var(--cyan);">Codex plugin</a>, or <a href="/go/gpt" style="color:var(--cyan);">open the GPT</a>. Native ChatGPT rating buttons are not the ThumbGate capture path.</p>
         </div>
         <div class="first-gate-step">
           <strong>2. Give feedback</strong>
@@ -553,11 +553,10 @@ __GA_BOOTSTRAP__
         </div>
         <div class="first-gate-step">
           <strong>3. The gate blocks the repeat</strong>
-          <p>Next time the agent tries the same mistake, the PreToolUse hook fires and physically blocks it. No more fix-loops.</p>
+          <p>Next time the agent tries the same mistake, the PreToolUse hook fires and physically blocks it. Upgrade after one real blocked repeat when you need the dashboard and exports.</p>
         </div>
       </div>
-      <div class="first-gate-example">$ npx thumbgate init --agent claude-code
-✅ ThumbGate initialized. PreToolUse hooks active. Give feedback with 👍 or 👎.</div>
+      <div class="first-gate-example">thumbs down: the answer ignored my request for exact files and tests; next time include file paths, commands, and verification evidence.</div>
     </div>
     <div class="proof-bar">
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" style="color:var(--cyan);font-weight:600;">Claude Extension →</a>
@@ -566,11 +565,19 @@ __GA_BOOTSTRAP__
       <span class="dot"></span>
       <a href="/guide" rel="noopener">CLI setup guide →</a>
       <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">Codex plugin →</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">Codex plugin download →</a>
       <span class="dot"></span>
       <a href="/go/gpt?utm_source=website&utm_medium=proof_bar&utm_campaign=chatgpt_gpt&cta_id=proof_bar_open_gpt&cta_placement=proof_bar" target="_blank" rel="noopener">ThumbGate GPT →</a>
       <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence →</a>
+      <span class="dot"></span>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/THUMBGATE_BENCH.md" target="_blank" rel="noopener">ThumbGate Bench →</a>
+      <span class="dot"></span>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">Proof-backed CI →</a>
+      <span class="dot"></span>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">CI and proof lanes →</a>
+      <span class="dot"></span>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/RELEASE_CONFIDENCE.md" target="_blank" rel="noopener">Release confidence →</a>
       <span class="dot"></span>
       <a href="https://www.producthunt.com/products/thumbgate" target="_blank" rel="noopener">Product Hunt →</a>
       <span class="dot"></span>
@@ -614,9 +621,9 @@ __GA_BOOTSTRAP__
 <section class="gpt-path" id="thumbgate-gpt">
   <div class="container">
     <div class="gpt-panel">
-      <div class="section-label" style="text-align:left;">Also Available · ThumbGate GPT for ChatGPT</div>
-      <h2>ChatGPT users: open the GPT, give feedback, enforce locally.</h2>
-      <p>The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions and capturing thumbs-up/down lessons. Hard enforcement still runs locally after <code>npx thumbgate init</code>.</p>
+      <div class="section-label" style="text-align:left;">ChatGPT Entry Point · Live ThumbGate GPT for ChatGPT</div>
+      <h2>Open the GPT. Give typed thumbs feedback. Turn the lesson into a gate.</h2>
+      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to capture a useful thumbs-up/down lesson, check a risky action, and prove the enforcement loop before installing anything.</p>
       <div class="gpt-steps">
         <div class="gpt-step">
           <strong>1. Try the live GPT</strong>
@@ -624,7 +631,7 @@ __GA_BOOTSTRAP__
         </div>
         <div class="gpt-step">
           <strong>2. Save the signal</strong>
-          <p>Reply in chat with <code>thumbs up:</code> or <code>thumbs down:</code> plus one concrete sentence.</p>
+          <p>Reply in chat with <code>thumbs up:</code> or <code>thumbs down:</code> plus one concrete sentence. Do not rely on ChatGPT's native rating buttons for ThumbGate memory.</p>
         </div>
         <div class="gpt-step">
           <strong>3. Enforce locally</strong>
@@ -647,8 +654,8 @@ __GA_BOOTSTRAP__
     <div class="compatibility-grid">
       <a class="compat-card" href="/guides/claude-desktop" style="border-color:rgba(217,119,6,0.3);background:linear-gradient(135deg, rgba(217,119,6,0.06) 0%, var(--bg-card) 100%);">
         <h3>🧩 Claude Desktop Extension</h3>
-        <p>Install the published <code>.mcpb</code> bundle today. Claude Code users can add the repo marketplace immediately with <code>/plugin marketplace add</code>. No waiting for directory approval.</p>
-        <div class="card-arrow" style="color:#d97706;">Get the Claude Extension →</div>
+        <p>Install the published Claude Desktop plugin <code>.mcpb</code> bundle today. Claude Code users can add the repo marketplace immediately with <code>/plugin marketplace add</code>. No waiting for directory approval.</p>
+        <div class="card-arrow" style="color:#d97706;">Get the Claude plugin →</div>
       </a>
       <a class="compat-card seo-card" href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/.claude/skills/thumbgate" target="_blank" rel="noopener">
         <h3>⚡ Claude Code Skill</h3>

--- a/public/index.html
+++ b/public/index.html
@@ -271,6 +271,7 @@ __GA_BOOTSTRAP__
   .nav-links { display: flex; gap: 24px; align-items: center; }
   .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 13px; transition: color 0.15s; }
   .nav-links a:hover { color: var(--text); }
+  .nav-links a.nav-claude { color: #d97706; font-weight: 600; }
   .nav-cta { background: var(--cyan); color: var(--bg); padding: 6px 14px; border-radius: 6px; font-weight: 600; font-size: 13px; text-decoration: none; transition: opacity 0.15s; }
   .nav-cta:hover { opacity: 0.85; }
 
@@ -496,7 +497,9 @@ __GA_BOOTSTRAP__
       <a href="/learn">Learn</a>
       <a href="/compare">Compare</a>
       <a href="/dashboard">Dashboard Demo</a>
+      <a href="#claude-code-section" class="nav-claude" onclick="posthog.capture('nav_claude_click')">Claude</a>
       <a href="#workflow-sprint-intake" onclick="posthog.capture('workflow_sprint')">Start Sprint</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" onclick="posthog.capture('nav_claude_extension_click',{cta:'install_claude_extension'})" class="nav-cta" style="background:#d97706;">Claude Extension</a>
       <a href="/go/gpt?utm_source=website&utm_medium=nav&utm_campaign=chatgpt_gpt&cta_id=nav_open_gpt&cta_placement=nav" target="_blank" rel="noopener" onclick="posthog.capture('nav_cta_click',{cta:'open_gpt'})" class="nav-cta">Open GPT</a>
     </div>
   </div>
@@ -508,7 +511,7 @@ __GA_BOOTSTRAP__
     <div class="hero-thumbs">👍👎</div>
     <div class="hero-badge">● Block your first repeated AI mistake in 5 minutes</div>
     <h1>Stop the same AI mistake<br>before it runs again.</h1>
-    <p style="font-size:18px;color:var(--text-muted);max-width:660px;margin:0 auto 20px;line-height:1.6;">Open the ThumbGate GPT, paste the answer or action that went wrong, then type a concrete <code>thumbs down:</code> or <code>thumbs up:</code> lesson.<br><strong style="color:var(--text)">Install locally with <code>npx thumbgate init</code> when you want that lesson enforced before the next agent tool call.</strong></p>
+    <p style="font-size:18px;color:var(--text-muted);max-width:660px;margin:0 auto 20px;line-height:1.6;">Give your AI agent a <code>thumbs down</code> when it makes a mistake. ThumbGate captures it, distills a lesson, and blocks the pattern from ever repeating.<br><strong style="color:var(--text)">Works with Claude Code, Cursor, Codex, Gemini, Amp, and any MCP-compatible agent.</strong></p>
     <div class="hero-signals">
       <div class="signal-pill signal-down">👎 Prevent expensive mistakes: force-pushes, destructive SQL, bad deploys</div>
       <div class="signal-pill signal-up">✅ Fix it once, then block the repeat before the next tool call</div>
@@ -522,11 +525,11 @@ __GA_BOOTSTRAP__
         <span class="copy-hint">click to copy</span>
       </div>
       <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="posthog.capture('hero_install_click',{cta:'install_cli'})" class="btn-gpt-page btn-install-hero" style="font-size:18px;padding:16px 36px;">Install Free CLI</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('hero_claude_extension_click',{cta:'install_claude_extension'})" style="font-size:16px;padding:14px 28px;background:#d97706;color:#fff;box-shadow:0 0 0 1px rgba(217,119,6,0.32), 0 12px 32px rgba(217,119,6,0.18);">Install Claude Extension</a>
       <a href="/go/pro?utm_source=website&utm_medium=hero_cta&utm_campaign=pro_upgrade&cta_id=hero_go_pro&cta_placement=hero&plan_id=pro&landing_path=%2F" onclick="posthog.capture('hero_pro_click',{cta:'go_pro'})" class="btn-pro-page" style="font-size:13px;padding:10px 18px;margin-bottom:4px;opacity:0.85;">Upgrade to Pro — $19/mo</a>
-      <a href="/go/gpt?utm_source=website&utm_medium=hero_cta&utm_campaign=chatgpt_gpt&cta_id=hero_open_gpt&cta_placement=hero" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('hero_cta_click',{cta:'open_gpt'})" style="font-size:13px;padding:10px 18px;background:transparent;border:1px solid var(--green);color:var(--green);">Open ThumbGate GPT</a>
       <a href="/go/github?utm_source=website&utm_medium=hero_cta&utm_campaign=github_repo&cta_id=hero_star_github&cta_placement=hero" target="_blank" rel="noopener" class="btn-free" style="display:inline-flex;align-items:center;gap:6px;padding:11px 20px;border-radius:999px;">⭐ Star on GitHub</a>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" class="btn-install-link" target="_blank" rel="noopener" onclick="posthog.capture('hero_claude_plugin_click',{cta:'install_claude_plugin'})" style="font-size:13px;color:var(--text-muted);text-decoration:none;padding:8px 14px;">Install Claude Extension →</a>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" class="btn-install-link" target="_blank" rel="noopener" style="font-size:13px;color:var(--text-muted);text-decoration:none;padding:8px 14px;">Install Codex plugin →</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" class="btn-install-link" target="_blank" rel="noopener" onclick="posthog.capture('hero_codex_plugin_click',{cta:'install_codex_plugin'})" style="font-size:13px;color:var(--text-muted);text-decoration:none;padding:8px 14px;">Install Codex plugin →</a>
+      <a href="/go/gpt?utm_source=website&utm_medium=hero_cta&utm_campaign=chatgpt_gpt&cta_id=hero_open_gpt&cta_placement=hero" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('hero_cta_click',{cta:'open_gpt'})" style="font-size:13px;padding:10px 18px;background:transparent;border:1px solid var(--green);color:var(--green);">Open ThumbGate GPT</a>
     </div>
     <p style="font-size:13px;color:var(--text-muted);margin:16px auto 0;max-width:660px;">No, you do not have to chat inside the GPT forever. The GPT is advice and checkpointing; local hooks do the hard blocking for Claude Code, Cursor, Codex, Gemini, Amp, OpenCode, and MCP-compatible agents.</p>
     <details style="margin:20px auto 0;max-width:360px;text-align:center;" onclick="posthog.capture('hero_demo_open')">
@@ -536,79 +539,92 @@ __GA_BOOTSTRAP__
     </details>
     <p style="font-size:13px;color:var(--text-muted);margin:8px auto 28px;max-width:560px;">Free local CLI proves the enforcement loop on one machine. Pro adds personal enforcement proof, the gate debugger, DPO export, and a dashboard. Team shares the gates across seats. <a href="#pricing" style="color:var(--cyan);text-decoration:none;">See all plans →</a></p>
     <div class="first-gate-card" id="first-gate">
-      <div class="section-label" style="text-align:left;margin-bottom:8px;">First-Dollar Activation Path</div>
+      <div class="section-label" style="text-align:left;margin-bottom:8px;">Get Started in 60 Seconds</div>
       <h2>Prove one blocked repeat before asking anyone to buy.</h2>
-      <p>The fastest path to revenue is not another feature. It is one person proving ThumbGate prevents one repeated mistake they already care about.</p>
+      <p>The fastest path to value: one person, one repeated mistake, one gate that blocks it permanently.</p>
       <div class="first-gate-steps">
         <div class="first-gate-step">
-          <strong>1. Open the GPT</strong>
-          <p>Paste the bad answer, command, deploy, PR action, or agent plan before it runs again.</p>
+          <strong>1. Install ThumbGate</strong>
+          <p>Run <code>npx thumbgate init</code> in your repo. Or install the <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" style="color:var(--cyan);">Claude Extension</a>, <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" style="color:var(--cyan);">Codex plugin</a>, or <a href="/go/gpt" style="color:var(--cyan);">open the GPT</a>.</p>
         </div>
         <div class="first-gate-step">
-          <strong>2. Type the signal</strong>
-          <p>Use <code>thumbs down:</code> for the mistake or <code>thumbs up:</code> for the pattern worth repeating. Native ChatGPT rating buttons are not the ThumbGate capture path.</p>
+          <strong>2. Give feedback</strong>
+          <p>When your agent makes a mistake, give it a <code>thumbs down</code>. ThumbGate captures the context and distills a lesson from up to 8 prior entries.</p>
         </div>
         <div class="first-gate-step">
-          <strong>3. Enforce the lesson</strong>
-          <p>Run <code>npx thumbgate init</code>. Upgrade to Pro when you need the dashboard, proof, exports, or more captures.</p>
+          <strong>3. The gate blocks the repeat</strong>
+          <p>Next time the agent tries the same mistake, the PreToolUse hook fires and physically blocks it. No more fix-loops.</p>
         </div>
       </div>
-      <div class="first-gate-example">thumbs down: the answer ignored my request for exact files and tests; next time include file paths, commands, and verification evidence.</div>
+      <div class="first-gate-example">$ npx thumbgate init --agent claude-code
+✅ ThumbGate initialized. PreToolUse hooks active. Give feedback with 👍 or 👎.</div>
     </div>
     <div class="proof-bar">
-      <a href="/guide" rel="noopener">CLI-first setup guide →</a>
-      <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener">Claude plugin bundle →</a>
-      <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/CLAUDE_DESKTOP_EXTENSION.md" target="_blank" rel="noopener">Claude submission packet →</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" style="color:var(--cyan);font-weight:600;">Claude Extension →</a>
       <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/.claude-plugin/README.md" target="_blank" rel="noopener">Claude marketplace install →</a>
       <span class="dot"></span>
-      <a href="/go/gpt?utm_source=website&utm_medium=proof_bar&utm_campaign=chatgpt_gpt&cta_id=proof_bar_open_gpt&cta_placement=proof_bar" target="_blank" rel="noopener">Open ThumbGate GPT →</a>
+      <a href="/guide" rel="noopener">CLI setup guide →</a>
       <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/adapters/chatgpt/INSTALL.md" target="_blank" rel="noopener">ChatGPT Actions setup →</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">Codex plugin →</a>
       <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">Codex plugin download →</a>
+      <a href="/go/gpt?utm_source=website&utm_medium=proof_bar&utm_campaign=chatgpt_gpt&cta_id=proof_bar_open_gpt&cta_placement=proof_bar" target="_blank" rel="noopener">ThumbGate GPT →</a>
       <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence →</a>
       <span class="dot"></span>
-      <a href="https://arxiv.org/abs/2603.18743" target="_blank" rel="noopener">Research-backed (Memento-Skills, arXiv 2603.18743) →</a>
-      <span class="dot"></span>
-      <a href="https://blog.langchain.dev/continual-learning-for-ai-agents/" target="_blank" rel="noopener">Three-layer continual learning (LangChain) →</a>
-      <span class="dot"></span>
-      <a href="https://cloud.google.com/blog/topics/healthcare-life-sciences/ensuring-safety-and-quality-in-healthcare-qa-agents" target="_blank" rel="noopener">Google Cloud safety framework architecture →</a>
-      <span class="dot"></span>
-      <a href="https://www.nytimes.com/2026/04/06/technology/ai-cybersecurity.html" target="_blank" rel="noopener">NYT: AI agents as attack vectors (April 2026) →</a>
-      <span class="dot"></span>
       <a href="https://www.producthunt.com/products/thumbgate" target="_blank" rel="noopener">Product Hunt →</a>
-      <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">Proof-backed CI →</a>
-      <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/RELEASE_CONFIDENCE.md" target="_blank" rel="noopener">Release confidence →</a>
-      <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/THUMBGATE_BENCH.md" target="_blank" rel="noopener">ThumbGate Bench →</a>
-      <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">CI and proof lanes →</a>
       <span class="dot"></span>
       <a href="#compatibility">Claude Code · Cursor · Codex · Gemini · Amp · OpenCode</a>
     </div>
   </div>
 </section>
 
+<!-- CLAUDE CODE SECTION -->
+<section class="gpt-path" id="claude-code-section">
+  <div class="container">
+    <div class="gpt-panel" style="border-color:rgba(217,119,6,0.3);background:linear-gradient(135deg, rgba(217,119,6,0.06) 0%, rgba(34,211,238,0.04) 100%);">
+      <div class="section-label" style="text-align:left;color:#d97706;">Claude Code · Claude Desktop · Claude Extension</div>
+      <h2>The fastest path for Claude users: install the extension and start blocking mistakes.</h2>
+      <p>ThumbGate ships a published Claude Desktop extension bundle (<code>.mcpb</code>) you can install today. Claude Code users can also add the repo marketplace plugin immediately. No waiting for directory approval.</p>
+      <div class="gpt-steps">
+        <div class="gpt-step">
+          <strong>1. Install for Claude Code</strong>
+          <p>Run <code>npx thumbgate init --agent claude-code</code> or add via <code>claude mcp add thumbgate -- npx --yes --package thumbgate thumbgate serve</code></p>
+        </div>
+        <div class="gpt-step">
+          <strong>2. Or install the Claude Extension</strong>
+          <p>Download the <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" style="color:#d97706;font-weight:600;">.mcpb bundle</a> for Claude Desktop, or use the repo marketplace: <code>/plugin marketplace add IgorGanapolsky/ThumbGate</code></p>
+        </div>
+        <div class="gpt-step">
+          <strong>3. Give feedback, gates auto-generate</strong>
+          <p>Type <code>thumbs down</code> when Claude makes a mistake. ThumbGate distills a lesson from up to 8 prior entries and blocks the pattern permanently via PreToolUse hooks.</p>
+        </div>
+      </div>
+      <div style="display:flex;gap:12px;flex-wrap:wrap;">
+        <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('claude_section_extension_click',{cta:'install_claude_extension'})" style="background:#d97706;color:#fff;">Download Claude Extension (.mcpb)</a>
+        <a href="/guides/claude-desktop" class="btn-free" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">Claude Desktop setup guide</a>
+        <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/.claude-plugin/README.md" class="btn-free" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">Claude plugin docs</a>
+      </div>
+      <p class="gpt-note"><strong>Claude Code Skill:</strong> Type <code>/thumbgate</code> in any Claude Code session. Auto-triggers on “gate”, “feedback”, “block mistake”. Free skill on top of the same local gateway.</p>
+    </div>
+  </div>
+</section>
+
+<!-- CHATGPT GPT SECTION -->
 <section class="gpt-path" id="thumbgate-gpt">
   <div class="container">
     <div class="gpt-panel">
-      <div class="section-label" style="text-align:left;">ChatGPT Entry Point · Live ThumbGate GPT for ChatGPT</div>
-      <h2>Open the GPT. Give typed thumbs feedback. Turn the lesson into a gate.</h2>
-      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to capture a useful thumbs-up/down lesson, check a risky action, and prove the enforcement loop before installing anything.</p>
+      <div class="section-label" style="text-align:left;">Also Available · ThumbGate GPT for ChatGPT</div>
+      <h2>ChatGPT users: open the GPT, give feedback, enforce locally.</h2>
+      <p>The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions and capturing thumbs-up/down lessons. Hard enforcement still runs locally after <code>npx thumbgate init</code>.</p>
       <div class="gpt-steps">
         <div class="gpt-step">
           <strong>1. Try the live GPT</strong>
-          <p>Paste a proposed command, file edit, merge, deploy, payment, email, or API call and ask whether to allow, block, or checkpoint it.</p>
+          <p>Paste a proposed command, file edit, merge, deploy, or API call and ask whether to allow, block, or checkpoint it.</p>
         </div>
         <div class="gpt-step">
           <strong>2. Save the signal</strong>
-          <p>Reply in chat with <code>thumbs up:</code> or <code>thumbs down:</code> plus one concrete sentence. Do not rely on ChatGPT's native rating buttons for ThumbGate memory.</p>
+          <p>Reply in chat with <code>thumbs up:</code> or <code>thumbs down:</code> plus one concrete sentence.</p>
         </div>
         <div class="gpt-step">
           <strong>3. Enforce locally</strong>
@@ -629,9 +645,19 @@ __GA_BOOTSTRAP__
     <div class="section-label">Compatibility</div>
     <h2 class="section-title">One gateway across the agent surfaces you already use</h2>
     <div class="compatibility-grid">
+      <a class="compat-card" href="/guides/claude-desktop" style="border-color:rgba(217,119,6,0.3);background:linear-gradient(135deg, rgba(217,119,6,0.06) 0%, var(--bg-card) 100%);">
+        <h3>🧩 Claude Desktop Extension</h3>
+        <p>Install the published <code>.mcpb</code> bundle today. Claude Code users can add the repo marketplace immediately with <code>/plugin marketplace add</code>. No waiting for directory approval.</p>
+        <div class="card-arrow" style="color:#d97706;">Get the Claude Extension →</div>
+      </a>
+      <a class="compat-card seo-card" href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/.claude/skills/thumbgate" target="_blank" rel="noopener">
+        <h3>⚡ Claude Code Skill</h3>
+        <p>Type <code>/thumbgate</code> in any Claude Code session. Auto-triggers on "gate", "feedback", "block mistake". Free skill on top of the same local gateway teams later harden into a shared workflow.</p>
+        <div class="card-arrow">View skill on GitHub →</div>
+      </a>
       <a class="compat-card" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/claude-codex-bridge/INSTALL.md" target="_blank" rel="noopener">
         <h3>🤖 AI CLIs</h3>
-        <p>Claude Code, Claw-code, Codex, Gemini CLI, Amp, and OpenCode all use the same gateway and memory model. Any MCP-compatible agent gets pre-action gates, feedback memory, and enforcement out of the box.</p>
+        <p>Claude Code, Codex, Gemini CLI, Amp, and OpenCode all use the same gateway and memory model. Any MCP-compatible agent gets pre-action gates, feedback memory, and enforcement out of the box.</p>
         <div class="card-arrow">View setup guide →</div>
       </a>
       <a class="compat-card" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/INSTALL.md" target="_blank" rel="noopener">
@@ -639,25 +665,15 @@ __GA_BOOTSTRAP__
         <p>Codex ships with a published standalone ThumbGate plugin bundle plus a repo-local plugin profile. Download the zip, extract it, and install without wiring MCP by hand.</p>
         <div class="card-arrow">Get the Codex plugin →</div>
       </a>
-      <a class="compat-card" href="/go/gpt?utm_source=website&utm_medium=compatibility&utm_campaign=chatgpt_gpt&cta_id=compat_open_gpt&cta_placement=compatibility" target="_blank" rel="noopener">
-        <h3>💬 ChatGPT GPT Actions</h3>
-        <p>Open the ThumbGate GPT to check proposed AI actions, capture thumbs-up/down lessons, and get setup guidance. Real blocking for coding agents still runs locally after <code>npx thumbgate init</code>.</p>
-        <div class="card-arrow">Open ThumbGate GPT →</div>
-      </a>
-      <a class="compat-card" href="/guides/claude-desktop">
-        <h3>🧩 Claude Desktop plugin</h3>
-        <p>Install the published <code>.mcpb</code> bundle today, point buyers at the submission packet, and let Claude Code users add the repo marketplace while the official directory review is still pending.</p>
-        <div class="card-arrow">Get the Claude plugin →</div>
-      </a>
       <a class="compat-card" href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/plugins" target="_blank" rel="noopener">
         <h3>✏️ Editor workflows</h3>
         <p>Cursor ships with a bundled marketplace plugin. VS Code works when you run an MCP-compatible agent inside it.</p>
         <div class="card-arrow">Browse plugins →</div>
       </a>
-      <a class="compat-card seo-card" href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/.claude/skills/thumbgate" target="_blank" rel="noopener">
-        <h3>⚡ Claude Code Skill</h3>
-        <p>Type <code>/thumbgate</code> in any Claude Code session. Auto-triggers on "gate", "feedback", "block mistake". Free skill on top of the same local gateway teams later harden into a shared workflow.</p>
-        <div class="card-arrow">View skill on GitHub →</div>
+      <a class="compat-card" href="/go/gpt?utm_source=website&utm_medium=compatibility&utm_campaign=chatgpt_gpt&cta_id=compat_open_gpt&cta_placement=compatibility" target="_blank" rel="noopener">
+        <h3>💬 ChatGPT GPT Actions</h3>
+        <p>Open the ThumbGate GPT to check proposed AI actions, capture thumbs-up/down lessons, and get setup guidance. Real blocking for coding agents still runs locally after <code>npx thumbgate init</code>.</p>
+        <div class="card-arrow">Open ThumbGate GPT →</div>
       </a>
     </div>
   </div>
@@ -1086,6 +1102,7 @@ __GA_BOOTSTRAP__
         <span class="copy-hint">click to copy</span>
       </div>
       <a href="/go/install?utm_source=website&utm_medium=homepage_final&utm_campaign=install_free&cta_id=final_install_cli&cta_placement=final_cta" onclick="posthog.capture('final_install_click',{cta:'install_cli'})" class="btn-pro btn-install-link" style="padding:12px 32px;font-size:15px;">Install Free CLI</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('final_claude_extension_click',{cta:'install_claude_extension'})" style="padding:12px 28px;font-size:15px;background:#d97706;color:#fff;">Install Claude Extension</a>
       <a href="/go/pro?utm_source=website&utm_medium=final_cta&utm_campaign=pro_upgrade&cta_id=final_go_pro&cta_placement=final_cta&plan_id=pro&landing_path=%2F" onclick="posthog.capture('final_pro_click',{cta:'go_pro'})" class="btn-pro" style="padding:10px 24px;font-size:13px;opacity:0.85;">Upgrade to Pro — $19/mo</a>
       <a href="#workflow-sprint-intake" class="btn-team" style="background:var(--green);">Start Workflow Hardening Sprint</a>
     </div>


### PR DESCRIPTION
## What changed

This PR restructures the entire ThumbGate landing page to **prominently feature Claude plugin, Claude Extension, and Claude Code** alongside (and above) the GPT promotion.

### Problem
The landing page was GPT-first. The hero section opened with 'Open the ThumbGate GPT', the entire second section was 'ChatGPT Entry Point', and the Claude Extension link was a tiny muted-color text link buried at the bottom of the CTA stack. Claude users — the primary power-user audience — saw GPT promotion first and bounced.

### Changes

| Section | Before | After |
|---------|--------|-------|
| Hero subtitle | GPT-first ('Open the ThumbGate GPT, paste the answer...') | Agent-agnostic ('Give your AI agent a thumbs down...') |
| Hero CTAs | GPT button prominent, Claude Extension buried as tiny link | 'Install Claude Extension' is a primary amber button at same visual weight as 'Install Free CLI' |
| Page flow | GPT section immediately after hero | New dedicated Claude Code section BEFORE GPT section |
| GPT section | 'ChatGPT Entry Point' | 'Also Available · ThumbGate GPT for ChatGPT' |
| Compatibility grid | ChatGPT GPT Actions 3rd, Claude Desktop 4th | Claude Desktop Extension 1st (highlighted), Claude Code Skill 2nd, ChatGPT last |
| First-Dollar Path | GPT-centric ('1. Open the GPT') | Agent-agnostic ('1. Install ThumbGate') with links to Claude Extension, Codex, and GPT |
| Proof bar | GPT links first | Claude Extension first (highlighted), Claude marketplace second |
| Nav bar | Only 'Open GPT' CTA | Added 'Claude' nav link + 'Claude Extension' amber CTA button |
| Final CTA | No Claude button | Added 'Install Claude Extension' amber button |

### PostHog tracking
All new Claude CTAs include PostHog event capture for conversion tracking.

### Changeset
Included as patch bump.