### PR TITLE
chore: one-off workflow to dispatch Instagram autopilots

### DIFF
--- a/.github/workflows/trigger-instagram-autopilots.yml
+++ b/.github/workflows/trigger-instagram-autopilots.yml
@@ -1,0 +1,46 @@
+name: Trigger Instagram Autopilots (one-off)
+
+# One-off workflow that fires the Video Autopilot and Instagram Autopilot
+# workflows on main after this PR merges. Intended to validate the Instagram
+# presign fix (#879) actually lands a Reel + static card on the grid without
+# waiting for the next cron slot.
+#
+# Fires exactly once on the merge commit that introduces / modifies this file
+# (path-scoped push trigger). A follow-up PR removes this workflow after it
+# runs.
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/trigger-instagram-autopilots.yml']
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch Video Autopilot
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/video-autopilot.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"template":"auto","platforms":"tiktok,youtube,instagram","dry_run":"false"}}'
+          echo "Video Autopilot dispatched."
+
+      - name: Dispatch Instagram Autopilot
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/instagram-autopilot.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"image_only":"false","dry_run":"false"}}'
+          echo "Instagram Autopilot dispatched."


### PR DESCRIPTION
**What**

One-off workflow that fires Video Autopilot (Reels) + Instagram Autopilot (static card) exactly once on the merge commit.

**Why**

Validates the Instagram presign fix from #879 actually lands real content on the grid rather than waiting for the next cron slot (`0 */4 * * *`). No manual UI click required.

**How**

Path-scoped `push` trigger on `main` — fires only when this workflow file itself changes. Two `curl` calls to the GH Actions API dispatch the real autopilot workflows with their default inputs.

**Follow-up**

A second PR will delete this workflow after it fires. Keeping as a trigger-once pattern in git history is acceptable but not desirable long-term.

[https://claude.ai/code/session_01HvjDThU4aXFkRwnA7mqXAu](https://claude.ai/code/session_01HvjDThU4aXFkRwnA7mqXAu)