### PR TITLE
fix(autopilots): reset marketing DB cache + add Instagram pre-flight diagnostics

### DIFF
--- a/.github/workflows/instagram-autopilot.yml
+++ b/.github/workflows/instagram-autopilot.yml
@@ -71,9 +71,36 @@ jobs:
             .thumbgate/marketing-analytics.sqlite
             .thumbgate/marketing-analytics.sqlite-shm
             .thumbgate/marketing-analytics.sqlite-wal
-          key: marketing-db-${{ github.run_id }}
+          # v2 cache key — matches video-autopilot.yml's invalidation so
+          # both workflows share a fresh marketing DB after the presign fix.
+          key: marketing-db-v2-${{ github.run_id }}
           restore-keys: |
-            marketing-db-
+            marketing-db-v2-
+
+      - name: Diagnostic — Zernio + marketing DB pre-flight
+        env:
+          GH_ZERNIO_API_KEY_PRESENT: ${{ secrets.ZERNIO_API_KEY && 'set' || 'MISSING' }}
+          GH_ZERNIO_IG_ACCT: ${{ secrets.ZERNIO_INSTAGRAM_ACCOUNT_ID && 'set' || 'MISSING' }}
+        run: |
+          echo "=== SECRET PRESENCE ==="
+          echo "ZERNIO_API_KEY: $GH_ZERNIO_API_KEY_PRESENT"
+          echo "ZERNIO_INSTAGRAM_ACCOUNT_ID: $GH_ZERNIO_IG_ACCT"
+          echo ""
+          echo "=== MARKETING DB SUMMARY (pre-run) ==="
+          node -e "try { const db=require('./scripts/social-analytics/db/marketing-db'); console.log(JSON.stringify(db.summary(), null, 2)); } catch(e){ console.log('(empty or unreadable:', e.message, ')'); }" || true
+          echo ""
+          echo "=== ZERNIO CONNECTED ACCOUNTS ==="
+          node -e "
+            (async () => {
+              try {
+                const { getConnectedAccounts } = require('./scripts/social-analytics/publishers/zernio');
+                const accts = await getConnectedAccounts();
+                console.log(JSON.stringify(accts.map(a => ({platform: a.platform, accountId: a.accountId, name: a.name, username: a.username})), null, 2));
+              } catch(e) {
+                console.log('getConnectedAccounts failed:', e.message);
+              }
+            })();
+          " || true
 
       - name: Publish Instagram card
         env:

--- a/.github/workflows/video-autopilot.yml
+++ b/.github/workflows/video-autopilot.yml
@@ -73,9 +73,52 @@ jobs:
             .thumbgate/marketing-analytics.sqlite
             .thumbgate/marketing-analytics.sqlite-shm
             .thumbgate/marketing-analytics.sqlite-wal
-          key: marketing-db-${{ github.run_id }}
+          # v2 cache key — bumped 2026-04-15 to clear stuck Instagram
+          # dedup/cooldown state. After the presign fix (#879) the DB may
+          # still contain 'published' rows whose Instagram delivery actually
+          # failed downstream, causing every subsequent run to skip via
+          # 8h cooldown. Starting from a fresh DB lets us see real behaviour.
+          key: marketing-db-v2-${{ github.run_id }}
           restore-keys: |
-            marketing-db-
+            marketing-db-v2-
+
+      - name: Diagnostic — Zernio + marketing DB pre-flight
+        env:
+          GH_ZERNIO_API_KEY_LEN: ${{ secrets.ZERNIO_API_KEY && 'set' || 'MISSING' }}
+          GH_ZERNIO_IG_ACCT: ${{ secrets.ZERNIO_INSTAGRAM_ACCOUNT_ID && 'set' || 'MISSING' }}
+          GH_ZERNIO_TT_ACCT: ${{ secrets.ZERNIO_TIKTOK_ACCOUNT_ID && 'set' || 'MISSING' }}
+          GH_ZERNIO_YT_ACCT: ${{ secrets.ZERNIO_YOUTUBE_ACCOUNT_ID && 'set' || 'MISSING' }}
+        run: |
+          echo "=== SECRET PRESENCE ==="
+          echo "ZERNIO_API_KEY: $GH_ZERNIO_API_KEY_LEN"
+          echo "ZERNIO_INSTAGRAM_ACCOUNT_ID: $GH_ZERNIO_IG_ACCT"
+          echo "ZERNIO_TIKTOK_ACCOUNT_ID: $GH_ZERNIO_TT_ACCT"
+          echo "ZERNIO_YOUTUBE_ACCOUNT_ID: $GH_ZERNIO_YT_ACCT"
+          echo ""
+          echo "=== MARKETING DB SUMMARY (pre-run) ==="
+          node -e "try { const db=require('./scripts/social-analytics/db/marketing-db'); console.log(JSON.stringify(db.summary(), null, 2)); } catch(e){ console.log('(empty or unreadable:', e.message, ')'); }" || true
+          echo ""
+          echo "=== ZERNIO CONNECTED ACCOUNTS ==="
+          node -e "
+            (async () => {
+              try {
+                const { getConnectedAccounts } = require('./scripts/social-analytics/publishers/zernio');
+                const accts = await getConnectedAccounts();
+                console.log(JSON.stringify(accts.map(a => ({platform: a.platform, accountId: a.accountId, name: a.name, username: a.username})), null, 2));
+              } catch(e) {
+                console.log('getConnectedAccounts failed:', e.message);
+              }
+            })();
+          " || true
+          echo ""
+          echo "=== RECENT MARKETING_POSTS (pre-run) ==="
+          node -e "
+            try {
+              const { getDb } = require('./scripts/social-analytics/db/marketing-db');
+              const rows = getDb().prepare(\"SELECT platform, type, status, published_at, post_url, campaign FROM marketing_posts ORDER BY published_at DESC LIMIT 20\").all();
+              console.log(JSON.stringify(rows, null, 2));
+            } catch(e) { console.log('read failed:', e.message); }
+          " || true
 
       - name: Install Python + Pillow (slide renderer)
         run: pip install Pillow --quiet


### PR DESCRIPTION
## Symptom

After #879 merged, every scheduled Video Autopilot run exits in ~45–50s with a green checkmark — but zero new Reels land on the Instagram grid (still 9 posts). Instagram Autopilot shows the same pattern (58s, no posts).

## Hypothesis

The cached marketing DB carries `status: 'published'` rows whose Instagram delivery failed downstream *before* the presign fix. Both `post-video.js` and `publishers/zernio.js` check cooldowns against that DB (8h Instagram, 4h TikTok, 12h YouTube), so every new run now skips silently and exits 0.

## What this PR does

**1. Invalidates the marketing DB cache.** Bumps the key from `marketing-db-` → `marketing-db-v2-` on both autopilot workflows. Next run starts with a fresh DB and the fix from #879 actually gets exercised.

**2. Adds pre-flight diagnostic.** Before the post step runs, prints:
- Presence (set/MISSING) of `ZERNIO_API_KEY`, `ZERNIO_INSTAGRAM_ACCOUNT_ID`, etc.
- `marketing_posts` summary by platform/type/status
- Zernio connected accounts list (confirms Instagram is actually linked on the Zernio side)
- Last 20 rows of `marketing_posts` (timestamps, URLs)

If the cache bust alone doesn't unblock posting, this diagnostic output replaces the current 50-second-mystery with a plain-English reason (missing secret, no Instagram account connected to Zernio, quality-gate block, quota, etc.).

## Test plan

- [ ] CI green
- [ ] Next scheduled Video Autopilot run (`0 */4 * * *`) produces a non-trivial duration (>2 min) and diagnostic output appears in the log
- [ ] New Reel appears on @igor.ganapolsky Instagram grid within 1 cron cycle

https://claude.ai/code/session_01HvjDThU4aXFkRwnA7mqXAu