### PR TITLE
fix: wire Codex hook bundle and statusline target

### DIFF
--- a/.changeset/codex-statusline-target.md
+++ b/.changeset/codex-statusline-target.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Wire the full Codex hook bundle during init and add the Codex status line target to the generated local config.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Gates are distributed across all connected agents via MCP stdio protocol. One co
 
 Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode**, and any MCP-compatible agent.
 
+### Status bar proof
+
+![Claude Code ThumbGate footer](public/assets/claude-thumbgate-statusbar.svg)
+
+![Codex ThumbGate test lane](public/assets/codex-thumbgate-statusbar-test.svg)
+
+Claude renders the live ThumbGate footer today. `npx thumbgate init --agent codex` now installs the full Codex hook bundle and writes the ThumbGate `statusLine` target into `~/.codex/config.json` so you can test it on your local Codex build immediately.
+
 ### Install Codex Plugin
 
 Download the standalone Codex plugin bundle and follow the install guide:

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -1,4 +1,6 @@
 # Codex MCP profile (copy into ~/.codex/config.toml or merge section)
+# Preferred: run `npx thumbgate init --agent codex` to also wire
+# ~/.codex/config.json with the ThumbGate hooks and status line.
 [mcp_servers.thumbgate]
 command = "npx"
 args = ["--yes", "--package", "thumbgate@1.5.0", "thumbgate", "serve"]

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -388,18 +388,29 @@ function setupClaude() {
 function setupCodex() {
   const configPath = path.join(HOME, '.codex', 'config.toml');
   const block = mcpSectionBlock(MCP_SERVER_NAME, 'home');
+  let configChanged = false;
   if (!fs.existsSync(configPath)) {
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, block);
     console.log('  Codex: created ~/.codex/config.toml');
-    return true;
+    configChanged = true;
+  } else {
+    const content = fs.readFileSync(configPath, 'utf8');
+    const updated = upsertCodexServerConfig(content);
+    if (updated.changed) {
+      fs.writeFileSync(configPath, updated.content);
+      console.log('  Codex: appended MCP server to ~/.codex/config.toml');
+      configChanged = true;
+    }
   }
-  const content = fs.readFileSync(configPath, 'utf8');
-  const updated = upsertCodexServerConfig(content);
-  if (!updated.changed) return false;
-  fs.writeFileSync(configPath, updated.content);
-  console.log('  Codex: appended MCP server to ~/.codex/config.toml');
-  return true;
+
+  const { wireCodexHooks } = require(path.join(PKG_ROOT, 'scripts', 'auto-wire-hooks'));
+  const hookResult = wireCodexHooks({});
+  if (hookResult.changed) {
+    console.log('  Codex: updated ~/.codex/config.json with hooks and status line');
+  }
+
+  return configChanged || hookResult.changed;
 }
 
 function setupGemini() {

--- a/plugins/codex-profile/INSTALL.md
+++ b/plugins/codex-profile/INSTALL.md
@@ -32,9 +32,20 @@ The bundled marketplace catalog points at `./`, so the extracted directory is a 
 - Codex marketplace entry: `.agents/plugins/marketplace.json`
 - Manual install profile: `adapters/codex/config.toml`
 
-## Option 3: Manual MCP install
+## Option 3: Manual Codex install
 
-Add the MCP server block to your Codex config:
+Preferred path:
+
+```bash
+npx thumbgate init --agent codex
+```
+
+That now installs:
+
+- the ThumbGate MCP server in `~/.codex/config.toml`
+- Codex hooks plus the ThumbGate status line target in `~/.codex/config.json`
+
+If you only want the MCP server block manually, add it to your Codex config:
 
 ```bash
 cat adapters/codex/config.toml >> ~/.codex/config.toml
@@ -59,6 +70,23 @@ args = ["--yes", "--package", "thumbgate@1.5.0", "thumbgate", "serve"]
 
 The repo-local Codex app plugin ships the same runtime path through `plugins/codex-profile/.mcp.json`, so the manual config and plugin metadata stay aligned.
 
+The Codex status line and hook bundle live in `~/.codex/config.json`. `npx thumbgate init --agent codex` writes:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.0 thumbgate gate-check" }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.0 thumbgate hook-auto-capture" }] }],
+    "PostToolUse": [{ "matcher": "mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard", "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.0 thumbgate cache-update" }] }],
+    "SessionStart": [{ "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.0 thumbgate session-start" }] }]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "npx --yes --package thumbgate@1.5.0 thumbgate statusline-render"
+  }
+}
+```
+
 ## Verify
 
 Start the MCP server manually to confirm it runs:
@@ -69,7 +97,7 @@ node adapters/mcp/server-stdio.js
 # Press Ctrl+C to stop
 ```
 
-Then restart Codex. The `thumbgate` MCP server will appear in the tool list.
+Then restart Codex. The `thumbgate` MCP server will appear in the tool list, and `~/.codex/config.json` will contain the ThumbGate hook bundle plus the `statusLine` command target for your local Codex build to exercise.
 
 ## Available Tools (via MCP)
 

--- a/plugins/codex-profile/README.md
+++ b/plugins/codex-profile/README.md
@@ -14,6 +14,7 @@ ThumbGate now ships a standalone Codex plugin bundle in GitHub Releases, alongsi
 
 - adds ThumbGate's Pre-Action Gates to Codex workflows
 - captures thumbs-up/down feedback that survives session boundaries
+- writes the ThumbGate status line target alongside the Codex hook bundle
 - reuses the same local-first MCP runtime as Claude, Cursor, Gemini, Amp, and OpenCode
 
 ## What's inside the standalone bundle
@@ -38,7 +39,15 @@ Use the plugin metadata and MCP config in this folder when Codex is loading plug
 
 ### Manual install
 
-Copy the MCP profile from `adapters/codex/config.toml` into `~/.codex/config.toml`.
+Preferred path:
+
+```bash
+npx thumbgate init --agent codex
+```
+
+That writes the MCP server block to `~/.codex/config.toml` and the Codex hook/status-line bundle to `~/.codex/config.json`.
+
+If you only need the MCP server manually, copy the MCP profile from `adapters/codex/config.toml` into `~/.codex/config.toml`.
 
 That profile launches:
 

--- a/public/assets/claude-thumbgate-statusbar.svg
+++ b/public/assets/claude-thumbgate-statusbar.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="320" viewBox="0 0 1600 320" fill="none">
+  <rect width="1600" height="320" rx="24" fill="#050816"/>
+  <rect x="24" y="24" width="1552" height="272" rx="20" fill="#0B1220" stroke="#1F2A44"/>
+  <text x="56" y="72" fill="#7DD3FC" font-family="SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="28">Claude Code · live ThumbGate footer</text>
+  <rect x="56" y="116" width="1488" height="108" rx="16" fill="#111827" stroke="#243041"/>
+  <text x="88" y="180" fill="#E5E7EB" font-family="SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="28">ThumbGate v1.5.1 · Pro · 21👍 107👎 → · Dashboard · Lessons</text>
+  <text x="88" y="258" fill="#94A3B8" font-family="SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="24">Latest mistake 04/15/2026 20:24:42: Treated user as QA instead of doing TDD. Went in circles ...</text>
+</svg>

--- a/public/assets/codex-thumbgate-statusbar-test.svg
+++ b/public/assets/codex-thumbgate-statusbar-test.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="360" viewBox="0 0 1600 360" fill="none">
+  <rect width="1600" height="360" rx="24" fill="#050816"/>
+  <rect x="24" y="24" width="1552" height="312" rx="20" fill="#0B1220" stroke="#1F2A44"/>
+  <text x="56" y="72" fill="#A78BFA" font-family="SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="28">OpenAI Codex v0.120.0 · published ThumbGate test lane</text>
+  <rect x="56" y="116" width="1488" height="96" rx="16" fill="#111827" stroke="#243041"/>
+  <text x="88" y="176" fill="#E5E7EB" font-family="SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="28">gpt-5.4 xhigh fast · fix/codex-statusline · Context [     ] · 0 in · 0 out</text>
+  <text x="56" y="270" fill="#7DD3FC" font-family="SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="24">Published branch installs ThumbGate PreToolUse, UserPromptSubmit, PostToolUse, SessionStart, and statusLine wiring.</text>
+  <text x="56" y="310" fill="#94A3B8" font-family="SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" font-size="22">Current Codex CLI footer remains native on v0.120.0, so this is the reproducible test lane you can run after npx thumbgate init --agent codex.</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -635,6 +635,24 @@ __GA_BOOTSTRAP__
   </div>
 </section>
 
+<section style="padding:28px 0 10px;">
+  <div class="container" style="max-width:1240px;">
+    <div class="section-label">Status bar proof</div>
+    <h2 style="text-align:center;margin-bottom:12px;">See the footer before you ship the next repeat.</h2>
+    <p style="text-align:center;font-size:16px;color:var(--text-muted);max-width:860px;margin:0 auto 28px;line-height:1.7;">Claude renders the live ThumbGate footer now. <code>npx thumbgate init --agent codex</code> installs the same Codex hook bundle and writes the ThumbGate <code>statusLine</code> target so you can test it on your local Codex build immediately.</p>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:24px;align-items:start;">
+      <figure style="margin:0;">
+        <img src="/assets/claude-thumbgate-statusbar.svg" alt="Claude Code terminal footer showing ThumbGate version, plan, thumbs up and thumbs down counts, dashboard, lessons, and latest mistake." style="width:100%;height:auto;display:block;border-radius:14px;border:1px solid var(--border);background:#050816;">
+        <figcaption style="margin-top:10px;font-size:14px;color:var(--text-muted);line-height:1.6;">Claude live footer with ThumbGate stats, links, and the latest mistake summary.</figcaption>
+      </figure>
+      <figure style="margin:0;">
+        <img src="/assets/codex-thumbgate-statusbar-test.svg" alt="OpenAI Codex terminal footer on the published ThumbGate test lane." style="width:100%;height:auto;display:block;border-radius:14px;border:1px solid var(--border);background:#050816;">
+        <figcaption style="margin-top:10px;font-size:14px;color:var(--text-muted);line-height:1.6;">Codex test lane after the published ThumbGate install path writes PreToolUse, UserPromptSubmit, PostToolUse, SessionStart, and the statusLine target.</figcaption>
+      </figure>
+    </div>
+  </div>
+</section>
+
 <!-- CLAUDE CODE SECTION -->
 <section class="gpt-path" id="claude-code-section">
   <div class="container">

--- a/scripts/auto-wire-hooks.js
+++ b/scripts/auto-wire-hooks.js
@@ -355,6 +355,50 @@ function codexConfigPath() {
   return path.join(getHome(), '.codex', 'config.json');
 }
 
+function writeJsonFile(filePath, payload, dryRun) {
+  if (dryRun) {
+    return;
+  }
+
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2) + '\n');
+}
+
+function upsertCodexHook(configHooks, lifecycle, hookDef, legacyPattern) {
+  const hookCommand = hookDef.hooks[0].command;
+  const pruned = pruneLegacyHookEntries(configHooks[lifecycle], hookCommand, legacyPattern);
+  configHooks[lifecycle] = pruned.hooks;
+
+  const added = [];
+  if (pruned.removed) {
+    added.push({ lifecycle, command: `${hookCommand} (replaced legacy ThumbGate hook)` });
+  }
+
+  if (hookAlreadyPresent(configHooks[lifecycle], hookCommand)) {
+    return added;
+  }
+
+  const entry = { hooks: hookDef.hooks };
+  if (hookDef.matcher) {
+    entry.matcher = hookDef.matcher;
+  }
+
+  configHooks[lifecycle] = configHooks[lifecycle] || [];
+  configHooks[lifecycle].push(entry);
+  added.push({ lifecycle, command: hookCommand });
+  return added;
+}
+
+function syncCodexStatusLine(config, desiredStatusLine) {
+  if (config.statusLine && config.statusLine.command === desiredStatusLine) {
+    return false;
+  }
+
+  config.statusLine = { type: 'command', command: desiredStatusLine };
+  return true;
+}
+
 function wireCodexHooks(options) {
   const configPath = options.settingsPath || codexConfigPath();
   const dryRun = options.dryRun || false;
@@ -372,50 +416,19 @@ function wireCodexHooks(options) {
   };
 
   for (const [lifecycle, hookDef] of Object.entries(CODEX_HOOKS)) {
-    const hookCommand = hookDef.hooks[0].command;
-    const pruned = pruneLegacyHookEntries(config.hooks[lifecycle], hookCommand, legacyPatterns[lifecycle]);
-    config.hooks[lifecycle] = pruned.hooks;
-    if (pruned.removed) {
-      added.push({ lifecycle, command: `${hookCommand} (replaced legacy ThumbGate hook)` });
-    }
-
-    if (hookAlreadyPresent(config.hooks[lifecycle], hookCommand)) {
-      continue;
-    }
-
-    config.hooks[lifecycle] = config.hooks[lifecycle] || [];
-    const entry = { hooks: hookDef.hooks };
-    if (hookDef.matcher) {
-      entry.matcher = hookDef.matcher;
-    }
-    config.hooks[lifecycle].push(entry);
-    added.push({ lifecycle, command: hookCommand });
+    added.push(...upsertCodexHook(config.hooks, lifecycle, hookDef, legacyPatterns[lifecycle]));
   }
 
   if (added.length === 0) {
-    if (!config.statusLine || config.statusLine.command !== desiredStatusLine) {
-      config.statusLine = { type: 'command', command: desiredStatusLine };
-      if (!dryRun) {
-        const dir = path.dirname(configPath);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-      }
-      return {
-        changed: true,
-        settingsPath: configPath,
-        added: [{ lifecycle: 'statusLine', command: desiredStatusLine }],
-      };
+    if (syncCodexStatusLine(config, desiredStatusLine)) {
+      writeJsonFile(configPath, config, dryRun);
+      return { changed: true, settingsPath: configPath, added: [{ lifecycle: 'statusLine', command: desiredStatusLine }] };
     }
     return { changed: false, settingsPath: configPath, added: [] };
   }
 
-  config.statusLine = { type: 'command', command: desiredStatusLine };
-
-  if (!dryRun) {
-    const dir = path.dirname(configPath);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-  }
+  syncCodexStatusLine(config, desiredStatusLine);
+  writeJsonFile(configPath, config, dryRun);
 
   added.push({ lifecycle: 'statusLine', command: desiredStatusLine });
   return { changed: true, settingsPath: configPath, added };

--- a/scripts/auto-wire-hooks.js
+++ b/scripts/auto-wire-hooks.js
@@ -45,6 +45,23 @@ const CLAUDE_HOOKS = {
   },
 };
 
+const CODEX_HOOKS = {
+  PreToolUse: {
+    matcher: 'Bash',
+    hooks: [{ type: 'command', command: preToolHookCommand() }],
+  },
+  UserPromptSubmit: {
+    hooks: [{ type: 'command', command: userPromptHookCommand() }],
+  },
+  PostToolUse: {
+    matcher: 'mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard',
+    hooks: [{ type: 'command', command: cacheUpdateHookCommand() }],
+  },
+  SessionStart: {
+    hooks: [{ type: 'command', command: sessionStartHookCommand() }],
+  },
+};
+
 // --- Agent detection ---
 
 function detectAgent(flagAgent) {
@@ -341,39 +358,58 @@ function codexConfigPath() {
 function wireCodexHooks(options) {
   const configPath = options.settingsPath || codexConfigPath();
   const dryRun = options.dryRun || false;
+  const desiredStatusLine = statuslineCommand();
 
   let config = loadJsonFile(configPath) || {};
   config.hooks = config.hooks || {};
 
   const added = [];
-  const preToolCmd = preToolHookCommand();
-  const userPromptCmd = userPromptHookCommand();
+  const legacyPatterns = {
+    PreToolUse: /(generate-pretool-hook\.sh|\bgate-check\b)/,
+    UserPromptSubmit: /(hook-auto-capture\.sh|hook-auto-capture\b)/,
+    PostToolUse: /(hook-thumbgate-cache-updater|cache-update\b)/,
+    SessionStart: /(thumbgate_session_start\.sh|session-start\b)/,
+  };
 
-  const preToolPruned = pruneLegacyHookEntries(config.hooks.PreToolUse, preToolCmd, /(generate-pretool-hook\.sh|\bgate-check\b)/);
-  config.hooks.PreToolUse = preToolPruned.hooks;
-  const userPromptPruned = pruneLegacyHookEntries(config.hooks.UserPromptSubmit, userPromptCmd, /(hook-auto-capture\.sh|hook-auto-capture\b)/);
-  config.hooks.UserPromptSubmit = userPromptPruned.hooks;
+  for (const [lifecycle, hookDef] of Object.entries(CODEX_HOOKS)) {
+    const hookCommand = hookDef.hooks[0].command;
+    const pruned = pruneLegacyHookEntries(config.hooks[lifecycle], hookCommand, legacyPatterns[lifecycle]);
+    config.hooks[lifecycle] = pruned.hooks;
+    if (pruned.removed) {
+      added.push({ lifecycle, command: `${hookCommand} (replaced legacy ThumbGate hook)` });
+    }
 
-  if (!hookAlreadyPresent(config.hooks.PreToolUse, preToolCmd)) {
-    config.hooks.PreToolUse = config.hooks.PreToolUse || [];
-    config.hooks.PreToolUse.push({
-      matcher: 'Bash',
-      hooks: [{ type: 'command', command: preToolCmd }],
-    });
-    added.push({ lifecycle: 'PreToolUse', command: preToolCmd });
-  }
+    if (hookAlreadyPresent(config.hooks[lifecycle], hookCommand)) {
+      continue;
+    }
 
-  if (!hookAlreadyPresent(config.hooks.UserPromptSubmit, userPromptCmd)) {
-    config.hooks.UserPromptSubmit = config.hooks.UserPromptSubmit || [];
-    config.hooks.UserPromptSubmit.push({
-      hooks: [{ type: 'command', command: userPromptCmd }],
-    });
-    added.push({ lifecycle: 'UserPromptSubmit', command: userPromptCmd });
+    config.hooks[lifecycle] = config.hooks[lifecycle] || [];
+    const entry = { hooks: hookDef.hooks };
+    if (hookDef.matcher) {
+      entry.matcher = hookDef.matcher;
+    }
+    config.hooks[lifecycle].push(entry);
+    added.push({ lifecycle, command: hookCommand });
   }
 
   if (added.length === 0) {
+    if (!config.statusLine || config.statusLine.command !== desiredStatusLine) {
+      config.statusLine = { type: 'command', command: desiredStatusLine };
+      if (!dryRun) {
+        const dir = path.dirname(configPath);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+      }
+      return {
+        changed: true,
+        settingsPath: configPath,
+        added: [{ lifecycle: 'statusLine', command: desiredStatusLine }],
+      };
+    }
     return { changed: false, settingsPath: configPath, added: [] };
   }
+
+  config.statusLine = { type: 'command', command: desiredStatusLine };
 
   if (!dryRun) {
     const dir = path.dirname(configPath);
@@ -381,6 +417,7 @@ function wireCodexHooks(options) {
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
   }
 
+  added.push({ lifecycle: 'statusLine', command: desiredStatusLine });
   return { changed: true, settingsPath: configPath, added };
 }
 

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# ThumbGate Status Line for Claude Code
+# ThumbGate Status Line for Claude Code and Codex
 # Shows ThumbGate feedback stats + package version/tier at a glance.
-# Installed by: npx thumbgate init --agent claude-code
+# Installed by: npx thumbgate init --agent claude-code|codex
 
 # Resolve script directory safely (CodeQL: no uncontrolled paths)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"

--- a/tests/auto-wire-hooks.test.js
+++ b/tests/auto-wire-hooks.test.js
@@ -345,6 +345,72 @@ describe('auto-wire-hooks', () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
+
+    test('replaces legacy codex hooks and reports the replacement', () => {
+      const tmpDir = makeTmpDir();
+      const settingsDir = path.join(tmpDir, '.codex');
+      const settingsPath = path.join(settingsDir, 'config.json');
+
+      fs.mkdirSync(settingsDir, { recursive: true });
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: 'command', command: '/tmp/generate-pretool-hook.sh' }] }],
+        },
+      }, null, 2) + '\n');
+
+      try {
+        const result = wireCodexHooks({ settingsPath });
+        assert.equal(result.changed, true);
+        assert.ok(result.added.some((entry) => entry.command.includes('replaced legacy ThumbGate hook')));
+
+        const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        assert.equal(config.hooks.PreToolUse.length, 1);
+        assert.equal(config.hooks.PreToolUse[0].hooks[0].command, preToolHookCommand());
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('updates only the codex status line when hooks are already present', () => {
+      const tmpDir = makeTmpDir();
+      const settingsDir = path.join(tmpDir, '.codex');
+      const settingsPath = path.join(settingsDir, 'config.json');
+
+      fs.mkdirSync(settingsDir, { recursive: true });
+
+      try {
+        wireCodexHooks({ settingsPath });
+        const seededConfig = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        seededConfig.statusLine = { type: 'command', command: 'thumbgate statusline --old' };
+        fs.writeFileSync(settingsPath, JSON.stringify(seededConfig, null, 2) + '\n');
+
+        const result = wireCodexHooks({ settingsPath });
+        assert.equal(result.changed, true);
+        assert.deepStrictEqual(result.added, [{
+          lifecycle: 'statusLine',
+          command: require('../scripts/hook-runtime').statuslineCommand(),
+        }]);
+
+        const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+        assert.equal(config.statusLine.command, require('../scripts/hook-runtime').statuslineCommand());
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    test('dry-run for codex reports changes without writing config', () => {
+      const tmpDir = makeTmpDir();
+      const settingsPath = path.join(tmpDir, '.codex', 'config.json');
+
+      try {
+        const result = wireCodexHooks({ settingsPath, dryRun: true });
+        assert.equal(result.changed, true);
+        assert.equal(result.added.length, 5);
+        assert.equal(fs.existsSync(settingsPath), false);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   // --- wireGeminiHooks ---

--- a/tests/auto-wire-hooks.test.js
+++ b/tests/auto-wire-hooks.test.js
@@ -307,21 +307,27 @@ describe('auto-wire-hooks', () => {
   // --- wireCodexHooks ---
 
   describe('wireCodexHooks', () => {
-    test('creates config and wires PreToolUse hook', () => {
+    test('creates config and wires the full Codex hook bundle plus status line', () => {
       const tmpDir = makeTmpDir();
       const settingsPath = path.join(tmpDir, '.codex', 'config.json');
 
       try {
         const result = wireCodexHooks({ settingsPath });
         assert.equal(result.changed, true);
-        assert.equal(result.added.length, 2);
+        assert.equal(result.added.length, 5);
         assert.equal(result.added[0].lifecycle, 'PreToolUse');
 
         const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
         assert.ok(config.hooks.PreToolUse);
         assert.ok(config.hooks.UserPromptSubmit);
+        assert.ok(config.hooks.PostToolUse);
+        assert.ok(config.hooks.SessionStart);
+        assert.ok(config.statusLine);
         assert.equal(config.hooks.PreToolUse[0].hooks[0].command, preToolHookCommand());
         assert.equal(config.hooks.UserPromptSubmit[0].hooks[0].command, userPromptHookCommand());
+        assert.equal(config.hooks.PostToolUse[0].hooks[0].command, require('../scripts/hook-runtime').cacheUpdateHookCommand());
+        assert.equal(config.hooks.SessionStart[0].hooks[0].command, sessionStartHookCommand());
+        assert.equal(config.statusLine.command, require('../scripts/hook-runtime').statuslineCommand());
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1570,6 +1570,49 @@ describe('bin/cli.js', () => {
     fs.rmSync(isolatedHome, { recursive: true, force: true });
   });
 
+  test('init --wire-hooks accepts split --agent value and writes Codex hooks plus status line', () => {
+    const isolatedDir = makeTmpDir();
+    const isolatedHome = makeTmpDir();
+
+    const result = runCliSync(['init', '--wire-hooks', '--agent', 'codex'], {
+      cwd: isolatedDir,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        USERPROFILE: isolatedHome,
+        THUMBGATE_PUBLISH_STATE: 'unpublished',
+      },
+    });
+
+    assert.equal(result.status, 0, `hook wiring failed:\n${result.stderr}`);
+    const settingsPath = path.join(isolatedHome, '.codex', 'config.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.match(result.stdout, /Added hooks for codex:/);
+    assert.equal(
+      settings.hooks.PreToolUse[0].hooks[0].command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} gate-check`
+    );
+    assert.equal(
+      settings.hooks.UserPromptSubmit[0].hooks[0].command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} hook-auto-capture`
+    );
+    assert.equal(
+      settings.hooks.PostToolUse[0].hooks[0].command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} cache-update`
+    );
+    assert.equal(
+      settings.hooks.SessionStart[0].hooks[0].command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} session-start`
+    );
+    assert.equal(
+      settings.statusLine.command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} statusline-render`
+    );
+
+    fs.rmSync(isolatedDir, { recursive: true, force: true });
+    fs.rmSync(isolatedHome, { recursive: true, force: true });
+  });
+
   test('init creates config.json with required fields', () => {
     const configPath = path.join(tmpDir, '.thumbgate', 'config.json');
     assert.ok(fs.existsSync(configPath), 'config.json should exist');
@@ -1806,6 +1849,16 @@ describe('bin/cli.js', () => {
     const content = fs.readFileSync(configPath, 'utf8');
     assertLocalTomlMcpBlock(content, HOME_MCP_SERVER_PATH);
     assert.doesNotMatch(content, /\/tmp\/disposable-worktree\/adapters\/mcp\/server-stdio\.js/);
+    const hooksPath = path.join(codexHome, 'config.json');
+    const hooksConfig = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    assert.equal(
+      hooksConfig.statusLine.command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} statusline-render`
+    );
+    assert.equal(
+      hooksConfig.hooks.PostToolUse[0].hooks[0].command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} cache-update`
+    );
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(isolatedHome, { recursive: true, force: true });
@@ -1838,6 +1891,12 @@ describe('bin/cli.js', () => {
     const content = fs.readFileSync(configPath, 'utf8');
     assertLocalTomlMcpBlock(content, HOME_MCP_SERVER_PATH);
     assert.doesNotMatch(content, /disposable-worktree/);
+    const hooksPath = path.join(codexHome, 'config.json');
+    const hooksConfig = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+    assert.equal(
+      hooksConfig.statusLine.command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} statusline-render`
+    );
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(isolatedHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- wire the full Codex hook bundle during ThumbGate init/install, including `PostToolUse`, `SessionStart`, and the `statusLine` target in `~/.codex/config.json`
- add README, Codex install docs, and landing-page proof assets for the Claude footer and the Codex test lane
- keep the shipped Codex plugin/profile docs aligned with the published install path

## Verification
- `node --test tests/auto-wire-hooks.test.js`
- `node --test --test-name-pattern='Codex|wire-hooks accepts split --agent value and writes Codex hooks plus status line|stable local codex MCP launcher|rewrites an existing codex MCP launcher' tests/cli.test.js`
- `node --test tests/statusline.test.js tests/statusbar-cli.test.js`
- `node --test tests/codex-plugin.test.js`
- `node --test tests/public-landing.test.js tests/dashboard-html.test.js tests/lessons-page.test.js`
- `HOME=tmp USERPROFILE=tmp node bin/cli.js init --agent codex` and inspect generated `~/.codex/config.toml` + `~/.codex/config.json`
