### PR TITLE
docs: add prompt evaluation positioning

### DIFF
--- a/.changeset/prompt-evaluation-positioning.md
+++ b/.changeset/prompt-evaluation-positioning.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add prompt-evaluation positioning to the README and landing page so ThumbGate explains that prompt engineering is only the start, and proof lanes plus self-heal checks are how behavior gets measured and enforced.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Before any agent action executes, ThumbGate's `PreToolUse` hook intercepts the c
 ### Layer 4: Multi-Agent Distribution
 Gates are distributed across all connected agents via MCP stdio protocol. One correction in Claude Code protects Cursor, Codex, Gemini CLI, and any MCP-compatible agent.
 
+Prompt engineering still matters, but it is only the starting point. ThumbGate adds prompt evaluation on top: proof lanes, benchmarks, and self-heal checks tell you whether your prompt and workflow actually held up under execution instead of leaving you to guess from vibes.
+
 ![Feedback Pipeline](docs/diagrams/feedback_pipeline.png)
 
 ![Agent Integration](docs/diagrams/agent_integration.png)
@@ -141,6 +143,7 @@ ThumbGate sells three concrete outcomes:
 - **Prevent expensive AI mistakes** — catch bad commands, destructive database actions, unsafe publishes, and risky API calls before they run.
 - **Make AI stop repeating mistakes** — fix it once, turn the lesson into a rule, and block the repeat before the next tool call lands.
 - **Turn AI into a reliable operator** — move from a smart assistant that apologizes after damage to a production-ready operator with checkpoints, proof, and enforcement.
+- **Measure prompts instead of rewriting them blindly** — use proof lanes, ThumbGate Bench, and `self-heal:check` to evaluate whether prompts and workflows actually improved behavior.
 
 ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -1147,7 +1147,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How are pre-action gates different from prompt rules?</div>
-        <div class="faq-a">Prompt rules are suggestions that agents can ignore. Pre-Action Gates are enforcement — they block the action before execution. Gates are auto-generated from your human-in-the-loop feedback and use Thompson Sampling to adapt over time.</div>
+        <div class="faq-a">Prompt rules are a starting point, not a finish line. Without prompt evaluation you do not know whether they still hold up under real tool use. ThumbGate adds the human-in-the-loop measurement loop and the enforcement layer: proof lanes, ThumbGate Bench, and self-heal checks show whether behavior improved, and Pre-Action Gates block the action before execution when it did not.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What does Pro cost?</div>

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -28,6 +28,7 @@ test('README explains the product as self-improving agent enforcement', () => {
   assert.match(readme, /self-improv/i);
   assert.match(readme, /enforcement/i);
   assert.match(readme, /permanently/i);
+  assert.match(readme, /prompt evaluation/i);
 });
 
 test('public surfaces lead with outcomes instead of infrastructure abstractions', () => {

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -27,6 +27,7 @@ test('public landing page keeps FAQPage JSON-LD parity for SEO and GEO', () => {
   assert.match(landingPage, /behavioral immune system/i);
   assert.match(landingPage, /PreToolUse hook enforcement/i);
   assert.match(landingPage, /Thompson Sampling/i);
+  assert.match(landingPage, /prompt evaluation/i);
 });
 
 test('public landing page routes Pro buyers through the hosted checkout surface', () => {


### PR DESCRIPTION
## Summary
- add explicit prompt-evaluation language to the README architecture and value props
- update the landing-page FAQ to say prompt rules need measurement as well as enforcement
- lock the wording in the README and landing-page contract tests

## Verification
- node --test tests/public-landing.test.js
- node --test tests/positioning-contract.test.js