### PR TITLE
chore(smithery): align MCP registry description with token-cost mission

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -14,4 +14,4 @@ startCommand:
       - "-y"
       - "thumbgate"
       - "serve"
-description: "Agent quality feedback loop with Pre-Action Gates — configurable checkpoints that block dangerous tool calls before they execute. Includes prevention rules, ThumbGate capture, and commerce quality scores."
+description: "Stop paying $ for the same AI mistake. ThumbGate turns thumbs-down feedback into Pre-Action Gates that block repeat hallucinations, retry loops, and known-bad tool calls before they reach the model — zero tokens spent on mistakes you've already corrected. Works with Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, and any MCP-compatible agent."


### PR DESCRIPTION
## Summary
- Update `smithery.yaml` description to match the token-cost mission hero copy that landed in #889
- Registry listing now leads with \"Stop paying \$ for the same AI mistake\" instead of legacy \"Agent quality feedback loop\" phrasing
- Matches README, landing page, and llms.txt positioning — one consistent message across every acquisition surface

## Test plan
- [ ] CI passes (lint, positioning contract, smithery schema if any)
- [ ] Smithery listing reflects new description after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)