### PR TITLE
feat(revenue): rewrite postinstall banner for first-dollar conversion

### DIFF
--- a/.changeset/conversion-postinstall-v2.md
+++ b/.changeset/conversion-postinstall-v2.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Rewrite postinstall banner to drive first-dollar conversion. Lead with concrete token-waste pain point, add tracked `/go/pro` click-through (UTM: source=npm, medium=postinstall, campaign=first_dollar) alongside direct Stripe link, clean up ragged box formatting. Every npm install sees this banner — making it the highest-leverage conversion touchpoint.

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -17,27 +17,35 @@ const {
   PRO_PRICE_LABEL,
   TEAM_PRICE_LABEL,
 } = require('../scripts/commercial-offer');
+
+// Tracked click-through path: /go/pro → /checkout/pro → Stripe.
+// This captures UTM attribution in our funnel before handing off to Stripe.
+const PRO_CTA_URL = 'https://thumbgate-production.up.railway.app/go/pro?utm_source=npm&utm_medium=postinstall&utm_campaign=first_dollar';
 const WORKFLOW_SPRINT_URL = 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake';
 
 process.stderr.write(`
-  ┌─────────────────────────────────────────────────────┐
+  ╭─────────────────────────────────────────────────────╮
+  │  ThumbGate installed.                               │
   │                                                     │
-  │   ThumbGate installed successfully.                 │
+  │  Every repeat-mistake your agent makes costs        │
+  │  tokens. ThumbGate blocks known-bad tool calls      │
+  │  BEFORE the model sees them — zero tokens spent     │
+  │  on mistakes you've already corrected.              │
   │                                                     │
-  │   Quick start:                                      │
-  │     npx thumbgate init                     │
-  │     npx thumbgate stats                    │
-  │                                                     │
-  │   Team rollout starts with the Workflow Hardening   │
-  │   Sprint: ${WORKFLOW_SPRINT_URL} │
-  │                                                     │
-  │   Solo side lane: Pro (personal local dashboard,    │
-  │   DPO export) — ${PRO_PRICE_LABEL}: │
-  │     ${PRO_MONTHLY_PAYMENT_LINK}       │
-  │   Team: ${TEAM_PRICE_LABEL} after intake. │
-  │                                                     │
-  │   Or run: npx thumbgate pro                │
-  │                                                     │
-  └─────────────────────────────────────────────────────┘
+  │  Start free:                                        │
+  │    npx thumbgate init                               │
+  │    npx thumbgate stats                              │
+  ╰─────────────────────────────────────────────────────╯
+
+  Pro — ${PRO_PRICE_LABEL}
+    personal local dashboard, DPO export
+    Upgrade: ${PRO_CTA_URL}
+    Direct:  ${PRO_MONTHLY_PAYMENT_LINK}
+
+  Team: ${TEAM_PRICE_LABEL}
+    Workflow Hardening Sprint intake:
+    ${WORKFLOW_SPRINT_URL}
+
+  Or run: npx thumbgate pro
 
 `);


### PR DESCRIPTION
## Summary
- Lead with token-waste pain instead of feature list
- Add tracked `/go/pro` URL (utm_source=npm, utm_medium=postinstall, utm_campaign=first_dollar) alongside direct Stripe link
- Clean up ragged box formatting

## Why
Every `npm install thumbgate` user sees this banner (~1,253 installs last 7 days per npm registry). Previous version:
- Buried \$19/mo individual offer behind Team messaging
- Had broken right-aligned box borders
- Routed direct to buy.stripe.com so we couldn't see click-through metrics

This is the highest-leverage conversion surface — the ONE touchpoint every user hits.

## Test plan
- [x] npm run test:postinstall (4 tests pass)
- [x] Full test suite passes (same 2 pre-existing reflector-agent failures on main)
- [x] Manually previewed banner output — clean formatting, all CTAs clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)