### PR TITLE
feat(hooks): pre-commit + pre-push regression guards + publish no-op detector

### DIFF
--- a/.changeset/pre-commit-hooks.md
+++ b/.changeset/pre-commit-hooks.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Add pre-commit + pre-push git hooks to catch regressions before CI. Hooks live in `.githooks/` (no new npm deps), auto-activate via `prepare` npm script, enforce: public/ HTML package parity, version sync, check-congruence, landing-page-claims, gates-engine regression tests, npm pack dry-run, internal link validation. Also adds CI publish-guard that fails when a merge leaves shipped content un-bumped (prevents the "1.5.2 already on npm, content didn't ship" silent no-op that forced 1.5.3/1.5.4).

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ThumbGate pre-commit hook — fast, fail-early guardrails.
+#
+# Activate for your local checkout:
+#   git config core.hooksPath .githooks
+#
+# Or run bin/install-hooks.sh to activate automatically.
+
+set -e
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+has_staged() {
+  git diff --cached --name-only --diff-filter=ACMR | grep -qE "$1"
+}
+
+# 1. Block commits if packaging references missing files OR HTML not in whitelist.
+# This catches the 1.5.0/1.5.1/1.5.3 regression class (HTML not in package.json "files").
+if has_staged '(package\.json|public/.*\.html|scripts/.*\.js)$'; then
+  echo -e "${YELLOW}ThumbGate pre-commit:${NC} validating public/ package parity..."
+  if ! node --test tests/public-package-parity.test.js >/dev/null 2>&1; then
+    echo -e "${RED}✗ public-package-parity test failed${NC}"
+    node --test tests/public-package-parity.test.js 2>&1 | grep -A3 "not ok" | head -20
+    exit 1
+  fi
+  echo -e "${GREEN}✓ package parity${NC}"
+fi
+
+# 2. Version sync — every version string across the repo must match package.json
+if has_staged '(package\.json|public/.*\.html|adapters/.*|plugins/.*|mcpize\.yaml|server-stdio\.js)$'; then
+  echo -e "${YELLOW}ThumbGate pre-commit:${NC} checking version sync..."
+  if ! node scripts/sync-version.js --check >/dev/null 2>&1; then
+    echo -e "${RED}✗ Version drift detected. Run: node scripts/sync-version.js${NC}"
+    node scripts/sync-version.js --check 2>&1 | tail -5
+    exit 1
+  fi
+  echo -e "${GREEN}✓ versions synced${NC}"
+fi
+
+# 3. Congruence — landing page / README text invariants
+if has_staged '(README\.md|public/index\.html|public/pro\.html|public/compare\.html|docs/COMMERCIAL_TRUTH\.md)$'; then
+  echo -e "${YELLOW}ThumbGate pre-commit:${NC} running congruence check..."
+  if ! node scripts/check-congruence.js >/dev/null 2>&1; then
+    echo -e "${RED}✗ Congruence check failed${NC}"
+    node scripts/check-congruence.js 2>&1 | tail -10
+    exit 1
+  fi
+  echo -e "${GREEN}✓ congruence${NC}"
+fi
+
+# 4. Landing-page-claims test — asserts every pricing bullet has code evidence
+if has_staged '(public/index\.html|scripts/rate-limiter\.js|src/api/server\.js)$'; then
+  if [ -f tests/landing-page-claims.test.js ]; then
+    echo -e "${YELLOW}ThumbGate pre-commit:${NC} landing page claims vs code..."
+    if ! node --test tests/landing-page-claims.test.js >/dev/null 2>&1; then
+      echo -e "${RED}✗ landing-page-claims failed — a pricing claim is unsupported by code${NC}"
+      node --test tests/landing-page-claims.test.js 2>&1 | grep -A3 "not ok" | head -15
+      exit 1
+    fi
+    echo -e "${GREEN}✓ claims${NC}"
+  fi
+fi
+
+# 5. Gates engine — regression guard when changing enforcement code
+if has_staged '(scripts/gates-engine\.js|scripts/rate-limiter\.js|scripts/feedback-loop\.js)$'; then
+  echo -e "${YELLOW}ThumbGate pre-commit:${NC} gate + feedback tests..."
+  if ! node --test tests/gate-stats.test.js tests/mcp-tools-gates.test.js >/dev/null 2>&1; then
+    echo -e "${RED}✗ Gate tests failed${NC}"
+    node --test tests/gate-stats.test.js tests/mcp-tools-gates.test.js 2>&1 | tail -10
+    exit 1
+  fi
+  echo -e "${GREEN}✓ gates${NC}"
+fi
+
+echo -e "${GREEN}ThumbGate pre-commit: all guards passed${NC}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,80 @@
+#!/bin/bash
+# ThumbGate pre-push hook — catches packaging + publish regressions before CI.
+#
+# Activate: git config core.hooksPath .githooks
+
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Only run on branches that could hit main (skip drafts, dependabot branches)
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+case "$CURRENT" in
+  dependabot/*|wip/*|spike/*) exit 0 ;;
+esac
+
+# 1. npm pack --dry-run — catches missing HTML / script files BEFORE CI catches them
+echo -e "${YELLOW}pre-push:${NC} npm pack dry-run to detect missing files..."
+PACK_OUT=$(npm pack --dry-run --silent 2>&1)
+if echo "$PACK_OUT" | grep -qE "(error|ERR)"; then
+  echo -e "${RED}✗ npm pack reported errors${NC}"
+  echo "$PACK_OUT" | tail -20
+  exit 1
+fi
+
+# 2. Detect HTML <a href="..."> pointing to files NOT in the npm package
+echo -e "${YELLOW}pre-push:${NC} validating internal links in public/ HTML..."
+node -e '
+const fs = require("fs");
+const path = require("path");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const filesInPackage = new Set(pkg.files);
+let errors = [];
+
+const htmlFiles = pkg.files.filter(f => f.startsWith("public/") && f.endsWith(".html"));
+for (const htmlPath of htmlFiles) {
+  if (!fs.existsSync(htmlPath)) continue;
+  const html = fs.readFileSync(htmlPath, "utf8");
+  // Match href="/pro", "/compare", etc — internal paths pointing to top-level routes
+  const re = /href="\/([a-z][a-z0-9_-]*)"(?![^>]*target=)/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const route = m[1];
+    // Skip query/hash-only, external markers, known non-file routes
+    if (["", "checkout", "feedback", "go", "assets", "learn", "guides", "compare"].includes(route)) continue;
+    // Routes commonly backed by public/<route>.html
+    const candidate = `public/${route}.html`;
+    if (fs.existsSync(candidate) && !filesInPackage.has(candidate)) {
+      errors.push(`  ${htmlPath} links to /${route} but ${candidate} is NOT in package.json files`);
+    }
+  }
+}
+if (errors.length) {
+  console.error("Broken internal links in shipped HTML:\n" + errors.join("\n"));
+  process.exit(1);
+}
+' || exit 1
+
+# 3. Full repo test chain quick subset — DON'T run everything (would be too slow for pre-push)
+# Run only the regression-guard tests that protect against common mistakes
+if [ -f tests/public-package-parity.test.js ]; then
+  echo -e "${YELLOW}pre-push:${NC} running regression-guard tests..."
+  if ! node --test \
+      tests/public-package-parity.test.js \
+      tests/test-suite-parity.test.js \
+      $( [ -f tests/landing-page-claims.test.js ] && echo tests/landing-page-claims.test.js ) \
+      >/dev/null 2>&1; then
+    echo -e "${RED}✗ Regression-guard tests failed${NC}"
+    node --test \
+      tests/public-package-parity.test.js \
+      tests/test-suite-parity.test.js \
+      $( [ -f tests/landing-page-claims.test.js ] && echo tests/landing-page-claims.test.js ) \
+      2>&1 | grep -A3 "not ok" | head -20
+    exit 1
+  fi
+fi
+
+echo -e "${GREEN}pre-push: all guards passed${NC}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -86,6 +86,31 @@ jobs:
       - name: Report publish no-op
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.skip_publish == 'true'
         run: echo "${{ steps.plan.outputs.reason }}"
+      - name: Guard against silent no-op when main has content changes since last publish
+        # Prevents the "1.5.2 already on npm, content changes don't ship" failure mode.
+        # If the published version already exists but main has meaningful source changes
+        # (README, HTML, scripts) since that tag, we should have bumped the version.
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.npm.outputs.published == 'true' && steps.plan.outputs.skip_publish == 'true'
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          set -e
+          # Find the last release tag. If main has commits touching shipped content
+          # that aren't in that tag's tree, the author forgot to bump.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            echo "::notice::No prior release tag — cannot compare content drift."
+            exit 0
+          fi
+          # Count changes in shipped surfaces since that tag
+          SHIPPED_CHANGES=$(git diff --name-only "$LAST_TAG"..HEAD -- \
+            'public/*.html' 'scripts/*.js' 'src/**' 'bin/**' 'README.md' 'CHANGELOG.md' 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$SHIPPED_CHANGES" -gt 0 ]; then
+            echo "::error::Silent no-op detected: ${SHIPPED_CHANGES} shipped files changed since ${LAST_TAG} but package.json still says ${VERSION} (already on npm). Bump the version or tests won't verify the content ships."
+            git diff --name-only "$LAST_TAG"..HEAD -- 'public/*.html' 'scripts/*.js' 'src/**' 'bin/**' 'README.md' | head -20
+            exit 1
+          fi
+          echo "::notice::No shipped content changes since ${LAST_TAG} — no-op is legitimate."
       - name: Create release tag
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.create_tag == 'true'
         env:

--- a/bin/install-hooks.sh
+++ b/bin/install-hooks.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# ThumbGate — install local git hooks into this checkout.
+# Run once after cloning. Idempotent. No new npm dependencies.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ ! -d .githooks ]; then
+  echo "No .githooks directory found at $REPO_ROOT/.githooks"
+  exit 1
+fi
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+echo "✓ Git hooks activated at .githooks/ (core.hooksPath set)"
+echo "  pre-commit: package parity, version sync, congruence, claims, gates"
+echo "  pre-push:   npm pack dry-run, internal link validation, regression guards"

--- a/package.json
+++ b/package.json
@@ -485,7 +485,9 @@
     "test:lesson-export-import": "node --test tests/lesson-export-import.test.js",
     "test:landing-page-claims": "node --test tests/landing-page-claims.test.js",
     "test:dashboard-deeplink-e2e": "node --test tests/dashboard-deeplink-e2e.test.js",
-    "test:public-package-parity": "node --test tests/public-package-parity.test.js"
+    "test:public-package-parity": "node --test tests/public-package-parity.test.js",
+    "prepare": "bash bin/install-hooks.sh >/dev/null 2>&1 || true",
+    "install:hooks": "bash bin/install-hooks.sh"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Why

This session hit the same regression 4 times: public/*.html files not in npm files whitelist → 1.5.0, 1.5.1, 1.5.3 all shipped broken. Plus a silent no-op: 1.5.2 was already on npm when content PR #914 merged, so the publish workflow logged success without shipping anything.

No pre-commit hooks existed. Every commit went to CI cold.

## What

**.githooks/pre-commit** — fast guards on staged files:
- public-package-parity (the recurring bug)
- sync-version
- check-congruence
- landing-page-claims (pricing claims must have code evidence)
- gates-engine regression tests

**.githooks/pre-push** — fail before CI:
- `npm pack --dry-run`
- Internal link validation (`href="/pro"` pointing to an un-shipped pro.html)
- Regression-guard test subset

**CI publish-guard** in `publish-npm.yml`:
- Fails when main has shipped-content changes since the last release tag but version wasn't bumped (catches the silent no-op)

**Zero new npm dependencies** — uses `core.hooksPath`. Auto-activates via `npm install` prepare script.

## Install locally
`bash bin/install-hooks.sh` (or just run `npm install`)

## Tests
Hook scripts verified with live dry-run on this branch. No regressions.