### PR TITLE
fix: auto-update Codex ThumbGate runtime

### DIFF
--- a/.changeset/codex-mcp-autoupdate.md
+++ b/.changeset/codex-mcp-autoupdate.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Codex MCP installs now resolve `thumbgate@latest` when Codex starts the MCP server or hook bundle, instead of preferring a stale already-installed runtime binary. The repo-local Codex plugin, standalone bundle config, README, landing page, and distribution docs now advertise the auto-updating Codex plugin path truthfully while preserving local source fallback for unpublished development builds.

--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ Claude renders the live ThumbGate footer today. `npx thumbgate init --agent code
 
 ### Install Codex Plugin
 
-Download the standalone Codex plugin bundle and follow the install guide:
+Open the Codex plugin install page or download the standalone bundle from GitHub Releases. The Codex launcher resolves `thumbgate@latest` when MCP and hooks start, so published npm fixes reach active Codex installs without hand-editing `~/.codex/config.toml`.
 
-1. Download: [thumbgate-codex-plugin.zip](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)
-2. Follow: [plugins/codex-profile/INSTALL.md](plugins/codex-profile/INSTALL.md)
+1. Install page: [thumbgate-production.up.railway.app/codex-plugin](https://thumbgate-production.up.railway.app/codex-plugin)
+2. Direct zip: [thumbgate-codex-plugin.zip](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)
+3. Follow: [plugins/codex-profile/INSTALL.md](plugins/codex-profile/INSTALL.md)
 
 ---
 
@@ -344,7 +345,7 @@ Every Changeset is tied to the exact `main` merge commit and generates Verificat
 
 - **[Open ThumbGate GPT](https://thumbgate-production.up.railway.app/go/gpt?utm_source=github&utm_medium=readme&utm_campaign=readme_gpt)** — ThumbGate GPT: start here. Paste agent actions, get advice + checkpointing. No, users do not have to keep chatting inside the ThumbGate GPT to use ThumbGate — the hard enforcement layer still runs where the work happens.
 - **[Claude Desktop Extension](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb)** — One-click install for Claude Desktop
-- **[Codex Plugin](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)** — Standalone bundle for Codex CLI
+- **[Codex Plugin](https://thumbgate-production.up.railway.app/codex-plugin)** — Auto-updating standalone bundle and install page for Codex CLI
 - **[Perplexity Command Center](docs/PERPLEXITY_MAX_COMMAND_CENTER.md)** — AI-search visibility + lead discovery
 - **[ThumbGate Bench](docs/THUMBGATE_BENCH.md)** — Reliability benchmark for gate evaluation
 - **[Manus AI Skill](skills/thumbgate/SKILL.md)** — ThumbGate integration for Manus AI agents

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -2,10 +2,10 @@
 # Preferred: run `npx thumbgate init --agent codex` to also wire
 # ~/.codex/config.json with the ThumbGate hooks and status line.
 [mcp_servers.thumbgate]
-command = "npx"
-args = ["--yes", "--package", "thumbgate@1.5.8", "thumbgate", "serve"]
+command = "sh"
+args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""]
 
 # Hard PreToolUse hook for Codex
 [hooks.pre_tool_use]
-command = "npx"
-args = ["--yes", "--package", "thumbgate@1.5.8", "thumbgate", "gate-check"]
+command = "sh"
+args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"gate-check\""]

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,7 +22,14 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { execSync, execFileSync } = require('child_process');
-const { resolveMcpEntry } = require(path.join(__dirname, '..', 'scripts', 'mcp-config'));
+const {
+  codexAutoUpdateCliEntry,
+  codexAutoUpdateMcpEntry,
+  isSourceCheckout,
+  publishedCliAvailable,
+  localMcpEntry,
+  resolveMcpEntry,
+} = require(path.join(__dirname, '..', 'scripts', 'mcp-config'));
 const { trackEvent } = require(path.join(__dirname, '..', 'scripts', 'cli-telemetry'));
 const {
   cacheUpdateHookCommand,
@@ -215,9 +222,38 @@ function canonicalMcpEntry(scope = 'project') {
   });
 }
 
+function canonicalCodexMcpEntry() {
+  const version = pkgVersion();
+  if (isSourceCheckout(PKG_ROOT) && !publishedCliAvailable(version)) {
+    return localMcpEntry(PKG_ROOT, 'home');
+  }
+  return codexAutoUpdateMcpEntry();
+}
+
+function canonicalCodexCliEntry(commandArgs) {
+  const version = pkgVersion();
+  if (isSourceCheckout(PKG_ROOT) && !publishedCliAvailable(version)) {
+    return {
+      command: 'node',
+      args: [path.join(PKG_ROOT, 'bin', 'cli.js'), ...commandArgs],
+    };
+  }
+  return codexAutoUpdateCliEntry(commandArgs);
+}
+
 function mcpSectionBlock(name = MCP_SERVER_NAME, scope = 'project') {
   const entry = canonicalMcpEntry(scope);
   return `[mcp_servers.${name}]\ncommand = "${entry.command}"\nargs = ${formatTomlStringArray(entry.args)}\n`;
+}
+
+function codexMcpSectionBlock(name = MCP_SERVER_NAME) {
+  const entry = canonicalCodexMcpEntry();
+  return `[mcp_servers.${name}]\ncommand = "${entry.command}"\nargs = ${formatTomlStringArray(entry.args)}\n`;
+}
+
+function codexPreToolHookSectionBlock() {
+  const entry = canonicalCodexCliEntry(['gate-check']);
+  return `[hooks.pre_tool_use]\ncommand = "${entry.command}"\nargs = ${formatTomlStringArray(entry.args)}\n`;
 }
 
 function mcpSectionRegex(name) {
@@ -227,8 +263,16 @@ function mcpSectionRegex(name) {
   );
 }
 
+function tomlSectionRegex(name) {
+  return new RegExp(
+    `^\\[${escapeRegExp(name)}\\]\\n(?:^(?!\\[).*(?:\\n|$))*`,
+    'm'
+  );
+}
+
 function upsertCodexServerConfig(content) {
-  const canonicalBlock = mcpSectionBlock(MCP_SERVER_NAME, 'home');
+  const canonicalBlock = codexMcpSectionBlock(MCP_SERVER_NAME);
+  const canonicalHookBlock = codexPreToolHookSectionBlock();
   const sections = MCP_SERVER_NAMES.map((name) => ({
     name,
     regex: mcpSectionRegex(name),
@@ -241,7 +285,7 @@ function upsertCodexServerConfig(content) {
     const prefix = content.trimEnd();
     return {
       changed: true,
-      content: `${prefix}${prefix ? '\n\n' : ''}${canonicalBlock}`,
+      content: `${prefix}${prefix ? '\n\n' : ''}${canonicalBlock}\n${canonicalHookBlock}`,
     };
   }
 
@@ -269,6 +313,19 @@ function upsertCodexServerConfig(content) {
   if (!canonicalPresent) {
     const prefix = nextContent.trimEnd();
     nextContent = `${prefix}${prefix ? '\n\n' : ''}${canonicalBlock}`;
+    changed = true;
+  }
+
+  const hookRegex = tomlSectionRegex('hooks.pre_tool_use');
+  if (hookRegex.test(nextContent)) {
+    const current = nextContent.match(hookRegex)[0];
+    if (current !== canonicalHookBlock) {
+      nextContent = nextContent.replace(hookRegex, canonicalHookBlock);
+      changed = true;
+    }
+  } else {
+    const prefix = nextContent.trimEnd();
+    nextContent = `${prefix}${prefix ? '\n\n' : ''}${canonicalHookBlock}`;
     changed = true;
   }
 
@@ -387,11 +444,10 @@ function setupClaude() {
 
 function setupCodex() {
   const configPath = path.join(HOME, '.codex', 'config.toml');
-  const block = mcpSectionBlock(MCP_SERVER_NAME, 'home');
   let configChanged = false;
   if (!fs.existsSync(configPath)) {
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(configPath, block);
+    fs.writeFileSync(configPath, upsertCodexServerConfig('').content);
     console.log('  Codex: created ~/.codex/config.toml');
     configChanged = true;
   } else {

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -90,14 +90,16 @@ This lane is for Claude Code users who want Codex review, adversarial review, an
 - Manual profile: `adapters/codex/config.toml`
 - Standalone Codex bundle build command: `npm run build:codex-plugin`
 - Standalone Codex release workflow: `.github/workflows/publish-codex-plugin.yml`
+- Standalone Codex install page: `https://thumbgate-production.up.railway.app/codex-plugin`
 - Standalone Codex latest download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip`
 - Standalone Codex versioned asset pattern: `thumbgate-codex-plugin-v<VERSION>.zip`
 - Repo-local Codex plugin manifest: `plugins/codex-profile/.codex-plugin/plugin.json`
 - Repo-local Codex MCP config: `plugins/codex-profile/.mcp.json`
 - Repo-local Codex marketplace: `.agents/plugins/marketplace.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.5.8 serve`
+- Transport: local stdio MCP server launched through `npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest` followed by `~/.thumbgate/runtime/node_modules/.bin/thumbgate serve`
+- Update policy: Codex MCP and hook launchers resolve `thumbgate@latest` at startup instead of preferring a stale installed runtime binary; unpublished local source checkouts fall back to the local server path
 
-The standalone Codex bundle ships `.codex-plugin/plugin.json`, `.mcp.json`, `.agents/plugins/marketplace.json`, `config.toml`, and install docs in one zip. Stable releases publish `thumbgate-codex-plugin.zip`; prereleases publish `thumbgate-codex-plugin-next.zip`.
+The standalone Codex bundle ships `.codex-plugin/plugin.json`, `.mcp.json`, `.agents/plugins/marketplace.json`, `config.toml`, and install docs in one zip. Stable releases publish `thumbgate-codex-plugin.zip`; prereleases publish `thumbgate-codex-plugin-next.zip`. The bundle metadata remains versioned for marketplace review, while the runtime follows the latest npm release for active Codex installs.
 
 ## Cursor Plugins
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "config/",
     "openapi/",
     "public/blog.html",
+    "public/codex-plugin.html",
     "public/compare.html",
     "public/dashboard.html",
     "public/guide.html",

--- a/plugins/codex-profile/.mcp.json
+++ b/plugins/codex-profile/.mcp.json
@@ -1,13 +1,10 @@
 {
   "mcpServers": {
     "thumbgate": {
-      "command": "npx",
+      "command": "sh",
       "args": [
-        "--yes",
-        "--package",
-        "thumbgate@1.5.8",
-        "thumbgate",
-        "serve"
+        "-lc",
+        "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""
       ]
     }
   }

--- a/plugins/codex-profile/INSTALL.md
+++ b/plugins/codex-profile/INSTALL.md
@@ -1,6 +1,6 @@
 # ThumbGate for Codex
 
-ThumbGate now ships a standalone Codex plugin bundle, a repo-local Codex app plugin surface, and the version-pinned MCP profile.
+ThumbGate now ships a standalone Codex plugin bundle, a repo-local Codex app plugin surface, and an auto-updating Codex MCP profile.
 
 ## Option 1: Use the standalone release bundle
 
@@ -60,32 +60,36 @@ cat adapters/codex/config.toml >> ~/.codex/config.toml
 
 ## What Gets Added
 
-The following block is appended to `~/.codex/config.toml`:
+The following block is appended to `~/.codex/config.toml` when the published package is available:
 
 ```toml
 [mcp_servers.thumbgate]
-command = "npx"
-args = ["--yes", "--package", "thumbgate@1.5.8", "thumbgate", "serve"]
+command = "sh"
+args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""]
 ```
 
-The repo-local Codex app plugin ships the same runtime path through `plugins/codex-profile/.mcp.json`, so the manual config and plugin metadata stay aligned.
+The launcher resolves `thumbgate@latest` each time Codex starts the MCP server instead of reusing a stale installed binary. If you are developing from an unpublished local checkout, `npx thumbgate init --agent codex` falls back to the local `adapters/mcp/server-stdio.js` path so work-in-progress code still runs.
+
+The repo-local Codex app plugin ships the same auto-updating runtime path through `plugins/codex-profile/.mcp.json`, so the manual config and plugin metadata stay aligned.
 
 The Codex status line and hook bundle live in `~/.codex/config.json`. `npx thumbgate init --agent codex` writes:
 
 ```json
 {
   "hooks": {
-    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.8 thumbgate gate-check" }] }],
-    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.8 thumbgate hook-auto-capture" }] }],
-    "PostToolUse": [{ "matcher": "mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard", "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.8 thumbgate cache-update" }] }],
-    "SessionStart": [{ "hooks": [{ "type": "command", "command": "npx --yes --package thumbgate@1.5.8 thumbgate session-start" }] }]
+    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate gate-check" }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate hook-auto-capture" }] }],
+    "PostToolUse": [{ "matcher": "mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard", "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate cache-update" }] }],
+    "SessionStart": [{ "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate session-start" }] }]
   },
   "statusLine": {
     "type": "command",
-    "command": "npx --yes --package thumbgate@1.5.8 thumbgate statusline-render"
+    "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate statusline-render"
   }
 }
 ```
+
+The real generated command includes a `mkdir -p ~/.thumbgate/runtime` guard before the `npm install` call and suppresses install noise.
 
 ## Verify
 

--- a/plugins/codex-profile/README.md
+++ b/plugins/codex-profile/README.md
@@ -9,11 +9,13 @@ ThumbGate now ships a standalone Codex plugin bundle in GitHub Releases, alongsi
 - Source plugin manifest: `plugins/codex-profile/.codex-plugin/plugin.json`
 - Source MCP config: `plugins/codex-profile/.mcp.json`
 - Manual install profile: `adapters/codex/config.toml`
+- Update policy: Codex resolves `thumbgate@latest` on MCP and hook startup; unpublished local source checkouts still fall back to the local server path
 
 ## What it does
 
 - adds ThumbGate's Pre-Action Gates to Codex workflows
 - captures thumbs-up/down feedback that survives session boundaries
+- auto-refreshes the Codex MCP/hook runtime from the latest npm release on startup
 - writes the ThumbGate status line target alongside the Codex hook bundle
 - reuses the same local-first MCP runtime as Claude, Cursor, Gemini, Amp, and OpenCode
 
@@ -49,12 +51,12 @@ That writes the MCP server block to `~/.codex/config.toml` and the Codex hook/st
 
 If you only need the MCP server manually, copy the MCP profile from `adapters/codex/config.toml` into `~/.codex/config.toml`.
 
-That profile launches:
+That profile launches the latest npm release instead of pinning a stale local runtime:
 
 ```toml
 [mcp_servers.thumbgate]
-command = "npx"
-args = ["--yes", "--package", "thumbgate@1.5.8", "thumbgate", "serve"]
+command = "sh"
+args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""]
 ```
 
 ### Build from source
@@ -67,4 +69,4 @@ npm run build:codex-plugin
 
 ## Why this exists
 
-The Codex support story is no longer just "copy this config block." ThumbGate now has a direct-download Codex plugin bundle, a repo-local plugin surface, and a pinned manual MCP profile so release assets, install docs, and the runtime stay aligned.
+The Codex support story is no longer just "copy this config block." ThumbGate now has a direct-download Codex plugin bundle, a repo-local plugin surface, and an auto-updating manual MCP profile so release assets, install docs, and the runtime stay aligned with npm.

--- a/public/codex-plugin.html
+++ b/public/codex-plugin.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ThumbGate for Codex - Auto-Updating MCP Plugin</title>
+<script defer data-domain="thumbgate-production.up.railway.app" src="https://plausible.io/js/script.js"></script>
+<meta name="description" content="Install ThumbGate for Codex with an auto-updating MCP plugin, Pre-Action Gates, thumbs-up/down feedback memory, and a local-first Reliability Gateway.">
+<meta name="keywords" content="ThumbGate Codex plugin, Codex MCP server, Codex pre-action gates, Codex guardrails, thumbgate latest, AI coding agent reliability">
+<meta property="og:title" content="ThumbGate for Codex">
+<meta property="og:description" content="Auto-updating MCP and hook launcher for Codex. One install, then ThumbGate resolves the latest npm runtime when Codex starts.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://thumbgate-production.up.railway.app/codex-plugin">
+<link rel="canonical" href="https://thumbgate-production.up.railway.app/codex-plugin">
+<link rel="llm-context" href="/public/llm-context.md" type="text/markdown">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "ThumbGate for Codex",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "macOS, Linux, Windows with Node.js",
+  "description": "ThumbGate for Codex installs an MCP server and hook launcher that resolves thumbgate@latest at startup, captures thumbs-up/down feedback, and enforces Pre-Action Gates before risky agent actions run.",
+  "url": "https://thumbgate-production.up.railway.app/codex-plugin",
+  "downloadUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip",
+  "installUrl": "https://thumbgate-production.up.railway.app/codex-plugin",
+  "license": "https://opensource.org/licenses/MIT",
+  "creator": {
+    "@type": "Person",
+    "name": "Igor Ganapolsky",
+    "url": "https://github.com/IgorGanapolsky"
+  },
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD",
+    "description": "Free local Codex MCP setup with optional Pro dashboard upgrade."
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does the ThumbGate Codex MCP server update automatically?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Codex MCP and hook launcher resolves thumbgate@latest when Codex starts. After a new npm release is published, restarting Codex lets the launcher install the latest runtime into the local ThumbGate runtime cache before it serves MCP or checks gates."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do Codex thumbs-up and thumbs-down signals work by default?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ThumbGate works when the MCP server and hooks are enabled in Codex settings. The Codex settings page should show the thumbgate MCP server toggled on. Typed thumbs-up/down feedback with concrete context can then be captured and promoted into prevention rules."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the fastest Codex install path?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Run npx thumbgate init --agent codex for the automatic local setup, or use the standalone Codex plugin bundle if you want a portable plugin surface."
+      }
+    }
+  ]
+}
+</script>
+
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  :root {
+    --bg: #090a0d;
+    --panel: #12141a;
+    --panel-2: #171a21;
+    --line: #2b313c;
+    --text: #f1f5f9;
+    --muted: #9aa4b2;
+    --cyan: #22d3ee;
+    --green: #4ade80;
+    --red: #fb7185;
+    --yellow: #facc15;
+  }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.65;
+  }
+  a { color: var(--cyan); }
+  nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 28px;
+    border-bottom: 1px solid var(--line);
+    background: rgba(9, 10, 13, 0.88);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    backdrop-filter: blur(12px);
+  }
+  nav a { color: var(--muted); text-decoration: none; font-size: 14px; }
+  nav .brand { color: var(--text); font-weight: 800; }
+  .nav-links { display: flex; gap: 14px; flex-wrap: wrap; justify-content: flex-end; }
+  .wrap { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
+  .hero { padding: 72px 0 42px; }
+  .eyebrow { color: var(--green); font: 700 13px ui-monospace, SFMono-Regular, Menlo, monospace; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 14px; }
+  h1 { font-size: clamp(38px, 7vw, 76px); line-height: 1.02; margin: 0 0 22px; letter-spacing: 0; max-width: 980px; }
+  .sub { color: var(--muted); font-size: 20px; max-width: 820px; margin: 0 0 28px; }
+  .actions { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+  .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    padding: 13px 18px;
+    min-height: 48px;
+    text-decoration: none;
+    font-weight: 800;
+    border: 1px solid var(--line);
+  }
+  .button.primary { background: var(--cyan); color: #061014; border-color: var(--cyan); }
+  .button.secondary { background: var(--panel); color: var(--text); }
+  .terminal {
+    background: #050608;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 18px;
+    color: var(--green);
+    font: 14px ui-monospace, SFMono-Regular, Menlo, monospace;
+    overflow-x: auto;
+    margin: 28px 0 0;
+  }
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin: 38px 0; }
+  .tile, .proof, .step, .faq {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 22px;
+  }
+  .tile h3, .step h3, .faq h3 { margin: 0 0 10px; font-size: 19px; }
+  .tile p, .step p, .faq p { color: var(--muted); margin: 0; }
+  .split { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 28px; align-items: center; margin: 54px 0; }
+  .proof img { width: 100%; height: auto; display: block; border-radius: 8px; border: 1px solid var(--line); background: #050608; }
+  .caption { color: var(--muted); font-size: 14px; margin-top: 10px; }
+  h2 { font-size: 32px; line-height: 1.15; margin: 0 0 16px; letter-spacing: 0; }
+  .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin: 24px 0 44px; }
+  code {
+    background: rgba(34, 211, 238, 0.1);
+    border: 1px solid rgba(34, 211, 238, 0.2);
+    border-radius: 6px;
+    padding: 2px 6px;
+    color: var(--text);
+  }
+  .status { color: var(--yellow); }
+  .faq-list { display: grid; gap: 14px; margin: 24px 0 54px; }
+  footer { border-top: 1px solid var(--line); padding: 28px 0 42px; color: var(--muted); }
+  @media (max-width: 820px) {
+    nav { align-items: flex-start; flex-direction: column; }
+    .grid, .split, .steps { grid-template-columns: 1fr; }
+    .hero { padding-top: 44px; }
+    h1 { font-size: 38px; }
+    .sub { font-size: 18px; }
+  }
+</style>
+</head>
+<body>
+<nav>
+  <a class="brand" href="/">ThumbGate</a>
+  <div class="nav-links">
+    <a href="/guide">Setup Guide</a>
+    <a href="/dashboard">Dashboard</a>
+    <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub</a>
+    <a href="https://www.npmjs.com/package/thumbgate" target="_blank" rel="noopener">npm</a>
+  </div>
+</nav>
+
+<main>
+  <section class="hero">
+    <div class="wrap">
+      <div class="eyebrow">Codex MCP plugin + Pre-Action Gates</div>
+      <h1>Give Codex a thumbs-down once. Block the repeat before it runs again.</h1>
+      <p class="sub">ThumbGate wires Codex into local-first feedback memory, MCP tools, and hook enforcement. The launcher resolves <code>thumbgate@latest</code> when Codex starts, so published npm fixes reach your active MCP server after a restart.</p>
+      <div class="actions">
+        <a class="button primary" href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener" onclick="if(typeof plausible==='function')plausible('codex_plugin_download')">Download Codex plugin</a>
+        <a class="button secondary" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/INSTALL.md" target="_blank" rel="noopener">Read install docs</a>
+        <a class="button secondary" href="/guide">Use CLI setup</a>
+      </div>
+      <pre class="terminal">$ npx thumbgate init --agent codex
+# Writes ~/.codex/config.toml and ~/.codex/config.json
+# MCP + hooks install thumbgate@latest before serving or checking gates</pre>
+    </div>
+  </section>
+
+  <section class="wrap grid" aria-label="Codex install promises">
+    <div class="tile">
+      <h3>Always-on when enabled</h3>
+      <p>If Codex settings show the <code>thumbgate</code> MCP server toggled on, Codex can call the local ThumbGate tools. Typed feedback still needs useful context before it becomes a durable rule.</p>
+    </div>
+    <div class="tile">
+      <h3>Latest runtime on restart</h3>
+      <p>The Codex launcher installs <code>thumbgate@latest</code> into <code>~/.thumbgate/runtime</code> before running MCP or gate checks. A new npm publish reaches Codex after the app restarts.</p>
+    </div>
+    <div class="tile">
+      <h3>Hard stop before action</h3>
+      <p>Pre-Action Gates evaluate commands, file edits, publishes, merges, and other high-risk actions before execution. Bad repeats get blocked before they burn time or tokens.</p>
+    </div>
+  </section>
+
+  <section class="wrap split">
+    <div>
+      <div class="eyebrow">What Codex gets</div>
+      <h2>MCP memory, hook checks, and a dashboard lane in the same install path.</h2>
+      <p>Use the standalone plugin when you want a portable Codex bundle. Use <code>npx thumbgate init --agent codex</code> when you want the shortest path on this machine. Both paths point at the same Reliability Gateway and the same npm runtime.</p>
+      <p class="status">The Codex launcher checks npm on startup. Restart Codex after a ThumbGate publish to let the MCP server and hook bundle pick up the latest runtime.</p>
+    </div>
+    <figure class="proof">
+      <img src="/assets/codex-thumbgate-statusbar-test.svg" alt="Codex terminal footer test lane with ThumbGate status and enforcement proof.">
+      <figcaption class="caption">Codex test lane after ThumbGate writes MCP, PreToolUse, UserPromptSubmit, PostToolUse, SessionStart, and the status line target.</figcaption>
+    </figure>
+  </section>
+
+  <section class="wrap">
+    <div class="eyebrow">Install flow</div>
+    <h2>Three paths. Same local gateway.</h2>
+    <div class="steps">
+      <div class="step">
+        <h3>1. Automatic setup</h3>
+        <p>Run <code>npx thumbgate init --agent codex</code>. ThumbGate writes the MCP server block and hook bundle into your Codex config files.</p>
+      </div>
+      <div class="step">
+        <h3>2. Standalone plugin</h3>
+        <p>Use the release bundle when Codex loads plugin surfaces directly. The bundle includes the manifest, MCP config, marketplace entry, and install docs.</p>
+      </div>
+      <div class="step">
+        <h3>3. Verify in Codex</h3>
+        <p>Open Codex settings, confirm <code>thumbgate</code> is toggled on, then restart Codex after npm releases to pick up the latest runtime.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="wrap">
+    <div class="eyebrow">Operator questions</div>
+    <h2>What happens when I click thumbs up or thumbs down?</h2>
+    <div class="faq-list">
+      <div class="faq">
+        <h3>Is the MCP server always on?</h3>
+        <p>It is on when the Codex MCP settings toggle is enabled and the configured command can start successfully. In the Codex app, the blue toggle next to <code>thumbgate</code> is the visible check.</p>
+      </div>
+      <div class="faq">
+        <h3>Does bare feedback become a rule?</h3>
+        <p>No. Bare "thumbs down" is intentionally too vague for memory promotion. Add one concrete sentence about what went wrong, the file, command, or behavior to block next time.</p>
+      </div>
+      <div class="faq">
+        <h3>Where is the direct asset?</h3>
+        <p>The standalone zip remains available at <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">GitHub Releases</a>. This page is the human install surface so users do not land on an unexplained file download.</p>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    ThumbGate MIT License. Pre-Action Gates, DPO-ready feedback, and local-first Codex enforcement.
+  </div>
+</footer>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -603,7 +603,7 @@ __GA_BOOTSTRAP__
       <div class="hero-secondary-ctas" style="display:flex;gap:10px;flex-wrap:wrap;justify-content:center;margin-top:8px;opacity:0.7;">
         <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('hero_claude_extension_click',{cta:'install_claude_extension'})" style="font-size:12px;padding:8px 16px;background:#d97706;color:#fff;box-shadow:none;">Install Claude Extension</a>
         <a href="/go/github?utm_source=website&utm_medium=hero_cta&utm_campaign=github_repo&cta_id=hero_star_github&cta_placement=hero" target="_blank" rel="noopener" class="btn-free" style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:999px;font-size:12px;">⭐ Star on GitHub</a>
-        <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" class="btn-install-link" target="_blank" rel="noopener" onclick="posthog.capture('hero_codex_plugin_click',{cta:'install_codex_plugin'})" style="font-size:11px;color:var(--text-muted);text-decoration:none;padding:6px 10px;">Install Codex plugin →</a>
+        <a href="/codex-plugin?utm_source=website&utm_medium=hero_cta&utm_campaign=codex_plugin&cta_id=hero_codex_plugin&cta_placement=hero" class="btn-install-link" onclick="posthog.capture('hero_codex_plugin_click',{cta:'install_codex_plugin'})" style="font-size:11px;color:var(--text-muted);text-decoration:none;padding:6px 10px;">Install Codex plugin →</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/plugins/cursor-marketplace" class="btn-install-link" target="_blank" rel="noopener" onclick="posthog.capture('hero_cursor_plugin_click',{cta:'install_cursor_plugin'})" style="font-size:11px;color:var(--text-muted);text-decoration:none;padding:6px 10px;">Install Cursor plugin →</a>
         <a href="/go/gpt?utm_source=website&utm_medium=hero_cta&utm_campaign=chatgpt_gpt&cta_id=hero_open_gpt&cta_placement=hero" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('hero_cta_click',{cta:'open_gpt'})" style="font-size:11px;padding:6px 12px;background:transparent;border:1px solid rgba(74,222,128,0.3);color:var(--green);">Open ThumbGate GPT</a>
       </div>
@@ -628,7 +628,7 @@ __GA_BOOTSTRAP__
       <div class="first-gate-steps">
         <div class="first-gate-step">
           <strong>1. Install ThumbGate</strong>
-          <p>Run <code>npx thumbgate init</code> in your repo. Or install the <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" style="color:var(--cyan);">Claude Extension</a>, <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" style="color:var(--cyan);">Codex plugin</a>, <a href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/plugins/cursor-marketplace" style="color:var(--cyan);">Cursor plugin</a>, or <a href="/go/gpt" style="color:var(--cyan);">open the GPT</a>. Native ChatGPT rating buttons are not the ThumbGate capture path.</p>
+          <p>Run <code>npx thumbgate init</code> in your repo. Or install the <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" style="color:var(--cyan);">Claude Extension</a>, <a href="/codex-plugin" style="color:var(--cyan);">Codex plugin</a>, <a href="https://github.com/IgorGanapolsky/ThumbGate/tree/main/plugins/cursor-marketplace" style="color:var(--cyan);">Cursor plugin</a>, or <a href="/go/gpt" style="color:var(--cyan);">open the GPT</a>. Native ChatGPT rating buttons are not the ThumbGate capture path.</p>
         </div>
         <div class="first-gate-step">
           <strong>2. Give feedback</strong>
@@ -648,7 +648,7 @@ __GA_BOOTSTRAP__
       <span class="dot"></span>
       <a href="/guide" rel="noopener">CLI setup guide →</a>
       <span class="dot"></span>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener">Codex plugin download →</a>
+      <a href="/codex-plugin?utm_source=website&utm_medium=proof_bar&utm_campaign=codex_plugin&cta_id=proof_bar_codex_plugin&cta_placement=proof_bar">Codex plugin setup →</a>
       <span class="dot"></span>
       <a href="/go/gpt?utm_source=website&utm_medium=proof_bar&utm_campaign=chatgpt_gpt&cta_id=proof_bar_open_gpt&cta_placement=proof_bar" target="_blank" rel="noopener">ThumbGate GPT →</a>
       <span class="dot"></span>
@@ -793,10 +793,10 @@ __GA_BOOTSTRAP__
         <p>Claude Code, Codex, Gemini CLI, Amp, and OpenCode all use the same gateway and memory model. Any MCP-compatible agent gets pre-action gates, feedback memory, and enforcement out of the box.</p>
         <div class="card-arrow">Open the setup guide →</div>
       </a>
-      <a class="compat-card" href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener" onclick="if(typeof posthog!=='undefined')posthog.capture('compat_codex_plugin_click',{cta:'download_codex_plugin'})">
+      <a class="compat-card" href="/codex-plugin?utm_source=website&utm_medium=compatibility&utm_campaign=codex_plugin&cta_id=compat_codex_plugin&cta_placement=compatibility" rel="noopener" onclick="if(typeof posthog!=='undefined')posthog.capture('compat_codex_plugin_click',{cta:'open_codex_plugin_page'})">
         <h3>🧩 Codex plugin</h3>
-        <p>Codex ships with a published standalone ThumbGate plugin bundle plus a repo-local plugin profile. Download the zip, extract it, and install without wiring MCP by hand. <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/INSTALL.md" target="_blank" rel="noopener" style="color:var(--text-muted);text-decoration:underline;" onclick="event.stopPropagation();">Setup instructions →</a></p>
-        <div class="card-arrow">Download the Codex plugin →</div>
+        <p>Codex gets a standalone ThumbGate plugin bundle, a repo-local plugin profile, and the same auto-updating MCP launcher. The runtime resolves <code>thumbgate@latest</code> when Codex starts, so npm fixes reach active installs. <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener" style="color:var(--text-muted);text-decoration:underline;" onclick="event.stopPropagation();">Direct zip →</a></p>
+        <div class="card-arrow">Open the Codex install page →</div>
       </a>
       <a class="compat-card" href="/guides/cursor-prevent-repeated-mistakes.html" rel="noopener">
         <h3>🎯 Cursor plugin</h3>

--- a/scripts/auto-wire-hooks.js
+++ b/scripts/auto-wire-hooks.js
@@ -17,6 +17,11 @@ const fs = require('fs');
 const path = require('path');
 const {
   cacheUpdateHookCommand,
+  codexCacheUpdateHookCommand,
+  codexPreToolHookCommand,
+  codexSessionStartHookCommand,
+  codexStatuslineCommand,
+  codexUserPromptHookCommand,
   preToolHookCommand,
   sessionStartHookCommand,
   statuslineCommand,
@@ -48,17 +53,17 @@ const CLAUDE_HOOKS = {
 const CODEX_HOOKS = {
   PreToolUse: {
     matcher: 'Bash',
-    hooks: [{ type: 'command', command: preToolHookCommand() }],
+    hooks: [{ type: 'command', command: codexPreToolHookCommand() }],
   },
   UserPromptSubmit: {
-    hooks: [{ type: 'command', command: userPromptHookCommand() }],
+    hooks: [{ type: 'command', command: codexUserPromptHookCommand() }],
   },
   PostToolUse: {
     matcher: 'mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard',
-    hooks: [{ type: 'command', command: cacheUpdateHookCommand() }],
+    hooks: [{ type: 'command', command: codexCacheUpdateHookCommand() }],
   },
   SessionStart: {
-    hooks: [{ type: 'command', command: sessionStartHookCommand() }],
+    hooks: [{ type: 'command', command: codexSessionStartHookCommand() }],
   },
 };
 
@@ -459,7 +464,7 @@ function syncCodexStatusLine(config, desiredStatusLine) {
 function wireCodexHooks(options) {
   const configPath = options.settingsPath || codexConfigPath();
   const dryRun = options.dryRun || false;
-  const desiredStatusLine = statuslineCommand();
+  const desiredStatusLine = codexStatuslineCommand();
 
   let config = loadJsonFile(configPath) || {};
   config.hooks = config.hooks || {};

--- a/scripts/hook-runtime.js
+++ b/scripts/hook-runtime.js
@@ -44,8 +44,23 @@ function resolveCliBaseCommand() {
   return publishedCliShellCommand(version);
 }
 
+function resolveCodexCliBaseCommand() {
+  const version = packageVersion();
+  if (publishedHookCommandsAvailable(version)) {
+    return publishedCliShellCommand('latest', [], { preferInstalled: false });
+  }
+  if (isSourceCheckout(PKG_ROOT)) {
+    return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))}`;
+  }
+  return publishedCliShellCommand('latest', [], { preferInstalled: false });
+}
+
 function buildPortableHookCommand(subcommand) {
   return `${resolveCliBaseCommand()} ${subcommand}`;
+}
+
+function buildCodexPortableHookCommand(subcommand) {
+  return `${resolveCodexCliBaseCommand()} ${subcommand}`;
 }
 
 function preToolHookCommand() {
@@ -68,12 +83,39 @@ function statuslineCommand() {
   return buildPortableHookCommand('statusline-render');
 }
 
+function codexPreToolHookCommand() {
+  return buildCodexPortableHookCommand('gate-check');
+}
+
+function codexUserPromptHookCommand() {
+  return buildCodexPortableHookCommand('hook-auto-capture');
+}
+
+function codexSessionStartHookCommand() {
+  return buildCodexPortableHookCommand('session-start');
+}
+
+function codexCacheUpdateHookCommand() {
+  return buildCodexPortableHookCommand('cache-update');
+}
+
+function codexStatuslineCommand() {
+  return buildCodexPortableHookCommand('statusline-render');
+}
+
 module.exports = {
   buildPortableHookCommand,
+  buildCodexPortableHookCommand,
   cacheUpdateHookCommand,
+  codexCacheUpdateHookCommand,
+  codexPreToolHookCommand,
+  codexSessionStartHookCommand,
+  codexStatuslineCommand,
+  codexUserPromptHookCommand,
   packageVersion,
   publishedHookCommandsAvailable,
   preToolHookCommand,
+  resolveCodexCliBaseCommand,
   resolveCliBaseCommand,
   sessionStartHookCommand,
   statuslineCommand,

--- a/scripts/mcp-config.js
+++ b/scripts/mcp-config.js
@@ -106,6 +106,17 @@ function portableMcpEntry(pkgVersion) {
   };
 }
 
+function codexAutoUpdateCliEntry(commandArgs = []) {
+  return {
+    command: 'sh',
+    args: ['-lc', publishedCliShellCommand('latest', commandArgs, { preferInstalled: false })],
+  };
+}
+
+function codexAutoUpdateMcpEntry() {
+  return codexAutoUpdateCliEntry(['serve']);
+}
+
 function localMcpEntry(pkgRoot, scope = 'project') {
   return {
     command: 'node',
@@ -201,4 +212,6 @@ module.exports = {
   resolveLocalServerPath,
   resolveMcpEntry,
   resolveStableSourceRoot,
+  codexAutoUpdateCliEntry,
+  codexAutoUpdateMcpEntry,
 };

--- a/scripts/published-cli.js
+++ b/scripts/published-cli.js
@@ -37,6 +37,14 @@ function publishedCliShellCommand(pkgVersion, commandArgs = [], options = {}) {
   const escapedArgs = commandArgs.map(shellQuote).join(' ');
   const fastPath = `[ -x ${shellQuote(runtimeBin)} ] && exec ${shellQuote(runtimeBin)}${escapedArgs ? ` ${escapedArgs}` : ''}`;
   const installPath = `mkdir -p ${shellQuote(prefixDir)} && exec npm ${publishedCliArgs(pkgVersion, commandArgs, { prefixDir }).map(shellQuote).join(' ')}`;
+  if (options.preferInstalled === false) {
+    const packageSpec = `thumbgate@${pkgVersion}`;
+    return [
+      `mkdir -p ${shellQuote(prefixDir)}`,
+      `npm "install" "--prefix" ${shellQuote(prefixDir)} "--no-save" "--omit=dev" ${shellQuote(packageSpec)} >/dev/null 2>&1`,
+      `exec ${shellQuote(runtimeBin)}${escapedArgs ? ` ${escapedArgs}` : ''}`,
+    ].join(' && ');
+  }
   return `${fastPath} || ${installPath}`;
 }
 

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -219,6 +219,7 @@ const PRO_PAGE_PATH = path.resolve(__dirname, '../../public/pro.html');
 const DASHBOARD_PAGE_PATH = path.resolve(__dirname, '../../public/dashboard.html');
 const LESSONS_PAGE_PATH = path.resolve(__dirname, '../../public/lessons.html');
 const GUIDE_PAGE_PATH = path.resolve(__dirname, '../../public/guide.html');
+const CODEX_PLUGIN_PAGE_PATH = path.resolve(__dirname, '../../public/codex-plugin.html');
 const COMPARE_PAGE_PATH = path.resolve(__dirname, '../../public/compare.html');
 const LEARN_PAGE_PATH = path.resolve(__dirname, '../../public/learn.html');
 const LEARN_DIR = path.resolve(__dirname, '../../public/learn');
@@ -1903,6 +1904,7 @@ function renderSitemapXml(runtimeConfig) {
     // so search engines don't chase the 301 instead of indexing the canonical
     // homepage directly.
     { path: '/llm-context.md', changefreq: 'weekly', priority: '0.8' },
+    { path: '/codex-plugin', changefreq: 'weekly', priority: '0.75' },
     ...THUMBGATE_SEO_SITEMAP_ENTRIES,
   ];
   return [
@@ -3482,6 +3484,16 @@ async function addContext(){
       return;
     }
 
+    if (isGetLikeRequest && pathname === '/codex-plugin') {
+      try {
+        const html = fs.readFileSync(CODEX_PLUGIN_PAGE_PATH, 'utf-8');
+        sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
+      } catch {
+        sendJson(res, 404, { error: 'Codex plugin page not found' });
+      }
+      return;
+    }
+
     if (isGetLikeRequest && pathname === '/compare') {
       try {
         const html = fs.readFileSync(COMPARE_PAGE_PATH, 'utf-8');
@@ -3592,7 +3604,7 @@ async function addContext(){
           version: pkg.version,
           status: 'ok',
           docs: 'https://github.com/IgorGanapolsky/ThumbGate',
-          endpoints: ['/health', '/dashboard', '/guide', '/compare', '/learn', '/v1/feedback/capture', '/v1/feedback/stats', '/v1/feedback/summary', '/v1/lessons/search', '/v1/search', '/v1/documents', '/v1/documents/import', '/v1/documents/{documentId}', '/v1/dashboard', '/v1/dashboard/render-spec', '/v1/decisions/evaluate', '/v1/decisions/outcome', '/v1/decisions/metrics', '/v1/settings/status', '/v1/dpo/export', '/v1/jobs', '/v1/jobs/harness', '/v1/analytics/databricks/export'],
+          endpoints: ['/health', '/dashboard', '/guide', '/codex-plugin', '/compare', '/learn', '/v1/feedback/capture', '/v1/feedback/stats', '/v1/feedback/summary', '/v1/lessons/search', '/v1/search', '/v1/documents', '/v1/documents/import', '/v1/documents/{documentId}', '/v1/dashboard', '/v1/dashboard/render-spec', '/v1/decisions/evaluate', '/v1/decisions/outcome', '/v1/decisions/metrics', '/v1/settings/status', '/v1/dpo/export', '/v1/jobs', '/v1/jobs/harness', '/v1/analytics/databricks/export'],
         }, {}, {
           headOnly: isHeadRequest,
         });

--- a/tests/adapters.test.js
+++ b/tests/adapters.test.js
@@ -14,6 +14,16 @@ const packageVersion = JSON.parse(fs.readFileSync(path.join(root, 'package.json'
 const explicitServeArgs = ['--yes', '--package', `thumbgate@${packageVersion}`, 'thumbgate', 'serve'];
 const explicitLatestServeArgs = ['--yes', '--package', 'thumbgate@latest', 'thumbgate', 'serve'];
 
+function assertCodexLatestShellEntry(entry) {
+  assert.equal(entry.command, 'sh');
+  assert.deepEqual(entry.args.slice(0, 1), ['-lc']);
+  assert.match(entry.args[1], /thumbgate@latest/);
+  assert.match(entry.args[1], /thumbgate/);
+  assert.match(entry.args[1], /serve/);
+  assert.match(entry.args[1], /\.thumbgate\/runtime/);
+  assert.doesNotMatch(entry.args[1], /\[ -x /);
+}
+
 test('adapter files exist', () => {
   const files = [
     'adapters/chatgpt/openapi.yaml',
@@ -81,12 +91,13 @@ test('codex config.toml contains mcp_servers section', () => {
   const content = fs.readFileSync(filePath, 'utf-8');
   assert.match(content, /\[mcp_servers\.thumbgate\]/, 'config.toml must contain canonical thumbgate section');
   
-  if (content.includes('command = "npx"')) {
-    assert.match(
-      content,
-      new RegExp(`args = \\["--yes", "--package", "thumbgate@${packageVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}", "thumbgate", "serve"\\]`),
-      'config.toml must launch the version-pinned package serve entrypoint'
-    );
+  if (content.includes('thumbgate@latest')) {
+    assert.match(content, /command = "sh"/);
+    assert.match(content, /npm \\"install\\"/);
+    assert.match(content, /node_modules\/\.bin\/thumbgate/);
+    assert.doesNotMatch(content, /\[ -x /);
+  } else if (content.includes('command = "npx"')) {
+    assert.match(content, new RegExp(`thumbgate@${packageVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
   } else {
     assert.match(content, /command = "node"/);
     assert.match(content, /"serve"/);
@@ -277,14 +288,19 @@ test('claude .mcp.json ThumbGate command is either npx or node', () => {
   }
 });
 
-test('codex config.toml uses either npx or node command', () => {
+test('codex config.toml uses npx, node, or latest-resolving shell command', () => {
   const filePath = path.join(root, 'adapters/codex/config.toml');
   const content = fs.readFileSync(filePath, 'utf-8');
   const usesNpx = content.includes('command = "npx"');
   const usesNode = content.includes('command = "node"');
-  assert.ok(usesNpx || usesNode, 'should use npx or node');
+  const usesShell = content.includes('command = "sh"');
+  assert.ok(usesNpx || usesNode || usesShell, 'should use npx, node, or sh');
   if (usesNode) {
     assert.match(content, /"serve"/, 'node command should include serve');
+  }
+  if (usesShell) {
+    assert.match(content, /thumbgate@latest/, 'shell command should resolve latest npm release');
+    assert.doesNotMatch(content, /\[ -x /, 'shell command should not prefer a stale installed runtime');
   }
 });
 
@@ -301,7 +317,7 @@ test('codex app plugin surface is present and aligned to ThumbGate metadata', ()
   assert.equal(pluginManifest.mcpServers, './.mcp.json');
   assert.ok(pluginEntry, 'codex plugin marketplace entry should exist');
   assert.equal(pluginEntry.source.path, './plugins/codex-profile');
-  assert.deepEqual(pluginConfig.mcpServers.thumbgate.args, explicitServeArgs);
+  assertCodexLatestShellEntry(pluginConfig.mcpServers.thumbgate);
 });
 
 test('Claude Codex bridge plugin surface is present and aligned to ThumbGate metadata', () => {

--- a/tests/auto-wire-hooks.test.js
+++ b/tests/auto-wire-hooks.test.js
@@ -323,11 +323,11 @@ describe('auto-wire-hooks', () => {
         assert.ok(config.hooks.PostToolUse);
         assert.ok(config.hooks.SessionStart);
         assert.ok(config.statusLine);
-        assert.equal(config.hooks.PreToolUse[0].hooks[0].command, preToolHookCommand());
-        assert.equal(config.hooks.UserPromptSubmit[0].hooks[0].command, userPromptHookCommand());
-        assert.equal(config.hooks.PostToolUse[0].hooks[0].command, require('../scripts/hook-runtime').cacheUpdateHookCommand());
-        assert.equal(config.hooks.SessionStart[0].hooks[0].command, sessionStartHookCommand());
-        assert.equal(config.statusLine.command, require('../scripts/hook-runtime').statuslineCommand());
+        assert.equal(config.hooks.PreToolUse[0].hooks[0].command, require('../scripts/hook-runtime').codexPreToolHookCommand());
+        assert.equal(config.hooks.UserPromptSubmit[0].hooks[0].command, require('../scripts/hook-runtime').codexUserPromptHookCommand());
+        assert.equal(config.hooks.PostToolUse[0].hooks[0].command, require('../scripts/hook-runtime').codexCacheUpdateHookCommand());
+        assert.equal(config.hooks.SessionStart[0].hooks[0].command, require('../scripts/hook-runtime').codexSessionStartHookCommand());
+        assert.equal(config.statusLine.command, require('../scripts/hook-runtime').codexStatuslineCommand());
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
@@ -365,7 +365,7 @@ describe('auto-wire-hooks', () => {
 
         const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
         assert.equal(config.hooks.PreToolUse.length, 1);
-        assert.equal(config.hooks.PreToolUse[0].hooks[0].command, preToolHookCommand());
+        assert.equal(config.hooks.PreToolUse[0].hooks[0].command, require('../scripts/hook-runtime').codexPreToolHookCommand());
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
@@ -388,11 +388,11 @@ describe('auto-wire-hooks', () => {
         assert.equal(result.changed, true);
         assert.deepStrictEqual(result.added, [{
           lifecycle: 'statusLine',
-          command: require('../scripts/hook-runtime').statuslineCommand(),
+          command: require('../scripts/hook-runtime').codexStatuslineCommand(),
         }]);
 
         const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-        assert.equal(config.statusLine.command, require('../scripts/hook-runtime').statuslineCommand());
+        assert.equal(config.statusLine.command, require('../scripts/hook-runtime').codexStatuslineCommand());
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -66,6 +66,13 @@ function assertLocalTomlMcpBlock(content, expectedPath = MCP_SERVER_PATH) {
   assert.match(content, new RegExp(escapeRegExp(expectedPath)));
 }
 
+function assertLocalCodexPreToolHook(content) {
+  assert.match(content, /\[hooks\.pre_tool_use\]/);
+  assert.match(content, /command = "node"/);
+  assert.match(content, new RegExp(escapeRegExp(path.join(PKG_ROOT, 'bin', 'cli.js'))));
+  assert.match(content, /"gate-check"/);
+}
+
 function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -1848,6 +1855,7 @@ describe('bin/cli.js', () => {
     const configPath = path.join(codexHome, 'config.toml');
     const content = fs.readFileSync(configPath, 'utf8');
     assertLocalTomlMcpBlock(content, HOME_MCP_SERVER_PATH);
+    assertLocalCodexPreToolHook(content);
     assert.doesNotMatch(content, /\/tmp\/disposable-worktree\/adapters\/mcp\/server-stdio\.js/);
     const hooksPath = path.join(codexHome, 'config.json');
     const hooksConfig = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
@@ -1873,7 +1881,7 @@ describe('bin/cli.js', () => {
     fs.mkdirSync(codexHome, { recursive: true });
     fs.writeFileSync(
       configPath,
-      '[mcp_servers.thumbgate]\ncommand = "node"\nargs = ["/tmp/disposable-worktree/adapters/mcp/server-stdio.js"]\n'
+      '[hooks.pre_tool_use]\ncommand = "sh"\nargs = ["-lc", "npx --yes --package thumbgate@1.4.6 thumbgate gate-check"]\n\n[mcp_servers.thumbgate]\ncommand = "node"\nargs = ["/tmp/disposable-worktree/adapters/mcp/server-stdio.js"]\n'
     );
 
     const result = runCliSync(['init'], {
@@ -1890,7 +1898,9 @@ describe('bin/cli.js', () => {
 
     const content = fs.readFileSync(configPath, 'utf8');
     assertLocalTomlMcpBlock(content, HOME_MCP_SERVER_PATH);
+    assertLocalCodexPreToolHook(content);
     assert.doesNotMatch(content, /disposable-worktree/);
+    assert.doesNotMatch(content, /thumbgate@1\.4\.6/);
     const hooksPath = path.join(codexHome, 'config.json');
     const hooksConfig = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
     assert.equal(

--- a/tests/codex-plugin.test.js
+++ b/tests/codex-plugin.test.js
@@ -23,6 +23,16 @@ function readJson(relativePath) {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf-8'));
 }
 
+function assertCodexLatestShellEntry(entry) {
+  assert.equal(entry.command, 'sh');
+  assert.deepEqual(entry.args.slice(0, 1), ['-lc']);
+  assert.match(entry.args[1], /thumbgate@latest/);
+  assert.match(entry.args[1], /\.thumbgate\/runtime/);
+  assert.match(entry.args[1], /thumbgate/);
+  assert.match(entry.args[1], /serve/);
+  assert.doesNotMatch(entry.args[1], /\[ -x /);
+}
+
 test('codex plugin marketplace points at the shipped codex profile', () => {
   const marketplace = readJson('.agents/plugins/marketplace.json');
   const plugin = readJson('plugins/codex-profile/.codex-plugin/plugin.json');
@@ -48,13 +58,15 @@ test('codex plugin manifest uses ThumbGate branding and local MCP config', () =>
   assert.equal(plugin.homepage, 'https://thumbgate-production.up.railway.app');
   assert.equal(plugin.repository, 'https://github.com/IgorGanapolsky/ThumbGate');
   assert.equal(plugin.mcpServers, './.mcp.json');
-  assert.deepEqual(mcpConfig.mcpServers.thumbgate.args, ['--yes', '--package', `thumbgate@${packageJson.version}`, 'thumbgate', 'serve']);
+  assertCodexLatestShellEntry(mcpConfig.mcpServers.thumbgate);
   assert.match(readme, /standalone Codex plugin bundle/i);
+  assert.match(readme, /auto-refreshes the Codex MCP\/hook runtime/i);
   assert.match(readme, new RegExp(getCodexPluginLatestDownloadUrl(root).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.match(readme, /build:codex-plugin/i);
   assert.match(readme, /Pre-Action Gates/i);
   assert.match(install, /thumbgate-codex-plugin\.zip/i);
   assert.match(install, /build:codex-plugin/i);
+  assert.match(install, /thumbgate@latest/i);
   assert.match(install, /marketplace catalog points at `\.\/`/i);
 });
 
@@ -62,7 +74,8 @@ test('root README promotes the Codex plugin as a first-class install path', () =
   const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf-8');
 
   assert.match(readme, /Install Codex Plugin/);
-  assert.match(readme, /Download the standalone Codex plugin bundle/i);
+  assert.match(readme, /Open the Codex plugin install page/i);
+  assert.match(readme, /thumbgate-production\.up\.railway\.app\/codex-plugin/i);
   assert.match(readme, /plugins\/codex-profile\/INSTALL\.md/);
   assert.match(readme, new RegExp(getCodexPluginLatestDownloadUrl(root).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 });
@@ -101,13 +114,15 @@ test('codex plugin staging writes a standalone bundle with self-contained market
     const configToml = fs.readFileSync(configTomlPath, 'utf8');
 
     assert.equal(plugin.version, packageJson.version);
-    assert.deepEqual(mcpConfig.mcpServers.thumbgate.args, ['--yes', '--package', `thumbgate@${packageJson.version}`, 'thumbgate', 'serve']);
+    assertCodexLatestShellEntry(mcpConfig.mcpServers.thumbgate);
     assert.equal(marketplace.plugins[0].source.path, './');
     assert.match(readme, /thumbgate-codex-plugin\.zip/i);
     assert.match(readme, /build:codex-plugin/i);
     assert.match(readme, /self-contained plugin root/i);
+    assert.match(readme, /auto-updating manual MCP profile/i);
     assert.match(install, /standalone release bundle/i);
-    assert.match(configToml, new RegExp(`thumbgate@${packageJson.version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+    assert.match(configToml, /thumbgate@latest/);
+    assert.doesNotMatch(configToml, /\[ -x /);
   } finally {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -231,7 +231,7 @@ describe('Pro tier bullets: code-backed claims', () => {
 
   test('compat cards that do NOT promise a download must link to a guide or real directory — never to a GitHub source browser', () => {
     // Rule: if the card does NOT promise a download, the outer href must be
-    //   (a) a local /guide.html or /guides/*.html page, or
+    //   (a) a local /guide.html, /guides/*.html, or dedicated install page, or
     //   (b) a real external directory/listing (mcp.so, chatgpt.com, npmjs.com,
     //       pulsemcp.com, smithery.ai, cursor.directory), or
     //   (c) an internal redirect like /go/gpt.
@@ -259,14 +259,15 @@ describe('Pro tier bullets: code-backed claims', () => {
       if (promisesDownload) continue;
 
       const isLocalGuide = /^\/guide(s)?(\.html|\/)/.test(outerHref);
+      const isLocalInstallPage = /^\/codex-plugin(?:[?#]|$)/.test(outerHref);
       const isInternalRedirect = /^\/go\//.test(outerHref);
       const isAllowedDirectory = allowedExternalDirectories.some((d) =>
         outerHref.includes(`://${d}`) || outerHref.includes(`://www.${d}`),
       );
 
       assert.ok(
-        isLocalGuide || isInternalRedirect || isAllowedDirectory,
-        `Non-download card (arrow: "${cardArrow.trim()}") has href "${outerHref}" — must link to /guide.html, /guides/*, /go/*, or a real external directory (mcp.so, chatgpt.com, npmjs.com, etc.), NOT a GitHub source browser`,
+        isLocalGuide || isLocalInstallPage || isInternalRedirect || isAllowedDirectory,
+        `Non-download card (arrow: "${cardArrow.trim()}") has href "${outerHref}" — must link to /guide.html, /guides/*, /codex-plugin, /go/*, or a real external directory (mcp.so, chatgpt.com, npmjs.com, etc.), NOT a GitHub source browser`,
       );
 
       assert.doesNotMatch(

--- a/tests/mcp-config.test.js
+++ b/tests/mcp-config.test.js
@@ -6,6 +6,8 @@ const {
   parseWorktreePaths,
   publishedCliAvailable,
   portableMcpEntry,
+  codexAutoUpdateCliEntry,
+  codexAutoUpdateMcpEntry,
   localMcpEntry,
   resolveLocalServerPath,
   resolveStableSourceRoot,
@@ -32,6 +34,26 @@ describe('mcp-config', () => {
     assert.match(entry.args[1], /thumbgate/);
     assert.match(entry.args[1], /serve/);
     assert.match(entry.args[1], /\.thumbgate\/runtime/);
+  });
+
+  it('codexAutoUpdateMcpEntry returns a latest-resolving shell wrapper without the stale binary fast path', () => {
+    const entry = codexAutoUpdateMcpEntry();
+    assert.strictEqual(entry.command, 'sh');
+    assert.deepStrictEqual(entry.args.slice(0, 1), ['-lc']);
+    assert.match(entry.args[1], /thumbgate@latest/);
+    assert.match(entry.args[1], /thumbgate/);
+    assert.match(entry.args[1], /serve/);
+    assert.match(entry.args[1], /\.thumbgate\/runtime/);
+    assert.doesNotMatch(entry.args[1], /\[ -x /);
+  });
+
+  it('codexAutoUpdateCliEntry supports hook commands with the same latest-resolving policy', () => {
+    const entry = codexAutoUpdateCliEntry(['gate-check']);
+    assert.strictEqual(entry.command, 'sh');
+    assert.match(entry.args[1], /thumbgate@latest/);
+    assert.match(entry.args[1], /gate-check/);
+    assert.match(entry.args[1], /npm "install"/);
+    assert.doesNotMatch(entry.args[1], /\[ -x /);
   });
 
   it('localMcpEntry returns node command pointing to server-stdio.js', () => {

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const landingPagePath = path.join(__dirname, '..', 'public', 'index.html');
+const codexPluginPagePath = path.join(__dirname, '..', 'public', 'codex-plugin.html');
 const buyerIntentScriptPath = path.join(__dirname, '..', 'public', 'js', 'buyer-intent.js');
 
 function readLandingPage() {
@@ -12,6 +13,10 @@ function readLandingPage() {
 
 function readBuyerIntentScript() {
   return fs.readFileSync(buyerIntentScriptPath, 'utf8');
+}
+
+function readCodexPluginPage() {
+  return fs.readFileSync(codexPluginPagePath, 'utf8');
 }
 
 test('public landing page keeps FAQPage JSON-LD parity for SEO and GEO', () => {
@@ -339,15 +344,24 @@ test('public landing page advertises the Codex standalone plugin install path', 
   const landingPage = readLandingPage();
 
   assert.match(landingPage, /Codex plugin/i);
-  // Arrow copy was "Codex plugin download →" / "Get the Codex plugin →" in
-  // older drafts; shipped copy is "Download the Codex plugin →". Assert on
-  // intent: any download-verbed Codex arrow works.
-  assert.match(landingPage, /(Download|Get) the Codex plugin →|Codex plugin download →/);
-  assert.match(landingPage, /plugins\/codex-profile\/INSTALL\.md/);
-  // Primary download link goes directly to the release asset — this is what
-  // "advertises the install path" actually means now that we fixed cards to
-  // link to real downloads instead of INSTALL.md source.
+  assert.match(landingPage, /\/codex-plugin\?utm_source=website/);
+  assert.match(landingPage, /Open the Codex install page →/);
   assert.match(landingPage, /thumbgate-codex-plugin\.zip/);
+});
+
+test('public Codex plugin page explains install, direct download, and latest runtime policy', () => {
+  const codexPage = readCodexPluginPage();
+
+  assert.match(codexPage, /ThumbGate for Codex/);
+  assert.match(codexPage, /SoftwareApplication/);
+  assert.match(codexPage, /FAQPage/);
+  assert.match(codexPage, /thumbgate@latest/);
+  assert.match(codexPage, /npx thumbgate init --agent codex/);
+  assert.match(codexPage, /thumbgate-codex-plugin\.zip/);
+  assert.match(codexPage, /plugins\/codex-profile\/INSTALL\.md/);
+  assert.match(codexPage, /Pre-Action Gates/);
+  assert.match(codexPage, /Codex settings/);
+  assert.match(codexPage, /Bare "thumbs down" is intentionally too vague/);
 });
 
 test('public landing page FAQ defaults first item open for credibility', () => {

--- a/tests/published-cli.test.js
+++ b/tests/published-cli.test.js
@@ -19,6 +19,20 @@ test('publishedCliShellCommand prefers the installed runtime binary before npm e
   assert.match(command, /npm "exec"/);
 });
 
+test('publishedCliShellCommand can bypass the installed runtime for latest-resolving launchers', () => {
+  const prefixDir = runtimePrefixDir('/tmp/thumbgate-runtime');
+  const command = publishedCliShellCommand('latest', ['serve'], {
+    prefixDir,
+    preferInstalled: false,
+  });
+
+  assert.doesNotMatch(command, /\[ -x /);
+  assert.match(command, /thumbgate@latest/);
+  assert.match(command, /npm "install"/);
+  assert.match(command, /node_modules\/\.bin\/thumbgate/);
+  assert.match(command, /serve/);
+});
+
 test('installedRuntimeBin resolves within the runtime prefix directory', () => {
   const binPath = installedRuntimeBin('/tmp/thumbgate-runtime');
   assert.match(binPath, /\/tmp\/thumbgate-runtime\/node_modules\/\.bin\/thumbgate$/);


### PR DESCRIPTION
## Summary
- Make Codex MCP and hook launchers install `thumbgate@latest` into the local runtime cache before serving MCP or checking gates, so Codex no longer prefers a stale already-installed binary.
- Add the hosted `/codex-plugin` marketing/install page with SoftwareApplication + FAQPage schema, direct zip fallback, CLI setup, and explicit latest-runtime/thumbs feedback semantics.
- Update README, landing-page CTAs, plugin profile docs, distribution docs, and tests so the Codex plugin path points to the install page instead of silently downloading the zip from primary marketing links.

## Operator notes
- Local Codex config on this machine has been updated: `~/.codex/config.toml` and `~/.codex/config.json` now resolve `thumbgate@latest` for MCP, pre-tool gates, statusline, cache update, and session hooks.
- This is not published to npm yet. `npm view thumbgate version` is still `1.5.8`; publish happens only after merge/release.
- The settings toggle means the `thumbgate` MCP server is enabled for Codex, but the current session may still need a reload/restart before the app exposes the refreshed MCP tool surface.

## Verification
- `npm ci --onnxruntime-node-install-cuda=skip`
- `node --test tests/public-landing.test.js tests/landing-page-claims.test.js tests/public-package-parity.test.js tests/api-server.test.js tests/codex-plugin.test.js tests/published-cli.test.js tests/mcp-config.test.js tests/adapters.test.js tests/auto-wire-hooks.test.js tests/cli.test.js` (302 pass, 0 fail)
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters` (48 pass, 0 fail)
- `npm run prove:automation` (55 pass, 0 fail)
- `npm run self-heal:check` (HEALTHY, 6/6 healthy)
- `git diff --check`
- pre-commit guards: package parity, version sync, congruence, landing-page claims
- pre-push guards: npm pack dry-run, public HTML link validation, regression guards
