### PR TITLE
fix: make proof links clickable

### DIFF
--- a/.changeset/proof-links-thumbs-up.md
+++ b/.changeset/proof-links-thumbs-up.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Make the landing-page proof-bar links individually clickable with padded hit targets and keyboard focus states, and show both thumbs-up reinforcement and thumbs-down correction examples in the first-dollar activation path.

--- a/public/index.html
+++ b/public/index.html
@@ -310,13 +310,17 @@ __GA_BOOTSTRAP__
   .first-gate-step { border: 1px solid var(--border); border-radius: 10px; background: rgba(10,10,11,0.62); padding: 14px; }
   .first-gate-step strong { display: block; color: var(--cyan); margin-bottom: 6px; }
   .first-gate-step p { font-size: 13px; line-height: 1.5; margin: 0; }
-  .first-gate-example { font-family: var(--mono); color: var(--green); background: rgba(74,222,128,0.08); border: 1px solid rgba(74,222,128,0.24); border-radius: 8px; padding: 10px 12px; font-size: 12px; margin-top: 12px; overflow-x: auto; }
+  .first-gate-examples { display: grid; gap: 8px; margin-top: 12px; }
+  .first-gate-example { font-family: var(--mono); border-radius: 8px; padding: 10px 12px; font-size: 12px; overflow-x: auto; line-height: 1.55; }
+  .first-gate-example.signal-good { color: var(--green); background: rgba(74,222,128,0.08); border: 1px solid rgba(74,222,128,0.24); }
+  .first-gate-example.signal-fix { color: #fda4af; background: rgba(251,113,133,0.08); border: 1px solid rgba(251,113,133,0.24); }
 
   /* SOCIAL PROOF BAR */
-  .proof-bar { display: flex; justify-content: center; flex-wrap: wrap; gap: 24px; font-size: 13px; color: var(--text-muted); padding: 0 0 8px; }
-  .proof-bar a { display: inline-flex; align-items: center; gap: 6px; color: var(--text-muted); text-decoration: none; transition: color 0.15s; }
-  .proof-bar a:hover { color: var(--cyan); }
-  .proof-bar .dot { width: 4px; height: 4px; background: var(--border); border-radius: 50%; display: inline-block; }
+  .proof-bar { display: flex; justify-content: center; flex-wrap: wrap; gap: 10px; font-size: 13px; color: var(--text-muted); padding: 4px 0 12px; max-width: 1040px; margin: 0 auto; }
+  .proof-bar a { display: inline-flex; align-items: center; justify-content: center; min-height: 36px; padding: 8px 12px; border: 1px solid rgba(34,211,238,0.14); border-radius: 8px; background: rgba(17,17,19,0.72); color: var(--text-muted); text-decoration: none; line-height: 1.25; white-space: nowrap; transition: color 0.15s, border-color 0.15s, background-color 0.15s; }
+  .proof-bar a:hover, .proof-bar a:focus-visible { color: var(--cyan); border-color: rgba(34,211,238,0.42); background: rgba(34,211,238,0.08); outline: none; }
+  .proof-bar a:focus-visible { box-shadow: 0 0 0 3px rgba(34,211,238,0.18); }
+  .proof-bar .dot { display: none; }
 
   /* COMPATIBILITY */
   .compatibility { padding: 0 0 80px; }
@@ -470,7 +474,7 @@ __GA_BOOTSTRAP__
   #claude-code-section:hover, #thumbgate-gpt:hover { opacity: 1; }
   
   /* Simplify proof bar — make it less overwhelming */
-  .proof-bar { font-size: 11px; gap: 16px; opacity: 0.8; }
+  .proof-bar { font-size: 13px; gap: 10px; opacity: 1; }
   
   /* RESPONSIVE */
   @media (max-width: 700px) {
@@ -485,7 +489,8 @@ __GA_BOOTSTRAP__
     .hero-actions { flex-direction: column; }
     .hero-actions a { width: 100%; }
     .nav-links a:not(.nav-cta) { display: none; }
-    .proof-bar { gap: 16px; }
+    .proof-bar { gap: 8px; justify-content: flex-start; }
+    .proof-bar a { width: 100%; min-height: 42px; white-space: normal; }
     .proof-bar .dot { display: none; }
   }
 </style>
@@ -632,40 +637,32 @@ __GA_BOOTSTRAP__
         </div>
         <div class="first-gate-step">
           <strong>2. Give feedback</strong>
-          <p>When your agent makes a mistake, give it a <code>thumbs down</code>. ThumbGate captures the context and distills a lesson from up to 8 prior entries.</p>
+          <p>Give <code>thumbs up</code> when the agent follows your standards, or <code>thumbs down</code> when it misses. ThumbGate captures the context and distills a lesson from up to 8 prior entries.</p>
         </div>
         <div class="first-gate-step">
           <strong>3. The gate blocks the repeat</strong>
           <p>Next time the agent tries the same mistake, the PreToolUse hook fires and physically blocks it. Upgrade after one real blocked repeat when you need the dashboard and exports.</p>
         </div>
       </div>
-      <div class="first-gate-example">thumbs down: the answer ignored my request for exact files and tests; next time include file paths, commands, and verification evidence.</div>
+      <div class="first-gate-examples" aria-label="ThumbGate feedback examples">
+        <div class="first-gate-example signal-good">thumbs up: this review named exact files, commands, and tests; repeat this evidence-first format.</div>
+        <div class="first-gate-example signal-fix">thumbs down: the answer ignored my request for exact files and tests; next time include file paths, commands, and verification evidence.</div>
+      </div>
     </div>
-    <div class="proof-bar">
+    <nav class="proof-bar" aria-label="ThumbGate install and proof links">
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" style="color:var(--cyan);font-weight:600;">Claude Extension →</a>
-      <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/.claude-plugin/README.md" target="_blank" rel="noopener">Claude marketplace install →</a>
-      <span class="dot"></span>
       <a href="/guide" rel="noopener">CLI setup guide →</a>
-      <span class="dot"></span>
       <a href="/codex-plugin?utm_source=website&utm_medium=proof_bar&utm_campaign=codex_plugin&cta_id=proof_bar_codex_plugin&cta_placement=proof_bar">Codex plugin setup →</a>
-      <span class="dot"></span>
       <a href="/go/gpt?utm_source=website&utm_medium=proof_bar&utm_campaign=chatgpt_gpt&cta_id=proof_bar_open_gpt&cta_placement=proof_bar" target="_blank" rel="noopener">ThumbGate GPT →</a>
-      <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence →</a>
-      <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/THUMBGATE_BENCH.md" target="_blank" rel="noopener">ThumbGate Bench →</a>
-      <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">Proof-backed CI →</a>
-      <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">CI and proof lanes →</a>
-      <span class="dot"></span>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/RELEASE_CONFIDENCE.md" target="_blank" rel="noopener">Release confidence →</a>
-      <span class="dot"></span>
       <a href="https://www.producthunt.com/products/thumbgate" target="_blank" rel="noopener">Product Hunt →</a>
-      <span class="dot"></span>
       <a href="#compatibility">Claude Code · Cursor · Codex · Gemini · Amp · OpenCode</a>
-    </div>
+    </nav>
   </div>
 </section>
 

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -182,8 +182,22 @@ test('public landing page gives cold users a first-dollar activation path', () =
   assert.match(landingPage, /First-Dollar Activation Path/i);
   assert.match(landingPage, /Prove one blocked repeat before asking anyone to buy/i);
   assert.match(landingPage, /Native ChatGPT rating buttons are not the ThumbGate capture path/i);
+  assert.match(landingPage, /Give <code>thumbs up<\/code> when the agent follows your standards/i);
+  assert.match(landingPage, /thumbs up: this review named exact files/i);
   assert.match(landingPage, /thumbs down: the answer ignored my request/i);
   assert.match(landingPage, /Upgrade after one real blocked repeat/i);
+});
+
+test('public landing page proof bar uses individually clickable link chips', () => {
+  const landingPage = readLandingPage();
+
+  assert.match(landingPage, /<nav class="proof-bar" aria-label="ThumbGate install and proof links">/);
+  assert.match(landingPage, /\.proof-bar a \{[^}]*min-height: 36px;[^}]*padding: 8px 12px;/);
+  assert.match(landingPage, /\.proof-bar a:hover, \.proof-bar a:focus-visible/);
+  assert.doesNotMatch(landingPage, /<span class="dot"><\/span>/);
+  assert.match(landingPage, /Claude Extension →/);
+  assert.match(landingPage, /Codex plugin setup →/);
+  assert.match(landingPage, /Verification evidence →/);
 });
 
 test('public landing page Pro tier uses outcome-framed bullets that justify upgrade', () => {


### PR DESCRIPTION
## Summary
- Convert the landing-page proof strip into a real `nav` of padded link chips so each bottom link has its own click/tap target.
- Remove the decorative dot separators from the markup so they cannot sit between or confuse link hit areas.
- Update the first-dollar activation copy to include both `thumbs up` reinforcement and `thumbs down` correction examples.

## Verification
- `npm ci --onnxruntime-node-install-cuda=skip`
- `node --test tests/public-landing.test.js tests/landing-page-claims.test.js tests/public-package-parity.test.js` (64 pass, 0 fail)
- `npm run test:sync-version` (11 pass, 0 fail)
- `npm run test:check-congruence` (11 pass, 0 fail)
- `git diff --check`
- Playwright desktop hit-box check: 12 proof links, no overlap, no undersized targets, center hit resolves to each anchor
- Playwright mobile hit-box check: 12 proof links, no overlap, no overflow, no undersized targets, center hit resolves to each anchor
- pre-commit guards: package parity, version sync, congruence, landing-page claims
- pre-push guards: npm pack dry-run, public HTML link validation, regression guards
