### PR TITLE
fix: clarify codex marketing links

### DIFF
--- a/.changeset/codex-marketing-links.md
+++ b/.changeset/codex-marketing-links.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Clarify the Codex plugin marketing card so it sends users to the install page and keeps MCP directory install copy on ThumbGate's npx path.

--- a/public/index.html
+++ b/public/index.html
@@ -803,7 +803,7 @@ __GA_BOOTSTRAP__
       </a>
       <a class="compat-card" href="/codex-plugin?utm_source=website&utm_medium=compatibility&utm_campaign=codex_plugin&cta_id=compat_codex_plugin&cta_placement=compatibility" rel="noopener" onclick="if(typeof posthog!=='undefined')posthog.capture('compat_codex_plugin_click',{cta:'open_codex_plugin_page'})">
         <h3>🧩 Codex plugin</h3>
-        <p>Codex gets a standalone ThumbGate plugin bundle, a repo-local plugin profile, and the same auto-updating MCP launcher. The runtime resolves <code>thumbgate@latest</code> when Codex starts, so npm fixes reach active installs. <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip" target="_blank" rel="noopener" style="color:var(--text-muted);text-decoration:underline;" onclick="event.stopPropagation();">Direct zip →</a></p>
+        <p>Codex gets a standalone ThumbGate plugin bundle, a repo-local plugin profile, and the same auto-updating MCP launcher. The runtime resolves <code>thumbgate@latest</code> when Codex starts, so npm fixes reach active installs. The install page includes the zip, MCP config, and verification path in one place.</p>
         <div class="card-arrow">Open the Codex install page →</div>
       </a>
       <a class="compat-card" href="/guides/cursor-prevent-repeated-mistakes.html" rel="noopener">
@@ -818,7 +818,7 @@ __GA_BOOTSTRAP__
       </a>
       <a class="compat-card" href="https://mcp.so/server/thumbgate" target="_blank" rel="noopener" onclick="if(typeof posthog!=='undefined')posthog.capture('compat_mcp_so_click',{cta:'view_mcp_directory'})">
         <h3>🗂️ MCP Server Directory</h3>
-        <p>ThumbGate is listed on <code>mcp.so</code> — the largest public MCP server directory. Install via Smithery CLI, copy-paste config for your client, or verify it's a legitimate server before running it.</p>
+        <p>ThumbGate is listed on <code>mcp.so</code> so MCP-compatible clients can verify the package, copy the npx config, and confirm they are installing the real Pre-Action Gates server.</p>
         <div class="card-arrow">View on mcp.so →</div>
       </a>
       <a class="compat-card" href="/go/gpt?utm_source=website&utm_medium=compatibility&utm_campaign=chatgpt_gpt&cta_id=compat_open_gpt&cta_placement=compatibility" target="_blank" rel="noopener">

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -360,7 +360,7 @@ test('public landing page advertises the Codex standalone plugin install path', 
   assert.match(landingPage, /Codex plugin/i);
   assert.match(landingPage, /\/codex-plugin\?utm_source=website/);
   assert.match(landingPage, /Open the Codex install page →/);
-  assert.match(landingPage, /thumbgate-codex-plugin\.zip/);
+  assert.doesNotMatch(landingPage, /thumbgate-codex-plugin\.zip/);
 });
 
 test('public Codex plugin page explains install, direct download, and latest runtime policy', () => {


### PR DESCRIPTION
## Summary\n- remove the stale nested Direct zip link from the Codex compatibility card so the card consistently opens the Codex install page\n- remove Smithery copy from the MCP directory card and keep the install language on ThumbGate/npx\n\n## Verification\n- npm run test:public-static-assets\n- npm run test:landing-page-claims\n- pre-commit guards\n- pre-push guards