### PR TITLE
fix: authenticate github about verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Verify live GitHub About congruence on main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           THUMBGATE_GITHUB_ABOUT_VERIFY_ATTEMPTS: 6
           THUMBGATE_GITHUB_ABOUT_VERIFY_DELAY_MS: 5000
         run: npm run test:congruence:live

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -438,7 +438,7 @@ test('CI workflow treats GitHub About sync as best-effort but still verifies the
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
 
   assert.match(workflow, /name: Sync GitHub About metadata on main[\s\S]*?continue-on-error:\s*true[\s\S]*?GITHUB_TOKEN:\s*\$\{\{\s*secrets\.GH_PAT\s*\}\}[\s\S]*?THUMBGATE_GITHUB_ABOUT_VERIFY_ATTEMPTS:\s*6[\s\S]*?THUMBGATE_GITHUB_ABOUT_VERIFY_DELAY_MS:\s*5000[\s\S]*?npm run github:about:sync/);
-  assert.match(workflow, /name: Verify live GitHub About congruence on main[\s\S]*?THUMBGATE_GITHUB_ABOUT_VERIFY_ATTEMPTS:\s*6[\s\S]*?THUMBGATE_GITHUB_ABOUT_VERIFY_DELAY_MS:\s*5000[\s\S]*?run:\s*npm run test:congruence:live/);
+  assert.match(workflow, /name: Verify live GitHub About congruence on main[\s\S]*?GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}[\s\S]*?THUMBGATE_GITHUB_ABOUT_VERIFY_ATTEMPTS:\s*6[\s\S]*?THUMBGATE_GITHUB_ABOUT_VERIFY_DELAY_MS:\s*5000[\s\S]*?run:\s*npm run test:congruence:live/);
   assert.doesNotMatch(workflow, /name: Verify live GitHub About congruence on main[\s\S]*?GITHUB_TOKEN:\s*\$\{\{\s*secrets\.GH_PAT\s*\}\}/);
 });
 


### PR DESCRIPTION
## Summary
- authenticate the main-branch live GitHub About verification step with the read-scoped GitHub Actions token
- keep the mutating About sync on GH_PAT while preventing the verification read from falling back to unauthenticated API limits
- cover the workflow contract in deployment tests so this does not regress

## Why
Main CI for the previous marketing/link fix reached product-code success but failed the live GitHub About congruence check with a 403 unauthenticated GitHub API rate limit. This makes the verifier use `${{ github.token }}` without exposing or requiring a PAT for the read path.

## Verification
- npm run feedback:summary
- npm run test:deployment
- npm run test:check-congruence
- pre-commit guards
- pre-push guards