### PR TITLE
fix: use transparent inline mark in site headers, not the app-icon tile

### DIFF
--- a/.changeset/header-logo-inline-mark.md
+++ b/.changeset/header-logo-inline-mark.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix header logo rendering as tiny iOS-launcher tile across all site surfaces. The existing `/assets/brand/thumbgate-mark.svg` is designed as an app-icon (full 512×512 canvas with a `#0a0d12` rounded-square backdrop filling the entire viewBox). When inlined in headers at 28–32px next to the wordmark it read as "a dark tile with a microscopic icon inside" rather than as a clean brand mark. Adds a new transparent full-bleed companion `/assets/brand/thumbgate-mark-inline.svg` and repoints every header `<img src=…>` (landing, dashboard, lessons, pro, learn hub + 5 learn articles, post-checkout success page, SEO-GSD generator — 12 surfaces) to the inline variant. `apple-touch-icon` / PWA / OG link tags intentionally still reference the app-icon tile — that is the correct asset for iOS home-screen bookmarks. Adds a regression-guard in `brand-assets.test.js` that fails if the app-icon tile is ever re-inlined in a header, and an inline-mark transparency assertion that blocks reintroducing a full-canvas dark rectangle.

--- a/public/assets/brand/thumbgate-mark-inline.svg
+++ b/public/assets/brand/thumbgate-mark-inline.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="tg-inline-title tg-inline-desc">
+  <title id="tg-inline-title">ThumbGate</title>
+  <desc id="tg-inline-desc">ThumbGate gate-and-signal mark, transparent background for inline use in site headers.</desc>
+  <defs>
+    <linearGradient id="tg-inline-cyan" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#22d3ee"/>
+      <stop offset="1" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="tg-inline-signal" x1="10" y1="48" x2="52" y2="14" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#4ade80"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+  </defs>
+  <!-- Gate body: rounded rect with two vertical bars (thumb up / thumb down gate pillars) -->
+  <path d="M10 14h44c4 0 7 3 7 7v22c0 4-3 7-7 7H10c-4 0-7-3-7-7V21c0-4 3-7 7-7Z" fill="none" stroke="url(#tg-inline-cyan)" stroke-width="3"/>
+  <path d="M18 22h6v20h-6V22Zm22 0h6v20h-6V22Z" fill="url(#tg-inline-cyan)"/>
+  <!-- Signal sweep through the gate -->
+  <path d="M6 46c7-14 16-22 27-24 5-1 9 0 12 1-6 3-11 7-15 12-4 6-11 9-24 11Z" fill="url(#tg-inline-signal)"/>
+  <!-- Status LEDs -->
+  <circle cx="50" cy="20" r="4" fill="#4ade80"/>
+  <circle cx="10" cy="44" r="3" fill="#fb7185"/>
+</svg>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -171,7 +171,7 @@
 
 <nav>
   <div class="container">
-    <a href="/" class="nav-logo"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate Dashboard</span></a>
+    <a href="/" class="nav-logo"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate Dashboard</span></a>
     <div class="nav-links">
       <a href="/dashboard" class="active" style="color:var(--cyan);">Dashboard</a>
       <a href="/lessons">Lessons</a>

--- a/public/index.html
+++ b/public/index.html
@@ -521,7 +521,7 @@ __GA_BOOTSTRAP__
 <!-- NAV -->
 <nav>
   <div class="container">
-    <a href="#" class="nav-logo"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+    <a href="#" class="nav-logo"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
     <div class="nav-links">
       <a href="#how-it-works">How It Works</a>
       <a href="#pricing">Pricing</a>

--- a/public/learn.html
+++ b/public/learn.html
@@ -178,7 +178,7 @@
 <body>
 
 <nav>
-  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
   <a href="/guide">Setup Guide</a>
   <a href="/learn">Learn</a>
   <a href="/dashboard">Dashboard</a>

--- a/public/learn/agent-harness-pattern.html
+++ b/public/learn/agent-harness-pattern.html
@@ -51,7 +51,7 @@
 <body>
 
 <nav>
-  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
   <a href="/guide">Setup Guide</a>
   <a href="/learn">Learn</a>
   <a href="/dashboard">Dashboard</a>

--- a/public/learn/ai-agent-persistent-memory.html
+++ b/public/learn/ai-agent-persistent-memory.html
@@ -52,7 +52,7 @@
 <body>
 
 <nav>
-  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
   <a href="/guide">Setup Guide</a>
   <a href="/learn">Learn</a>
   <a href="/dashboard">Dashboard</a>

--- a/public/learn/mcp-pre-action-gates-explained.html
+++ b/public/learn/mcp-pre-action-gates-explained.html
@@ -54,7 +54,7 @@
 <body>
 
 <nav>
-  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
   <a href="/guide">Setup Guide</a>
   <a href="/learn">Learn</a>
   <a href="/dashboard">Dashboard</a>

--- a/public/learn/stop-ai-agent-force-push.html
+++ b/public/learn/stop-ai-agent-force-push.html
@@ -45,7 +45,7 @@
 <body>
 
 <nav>
-  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
   <a href="/guide">Setup Guide</a>
   <a href="/learn">Learn</a>
   <a href="/dashboard">Dashboard</a>

--- a/public/learn/vibe-coding-safety-net.html
+++ b/public/learn/vibe-coding-safety-net.html
@@ -48,7 +48,7 @@
 <body>
 
 <nav>
-  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+  <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
   <a href="/guide">Setup Guide</a>
   <a href="/learn">Learn</a>
   <a href="/dashboard">Dashboard</a>

--- a/public/lessons.html
+++ b/public/lessons.html
@@ -188,7 +188,7 @@
 
 <nav>
   <div class="container">
-    <a href="/dashboard" class="nav-logo"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+    <a href="/dashboard" class="nav-logo"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
     <div class="nav-links">
       <a href="/dashboard">Dashboard</a>
       <a href="/lessons" class="active">Lessons</a>

--- a/public/pro.html
+++ b/public/pro.html
@@ -784,7 +784,7 @@ __GA_BOOTSTRAP__
 <body>
 <nav>
   <div class="container">
-    <a href="/" class="nav-logo"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate Pro</span></a>
+    <a href="/" class="nav-logo"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate Pro</span></a>
     <div class="nav-links">
       <a href="#why-pay">Why Pro</a>
       <a href="#proof">Proof</a>

--- a/scripts/seo-gsd.js
+++ b/scripts/seo-gsd.js
@@ -1247,7 +1247,7 @@ ${renderWebPageJsonLd(page, { appOrigin })}
 <body>
   <div class="topbar">
     <div class="container">
-      <a class="brand" href="/"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+      <a class="brand" href="/"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
       <a href="${escapeHtml(PRODUCT.verificationUrl)}" target="_blank" rel="noopener">Verification evidence</a>
     </div>
   </div>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1753,7 +1753,7 @@ nav .container { display: flex; justify-content: space-between; align-items: cen
 </head>
 <body>
 <nav><div class="container">
-  <a href="/dashboard" class="nav-logo"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+  <a href="/dashboard" class="nav-logo"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
   <div class="nav-links">
     <a href="/dashboard">Dashboard</a>
     <a href="/lessons">Lessons</a>
@@ -2143,7 +2143,7 @@ function renderCheckoutSuccessPage(runtimeConfig) {
 </head>
 <body>
   <main>
-    <a href="/" class="brand-header"><img src="/assets/brand/thumbgate-mark.svg" alt="ThumbGate" class="logo-mark" width="32" height="32"><span class="logo-text">ThumbGate</span></a>
+    <a href="/" class="brand-header"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="32" height="32"><span class="logo-text">ThumbGate</span></a>
     <span class="eyebrow">ThumbGate Pro</span>
     <h1>Your local Pro dashboard is ready.</h1>
     <p class="lead">This page verifies your Stripe session, provisions the key if needed, and gives you the exact command to save your license and launch your personal local dashboard.</p>

--- a/tests/brand-assets.test.js
+++ b/tests/brand-assets.test.js
@@ -4,17 +4,45 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const repoRoot = path.join(__dirname, '..');
+// App-icon style mark (full-canvas dark rounded tile) — correct for apple-touch-icon / PWA manifest / OG
 const markPath = path.join(repoRoot, 'public', 'assets', 'brand', 'thumbgate-mark.svg');
+// Transparent full-bleed mark — correct for site-header inline use next to the wordmark
+const inlineMarkPath = path.join(repoRoot, 'public', 'assets', 'brand', 'thumbgate-mark-inline.svg');
 const faviconPngPath = path.join(repoRoot, 'public', 'thumbgate-icon.png');
 const ogPngPath = path.join(repoRoot, 'public', 'og.png');
 
-test('ThumbGate brand mark SVG exists at /assets/brand and is a viewBox-defined vector', () => {
+test('ThumbGate app-icon mark SVG exists at /assets/brand (for apple-touch-icon / PWA)', () => {
   assert.equal(fs.existsSync(markPath), true, 'public/assets/brand/thumbgate-mark.svg must exist');
   const svg = fs.readFileSync(markPath, 'utf8');
   assert.match(svg, /<svg/);
   assert.match(svg, /viewBox="0 0 \d+ \d+"/);
   assert.match(svg, /fill=/);
   assert.match(svg, /<\/svg>/);
+});
+
+test('ThumbGate inline mark SVG exists with transparent backdrop for header use', () => {
+  assert.equal(
+    fs.existsSync(inlineMarkPath),
+    true,
+    'public/assets/brand/thumbgate-mark-inline.svg must exist for header use',
+  );
+  const svg = fs.readFileSync(inlineMarkPath, 'utf8');
+  assert.match(svg, /<svg/);
+  assert.match(svg, /viewBox="0 0 \d+ \d+"/);
+  assert.match(svg, /<\/svg>/);
+  // Guard: inline mark must NOT contain a full-canvas opaque rounded-rect tile. That tile
+  // backdrop is what made thumbgate-mark.svg render as a tiny iOS-launcher icon inside
+  // website headers. The inline variant exists specifically to avoid that look.
+  assert.doesNotMatch(
+    svg,
+    /<rect[^>]*\bwidth="512"[^>]*\bfill="#0a0d12"/,
+    'inline mark must be transparent — no full-canvas dark tile backdrop',
+  );
+  assert.doesNotMatch(
+    svg,
+    /<rect[^>]*\bfill="#0a0d12"[^>]*\bwidth="512"/,
+    'inline mark must be transparent — no full-canvas dark tile backdrop',
+  );
 });
 
 test('ThumbGate favicon PNG exists for crisp tab and bookmark rendering', () => {
@@ -40,12 +68,13 @@ test('ThumbGate og-image PNG exists for link previews', () => {
   assert.equal(buf[3], 0x47);
 });
 
-test('landing page header uses the /assets/brand SVG mark, not the emoji logo or /brand/', () => {
+test('landing page header uses the inline (transparent) mark, not the app-icon tile', () => {
   const indexHtml = fs.readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
-  // Header logo must reference the /assets/brand SVG mark (served 200 by Railway)
+  // Header logo must reference the transparent inline mark — not the app-icon tile,
+  // which renders as a tiny iOS-launcher icon when sized down to header proportions.
   assert.match(
     indexHtml,
-    /<a[^>]*class="nav-logo"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark\.svg"/,
+    /<a[^>]*class="nav-logo"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark-inline\.svg"/,
   );
   assert.match(indexHtml, /<span class="logo-text">ThumbGate<\/span>/);
   // Favicon link tag points at the PNG that actually resolves (not /favicon.svg which 401s)
@@ -58,9 +87,15 @@ test('landing page header uses the /assets/brand SVG mark, not the emoji logo or
     /src="\/brand\/thumbgate-mark\.svg"/,
     'legacy /brand/thumbgate-mark.svg path returns 401 on Railway; use /assets/brand/',
   );
+  // App-icon mark (with full dark tile) must not be inlined in the header — only inline variant.
+  assert.doesNotMatch(
+    indexHtml,
+    /class="nav-logo"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark\.svg"/,
+    'header must use thumbgate-mark-inline.svg; the app-icon thumbgate-mark.svg renders as a tiny tile inline',
+  );
 });
 
-test('dashboard, lessons, pro, and learn pages use the /assets/brand SVG mark in their header', () => {
+test('dashboard, lessons, pro, and learn pages use the inline mark in their header', () => {
   const files = [
     'public/dashboard.html',
     'public/lessons.html',
@@ -76,13 +111,19 @@ test('dashboard, lessons, pro, and learn pages use the /assets/brand SVG mark in
     const html = fs.readFileSync(path.join(repoRoot, relPath), 'utf8');
     assert.match(
       html,
-      /src="\/assets\/brand\/thumbgate-mark\.svg"/,
-      `${relPath} header must reference /assets/brand/thumbgate-mark.svg`,
+      /src="\/assets\/brand\/thumbgate-mark-inline\.svg"/,
+      `${relPath} header must reference /assets/brand/thumbgate-mark-inline.svg`,
     );
     assert.doesNotMatch(
       html,
       /src="\/brand\/thumbgate-mark\.svg"/,
       `${relPath} must not use legacy /brand/ path (returns 401)`,
+    );
+    // Header <img> must not point at the app-icon tile variant — only the transparent inline variant.
+    assert.doesNotMatch(
+      html,
+      /class="(?:nav-logo|brand|brand-header)"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark\.svg"/,
+      `${relPath} header must use the inline (transparent) mark, not the app-icon tile`,
     );
     assert.doesNotMatch(
       html,
@@ -92,22 +133,31 @@ test('dashboard, lessons, pro, and learn pages use the /assets/brand SVG mark in
   }
 });
 
-test('checkout success (Context Gateway Activated) page renders the /assets/brand header', () => {
+test('checkout success (Context Gateway Activated) page renders the inline mark in its header', () => {
   const server = fs.readFileSync(path.join(repoRoot, 'src', 'api', 'server.js'), 'utf8');
-  // The renderCheckoutSuccessPage body includes a brand-header anchor with the SVG mark
+  // The renderCheckoutSuccessPage body includes a brand-header anchor with the inline SVG mark.
   assert.match(
     server,
-    /class="brand-header"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark\.svg"/,
+    /class="brand-header"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark-inline\.svg"/,
   );
   // The legacy /brand/ path must not be referenced — it 401s on Railway
   assert.doesNotMatch(server, /src="\/brand\/thumbgate-mark\.svg"/);
   // The legacy emoji logo must no longer be served from server.js nav template
   assert.doesNotMatch(server, /class="nav-logo">👍👎/);
+  // App-icon mark must not be used as the inline header image (that's the iOS-launcher-tile bug)
+  assert.doesNotMatch(
+    server,
+    /class="brand-header"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark\.svg"/,
+    'success page header must use thumbgate-mark-inline.svg, not the app-icon tile variant',
+  );
 });
 
-test('SEO-GSD generated page template references the /assets/brand SVG mark, not the emoji logo', () => {
+test('SEO-GSD generated page template uses the inline mark, not the app-icon tile', () => {
   const seoGsd = fs.readFileSync(path.join(repoRoot, 'scripts', 'seo-gsd.js'), 'utf8');
-  assert.match(seoGsd, /class="brand"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark\.svg"/);
+  assert.match(
+    seoGsd,
+    /class="brand"[^>]*>\s*<img[^>]*src="\/assets\/brand\/thumbgate-mark-inline\.svg"/,
+  );
   assert.doesNotMatch(seoGsd, /src="\/brand\/thumbgate-mark\.svg"/);
   assert.doesNotMatch(seoGsd, /class="brand"[^>]*>👍👎 ThumbGate/);
 });

--- a/tests/learn-hub.test.js
+++ b/tests/learn-hub.test.js
@@ -466,7 +466,7 @@ test('no learn page references version numbers (evergreen content)', () => {
 
 test('no learn page has broken internal links', () => {
   const allFiles = [learnHubPath, ...fs.readdirSync(learnDir).filter(f => f.endsWith('.html')).map(f => path.join(learnDir, f))];
-  const validPaths = ['/learn', '/guide', '/dashboard', '/', '/learn/stop-ai-agent-force-push', '/learn/vibe-coding-safety-net', '/learn/mcp-pre-action-gates-explained', '/learn/agent-harness-pattern', '/learn/ai-agent-persistent-memory', '/learn/learn.css', '/favicon.svg', '/thumbgate-icon.png', '/og.png', '/assets/brand/thumbgate-mark.svg', '/guides/stop-repeated-ai-agent-mistakes', '/guides/cursor-agent-guardrails', '/guides/codex-cli-guardrails', '/guides/gemini-cli-feedback-memory'];
+  const validPaths = ['/learn', '/guide', '/dashboard', '/', '/learn/stop-ai-agent-force-push', '/learn/vibe-coding-safety-net', '/learn/mcp-pre-action-gates-explained', '/learn/agent-harness-pattern', '/learn/ai-agent-persistent-memory', '/learn/learn.css', '/favicon.svg', '/thumbgate-icon.png', '/og.png', '/assets/brand/thumbgate-mark.svg', '/assets/brand/thumbgate-mark-inline.svg', '/guides/stop-repeated-ai-agent-mistakes', '/guides/cursor-agent-guardrails', '/guides/codex-cli-guardrails', '/guides/gemini-cli-feedback-memory'];
   for (const file of allFiles) {
     const html = readFile(file);
     const links = html.match(/href="(\/[^"#]*?)"/g) || [];


### PR DESCRIPTION
## Problem

CEO flagged the `/success` (Context Gateway Activated) page header showing "a dark rounded-square tile with a microscopic icon inside" instead of a clean brand mark — looked like an iOS launcher icon dropped into a web header. Screenshot showed this at `/success?session_id=cs_live_…`.

Root cause: `/assets/brand/thumbgate-mark.svg` is shaped as an **app icon** — `<rect width="512" height="512" rx="112" fill="#0a0d12"/>` covers the full canvas, with the gate+signal mark occupying only the inner ~60%. Rendered at 28–32px in a header, the viewer sees mostly dark tile and a tiny icon.

## Fix

- **New asset**: `public/assets/brand/thumbgate-mark-inline.svg` — transparent 64×64 viewBox, gate + signal + LEDs going full-bleed, no dark backdrop.
- **Repointed 12 header surfaces** from `thumbgate-mark.svg` → `thumbgate-mark-inline.svg`:
  - `public/index.html`, `dashboard.html`, `lessons.html`, `pro.html`, `learn.html`
  - 5 learn articles: `stop-ai-agent-force-push`, `vibe-coding-safety-net`, `ai-agent-persistent-memory`, `mcp-pre-action-gates-explained`, `agent-harness-pattern`
  - `src/api/server.js` (nav + checkout-success brand-header)
  - `scripts/seo-gsd.js` (generated SEO page template)
- **Left untouched**: all `<link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">` entries. The full-bleed dark tile IS the correct asset shape for iOS home-screen bookmarks and PWA manifest icons.

## Regression guards

Updated `tests/brand-assets.test.js`:
- New test: inline mark must exist AND must NOT contain a full-canvas `#0a0d12` rect (catches anyone copying the app-icon into the inline slot).
- All header-surface assertions now require `thumbgate-mark-inline.svg` and fail if `thumbgate-mark.svg` is ever re-inlined in a `nav-logo` / `brand` / `brand-header` anchor.
- Success page assertion updated to require the inline variant.

Updated `tests/learn-hub.test.js` internal-link allowlist with the new path.

## Test plan

- [x] `node --test tests/brand-assets.test.js tests/learn-hub.test.js` — 70/70 pass locally
- [x] `node --test tests/deployment.test.js tests/public-static-assets.test.js tests/test-suite-parity.test.js` — 61/61 pass
- [ ] CI green on this PR
- [ ] Railway rebuild after merge → `/assets/brand/thumbgate-mark-inline.svg` returns 200
- [ ] `/success?session_id=…` header now shows a clean mark, not a dark tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)