### PR TITLE
fix(mailer): harden Resend env and sender DNS fallback

### DIFF
--- a/.changeset/mailer-env-harmonize.md
+++ b/.changeset/mailer-env-harmonize.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Mailer module now accepts `THUMBGATE_RESEND_API_KEY` as a fallback for the bare `RESEND_API_KEY`, matching the dual-read behavior already implemented in `scripts/billing.js`. Prevents a silent "skipped: no_api_key" regression if an operator sets only the prefixed variable name. Adds a positive unit test that sends with only the prefixed variant set.

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -511,6 +511,7 @@ function buildTrialActivationEmail({ customerEmail, apiKey, sessionId, planId, a
   const origin = resolvePublicAppOrigin(appOrigin);
   const dashboardUrl = joinPublicUrl(origin, '/dashboard');
   const docsUrl = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md';
+  const supportEmail = process.env.THUMBGATE_SUPPORT_EMAIL || CONFIG.TRIAL_EMAIL_REPLY_TO || 'igor.ganapolsky@gmail.com';
   const command = `npx thumbgate pro --activate --key=${apiKey || ''}`;
   const subject = 'Your 7-day ThumbGate Pro trial is live';
   const preheader = 'Activate Pro in one command, open the dashboard, and start blocking repeated AI coding mistakes.';
@@ -519,6 +520,7 @@ function buildTrialActivationEmail({ customerEmail, apiKey, sessionId, planId, a
   const exampleFeedback = 'thumbs down: the answer skipped exact files and tests; next time include paths, commands, and verification evidence.';
   const safeDashboardUrl = escapeHtml(dashboardUrl);
   const safeDocsUrl = escapeHtml(docsUrl);
+  const safeSupportEmail = escapeHtml(supportEmail);
   const safeCommand = escapeHtml(command);
   const safeApiKey = escapeHtml(apiKey || '');
   return {
@@ -544,7 +546,7 @@ function buildTrialActivationEmail({ customerEmail, apiKey, sessionId, planId, a
       apiKey,
       '',
       `Verification evidence: ${docsUrl}`,
-      'Keep this key private. Questions? Reply to this email or write hello@thumbgate.app.',
+      `Keep this key private. Questions? Reply to this email or write ${supportEmail}.`,
       sessionId ? `Stripe session: ${sessionId}` : null,
       planId ? `Plan: ${planId}` : null,
     ].filter(Boolean).join('\n'),
@@ -591,7 +593,7 @@ function buildTrialActivationEmail({ customerEmail, apiKey, sessionId, planId, a
 
                 <p style="margin:0;font-size:13px;line-height:1.6;color:#526273;">
                   Proof trail: <a href="${safeDocsUrl}" style="color:#087a91;">verification evidence</a>.
-                  Keep this key private. Questions? Reply here or write <a href="mailto:hello@thumbgate.app" style="color:#087a91;">hello@thumbgate.app</a>.
+                  Keep this key private. Questions? Reply here or write <a href="mailto:${safeSupportEmail}" style="color:#087a91;">${safeSupportEmail}</a>.
                 </p>
                 ${sessionId ? `<p style="margin:12px 0 0;font-size:12px;line-height:1.5;color:#7a8790;">Stripe session: ${escapeHtml(sessionId)}</p>` : ''}
               </td>

--- a/scripts/mailer/resend-mailer.js
+++ b/scripts/mailer/resend-mailer.js
@@ -15,12 +15,14 @@
  *    address, and a functional unsubscribe method.
  */
 
+const dns = require('node:dns').promises;
+
 const PRODUCT_NAME = 'ThumbGate Pro';
 const DASHBOARD_URL = 'https://thumbgate-production.up.railway.app/dashboard';
-const SUPPORT_EMAIL = 'hello@thumbgate.app';
+const DEFAULT_CONTACT_EMAIL = 'igor.ganapolsky@gmail.com';
 const DEFAULT_FROM = 'onboarding@resend.dev';
-const DEFAULT_REPLY_TO = 'hello@thumbgate.app';
-const DEFAULT_UNSUBSCRIBE_EMAIL = 'unsubscribe@thumbgate.app';
+const DEFAULT_REPLY_TO = DEFAULT_CONTACT_EMAIL;
+const DEFAULT_UNSUBSCRIBE_EMAIL = DEFAULT_CONTACT_EMAIL;
 const DEFAULT_BUSINESS_NAME = 'Max Smith KDP LLC';
 // CAN-SPAM requires a physical mailing address. Override via THUMBGATE_BUSINESS_ADDRESS.
 const DEFAULT_BUSINESS_ADDRESS = '2261 Market Street #4242, San Francisco, CA 94114';
@@ -28,6 +30,8 @@ const DEFAULT_BUSINESS_ADDRESS = '2261 Market Street #4242, San Francisco, CA 94
 const BRAND_MARK_URL = 'https://thumbgate-production.up.railway.app/thumbgate-icon.png';
 const RESEND_ENDPOINT = 'https://api.resend.com/emails';
 const TRIAL_LENGTH_DAYS = 7;
+const SENDER_DNS_CACHE_MS = 10 * 60 * 1000;
+const senderDnsCache = new Map();
 
 function getApiKey() {
   // Accept both `RESEND_API_KEY` (Railway default, matches provider docs) and
@@ -43,6 +47,10 @@ function getFromAddress() {
 
 function getReplyTo() {
   return process.env.THUMBGATE_TRIAL_EMAIL_REPLY_TO || DEFAULT_REPLY_TO;
+}
+
+function getSupportEmail() {
+  return process.env.THUMBGATE_SUPPORT_EMAIL || getReplyTo();
 }
 
 function getUnsubscribeEmail() {
@@ -61,11 +69,94 @@ function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function isTrueEnv(value) {
+  return /^(1|true|yes|on)$/i.test(String(value || '').trim());
+}
+
+function extractEmailAddress(value) {
+  const text = String(value || '').trim();
+  const angleMatch = text.match(/<([^<>@\s]+@[^<>\s]+)>/);
+  if (angleMatch) return angleMatch[1];
+  const bareMatch = text.match(/([^\s<>@]+@[^\s<>]+)/);
+  return bareMatch ? bareMatch[1] : '';
+}
+
+function getEmailDomain(value) {
+  const email = extractEmailAddress(value);
+  const at = email.lastIndexOf('@');
+  if (at === -1) return '';
+  return email.slice(at + 1).trim().replace(/[>),.;]+$/g, '').toLowerCase();
+}
+
+function splitCsv(value) {
+  return String(value || '')
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getVerifiedSenderDomains() {
+  return new Set(splitCsv(process.env.THUMBGATE_VERIFIED_SENDER_DOMAINS));
+}
+
+function flattenTxt(records) {
+  return (records || []).map((chunks) => Array.isArray(chunks) ? chunks.join('') : String(chunks));
+}
+
+async function hasResendSenderDns(domain, { dnsResolver } = {}) {
+  if (!domain || domain === 'resend.dev') return true;
+  if (isTrueEnv(process.env.THUMBGATE_ALLOW_UNVERIFIED_SENDER)) return true;
+  if (getVerifiedSenderDomains().has(domain)) return true;
+
+  const resolver = dnsResolver || dns;
+  const cacheKey = dnsResolver ? null : domain;
+  if (cacheKey) {
+    const cached = senderDnsCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) return cached.ready;
+  }
+
+  let ready = false;
+  try {
+    const [dkimRecords, mxRecords, spfRecords] = await Promise.all([
+      resolver.resolveTxt(`resend._domainkey.${domain}`),
+      resolver.resolveMx(`send.${domain}`),
+      resolver.resolveTxt(`send.${domain}`),
+    ]);
+    const dkim = flattenTxt(dkimRecords);
+    const spf = flattenTxt(spfRecords);
+    ready = dkim.some((record) => /^p=/i.test(record.trim())) &&
+      (mxRecords || []).some((record) => /feedback-smtp\..*amazonaws\.com\.?$/i.test(record.exchange || '')) &&
+      spf.some((record) => /include:amazonses\.com/i.test(record));
+  } catch (_) {
+    ready = false;
+  }
+
+  if (cacheKey) senderDnsCache.set(cacheKey, { ready, expiresAt: Date.now() + SENDER_DNS_CACHE_MS });
+  return ready;
+}
+
+async function resolveSenderAddress(requestedFrom, { dnsResolver } = {}) {
+  const from = requestedFrom || getFromAddress();
+  const domain = getEmailDomain(from);
+  const ready = await hasResendSenderDns(domain, { dnsResolver });
+  if (ready) return { from, senderFallback: null };
+
+  return {
+    from: DEFAULT_FROM,
+    senderFallback: {
+      requestedFrom: from,
+      fallbackFrom: DEFAULT_FROM,
+      domain,
+      reason: 'resend_dns_not_ready',
+    },
+  };
+}
+
 /**
  * Low-level send. Posts to the Resend API or no-ops when RESEND_API_KEY is
  * missing. Never throws on network errors; returns a structured result instead.
  */
-async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl } = {}) {
+async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl, dnsResolver } = {}) {
   if (!isNonEmptyString(to)) throw new Error('sendEmail: `to` is required');
   if (!isNonEmptyString(subject)) throw new Error('sendEmail: `subject` is required');
   if (!isNonEmptyString(html) && !isNonEmptyString(text)) {
@@ -79,8 +170,17 @@ async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl } =
     return { sent: false, reason: 'no_api_key' };
   }
 
+  const sender = await resolveSenderAddress(from || getFromAddress(), { dnsResolver });
+  if (sender.senderFallback) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[mailer] Sender domain ${sender.senderFallback.domain || '(unknown)'} is missing Resend DNS; ` +
+      `falling back to ${sender.senderFallback.fallbackFrom}`,
+    );
+  }
+
   const payload = {
-    from: from || getFromAddress(),
+    from: sender.from,
     to: Array.isArray(to) ? to : [to],
     subject,
     reply_to: replyTo || getReplyTo(),
@@ -117,7 +217,9 @@ async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl } =
       return { sent: false, reason: 'api_error', status: res.status, body: bodyJson || bodyText };
     }
 
-    return { sent: true, id: bodyJson && bodyJson.id ? bodyJson.id : null, status: res.status };
+    const result = { sent: true, id: bodyJson && bodyJson.id ? bodyJson.id : null, status: res.status };
+    if (sender.senderFallback) result.senderFallback = sender.senderFallback;
+    return result;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn('[mailer] send failed:', err && err.message ? err.message : err);
@@ -177,6 +279,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
   const exampleFeedback =
     'thumbs down: the answer skipped exact files and tests; next time include paths, commands, and verification evidence.';
   const proofUrl = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md';
+  const supportEmail = getSupportEmail();
   const unsubscribeEmail = getUnsubscribeEmail();
   const businessName = getBusinessName();
   const businessAddress = getBusinessAddress();
@@ -209,7 +312,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
     '',
     postscript,
     '',
-    `Questions? Just reply to this email or write ${SUPPORT_EMAIL}.`,
+    `Questions? Just reply to this email or write ${supportEmail}.`,
     '',
     '— Igor, founder of ThumbGate',
     '',
@@ -226,6 +329,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
   const safeDescription = escapeHtml(description);
   const safeExample = escapeHtml(exampleFeedback);
   const safePostscript = escapeHtml(postscript);
+  const safeSupportEmail = escapeHtml(supportEmail);
   const safeBusinessName = escapeHtml(businessName);
   const safeBusinessAddress = escapeHtml(businessAddress);
   const safeUnsubscribeEmail = escapeHtml(unsubscribeEmail);
@@ -285,7 +389,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
                 <p style="margin:0 0 4px;font-size:14px;line-height:1.6;color:#17212b;">— Igor, founder of ThumbGate</p>
                 <p style="margin:0;font-size:13px;line-height:1.55;color:#526273;">
                   Questions? Just reply to this email or write
-                  <a href="mailto:${SUPPORT_EMAIL}" style="color:#087a91;">${SUPPORT_EMAIL}</a>.
+                  <a href="mailto:${safeSupportEmail}" style="color:#087a91;">${safeSupportEmail}</a>.
                 </p>
               </td>
             </tr>
@@ -321,7 +425,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
  * Never throws on send failures (beyond input validation); the Stripe webhook
  * must keep working even if email breaks.
  */
-async function sendTrialWelcomeEmail({ to, licenseKey, customerId, customerName, trialEndAt, fetchImpl } = {}) {
+async function sendTrialWelcomeEmail({ to, licenseKey, customerId, customerName, trialEndAt, fetchImpl, dnsResolver } = {}) {
   if (!isNonEmptyString(to)) throw new Error('sendTrialWelcomeEmail: `to` is required');
   if (!isNonEmptyString(licenseKey)) throw new Error('sendTrialWelcomeEmail: `licenseKey` is required');
 
@@ -331,17 +435,19 @@ async function sendTrialWelcomeEmail({ to, licenseKey, customerId, customerName,
     ? `${name}, your ThumbGate Pro key is inside`
     : 'Your ThumbGate Pro key is inside';
 
-  return sendEmail({ to, subject, html, text, replyTo: getReplyTo(), fetchImpl });
+  return sendEmail({ to, subject, html, text, replyTo: getReplyTo(), fetchImpl, dnsResolver });
 }
 
 module.exports = {
   sendEmail,
   sendTrialWelcomeEmail,
   renderTrialWelcomeBodies,
+  _resolveSenderAddress: resolveSenderAddress,
+  _hasResendSenderDns: hasResendSenderDns,
   _constants: {
     PRODUCT_NAME,
     DASHBOARD_URL,
-    SUPPORT_EMAIL,
+    DEFAULT_CONTACT_EMAIL,
     DEFAULT_FROM,
     DEFAULT_REPLY_TO,
     DEFAULT_UNSUBSCRIBE_EMAIL,

--- a/scripts/mailer/resend-mailer.js
+++ b/scripts/mailer/resend-mailer.js
@@ -31,8 +31,10 @@ const BRAND_MARK_URL = 'https://thumbgate-production.up.railway.app/thumbgate-ic
 const RESEND_ENDPOINT = 'https://api.resend.com/emails';
 const TRIAL_LENGTH_DAYS = 7;
 const SENDER_DNS_CACHE_MS = 10 * 60 * 1000;
-const ANGLE_EMAIL_RE = /<([^<>@\s]+@[^<>\s]+)>/;
-const BARE_EMAIL_RE = /([^\s<>@]+@[^\s<>]+)/;
+// Bounded to RFC 5321 limits (local-part ≤ 64, domain ≤ 255) to prevent
+// super-linear backtracking on malformed input (Sonar javascript:S5852).
+const ANGLE_EMAIL_RE = /<([^<>@\s]{1,64}@[^<>@\s]{1,255})>/;
+const BARE_EMAIL_RE = /([^\s<>@]{1,64}@[^\s<>@]{1,255})/;
 const DKIM_PUBLIC_KEY_RE = /^p=/i;
 const AMAZON_SES_MX_RE = /feedback-smtp\..*amazonaws\.com\.?$/i;
 const AMAZON_SES_SPF_RE = /include:amazonses\.com/i;

--- a/scripts/mailer/resend-mailer.js
+++ b/scripts/mailer/resend-mailer.js
@@ -31,6 +31,12 @@ const BRAND_MARK_URL = 'https://thumbgate-production.up.railway.app/thumbgate-ic
 const RESEND_ENDPOINT = 'https://api.resend.com/emails';
 const TRIAL_LENGTH_DAYS = 7;
 const SENDER_DNS_CACHE_MS = 10 * 60 * 1000;
+const ANGLE_EMAIL_RE = /<([^<>@\s]+@[^<>\s]+)>/;
+const BARE_EMAIL_RE = /([^\s<>@]+@[^\s<>]+)/;
+const DKIM_PUBLIC_KEY_RE = /^p=/i;
+const AMAZON_SES_MX_RE = /feedback-smtp\..*amazonaws\.com\.?$/i;
+const AMAZON_SES_SPF_RE = /include:amazonses\.com/i;
+const TRAILING_EMAIL_DOMAIN_PUNCTUATION = new Set(['>', ')', ',', '.', ';']);
 const senderDnsCache = new Map();
 
 function getApiKey() {
@@ -75,9 +81,9 @@ function isTrueEnv(value) {
 
 function extractEmailAddress(value) {
   const text = String(value || '').trim();
-  const angleMatch = text.match(/<([^<>@\s]+@[^<>\s]+)>/);
+  const angleMatch = ANGLE_EMAIL_RE.exec(text);
   if (angleMatch) return angleMatch[1];
-  const bareMatch = text.match(/([^\s<>@]+@[^\s<>]+)/);
+  const bareMatch = BARE_EMAIL_RE.exec(text);
   return bareMatch ? bareMatch[1] : '';
 }
 
@@ -85,7 +91,11 @@ function getEmailDomain(value) {
   const email = extractEmailAddress(value);
   const at = email.lastIndexOf('@');
   if (at === -1) return '';
-  return email.slice(at + 1).trim().replace(/[>),.;]+$/g, '').toLowerCase();
+  let domain = email.slice(at + 1).trim();
+  while (domain && TRAILING_EMAIL_DOMAIN_PUNCTUATION.has(domain.at(-1))) {
+    domain = domain.slice(0, -1);
+  }
+  return domain.toLowerCase();
 }
 
 function splitCsv(value) {
@@ -103,36 +113,54 @@ function flattenTxt(records) {
   return (records || []).map((chunks) => Array.isArray(chunks) ? chunks.join('') : String(chunks));
 }
 
-async function hasResendSenderDns(domain, { dnsResolver } = {}) {
-  if (!domain || domain === 'resend.dev') return true;
-  if (isTrueEnv(process.env.THUMBGATE_ALLOW_UNVERIFIED_SENDER)) return true;
-  if (getVerifiedSenderDomains().has(domain)) return true;
+function getCachedSenderDnsReadiness(cacheKey) {
+  if (!cacheKey) return null;
+  const cached = senderDnsCache.get(cacheKey);
+  return cached && cached.expiresAt > Date.now() ? cached.ready : null;
+}
 
-  const resolver = dnsResolver || dns;
-  const cacheKey = dnsResolver ? null : domain;
-  if (cacheKey) {
-    const cached = senderDnsCache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) return cached.ready;
-  }
+function setCachedSenderDnsReadiness(cacheKey, ready) {
+  if (cacheKey) senderDnsCache.set(cacheKey, { ready, expiresAt: Date.now() + SENDER_DNS_CACHE_MS });
+  return ready;
+}
 
-  let ready = false;
+async function readResendDnsRecords(domain, resolver) {
   try {
     const [dkimRecords, mxRecords, spfRecords] = await Promise.all([
       resolver.resolveTxt(`resend._domainkey.${domain}`),
       resolver.resolveMx(`send.${domain}`),
       resolver.resolveTxt(`send.${domain}`),
     ]);
-    const dkim = flattenTxt(dkimRecords);
-    const spf = flattenTxt(spfRecords);
-    ready = dkim.some((record) => /^p=/i.test(record.trim())) &&
-      (mxRecords || []).some((record) => /feedback-smtp\..*amazonaws\.com\.?$/i.test(record.exchange || '')) &&
-      spf.some((record) => /include:amazonses\.com/i.test(record));
-  } catch (_) {
-    ready = false;
+    return { dkimRecords, mxRecords, spfRecords, errorCode: null };
+  } catch (error) {
+    return {
+      dkimRecords: [],
+      mxRecords: [],
+      spfRecords: [],
+      errorCode: error && error.code ? error.code : 'dns_lookup_failed',
+    };
   }
+}
 
-  if (cacheKey) senderDnsCache.set(cacheKey, { ready, expiresAt: Date.now() + SENDER_DNS_CACHE_MS });
-  return ready;
+function recordsHaveResendDns({ dkimRecords, mxRecords, spfRecords }) {
+  const dkim = flattenTxt(dkimRecords);
+  const spf = flattenTxt(spfRecords);
+  return dkim.some((record) => DKIM_PUBLIC_KEY_RE.exec(record.trim()) !== null) &&
+    (mxRecords || []).some((record) => AMAZON_SES_MX_RE.exec(record.exchange || '') !== null) &&
+    spf.some((record) => AMAZON_SES_SPF_RE.exec(record) !== null);
+}
+
+async function hasResendSenderDns(domain, { dnsResolver } = {}) {
+  if (!domain || domain === 'resend.dev') return true;
+  if (isTrueEnv(process.env.THUMBGATE_ALLOW_UNVERIFIED_SENDER)) return true;
+  if (getVerifiedSenderDomains().has(domain)) return true;
+
+  const cacheKey = dnsResolver ? null : domain;
+  const cached = getCachedSenderDnsReadiness(cacheKey);
+  if (cached !== null) return cached;
+
+  const records = await readResendDnsRecords(domain, dnsResolver || dns);
+  return setCachedSenderDnsReadiness(cacheKey, !records.errorCode && recordsHaveResendDns(records));
 }
 
 async function resolveSenderAddress(requestedFrom, { dnsResolver } = {}) {
@@ -152,16 +180,77 @@ async function resolveSenderAddress(requestedFrom, { dnsResolver } = {}) {
   };
 }
 
-/**
- * Low-level send. Posts to the Resend API or no-ops when RESEND_API_KEY is
- * missing. Never throws on network errors; returns a structured result instead.
- */
-async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl, dnsResolver } = {}) {
+function validateSendEmailInput({ to, subject, html, text }) {
   if (!isNonEmptyString(to)) throw new Error('sendEmail: `to` is required');
   if (!isNonEmptyString(subject)) throw new Error('sendEmail: `subject` is required');
   if (!isNonEmptyString(html) && !isNonEmptyString(text)) {
     throw new Error('sendEmail: at least one of `html` or `text` is required');
   }
+}
+
+function warnSenderFallback(senderFallback) {
+  if (!senderFallback) return;
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[mailer] Sender domain ${senderFallback.domain || '(unknown)'} is missing Resend DNS; ` +
+    `falling back to ${senderFallback.fallbackFrom}`,
+  );
+}
+
+function buildEmailPayload({ to, subject, html, text, replyTo, sender }) {
+  const payload = {
+    from: sender.from,
+    to: Array.isArray(to) ? to : [to],
+    subject,
+    reply_to: replyTo || getReplyTo(),
+  };
+  if (isNonEmptyString(html)) payload.html = html;
+  if (isNonEmptyString(text)) payload.text = text;
+  return payload;
+}
+
+function parseJsonOrNull(bodyText) {
+  if (!bodyText) return null;
+  try {
+    return JSON.parse(bodyText);
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
+    return null;
+  }
+}
+
+async function postResendEmail({ fetcher, apiKey, payload }) {
+  const res = await fetcher(RESEND_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  const bodyText = typeof res.text === 'function' ? await res.text() : '';
+  return { res, bodyText, bodyJson: parseJsonOrNull(bodyText) };
+}
+
+function formatSendFailure(error) {
+  return error && error.message ? error.message : String(error);
+}
+
+function buildSendSuccess({ bodyJson, status, senderFallback }) {
+  return {
+    sent: true,
+    id: bodyJson?.id || null,
+    status,
+    ...(senderFallback ? { senderFallback } : {}),
+  };
+}
+
+/**
+ * Low-level send. Posts to the Resend API or no-ops when RESEND_API_KEY is
+ * missing. Never throws on network errors; returns a structured result instead.
+ */
+async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl, dnsResolver } = {}) {
+  validateSendEmailInput({ to, subject, html, text });
 
   const apiKey = getApiKey();
   if (!apiKey) {
@@ -171,22 +260,8 @@ async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl, dn
   }
 
   const sender = await resolveSenderAddress(from || getFromAddress(), { dnsResolver });
-  if (sender.senderFallback) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[mailer] Sender domain ${sender.senderFallback.domain || '(unknown)'} is missing Resend DNS; ` +
-      `falling back to ${sender.senderFallback.fallbackFrom}`,
-    );
-  }
-
-  const payload = {
-    from: sender.from,
-    to: Array.isArray(to) ? to : [to],
-    subject,
-    reply_to: replyTo || getReplyTo(),
-  };
-  if (isNonEmptyString(html)) payload.html = html;
-  if (isNonEmptyString(text)) payload.text = text;
+  warnSenderFallback(sender.senderFallback);
+  const payload = buildEmailPayload({ to, subject, html, text, replyTo, sender });
 
   const fetcher = fetchImpl || globalThis.fetch;
   if (typeof fetcher !== 'function') {
@@ -196,34 +271,17 @@ async function sendEmail({ to, subject, html, text, from, replyTo, fetchImpl, dn
   }
 
   try {
-    const res = await fetcher(RESEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(payload),
-    });
-
-    const bodyText = typeof res.text === 'function' ? await res.text() : '';
-    let bodyJson = null;
-    if (bodyText) {
-      try { bodyJson = JSON.parse(bodyText); } catch (_) { /* leave as text */ }
-    }
-
+    const { res, bodyText, bodyJson } = await postResendEmail({ fetcher, apiKey, payload });
     if (!res.ok) {
       // eslint-disable-next-line no-console
       console.warn(`[mailer] Resend returned ${res.status}:`, bodyText);
       return { sent: false, reason: 'api_error', status: res.status, body: bodyJson || bodyText };
     }
-
-    const result = { sent: true, id: bodyJson && bodyJson.id ? bodyJson.id : null, status: res.status };
-    if (sender.senderFallback) result.senderFallback = sender.senderFallback;
-    return result;
+    return buildSendSuccess({ bodyJson, status: res.status, senderFallback: sender.senderFallback });
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn('[mailer] send failed:', err && err.message ? err.message : err);
-    return { sent: false, reason: 'exception', error: err && err.message ? err.message : String(err) };
+    console.warn('[mailer] send failed:', formatSendFailure(err));
+    return { sent: false, reason: 'exception', error: formatSendFailure(err) };
   }
 }
 

--- a/scripts/mailer/resend-mailer.js
+++ b/scripts/mailer/resend-mailer.js
@@ -30,7 +30,11 @@ const RESEND_ENDPOINT = 'https://api.resend.com/emails';
 const TRIAL_LENGTH_DAYS = 7;
 
 function getApiKey() {
-  return process.env.RESEND_API_KEY || '';
+  // Accept both `RESEND_API_KEY` (Railway default, matches provider docs) and
+  // the `THUMBGATE_`-prefixed variant that `scripts/billing.js` already honors.
+  // Keeping the two readers in sync prevents a silent "skipped: no_api_key"
+  // regression if an operator sets only the prefixed name.
+  return process.env.RESEND_API_KEY || process.env.THUMBGATE_RESEND_API_KEY || '';
 }
 
 function getFromAddress() {

--- a/tests/mailer.test.js
+++ b/tests/mailer.test.js
@@ -27,8 +27,9 @@ function savingEnv(keys) {
 }
 
 test('sendTrialWelcomeEmail returns {sent:false, reason:no_api_key} when RESEND_API_KEY is missing', async () => {
-  const restore = savingEnv(['RESEND_API_KEY', 'RESEND_FROM_EMAIL']);
+  const restore = savingEnv(['RESEND_API_KEY', 'THUMBGATE_RESEND_API_KEY', 'RESEND_FROM_EMAIL']);
   delete process.env.RESEND_API_KEY;
+  delete process.env.THUMBGATE_RESEND_API_KEY;
   const { sendTrialWelcomeEmail } = freshMailer();
 
   let calls = 0;
@@ -43,6 +44,31 @@ test('sendTrialWelcomeEmail returns {sent:false, reason:no_api_key} when RESEND_
 
   assert.deepEqual(res, { sent: false, reason: 'no_api_key' });
   assert.equal(calls, 0, 'fetch must not be called when API key is missing');
+  restore();
+});
+
+test('sendTrialWelcomeEmail accepts THUMBGATE_RESEND_API_KEY as a fallback for the bare RESEND_API_KEY', async () => {
+  const restore = savingEnv(['RESEND_API_KEY', 'THUMBGATE_RESEND_API_KEY', 'RESEND_FROM_EMAIL']);
+  delete process.env.RESEND_API_KEY;
+  process.env.THUMBGATE_RESEND_API_KEY = 're_prefixed_fallback_key';
+  const { sendTrialWelcomeEmail } = freshMailer();
+
+  let captured = null;
+  const fakeFetch = async (url, init) => {
+    captured = { url, headers: init.headers };
+    return { ok: true, status: 200, text: async () => '{"id":"email_fallback_1"}' };
+  };
+
+  const res = await sendTrialWelcomeEmail({
+    to: 'fallback@example.com',
+    licenseKey: 'tg_fallback_key',
+    customerId: 'cus_fallback',
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(res.sent, true, 'email must send when only THUMBGATE_RESEND_API_KEY is set');
+  assert.equal(captured.url, 'https://api.resend.com/emails');
+  assert.equal(captured.headers.Authorization, 'Bearer re_prefixed_fallback_key');
   restore();
 });
 

--- a/tests/mailer.test.js
+++ b/tests/mailer.test.js
@@ -77,10 +77,12 @@ test('sendTrialWelcomeEmail POSTs to Resend with correct headers, reply_to, and 
     'RESEND_API_KEY',
     'RESEND_FROM_EMAIL',
     'THUMBGATE_TRIAL_EMAIL_REPLY_TO',
+    'THUMBGATE_VERIFIED_SENDER_DOMAINS',
     'THUMBGATE_BUSINESS_ADDRESS',
   ]);
   process.env.RESEND_API_KEY = 're_test_123';
   process.env.RESEND_FROM_EMAIL = 'hello@thumbgate.app';
+  process.env.THUMBGATE_VERIFIED_SENDER_DOMAINS = 'thumbgate.app';
   delete process.env.THUMBGATE_TRIAL_EMAIL_REPLY_TO;
   delete process.env.THUMBGATE_BUSINESS_ADDRESS;
   const { sendTrialWelcomeEmail } = freshMailer();
@@ -117,8 +119,8 @@ test('sendTrialWelcomeEmail POSTs to Resend with correct headers, reply_to, and 
   assert.equal(body.from, 'hello@thumbgate.app');
   // Subject is personalized with the first name when available.
   assert.equal(body.subject, 'Igor, your ThumbGate Pro key is inside');
-  // reply_to defaults to hello@thumbgate.app — replies must not go into Resend's sandbox void.
-  assert.equal(body.reply_to, 'hello@thumbgate.app');
+  // reply_to defaults to a deliverable operator inbox until thumbgate.app is registered.
+  assert.equal(body.reply_to, 'igor.ganapolsky@gmail.com');
 
   // License key + activation command present in both bodies.
   assert.ok(body.html && body.html.includes('tg_09239a0a433649ba442467567af1825b'));
@@ -141,7 +143,7 @@ test('sendTrialWelcomeEmail POSTs to Resend with correct headers, reply_to, and 
   // CAN-SPAM compliance: business name + physical address + unsubscribe.
   assert.ok(body.html.includes('Max Smith KDP LLC'), 'html footer must carry business name');
   assert.ok(body.html.includes('2261 Market Street #4242, San Francisco, CA 94114'), 'html footer must carry business address');
-  assert.ok(body.html.includes('unsubscribe@thumbgate.app'), 'html footer must expose an unsubscribe mailto');
+  assert.ok(body.html.includes('igor.ganapolsky@gmail.com'), 'html footer must expose a deliverable unsubscribe mailto');
   assert.ok(body.text.includes('Max Smith KDP LLC'), 'text footer must carry business name');
   assert.ok(body.text.includes('Unsubscribe:'), 'text footer must carry unsubscribe instruction');
 
@@ -210,6 +212,48 @@ test('sendTrialWelcomeEmail defaults RESEND_FROM_EMAIL to onboarding@resend.dev'
     fetchImpl: fakeFetch,
   });
 
+  const body = JSON.parse(captured.init.body);
+  assert.equal(body.from, 'onboarding@resend.dev');
+  restore();
+});
+
+test('sendTrialWelcomeEmail falls back to resend.dev when configured sender lacks Resend DNS', async () => {
+  const restore = savingEnv([
+    'RESEND_API_KEY',
+    'RESEND_FROM_EMAIL',
+    'THUMBGATE_TRIAL_EMAIL_FROM',
+    'THUMBGATE_VERIFIED_SENDER_DOMAINS',
+    'THUMBGATE_ALLOW_UNVERIFIED_SENDER',
+  ]);
+  process.env.RESEND_API_KEY = 're_test_123';
+  process.env.RESEND_FROM_EMAIL = 'ThumbGate <onboarding@thumbgate.app>';
+  delete process.env.THUMBGATE_TRIAL_EMAIL_FROM;
+  delete process.env.THUMBGATE_VERIFIED_SENDER_DOMAINS;
+  delete process.env.THUMBGATE_ALLOW_UNVERIFIED_SENDER;
+  const { sendTrialWelcomeEmail } = freshMailer();
+
+  const dnsResolver = {
+    resolveTxt: async () => { throw Object.assign(new Error('queryTxt ENOTFOUND'), { code: 'ENOTFOUND' }); },
+    resolveMx: async () => { throw Object.assign(new Error('queryMx ENOTFOUND'), { code: 'ENOTFOUND' }); },
+  };
+
+  let captured = null;
+  const fakeFetch = (_url, init) => {
+    captured = { init };
+    return Promise.resolve({ ok: true, status: 200, text: async () => '{"id":"email_safe"}' });
+  };
+
+  const res = await sendTrialWelcomeEmail({
+    to: 'safe@example.com',
+    licenseKey: 'tg_safe',
+    fetchImpl: fakeFetch,
+    dnsResolver,
+  });
+
+  assert.equal(res.sent, true);
+  assert.equal(res.id, 'email_safe');
+  assert.equal(res.senderFallback.reason, 'resend_dns_not_ready');
+  assert.equal(res.senderFallback.domain, 'thumbgate.app');
   const body = JSON.parse(captured.init.body);
   assert.equal(body.from, 'onboarding@resend.dev');
   restore();
@@ -315,7 +359,7 @@ test('renderTrialWelcomeBodies embeds license key, activation command, dashboard
   assert.equal(activationCommand, 'npx thumbgate pro --activate --key=tg_abc');
   assert.equal(trialEndLabel, 'Apr 24, 2026');
   assert.equal(greeting, 'Hi Ada,');
-  assert.equal(unsubscribeEmail, 'unsubscribe@thumbgate.app');
+  assert.equal(unsubscribeEmail, 'igor.ganapolsky@gmail.com');
   assert.equal(businessName, 'Max Smith KDP LLC');
   assert.ok(businessAddress.length > 0);
   for (const fragment of [
@@ -330,8 +374,8 @@ test('renderTrialWelcomeBodies embeds license key, activation command, dashboard
     assert.ok(html.includes(fragment), `html missing: ${fragment}`);
     assert.ok(text.includes(fragment), `text missing: ${fragment}`);
   }
-  assert.ok(html.includes('hello@thumbgate.app'));
-  assert.ok(text.includes('hello@thumbgate.app'));
+  assert.ok(html.includes('igor.ganapolsky@gmail.com'));
+  assert.ok(text.includes('igor.ganapolsky@gmail.com'));
   // Customer ID shows in the html footer only — not in the customer-visible body prose.
   assert.ok(html.includes('cus_42'));
   // Customer ID must NOT appear in the text body — we want to stop leaking debug IDs in


### PR DESCRIPTION
## Summary\n- accept THUMBGATE_RESEND_API_KEY as a fallback for RESEND_API_KEY\n- fall back to onboarding@resend.dev when the configured sender domain is missing Resend DKIM/MX/SPF DNS\n- keep reply/unsubscribe defaults deliverable until thumbgate.app is registered and verified\n\n## Verification\n- npm run feedback:summary\n- npm run test:mailer\n- npm run test:billing\n- git diff --check\n- node --check scripts/mailer/resend-mailer.js && node --check scripts/billing.js\n- live DNS check: thumbgate.app Resend DNS records are absent / NXDOMAIN\n