### PR TITLE
chore(release): version 1.12.1

### DIFF
--- a/.changeset/dependabot-anthropic-sdk-0-90-0.md
+++ b/.changeset/dependabot-anthropic-sdk-0-90-0.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add the release note required for the `@anthropic-ai/sdk` 0.90.0 dependency bump so manifest-only Dependabot updates pass ThumbGate's release hygiene checks.

--- a/.changeset/dependabot-stripe-22-0-2.md
+++ b/.changeset/dependabot-stripe-22-0-2.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add the release note required for the `stripe` 22.0.2 dependency bump so manifest-only Dependabot updates pass ThumbGate's release hygiene checks.

--- a/.changeset/local-only-remote-side-effects.md
+++ b/.changeset/local-only-remote-side-effects.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+Add a structural local-only gate that blocks remote git, PR, release, and publish actions before configurable gate evaluation.
+
+Update published Claude Code MCP installers to resolve `thumbgate@latest` without reusing stale installed runtime binaries.

--- a/.changeset/local-only-remote-side-effects.md
+++ b/.changeset/local-only-remote-side-effects.md
@@ -1,7 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a structural local-only gate that blocks remote git, PR, release, and publish actions before configurable gate evaluation.
-
-Update published Claude Code MCP installers to resolve `thumbgate@latest` without reusing stale installed runtime binaries.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -13,7 +13,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.12.0",
+      "version": "1.12.1",
       "author": {
         "name": "Igor Ganapolsky"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -13,7 +13,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.12.1",
+      "version": "1.12.0",
       "author": {
         "name": "Igor Ganapolsky"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action gates, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action gates, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.12.1"
+    "version": "1.12.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.12.0"
+    "version": "1.12.1"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "transport": "stdio",

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.12.1
+
+### Patch Changes
+
+- [#990](https://github.com/IgorGanapolsky/ThumbGate/pull/990) [`6698e44`](https://github.com/IgorGanapolsky/ThumbGate/commit/6698e449d4e234b22bd6c772eba70b090237c5ce) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a structural local-only gate that blocks remote git, PR, release, and publish actions before configurable gate evaluation.
+
+  Update published Claude Code MCP installers to resolve `thumbgate@latest` without reusing stale installed runtime binaries.
+
+- [#980](https://github.com/IgorGanapolsky/ThumbGate/pull/980) [`81f81b4`](https://github.com/IgorGanapolsky/ThumbGate/commit/81f81b48a5cc3bfc66bd91e576c3f34fad7e86db) Thanks [@dependabot](https://github.com/apps/dependabot)! - Add the release note required for the `@anthropic-ai/sdk` 0.90.0 dependency bump so manifest-only Dependabot updates pass ThumbGate's release hygiene checks.
+
 ## 1.12.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## 1.12.1
-
-### Patch Changes
-
-- [#990](https://github.com/IgorGanapolsky/ThumbGate/pull/990) [`6698e44`](https://github.com/IgorGanapolsky/ThumbGate/commit/6698e449d4e234b22bd6c772eba70b090237c5ce) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a structural local-only gate that blocks remote git, PR, release, and publish actions before configurable gate evaluation.
-
-  Update published Claude Code MCP installers to resolve `thumbgate@latest` without reusing stale installed runtime binaries.
-
 ## 1.12.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.12.1
+
+### Patch Changes
+
+- [#990](https://github.com/IgorGanapolsky/ThumbGate/pull/990) [`6698e44`](https://github.com/IgorGanapolsky/ThumbGate/commit/6698e449d4e234b22bd6c772eba70b090237c5ce) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a structural local-only gate that blocks remote git, PR, release, and publish actions before configurable gate evaluation.
+
+  Update published Claude Code MCP installers to resolve `thumbgate@latest` without reusing stale installed runtime binaries.
+
 ## 1.12.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - [#980](https://github.com/IgorGanapolsky/ThumbGate/pull/980) [`81f81b4`](https://github.com/IgorGanapolsky/ThumbGate/commit/81f81b48a5cc3bfc66bd91e576c3f34fad7e86db) Thanks [@dependabot](https://github.com/apps/dependabot)! - Add the release note required for the `@anthropic-ai/sdk` 0.90.0 dependency bump so manifest-only Dependabot updates pass ThumbGate's release hygiene checks.
 
+- [#978](https://github.com/IgorGanapolsky/ThumbGate/pull/978) [`ff75751`](https://github.com/IgorGanapolsky/ThumbGate/commit/ff757516701c38d884c77bad7d535e7e29030f0b) Thanks [@dependabot](https://github.com/apps/dependabot)! - Add the release note required for the `stripe` 22.0.2 dependency bump so manifest-only Dependabot updates pass ThumbGate's release hygiene checks.
+
 ## 1.12.0
 
 ### Minor Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,7 +3,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.12.1 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.12.0 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,7 +3,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.12.0 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.12.1 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.12.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.12.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.12.0", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.12.1", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.12.1", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.12.0", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.12.1", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.12.0", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -153,7 +153,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.12.0' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.12.1' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -153,7 +153,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.12.1' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.12.0' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.12.0",
+        "thumbgate@1.12.1",
         "thumbgate",
         "serve"
       ],

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.12.1",
+        "thumbgate@1.12.0",
         "thumbgate",
         "serve"
       ],

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.12.0 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.12.1 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.12.0 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.12.1 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.12.1 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.12.0 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.12.1 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.12.0 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1515,7 +1515,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.12.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.12.0 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2732,7 +2732,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.12.1 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.12.0 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1515,7 +1515,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.12.0 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.12.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2732,7 +2732,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.12.0 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.12.1 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.12.1`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.12.0`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.12.0`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.12.1`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.12.1 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.12.0 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.12.1", "serve"],
+      "args": ["-y", "thumbgate@1.12.0", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.12.1", "serve"],
+      "args": ["-y", "thumbgate@1.12.0", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.12.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.12.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.12.1
+1.12.0
 
 ---
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.12.0 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.12.1 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.12.0", "serve"],
+      "args": ["-y", "thumbgate@1.12.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.12.0", "serve"],
+      "args": ["-y", "thumbgate@1.12.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.12.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.12.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.12.0
+1.12.1
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.12.1"
+version: "1.12.0"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.12.0"
+version: "1.12.1"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.12.1",
+      "version": "1.12.0",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "description": "Self-improving agent governance: type thumbs-up or thumbs-down on any AI agent action. ThumbGate turns every mistake into a prevention rule and blocks the pattern from repeating. One thumbs-down, never again. 33 pre-action gates, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Self-improving agent governance: type thumbs-up or thumbs-down on any AI agent action. ThumbGate turns every mistake into a prevention rule and blocks the pattern from repeating. One thumbs-down, never again. 33 pre-action gates, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.12.1",
+        "thumbgate@1.12.0",
         "thumbgate",
         "serve"
       ]

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.12.0",
+        "thumbgate@1.12.1",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.12.1",
+  "version": "1.12.0",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.12.1", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.12.0", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.12.0", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.12.1", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -974,7 +974,7 @@ __GA_BOOTSTRAP__
 <!-- HOW IT WORKS -->
 <section class="how-it-works" id="how-it-works">
   <div class="container">
-    <div class="section-label">New in v1.12.0</div>
+    <div class="section-label">New in v1.12.1</div>
     <h2 class="section-title">Three steps to stop repeated AI failures</h2>
     <div class="steps">
       <div class="step">
@@ -1330,7 +1330,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.12.0</span>
+    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.12.1</span>
   </div>
 </footer>
 

--- a/public/index.html
+++ b/public/index.html
@@ -974,7 +974,7 @@ __GA_BOOTSTRAP__
 <!-- HOW IT WORKS -->
 <section class="how-it-works" id="how-it-works">
   <div class="container">
-    <div class="section-label">New in v1.12.1</div>
+    <div class="section-label">New in v1.12.0</div>
     <h2 class="section-title">Three steps to stop repeated AI failures</h2>
     <div class="steps">
       <div class="step">
@@ -1330,7 +1330,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.12.1</span>
+    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.12.0</span>
   </div>
 </footer>
 

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.12.1",
+  "version": "1.12.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.12.1",
+      "version": "1.12.0",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.12.0",
+  "version": "1.12.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- release ThumbGate 1.12.1 from PR #990 and dependency PR #980
- consume the local-only remote side-effect gates and @anthropic-ai/sdk 0.90.0 changesets
- sync package, plugin, adapter, MCP discovery, docs, and landing-page version surfaces

## Verification
- node scripts/sync-version.js --check
- npm run test:sync-version
- npm run test:deployment

Note: Changesets' GitHub changelog adapter crashed resolving Dependabot metadata after #980 landed; this branch manually applies the same audited changelog/version output and keeps the release tests green.