### PR TITLE
fix(ci): accept socket pull request alert check

### DIFF
--- a/.changeset/socket-pr-alert-check.md
+++ b/.changeset/socket-pr-alert-check.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Accept the Socket Security Pull Request Alerts context in branch-protection congruence checks.

--- a/config/merge-quality-checks.json
+++ b/config/merge-quality-checks.json
@@ -6,7 +6,8 @@
     "Verify changeset",
     "SonarCloud Code Analysis",
     "GitGuardian Security Checks",
-    "Socket Security: Project Report"
+    "Socket Security: Project Report",
+    "Socket Security: Pull Request Alerts"
   ],
   "passingBuckets": [
     "pass",

--- a/tests/sync-branch-protection.test.js
+++ b/tests/sync-branch-protection.test.js
@@ -125,7 +125,8 @@ test('syncBranchProtection falls back to REST branch protection when GraphQL ret
             'Verify changeset',
             'SonarCloud Code Analysis',
             'GitGuardian Security Checks',
-            'Socket Security: Project Report'
+            'Socket Security: Project Report',
+            'Socket Security: Pull Request Alerts'
           ]
         }
       }),
@@ -184,7 +185,8 @@ test('syncBranchProtection updates REST-backed branch protection when GraphQL ha
           'Verify changeset',
           'SonarCloud Code Analysis',
           'GitGuardian Security Checks',
-          'Socket Security: Project Report'
+          'Socket Security: Project Report',
+          'Socket Security: Pull Request Alerts'
         ]
       }),
       stderr: ''
@@ -204,7 +206,7 @@ test('syncBranchProtection updates REST-backed branch protection when GraphQL ha
   assert.ok(patchCall, 'expected REST PATCH branch-protection call');
   assert.ok(patchCall.includes('repos/IgorGanapolsky/ThumbGate/branches/main/protection/required_status_checks'));
   assert.ok(patchCall.includes('contexts[]=Socket Security: Project Report'));
-  assert.equal(patchCall.includes('contexts[]=Socket Security: Pull Request Alerts'), false);
+  assert.ok(patchCall.includes('contexts[]=Socket Security: Pull Request Alerts'));
 });
 
 test('syncBranchProtection updates main branch protection to the configured quality checks', () => {
@@ -245,7 +247,8 @@ test('syncBranchProtection updates main branch protection to the configured qual
                 'Verify changeset',
                 'SonarCloud Code Analysis',
                 'GitGuardian Security Checks',
-                'Socket Security: Project Report'
+                'Socket Security: Project Report',
+                'Socket Security: Pull Request Alerts'
               ]
             }
           }


### PR DESCRIPTION
## Summary
- add the live Socket Security: Pull Request Alerts context to canonical merge quality checks
- update branch protection sync tests so current GitHub protection is expected instead of treated as drift

## Verification
- npm run branch-protection:check
- npm test