### PR TITLE
fix(gates): hard block destructive local actions

### DIFF
--- a/.changeset/hard-block-gate.md
+++ b/.changeset/hard-block-gate.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Hard-block destructive local shell actions in default gates and render CLI thumbs-down feedback with the correct label.

--- a/config/gates/default.json
+++ b/config/gates/default.json
@@ -147,6 +147,28 @@
       "compliance": ["NIST-CM-5", "SOC2-CC8.1", "CWE-863"]
     },
     {
+      "id": "git-reset-hard",
+      "layer": "Execution",
+      "trigger": "Bash:git_reset_hard",
+      "toolNames": ["Bash"],
+      "pattern": "(?:^|[;&|]\\s*)git\\s+reset\\s+--hard\\b",
+      "action": "block",
+      "message": "git reset --hard is blocked because it can destroy uncommitted work. Stash or use a non-destructive restore path with explicit user approval.",
+      "severity": "critical",
+      "compliance": ["NIST-CM-5", "SOC2-CC8.1", "CWE-863"]
+    },
+    {
+      "id": "git-clean-force",
+      "layer": "Execution",
+      "trigger": "Bash:git_clean_force",
+      "toolNames": ["Bash"],
+      "pattern": "(?:^|[;&|]\\s*)git\\s+clean\\s+(?:-[^\\s]*f[^\\s]*|--force)\\b",
+      "action": "block",
+      "message": "git clean --force is blocked because it can delete untracked user work. Inventory files and get explicit approval before destructive cleanup.",
+      "severity": "critical",
+      "compliance": ["NIST-CM-5", "SOC2-CC8.1", "CWE-863"]
+    },
+    {
       "id": "protected-branch-push",
       "layer": "Execution",
       "trigger": "Bash:protected_push",
@@ -154,6 +176,17 @@
       "action": "block",
       "message": "Direct push to protected branch. Use feature branches and PRs.",
       "severity": "critical"
+    },
+    {
+      "id": "rm-rf-home-or-root",
+      "layer": "Execution",
+      "trigger": "Bash:rm_rf_home_or_root",
+      "toolNames": ["Bash"],
+      "pattern": "(?:^|[;&|]\\s*)rm\\s+-(?=[^\\s]*r)(?=[^\\s]*f)[^\\s]+\\s+(?:/|/\\*|~(?:/[^\\s]*)?|\\$HOME(?:/[^\\s]*)?)(?:\\s|$)",
+      "action": "block",
+      "message": "Broad rm -rf against root or home is blocked. Use a narrow, reviewed path and explicit approval for destructive deletes.",
+      "severity": "critical",
+      "compliance": ["NIST-CM-5", "SOC2-CC8.1", "CWE-732"]
     },
     {
       "id": "env-file-edit",

--- a/scripts/cli-feedback.js
+++ b/scripts/cli-feedback.js
@@ -73,8 +73,7 @@ function processInlineFeedback({ signal, context, chatHistory, whatWentWrong, wh
  */
 function formatCliOutput(result) {
   const lines = [];
-  const feedbackSignal = result.feedbackResult
-    && (result.feedbackResult.signal || (result.feedbackResult.feedbackEvent && result.feedbackResult.feedbackEvent.signal));
+  const feedbackSignal = result.feedbackResult?.signal || result.feedbackResult?.feedbackEvent?.signal;
   const isDown = ['down', 'negative', 'thumbs_down'].includes(feedbackSignal);
 
   // Header

--- a/scripts/cli-feedback.js
+++ b/scripts/cli-feedback.js
@@ -73,7 +73,9 @@ function processInlineFeedback({ signal, context, chatHistory, whatWentWrong, wh
  */
 function formatCliOutput(result) {
   const lines = [];
-  const isDown = result.feedbackResult && result.feedbackResult.signal === 'negative';
+  const feedbackSignal = result.feedbackResult
+    && (result.feedbackResult.signal || (result.feedbackResult.feedbackEvent && result.feedbackResult.feedbackEvent.signal));
+  const isDown = ['down', 'negative', 'thumbs_down'].includes(feedbackSignal);
 
   // Header
   if (result.feedbackResult && result.feedbackResult.accepted !== false) {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -624,6 +624,27 @@ describe('bin/cli.js', () => {
     fs.rmSync(feedbackDir, { recursive: true, force: true });
   });
 
+  test('hook-auto-capture renders thumbs down for down feedback', () => {
+    const feedbackDir = makeTmpDir();
+    const result = runCliSync(['hook-auto-capture'], {
+      env: {
+        ...process.env,
+        THUMBGATE_FEEDBACK_DIR: feedbackDir,
+        CLAUDE_USER_PROMPT: 'thumbs down This response skipped the required verification',
+        THUMBGATE_NO_NUDGE: '1',
+      },
+    });
+
+    assert.equal(result.status, 0, `hook-auto-capture failed:\n${result.stderr}`);
+    assert.match(result.stdout, /Thumbs down recorded/);
+    assert.doesNotMatch(result.stdout, /Thumbs up recorded/);
+
+    const cache = JSON.parse(fs.readFileSync(path.join(feedbackDir, 'statusline_cache.json'), 'utf8'));
+    assert.equal(cache.thumbs_down, '1');
+    assert.equal(cache.total_feedback, '1');
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
+  });
+
   test('statusline-render syncs missed Claude feedback even when the cache is still fresh', () => {
     const projectDir = makeTmpDir();
     const feedbackDir = path.join(projectDir, '.thumbgate');

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -744,6 +744,42 @@ test('run blocks git push via stdin-like input', () => {
   cleanupStateFiles();
 });
 
+test('run blocks destructive local git cleanup by default', () => {
+  cleanupStateFiles();
+  const resetOutput = JSON.parse(run({
+    tool_name: 'Bash',
+    tool_input: { command: 'git reset --hard HEAD' },
+  }));
+  assert.equal(resetOutput.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(resetOutput.hookSpecificOutput.permissionDecisionReason, /git-reset-hard/);
+
+  const cleanOutput = JSON.parse(run({
+    tool_name: 'Bash',
+    tool_input: { command: 'git clean -fd' },
+  }));
+  assert.equal(cleanOutput.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(cleanOutput.hookSpecificOutput.permissionDecisionReason, /git-clean-force/);
+  cleanupStateFiles();
+});
+
+test('run blocks broad rm -rf against root or home by default', () => {
+  cleanupStateFiles();
+  const rootOutput = JSON.parse(run({
+    tool_name: 'Bash',
+    tool_input: { command: 'rm -rf /' },
+  }));
+  assert.equal(rootOutput.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(rootOutput.hookSpecificOutput.permissionDecisionReason, /rm-rf-home-or-root/);
+
+  const homeOutput = JSON.parse(run({
+    tool_name: 'Bash',
+    tool_input: { command: 'rm -rf $HOME/tmp' },
+  }));
+  assert.equal(homeOutput.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(homeOutput.hookSpecificOutput.permissionDecisionReason, /rm-rf-home-or-root/);
+  cleanupStateFiles();
+});
+
 test('run passes through non-matching commands', () => {
   const output = JSON.parse(run({
     tool_name: 'Bash',


### PR DESCRIPTION
## Summary
- add default hard-block gates for git reset --hard, git clean --force, and broad rm -rf against root/home
- fix CLI feedback output so down/negative feedback renders as thumbs-down
- add regression tests for destructive gate blocking and hook-auto-capture output

## Verification
- node --test tests/gates-engine.test.js tests/cli.test.js
- node scripts/sync-version.js --check
- node --test tests/package-boundary.test.js tests/publish-decision.test.js tests/deployment.test.js
- node scripts/check-congruence.js
- direct gate-check probes for git reset --hard, git clean -fd, rm -rf /, and rm -rf $HOME/tmp returned permissionDecision=deny
- direct hook-auto-capture probe for thumbs down rendered "Thumbs down recorded"