### PR TITLE
fix(social): block zero-stats "blocked 0 mistakes" posts from publishing

### DIFF
--- a/.changeset/block-zero-stats-social-posts.md
+++ b/.changeset/block-zero-stats-social-posts.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+fix(social): never publish "blocked 0 mistakes, saving ~0 hours" stats posts
+
+When `getMeteredUsageSummary` returns zero blocks AND zero warnings AND zero active agents for the period, `generateWeeklyStatsPost` now sets `suppressed: true` with a human-readable `suppressedReason`. `scripts/weekly-auto-post.js` refuses to write the markdown file or call any publisher when suppressed. `scripts/social-post-hourly.js` routes the `stats` angle (and the default branch) through an evergreen fallback chain (`educational` / `hot-take` / `tip`) so the daily post cron never ships raw zero-stats text.
+
+Triggered by a 2026-04-21 CEO thumbs-down on a Bluesky post reading "This week ThumbGate blocked 0 mistakes, saving ~0 hours. Pre-action gates > post-mortem fixes." The two existing offending posts were deleted live via `com.atproto.repo.deleteRecord`; this patch prevents the pattern from ever publishing again and adds regression tests in `tests/metaclaw-features.test.js`, `tests/weekly-auto-post.test.js`, and `tests/social-post-hourly.test.js`.

--- a/scripts/daily-digest.js
+++ b/scripts/daily-digest.js
@@ -7,5 +7,52 @@ const { createSchedule } = require('./schedule-manager');
 function formatDailyDigest(d) { const title = `ThumbGate Daily Digest — ${new Date().toISOString().slice(0, 10)}`; const lines = [`Agents: ${d.activeAgents} active / ${d.totalAgents} total`, `Tool calls: ${d.totalToolCalls}`, `Blocked: ${d.totalBlocked} | Warned: ${d.totalWarned} | Allowed: ${d.totalAllowed}`, `Adherence: ${d.orgAdherenceRate}%`]; if (d.totalBlocked > 0) { lines.push(`Hours saved: ~${Math.round(d.totalBlocked * MINUTES_SAVED_PER_BLOCK / 60 * 10) / 10}h (${d.totalBlocked} mistakes blocked)`); } if (d.topBlockedGates && d.topBlockedGates.length > 0) { lines.push('', 'Top blocked gates:'); for (const g of d.topBlockedGates.slice(0, 3)) lines.push(`  - ${g.gateId}: ${g.blocked} blocked, ${g.warned} warned`); } if (d.riskAgents && d.riskAgents.length > 0) { lines.push('', 'Risk agents (low adherence):'); for (const a of d.riskAgents.slice(0, 3)) lines.push(`  - ${a.id}: ${a.adherenceRate}% adherence (${a.toolCalls} calls)`); } return { title, message: lines.join('\n') }; }
 async function sendDailyDigest({ platform, webhookUrl, windowHours = 24 }) { const db = generateOrgDashboard({ windowHours, proOverride: true }); const { title, message } = formatDailyDigest(db); const delivery = await deliver(platform, webhookUrl, title, message); return { title, message, delivery }; }
 function createDailyDigestSchedule({ platform, webhookUrl, time = '9:00' }) { const cmd = [`const d = require(${JSON.stringify(__filename)});`, `d.sendDailyDigest(${JSON.stringify({ platform, webhookUrl })})`, '.then(r => { process.stdout.write(JSON.stringify(r, null, 2) + "\\n"); })', '.catch(e => { process.stderr.write(e.message + "\\n"); process.exit(1); });'].join(' '); return createSchedule({ id: 'thumbgate-daily-digest', name: 'ThumbGate Daily Digest', description: `Daily ${platform} digest at ${time}`, schedule: `daily ${time}`, command: cmd }); }
-function generateWeeklyStatsPost({ periodDays = 7 } = {}) { const u = getMeteredUsageSummary({ periodDays }); const db = generateOrgDashboard({ windowHours: periodDays * 24, proOverride: true }); const stats = { blockedCount: u.blockedCount, warnedCount: u.warnedCount, hoursSaved: u.hoursSaved, activeAgents: db.activeAgents, adherenceRate: db.orgAdherenceRate, topGate: db.topBlockedGates.length > 0 ? db.topBlockedGates[0].gateId : null }; const lines = [`This week ThumbGate blocked ${stats.blockedCount} mistakes, saving ~${stats.hoursSaved} hours.`]; if (stats.activeAgents > 0) lines.push(`${stats.activeAgents} agents running at ${stats.adherenceRate}% adherence.`); if (stats.warnedCount > 0) lines.push(`${stats.warnedCount} additional warnings surfaced before they became errors.`); if (stats.topGate) lines.push(`Most active gate: ${stats.topGate}`); lines.push('', 'Pre-action gates > post-mortem fixes.'); return { post: lines.join('\n'), stats }; }
+// Build-in-public stats post generator.
+//
+// SUPPRESSION CONTRACT (added 2026-04-21 after a zero-stats Bluesky incident
+// where "This week ThumbGate blocked 0 mistakes, saving ~0 hours" shipped
+// publicly — the CEO flagged it as a disaster). When the window has zero
+// blocks AND zero warnings AND zero active agents, we refuse to produce a
+// publishable post. Callers MUST check `suppressed` before publishing.
+// The `post` field is still returned for logging/observability, but must
+// not be posted to any public channel when suppressed is true.
+function generateWeeklyStatsPost({ periodDays = 7 } = {}) {
+  const u = getMeteredUsageSummary({ periodDays });
+  const db = generateOrgDashboard({ windowHours: periodDays * 24, proOverride: true });
+  const stats = {
+    blockedCount: u.blockedCount,
+    warnedCount: u.warnedCount,
+    hoursSaved: u.hoursSaved,
+    activeAgents: db.activeAgents,
+    adherenceRate: db.orgAdherenceRate,
+    topGate: db.topBlockedGates.length > 0 ? db.topBlockedGates[0].gateId : null,
+  };
+
+  const hasSignal =
+    stats.blockedCount > 0 || stats.warnedCount > 0 || stats.activeAgents > 0;
+
+  const lines = [
+    `This week ThumbGate blocked ${stats.blockedCount} mistakes, saving ~${stats.hoursSaved} hours.`,
+  ];
+  if (stats.activeAgents > 0) {
+    lines.push(`${stats.activeAgents} agents running at ${stats.adherenceRate}% adherence.`);
+  }
+  if (stats.warnedCount > 0) {
+    lines.push(`${stats.warnedCount} additional warnings surfaced before they became errors.`);
+  }
+  if (stats.topGate) lines.push(`Most active gate: ${stats.topGate}`);
+  lines.push('', 'Pre-action gates > post-mortem fixes.');
+
+  if (!hasSignal) {
+    return {
+      post: lines.join('\n'),
+      stats,
+      suppressed: true,
+      suppressedReason:
+        `no activity in ${periodDays}-day window (blocked=0, warned=0, activeAgents=0) — refusing to publish zero-stats post`,
+    };
+  }
+
+  return { post: lines.join('\n'), stats, suppressed: false };
+}
 module.exports = { formatDailyDigest, sendDailyDigest, createDailyDigestSchedule, generateWeeklyStatsPost };

--- a/scripts/social-post-hourly.js
+++ b/scripts/social-post-hourly.js
@@ -56,8 +56,21 @@ function getTodayAngle() {
   return DAILY_ANGLES[idx];
 }
 
+// Angles to rotate through when the primary 'stats' angle is suppressed
+// because there's no activity to report. Ordered by deterministic safety:
+// each entry is a purely evergreen angle with NO dynamic values that can
+// be zero. See 2026-04-21 Bluesky incident where an unsuppressed stats
+// post shipped "blocked 0 mistakes, saving ~0 hours" to the public feed.
+const STATS_FALLBACK_CHAIN = ['educational', 'hot-take', 'tip'];
+
+function pickStatsFallbackAngle() {
+  // UTCDay-driven rotation so different weeks don't repeat the same fallback.
+  const idx = new Date().getUTCDay() % STATS_FALLBACK_CHAIN.length;
+  return STATS_FALLBACK_CHAIN[idx];
+}
+
 function generatePost(angle) {
-  const { post, stats } = generateWeeklyStatsPost({ periodDays: 1 });
+  const { post, stats, suppressed } = generateWeeklyStatsPost({ periodDays: 1 });
   // Primary CTA routes through the production landing page so the funnel
   // ledger (scripts/funnel/*) can attribute views → installs → paid. Links
   // passed through `tagUrlsInText` auto-inject utm_source=zernio etc. because
@@ -144,9 +157,21 @@ function generatePost(angle) {
       ].join('\n');
 
     case 'stats':
-      return post; // Use the generated weekly stats
+      // Refuse to emit a zero-stats post; fall back to an evergreen angle.
+      if (suppressed) {
+        const fallback = pickStatsFallbackAngle();
+        return generatePost(fallback);
+      }
+      return post;
 
     default:
+      // When the caller requested an unknown angle and stats are empty, do
+      // NOT silently hand back a zero-stats post. Route through the same
+      // fallback chain as the 'stats' angle.
+      if (suppressed) {
+        const fallback = pickStatsFallbackAngle();
+        return generatePost(fallback);
+      }
       return post;
   }
 }
@@ -226,6 +251,7 @@ if (isCliEntrypoint()) {
 
 module.exports = {
   DAILY_ANGLES,
+  STATS_FALLBACK_CHAIN,
   TEXT_PLATFORMS,
   generatePost,
   getTodayAngle,
@@ -233,5 +259,6 @@ module.exports = {
   isCliEntrypoint,
   isNonFatalPostFailure,
   main,
+  pickStatsFallbackAngle,
   runCli,
 };

--- a/scripts/weekly-auto-post.js
+++ b/scripts/weekly-auto-post.js
@@ -21,12 +21,28 @@ const POSTS_DIR = path.join(os.homedir(), '.thumbgate', 'weekly-posts');
 
 /**
  * Generate a weekly stats post file in post-everywhere format.
- * Returns the file path.
+ * Returns the file path — OR a suppression marker with `filePath: null`
+ * when there is no activity to report. The file is NOT written when
+ * suppressed, because "This week ThumbGate blocked 0 mistakes, saving ~0
+ * hours" is actively harmful to ship publicly (see the 2026-04-21 Bluesky
+ * disaster flagged by the CEO).
  */
 function generateWeeklyPostFile({ periodDays = 7 } = {}) {
-  const { post, stats } = generateWeeklyStatsPost({ periodDays });
-
+  const { post, stats, suppressed, suppressedReason } = generateWeeklyStatsPost({ periodDays });
   const date = new Date().toISOString().slice(0, 10);
+
+  if (suppressed) {
+    return {
+      filePath: null,
+      filename: null,
+      post,
+      stats,
+      date,
+      suppressed: true,
+      suppressedReason,
+    };
+  }
+
   const filename = `weekly-stats-${date}.md`;
 
   // Build post-everywhere compatible frontmatter
@@ -46,15 +62,29 @@ function generateWeeklyPostFile({ periodDays = 7 } = {}) {
   const filePath = path.join(POSTS_DIR, filename);
   fs.writeFileSync(filePath, content);
 
-  return { filePath, filename, post, stats, date };
+  return { filePath, filename, post, stats, date, suppressed: false };
 }
 
 /**
  * Generate and post weekly stats. Full pipeline.
  * If dryRun is true, generates the file but doesn't post.
+ * If generation is suppressed (no activity), no file is written and no
+ * publish is attempted. The suppression reason is surfaced in the result.
  */
 async function runWeeklyPost({ periodDays = 7, platforms, dryRun = false } = {}) {
   const generated = generateWeeklyPostFile({ periodDays });
+
+  if (generated.suppressed) {
+    return {
+      generated,
+      posted: false,
+      suppressed: true,
+      suppressedReason: generated.suppressedReason,
+      zernioResult: null,
+      postResult: null,
+      dryRun,
+    };
+  }
 
   let postResult = null;
   let zernioResult = null;
@@ -82,6 +112,7 @@ async function runWeeklyPost({ periodDays = 7, platforms, dryRun = false } = {})
   return {
     generated,
     posted: !dryRun,
+    suppressed: false,
     zernioResult,
     postResult,
     dryRun,

--- a/tests/metaclaw-features.test.js
+++ b/tests/metaclaw-features.test.js
@@ -53,9 +53,40 @@ test('formatDailyDigest produces title and message', () => {
 test('formatDailyDigest empty dashboard', () => {
   assert.ok(!digest.formatDailyDigest({ activeAgents: 0, totalAgents: 0, totalToolCalls: 0, totalBlocked: 0, totalWarned: 0, totalAllowed: 0, orgAdherenceRate: 100, topBlockedGates: [], riskAgents: [] }).message.includes('Hours saved'));
 });
-test('generateWeeklyStatsPost returns post', () => {
-  const { post } = digest.generateWeeklyStatsPost({ periodDays: 1 });
-  assert.ok(post.includes('ThumbGate blocked')); assert.ok(post.includes('Pre-action gates'));
+test('generateWeeklyStatsPost returns post text and a suppression flag', () => {
+  const r = digest.generateWeeklyStatsPost({ periodDays: 1 });
+  assert.ok(r.post.includes('ThumbGate blocked'));
+  assert.ok(r.post.includes('Pre-action gates'));
+  // Contract: the return shape must always expose `suppressed` so callers
+  // can refuse to publish zero-stats posts (see 2026-04-21 Bluesky incident).
+  assert.equal(typeof r.suppressed, 'boolean');
+});
+test('generateWeeklyStatsPost suppresses zero-activity window', () => {
+  // Earlier `recordMeteredUsage` tests in this file intentionally seed the
+  // shared ledger (it lives under THUMBGATE_FEEDBACK_DIR). For this zero-
+  // stats suppression test we need a truly empty ledger, so re-point the
+  // env dir for the duration of this test, clear the cache, and restore.
+  const prev = process.env.THUMBGATE_FEEDBACK_DIR;
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-empty-'));
+  process.env.THUMBGATE_FEEDBACK_DIR = empty;
+  try {
+    // digest + org-dashboard + metered-billing cache module state; reload
+    // them against the empty dir so the summary is genuinely zero.
+    delete require.cache[require.resolve('../scripts/daily-digest')];
+    delete require.cache[require.resolve('../scripts/org-dashboard')];
+    delete require.cache[require.resolve('../scripts/metered-billing')];
+    const freshDigest = require('../scripts/daily-digest');
+    const r = freshDigest.generateWeeklyStatsPost({ periodDays: 1 });
+    assert.equal(r.suppressed, true);
+    assert.match(r.suppressedReason, /no activity/);
+  } finally {
+    process.env.THUMBGATE_FEEDBACK_DIR = prev;
+    fs.rmSync(empty, { recursive: true, force: true });
+    // Restore caches so subsequent tests see the shared tmpDir again.
+    delete require.cache[require.resolve('../scripts/daily-digest')];
+    delete require.cache[require.resolve('../scripts/org-dashboard')];
+    delete require.cache[require.resolve('../scripts/metered-billing')];
+  }
 });
 test('createDailyDigestSchedule works', () => {
   const r = digest.createDailyDigestSchedule({ platform: 'slack', webhookUrl: 'https://hooks.slack.com/test' });

--- a/tests/social-post-hourly.test.js
+++ b/tests/social-post-hourly.test.js
@@ -2,12 +2,21 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 
+const os = require('node:os');
+const fs = require('node:fs');
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-sph-'));
+// Force zero-activity stats so the suppression path is exercised.
+process.env.THUMBGATE_FEEDBACK_DIR = tmpDir;
+test.after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
 const {
   DAILY_ANGLES,
+  STATS_FALLBACK_CHAIN,
   generatePost,
   handlePostFailure,
   isCliEntrypoint,
   isNonFatalPostFailure,
+  pickStatsFallbackAngle,
   runCli,
 } = require('../scripts/social-post-hourly');
 const { ZernioQuotaError } = require('../scripts/social-analytics/publishers/zernio');
@@ -93,6 +102,41 @@ test('daily social poster detects its CLI entrypoint by filename', () => {
   assert.equal(isCliEntrypoint({ filename: scriptPath }), true);
   assert.equal(isCliEntrypoint({ filename: __filename }), false);
   assert.equal(isCliEntrypoint(null), false);
+});
+
+// Zero-stats Bluesky-disaster regression guard (2026-04-21): the CEO flagged
+// a public Bluesky post reading "This week ThumbGate blocked 0 mistakes,
+// saving ~0 hours. Pre-action gates > post-mortem fixes." — the worst
+// possible advertisement for a "pre-action gate" product. Under zero-
+// activity stats, the 'stats' and default branches MUST pick an evergreen
+// fallback angle, NOT emit the raw post text.
+test('stats angle falls back to an evergreen angle when there is no activity', () => {
+  const content = generatePost('stats');
+  assert.ok(
+    !/blocked 0 mistakes/i.test(content),
+    `stats angle must not publish "blocked 0 mistakes" in a zero-activity window; got:\n${content}`,
+  );
+  assert.ok(
+    !/saving ~0 hours/i.test(content),
+    `stats angle must not publish "saving ~0 hours" in a zero-activity window; got:\n${content}`,
+  );
+});
+
+test('unknown angles also fall back to evergreen angle on zero activity', () => {
+  const content = generatePost('this-angle-does-not-exist');
+  assert.ok(!/blocked 0 mistakes/i.test(content));
+  assert.ok(!/saving ~0 hours/i.test(content));
+});
+
+test('pickStatsFallbackAngle returns only evergreen angles with no dynamic zeros', () => {
+  for (const angle of STATS_FALLBACK_CHAIN) {
+    assert.ok(DAILY_ANGLES.includes(angle), `${angle} must be a real angle`);
+    const content = generatePost(angle);
+    assert.ok(!/\b0 mistakes\b/i.test(content));
+    assert.ok(!/saving ~0 hours/i.test(content));
+  }
+  const picked = pickStatsFallbackAngle();
+  assert.ok(STATS_FALLBACK_CHAIN.includes(picked));
 });
 
 // Funnel-attribution regression guard (2026-04-21): every daily post that

--- a/tests/weekly-auto-post.test.js
+++ b/tests/weekly-auto-post.test.js
@@ -12,32 +12,44 @@ const wp = require('../scripts/weekly-auto-post');
 test.after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
 // === Generate Post File ===
-test('generateWeeklyPostFile creates markdown with frontmatter', () => {
+// With THUMBGATE_FEEDBACK_DIR pointed at a fresh tmp, there is no activity,
+// so the generator MUST suppress the post — no file written, no content to
+// publish. This is the 2026-04-21 Bluesky-disaster regression guard.
+test('generateWeeklyPostFile suppresses zero-activity windows (no file written)', () => {
   const r = wp.generateWeeklyPostFile({ periodDays: 7 });
-  assert.ok(r.filePath.endsWith('.md'));
-  assert.ok(fs.existsSync(r.filePath));
-  const content = fs.readFileSync(r.filePath, 'utf-8');
-  assert.ok(content.includes('---'));
-  assert.ok(content.includes('title:'));
-  assert.ok(content.includes('ThumbGate blocked'));
-  assert.ok(content.includes('#ThumbGate'));
+  assert.equal(r.suppressed, true);
+  assert.equal(r.filePath, null);
+  assert.equal(r.filename, null);
   assert.ok(r.date);
   assert.ok(r.stats);
+  assert.match(r.suppressedReason, /no activity/);
 });
 
-test('generateWeeklyPostFile includes stats data', () => {
+test('generateWeeklyPostFile returns numeric stats even when suppressed', () => {
   const r = wp.generateWeeklyPostFile({ periodDays: 1 });
-  assert.ok(typeof r.stats.blockedCount === 'number');
-  assert.ok(typeof r.stats.hoursSaved === 'number');
+  assert.equal(typeof r.stats.blockedCount, 'number');
+  assert.equal(typeof r.stats.hoursSaved, 'number');
 });
 
 // === Run Weekly Post (dry run) ===
-test('runWeeklyPost dry run generates but does not post', async () => {
+test('runWeeklyPost dry run on zero-activity window returns suppressed', async () => {
   const r = await wp.runWeeklyPost({ periodDays: 7, dryRun: true });
-  assert.equal(r.dryRun, true);
+  assert.equal(r.suppressed, true);
   assert.equal(r.posted, false);
   assert.equal(r.postResult, null);
-  assert.ok(r.generated.filePath);
+  assert.equal(r.zernioResult, null);
+  assert.equal(r.generated.filePath, null);
+});
+
+test('runWeeklyPost does NOT attempt to publish when suppressed', async () => {
+  // Even with dryRun:false, a suppressed generation must short-circuit BEFORE
+  // any publisher is imported/called. This is the critical guarantee that
+  // blocks a "blocked 0 mistakes" post from reaching Bluesky/X/LinkedIn.
+  const r = await wp.runWeeklyPost({ periodDays: 7, dryRun: false });
+  assert.equal(r.suppressed, true);
+  assert.equal(r.posted, false);
+  assert.equal(r.zernioResult, null);
+  assert.equal(r.postResult, null);
 });
 
 // === Schedule ===
@@ -51,11 +63,19 @@ test('createWeeklyPostSchedule creates monday 10am schedule', () => {
 
 // === List Posts ===
 test('listWeeklyPosts returns generated files', () => {
-  wp.generateWeeklyPostFile({ periodDays: 7 });
-  const posts = wp.listWeeklyPosts();
-  assert.ok(posts.length >= 1);
-  assert.ok(posts[0].filename.endsWith('.md'));
-  assert.ok(posts[0].date);
+  // Seed a fixture directly because the generator now refuses to write when
+  // there is no activity in the window (anti-zero-stats-post guard).
+  fs.mkdirSync(wp.POSTS_DIR, { recursive: true });
+  const fixturePath = path.join(wp.POSTS_DIR, 'weekly-stats-2099-01-01.md');
+  fs.writeFileSync(fixturePath, '---\ntitle: fixture\n---\n\nseed\n');
+  try {
+    const posts = wp.listWeeklyPosts();
+    assert.ok(posts.length >= 1);
+    assert.ok(posts[0].filename.endsWith('.md'));
+    assert.ok(posts[0].date);
+  } finally {
+    fs.unlinkSync(fixturePath);
+  }
 });
 
 // === POSTS_DIR ===


### PR DESCRIPTION
## Incident

On 2026-04-21 the CEO flagged a live Bluesky post (@iganapolsky.bsky.social) reading:

> This week ThumbGate blocked 0 mistakes, saving ~0 hours.
>
> Pre-action gates > post-mortem fixes.

This is the worst possible advertisement for a "pre-action gate" product — a post that explicitly says zero actions were prevented.

**Two live offending posts were deleted during incident response** via `com.atproto.repo.deleteRecord` (Apr 13 — both confirmed gone via a follow-up `app.bsky.feed.getAuthorFeed` scan).

## Root cause

`scripts/daily-digest.js#generateWeeklyStatsPost` happily formatted zero-stats text with the `blockedCount=0, hoursSaved=0` values embedded, and three call-sites shipped it straight to public feeds:

- `scripts/social-post-hourly.js` — the `stats` daily-rotation angle and the default branch both returned `post` verbatim.
- `scripts/weekly-auto-post.js` — `runWeeklyPost` wrote the markdown + called Zernio unconditionally.

## Fix

- **Suppression contract on the generator.** `generateWeeklyStatsPost` now returns `{ post, stats, suppressed, suppressedReason }`. `suppressed === true` when `blockedCount === 0 && warnedCount === 0 && activeAgents === 0`. Callers must honor it — the `post` text is still returned for logging, but must not be published.
- **Weekly auto-poster short-circuits.** `runWeeklyPost` with `dryRun: false` now aborts BEFORE any publisher is imported/called when suppressed. No file written, no Zernio call, no post-everywhere fallback. The suppression reason is surfaced in the result object.
- **Daily poster falls back.** `generatePost('stats')` and the default-angle branch in `social-post-hourly.js` fall back through `STATS_FALLBACK_CHAIN = ['educational', 'hot-take', 'tip']` when suppression fires. These angles have zero dynamic values.

## Regression tests

- `tests/metaclaw-features.test.js` — asserts return shape exposes boolean `suppressed`, and asserts suppression on a fresh empty env (with require-cache clearing around the assertion so earlier meter-ledger tests in the same file don't pollute).
- `tests/weekly-auto-post.test.js` — asserts `generateWeeklyPostFile` returns `filePath: null, suppressed: true` on zero activity; asserts `runWeeklyPost({ dryRun: false })` does NOT call any publisher when suppressed.
- `tests/social-post-hourly.test.js` — pins that the `stats` angle and unknown angles must not emit `blocked 0 mistakes` or `saving ~0 hours` under zero-activity; pins `pickStatsFallbackAngle` output domain.

## Verification

- `npm test` — 0 failures (all 3 affected test files 55/55 pass; full suite also green locally).
- Live Bluesky feed scanned post-deletion: `remaining_garbage=0` across the last 100 author-feed posts.

## Not included

- No changes to publisher modules themselves (Zernio, post-everywhere). The fix is at the generator + orchestrator layer where it belongs.
- No X/Twitter code touched — per the retired-distribution directive in CLAUDE.md.