### PR TITLE
fix(ci): allow changeset-audited publish no-op

### DIFF
--- a/.changeset/publish-noop-guard-audited-release.md
+++ b/.changeset/publish-noop-guard-audited-release.md
@@ -1,0 +1,4 @@
+'thumbgate': patch
+---
+
+Treat pending changesets as an audited no-op path in the npm publish guard so main no longer fails when release-relevant content lands ahead of the next versioned publish.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -89,7 +89,8 @@ jobs:
       - name: Guard against silent no-op when main has content changes since last publish
         # Prevents the "1.5.2 already on npm, content changes don't ship" failure mode.
         # If the published version already exists but main has meaningful source changes
-        # (README, HTML, scripts) since that tag, we should have bumped the version.
+        # (README, HTML, scripts) since that tag, we should have bumped the version
+        # unless an audited changeset is still pending.
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.npm.outputs.published == 'true' && steps.plan.outputs.skip_publish == 'true'
         env:
           VERSION: ${{ steps.package.outputs.version }}
@@ -109,7 +110,13 @@ jobs:
             'package.json' 'package-lock.json' 'server.json' \
             'adapters/**' 'plugins/**' 'public/*.html' 'scripts/*.js' \
             'src/**' 'bin/**' 'README.md' 'CHANGELOG.md' 2>/dev/null | wc -l | tr -d ' ')
+          PENDING_CHANGESETS=$(git diff --name-only "$LAST_TAG"..HEAD -- '.changeset/*.md' 2>/dev/null | grep -v '^.changeset/README.md$' | wc -l | tr -d ' ')
           if [ "$SHIPPED_CHANGES" -gt 0 ]; then
+            if [ "$PENDING_CHANGESETS" -gt 0 ]; then
+              echo "::notice::Shipped content changed since ${LAST_TAG}, but ${PENDING_CHANGESETS} pending changeset file(s) were detected. Treating this no-op as release-audited until the next versioned publish lands."
+              git diff --name-only "$LAST_TAG"..HEAD -- '.changeset/*.md' | grep -v '^.changeset/README.md$' | head -20
+              exit 0
+            fi
             echo "::error::Silent no-op detected: ${SHIPPED_CHANGES} shipped files changed since ${LAST_TAG} but package.json still says ${VERSION} (already on npm). Bump the version or tests won't verify the content ships."
             git diff --name-only "$LAST_TAG"..HEAD -- \
               'package.json' 'package-lock.json' 'server.json' \

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -398,6 +398,9 @@ test('Publish to NPM workflow uses the tested publish-decision guardrail', () =>
   assert.match(workflow, /steps\.plan\.outputs\.publish_npm == 'true'/);
   assert.match(workflow, /'package\.json'\s+'package-lock\.json'\s+'server\.json'/);
   assert.match(workflow, /'adapters\/\*\*'\s+'plugins\/\*\*'/);
+  assert.match(workflow, /PENDING_CHANGESETS=\$\(git diff --name-only "\$LAST_TAG"\.\.HEAD -- '\.changeset\/\*\.md'/);
+  assert.match(workflow, /grep -v '\^\.changeset\/README\.md\$'/);
+  assert.match(workflow, /Treating this no-op as release-audited until the next versioned publish lands\./);
   assert.match(workflow, /npm publish --tag "\$\{\{\s*steps\.plan\.outputs\.npm_tag \|\| 'latest'\s*\}\}" --provenance/);
   assert.match(workflow, /--install-attempts 12 --install-delay-ms 10000/);
 });


### PR DESCRIPTION
## Summary
- let the publish no-op guard treat pending changesets as an audited release path instead of a hard failure
- keep the silent no-op protection for shipped content changes that land without a version bump or changeset
- add workflow coverage so the release guard stays aligned with the tested expectation

## Verification
- node --test tests/deployment.test.js tests/changeset-check.test.js