### PR TITLE
test(reflector-agent): isolate unit tests from developer feedback DB

### DIFF
--- a/.changeset/reflector-agent-test-isolation.md
+++ b/.changeset/reflector-agent-test-isolation.md
@@ -1,0 +1,18 @@
+---
+"thumbgate": patch
+---
+
+test(reflector-agent): isolate from developer feedback DB
+
+The `reflector-agent.test.js` unit tests call `checkRecurrence`, which
+transitively reads `memory-log.jsonl` under the resolved feedback dir.
+On developer machines with a populated lesson DB, assertions that
+expect zero matches (`severity: 'info'`, `recurrence.count: 0`) flip
+to `'warning'` / `1` because real recurring-mistake memories leak in.
+
+Pin `THUMBGATE_FEEDBACK_DIR` to a fresh empty `mkdtempSync` dir for the
+lifetime of the file, and restore the prior value in an `after` hook.
+This lets the full verification chain run head-to-tail without one
+stray test stopping the `&&` chain.
+
+No runtime change. Tests only.

--- a/tests/reflector-agent.test.js
+++ b/tests/reflector-agent.test.js
@@ -1,8 +1,21 @@
 #!/usr/bin/env node
 'use strict';
 
-const { describe, it, beforeEach } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Isolate these unit tests from the developer's real feedback DB.
+// `checkRecurrence` → `retrieveWithRerankingSync` → `retrieveRelevantLessons`
+// reads `memory-log.jsonl` under the resolved feedback dir. When the dev
+// machine has real lessons, assertions that expect zero matches flip. Pin
+// THUMBGATE_FEEDBACK_DIR to a fresh empty tmpdir for the lifetime of this
+// file so the tests exercise the pure logic under a deterministic DB state.
+const TMP_FEEDBACK_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-reflector-'));
+const PRIOR_FEEDBACK_DIR = process.env.THUMBGATE_FEEDBACK_DIR;
+process.env.THUMBGATE_FEEDBACK_DIR = TMP_FEEDBACK_DIR;
 
 // We test the pure functions directly — they don't call lesson-retrieval internally
 // except checkRecurrence, which we test with its try/catch fallback behavior
@@ -39,6 +52,15 @@ const emptyConversation = [];
 // --- Tests ---
 
 describe('reflector-agent', () => {
+
+  after(() => {
+    if (PRIOR_FEEDBACK_DIR === undefined) {
+      delete process.env.THUMBGATE_FEEDBACK_DIR;
+    } else {
+      process.env.THUMBGATE_FEEDBACK_DIR = PRIOR_FEEDBACK_DIR;
+    }
+    try { fs.rmSync(TMP_FEEDBACK_DIR, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
 
   describe('reflect()', () => {
     it('returns reflection_complete with conversation window + negative signal', () => {


### PR DESCRIPTION
## Summary

`tests/reflector-agent.test.js` fails 2 subtests on any dev machine with a populated lesson DB:

- `returns info severity on first occurrence (no matching lessons)` — expects `severity: 'info'`, gets `'warning'`
- `returns zero count when lesson retrieval has no data` — expects `count: 0`, gets `1`

Root cause: `checkRecurrence` → `retrieveWithRerankingSync` → `retrieveRelevantLessons` reads `memory-log.jsonl` under the resolved feedback dir. The test assumes a pristine DB but the dev machine has real memories, so "first occurrence" flips.

Fix: pin `THUMBGATE_FEEDBACK_DIR` to a fresh empty `mkdtempSync` directory for the lifetime of the file (set before `require`), restore the prior value in an `after` hook. No production-code change. 28/28 pass locally.

This unblocks the full verification chain (`npm test` hit this file early and short-circuited ~140 downstream suites).

## Test plan

- [x] `node --test tests/reflector-agent.test.js` → 28 pass, 0 fail
- [ ] CI green on this branch
- [ ] After merge: full `npm test` runs head-to-tail without hitting this failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)