### PR TITLE
fix(api): lazy-load lesson and semantic boundaries

### DIFF
--- a/.changeset/api-lesson-semantic-private-boundary.md
+++ b/.changeset/api-lesson-semantic-private-boundary.md
@@ -1,0 +1,21 @@
+---
+"thumbgate": patch
+---
+
+fix(api): lazy-load lesson search and semantic private boundaries
+
+Move the remaining lesson-search and semantic-schema routes in the HTTP
+API server behind the private API module loader. The hosted runtime keeps
+the current behavior when those modules are present, while public-shell
+or partially extracted runtimes now fail with the standard
+`PRIVATE_CORE_REQUIRED` 503 instead of assuming the modules are always
+bundled.
+
+This pins two more hosted-only edges:
+
+1. `/v1/lessons/search` now resolves through the lesson-search private
+   boundary.
+2. `/v1/semantic/describe` now resolves through the semantic-layer
+   private boundary.
+3. API regression tests cover both the normal route behavior and the
+   unavailable-module fallback contract.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -156,9 +156,6 @@ const {
   getSettingsStatus,
 } = require('../../scripts/settings-hierarchy');
 const {
-  searchLessons,
-} = require('../../scripts/lesson-search');
-const {
   updateRecordInJsonl,
   deleteRecordFromJsonl,
   readJSONLLocal,
@@ -239,6 +236,8 @@ const PRIVATE_API_MODULES = Object.freeze({
   delegationRuntime: path.resolve(__dirname, '../../scripts/delegation-runtime.js'),
   hostedJobLauncher: path.resolve(__dirname, '../../scripts/hosted-job-launcher.js'),
   workflowSprintIntake: path.resolve(__dirname, '../../scripts/workflow-sprint-intake.js'),
+  lessonSearch: path.resolve(__dirname, '../../scripts/lesson-search.js'),
+  semanticLayer: path.resolve(__dirname, '../../scripts/semantic-layer.js'),
 });
 
 function createPrivateCoreUnavailableError(feature) {
@@ -5224,7 +5223,8 @@ async function addContext(){
           .split(',')
           .map((tag) => tag.trim())
           .filter(Boolean);
-        const results = searchLessons(query, {
+        const lessonSearch = requirePrivateApiModule('lessonSearch', 'Lesson search');
+        const results = lessonSearch.searchLessons(query, {
           limit: Number.isFinite(limit) ? limit : 10,
           category,
           tags,
@@ -5727,12 +5727,12 @@ async function addContext(){
 
       // GET /v1/semantic/describe — get canonical definition of a business entity
       if (req.method === 'GET' && pathname === '/v1/semantic/describe') {
-        const { describeSemanticSchema } = require('../../scripts/semantic-layer');
+        const semanticLayer = requirePrivateApiModule('semanticLayer', 'Semantic schema');
         const type = parsed.query.type;
         if (!type) {
           throw createHttpError(400, 'type query parameter is required');
         }
-        const schema = describeSemanticSchema();
+        const schema = semanticLayer.describeSemanticSchema();
         const entity = schema.entities[type] || schema.metrics[type];
         if (!entity) {
           sendProblem(res, {

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -165,6 +165,14 @@ test('private-core API module helpers report unknown and unavailable modules cle
   const directError = __test__.createPrivateCoreUnavailableError('Hosted harness jobs');
   assert.equal(directError.statusCode, 503);
   assert.equal(directError.code, 'PRIVATE_CORE_REQUIRED');
+
+  await withMissingPrivateApiModules([
+    __test__.PRIVATE_API_MODULES.lessonSearch,
+    __test__.PRIVATE_API_MODULES.semanticLayer,
+  ], async () => {
+    assert.equal(__test__.loadPrivateApiModule('lessonSearch'), null);
+    assert.equal(__test__.loadPrivateApiModule('semanticLayer'), null);
+  });
 });
 
 test('PostHog ingest proxy forwards allowed analytics requests to PostHog', async () => {
@@ -2337,6 +2345,8 @@ test('private-core API endpoints return 503 when hosted/private modules are abse
     __test__.PRIVATE_API_MODULES.delegationRuntime,
     __test__.PRIVATE_API_MODULES.hostedJobLauncher,
     __test__.PRIVATE_API_MODULES.workflowSprintIntake,
+    __test__.PRIVATE_API_MODULES.lessonSearch,
+    __test__.PRIVATE_API_MODULES.semanticLayer,
   ];
 
   await withMissingPrivateApiModules(modulePaths, async () => {
@@ -2379,6 +2389,14 @@ test('private-core API endpoints return 503 when hosted/private modules are abse
       body: JSON.stringify({ leadId: 'lead_123', status: 'qualified' }),
     });
     assert.equal(advanceRes.status, 503);
+
+    const lessonsRes = await fetch(apiUrl('/v1/lessons/search?q=rollback&limit=5'), { headers: authHeader });
+    assert.equal(lessonsRes.status, 503);
+    assert.match(await lessonsRes.text(), /private core|hosted runtime/i);
+
+    const semanticRes = await fetch(apiUrl('/v1/semantic/describe?type=Customer'), { headers: authHeader });
+    assert.equal(semanticRes.status, 503);
+    assert.match(await semanticRes.text(), /private core|hosted runtime/i);
   });
 });
 


### PR DESCRIPTION
## Summary
- move lesson-search and semantic-schema API routes behind the private API module loader
- keep normal hosted behavior when modules exist and return the standard 503 private-core contract when they do not
- add API coverage for the new unavailable-module path and a changeset for later retargeting to main

## Verification
- node --test tests/api-server.test.js
- npm run test:deployment
- npm pack --dry-run --json --ignore-scripts
- npm run changeset:check

## Stack
- base: #1153
