### PR TITLE
fix(mcp): lazy-load lesson search boundary

### DIFF
--- a/.changeset/mcp-lesson-search-private-boundary.md
+++ b/.changeset/mcp-lesson-search-private-boundary.md
@@ -1,0 +1,17 @@
+---
+"thumbgate": patch
+---
+
+fix(mcp): lazy-load lesson search private boundary
+
+Move the remaining direct lesson-search import in the MCP stdio adapter
+behind the private module loader. This keeps the hosted/private runtime
+behavior unchanged while letting the public shell return the standard
+`private_core` availability payload if lesson search is extracted out of
+the public package.
+
+This pins the boundary in two ways:
+
+1. `search_lessons` now resolves through the MCP private-module loader.
+2. MCP tests cover the unavailable-module path for lesson search along
+   with the existing private-core tool matrix.

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -91,9 +91,6 @@ const {
   getReliability,
 } = require('../../scripts/thompson-sampling');
 const {
-  searchLessons,
-} = require('../../scripts/lesson-search');
-const {
   searchThumbgate,
 } = require('../../scripts/thumbgate-search');
 const {
@@ -131,6 +128,7 @@ const PRIVATE_MCP_MODULES = Object.freeze({
   managedLessonAgent: path.resolve(__dirname, '../../scripts/managed-lesson-agent.js'),
   semanticLayer: path.resolve(__dirname, '../../scripts/semantic-layer.js'),
   lessonInference: path.resolve(__dirname, '../../scripts/lesson-inference.js'),
+  lessonSearch: path.resolve(__dirname, '../../scripts/lesson-search.js'),
 });
 
 function loadPrivateMcpModule(key) {
@@ -531,12 +529,15 @@ async function callToolInner(name, args) {
       return toCaptureFeedbackTextResult(captureFeedback(args));
     case 'feedback_summary':
       return toTextResult(feedbackSummary(Number(args.recent || 20)));
-    case 'search_lessons':
-      return toTextResult(searchLessons(args.query || '', {
+    case 'search_lessons': {
+      const module = loadPrivateMcpModule('lessonSearch');
+      if (!module) return unavailablePrivateMcpFeature('search_lessons');
+      return toTextResult(module.searchLessons(args.query || '', {
         limit: Number(args.limit || 10),
         category: args.category,
         tags: Array.isArray(args.tags) ? args.tags : [],
       }));
+    }
     case 'retrieve_lessons': {
       // Cross-encoder reranking: retrieve more candidates, then rerank for precision
       const { retrieveWithRerankingSync } = require('../../scripts/cross-encoder-reranker');

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -540,8 +540,10 @@ test('private-core MCP module helpers report unknown and unavailable modules cle
 
   await withMissingPrivateModules([
     __test__.PRIVATE_MCP_MODULES.intentRouter,
+    __test__.PRIVATE_MCP_MODULES.lessonSearch,
   ], async () => {
     assert.equal(__test__.loadPrivateMcpModule('intentRouter'), null);
+    assert.equal(__test__.loadPrivateMcpModule('lessonSearch'), null);
   });
 
   const unavailable = JSON.parse(__test__.unavailablePrivateMcpFeature('plan_intent').content[0].text);
@@ -851,8 +853,10 @@ test('private-core MCP tools return availability markers when private modules ar
     __test__.PRIVATE_MCP_MODULES.managedLessonAgent,
     __test__.PRIVATE_MCP_MODULES.semanticLayer,
     __test__.PRIVATE_MCP_MODULES.lessonInference,
+    __test__.PRIVATE_MCP_MODULES.lessonSearch,
   ];
   const toolCalls = [
+    { name: 'search_lessons', arguments: { query: 'release checklist', limit: 5 } },
     { name: 'reflect_on_feedback', arguments: { conversationWindow: [{ role: 'user', content: 'Add a rule.' }] } },
     { name: 'list_intents', arguments: {} },
     { name: 'plan_intent', arguments: { intentId: 'improve_response_quality', context: 'Need a plan' } },


### PR DESCRIPTION
## Summary
- move the remaining MCP lesson-search edge behind the private module loader
- keep hosted behavior when lesson search exists and return the standard private_core availability payload when it does not
- extend the MCP private-core matrix to cover search_lessons and add a changeset for later retargeting to main

## Verification
- node --test tests/mcp-server.test.js tests/package-boundary.test.js
- npm run test:deployment
- npm pack --dry-run --json --ignore-scripts
- npm run changeset:check

## Stack
- base: #1153
