### PR TITLE
fix(api): lazy-load commercial offer boundary

### DIFF
--- a/.changeset/api-commercial-offer-private-boundary.md
+++ b/.changeset/api-commercial-offer-private-boundary.md
@@ -1,0 +1,21 @@
+---
+"thumbgate": patch
+---
+
+fix(api): lazy-load commercial offer private boundary
+
+Move the commercial-offer helpers used by the hosted billing checkout
+path behind the private API module loader. The hosted runtime keeps the
+same behavior when the module exists, while partially extracted or
+public-shell deployments now fail with the standard
+`PRIVATE_CORE_REQUIRED` contract instead of assuming commercial offer
+logic is always bundled.
+
+This pins the current split at the checkout boundary:
+
+1. checkout attribution parsing now resolves plan/cycle/seat helpers
+   through the private API module loader.
+2. checkout offer summaries now resolve pricing constants through the
+   private API module loader.
+3. API regression coverage asserts that `/v1/billing/checkout` returns
+   503 when the commercial-offer module is absent.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -111,14 +111,6 @@ const {
   buildHostedCancelUrl,
 } = require('../../scripts/hosted-config');
 const {
-  PRO_MONTHLY_PRICE_DOLLARS,
-  PRO_ANNUAL_PRICE_DOLLARS,
-  TEAM_MONTHLY_PRICE_DOLLARS,
-  normalizePlanId,
-  normalizeBillingCycle,
-  normalizeSeatCount,
-} = require('../../scripts/commercial-offer');
-const {
   generateSkills,
 } = require('../../scripts/skill-generator');
 const {
@@ -238,6 +230,7 @@ const PRIVATE_API_MODULES = Object.freeze({
   workflowSprintIntake: path.resolve(__dirname, '../../scripts/workflow-sprint-intake.js'),
   lessonSearch: path.resolve(__dirname, '../../scripts/lesson-search.js'),
   semanticLayer: path.resolve(__dirname, '../../scripts/semantic-layer.js'),
+  commercialOffer: path.resolve(__dirname, '../../scripts/commercial-offer.js'),
 });
 
 function createPrivateCoreUnavailableError(feature) {
@@ -270,6 +263,22 @@ function requirePrivateApiModule(key, feature) {
     throw createPrivateCoreUnavailableError(feature);
   }
   return module;
+}
+
+function getCommercialOfferModule() {
+  return requirePrivateApiModule('commercialOffer', 'Commercial offer planning');
+}
+
+function normalizePlanId(value) {
+  return getCommercialOfferModule().normalizePlanId(value);
+}
+
+function normalizeBillingCycle(value) {
+  return getCommercialOfferModule().normalizeBillingCycle(value);
+}
+
+function normalizeSeatCount(value, fallback) {
+  return getCommercialOfferModule().normalizeSeatCount(value, fallback);
 }
 
 function serveStaticFile(res, filePath, { headOnly = false, cacheSeconds = 86400 } = {}) {
@@ -1356,6 +1365,7 @@ function serveTrackedLinkRedirect({ req, res, parsed, hostedConfig, isHeadReques
 }
 
 function resolveCheckoutOfferSummary(metadata = {}) {
+  const commercialOffer = getCommercialOfferModule();
   const planId = normalizePlanId(metadata.planId);
   const billingCycle = normalizeBillingCycle(metadata.billingCycle);
 
@@ -1366,8 +1376,8 @@ function resolveCheckoutOfferSummary(metadata = {}) {
       billingCycle: 'monthly',
       seatCount,
       type: 'subscription',
-      price: TEAM_MONTHLY_PRICE_DOLLARS * seatCount,
-      priceLabel: `$${TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`,
+      price: commercialOffer.TEAM_MONTHLY_PRICE_DOLLARS * seatCount,
+      priceLabel: `$${commercialOffer.TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`,
     };
   }
 
@@ -1377,7 +1387,7 @@ function resolveCheckoutOfferSummary(metadata = {}) {
       billingCycle: 'annual',
       seatCount: 1,
       type: 'subscription',
-      price: PRO_ANNUAL_PRICE_DOLLARS,
+      price: commercialOffer.PRO_ANNUAL_PRICE_DOLLARS,
       priceLabel: '$149/yr',
     };
   }
@@ -1387,7 +1397,7 @@ function resolveCheckoutOfferSummary(metadata = {}) {
     billingCycle: 'monthly',
     seatCount: 1,
     type: 'subscription',
-    price: PRO_MONTHLY_PRICE_DOLLARS,
+    price: commercialOffer.PRO_MONTHLY_PRICE_DOLLARS,
     priceLabel: '$19/mo',
   };
 }

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -169,9 +169,11 @@ test('private-core API module helpers report unknown and unavailable modules cle
   await withMissingPrivateApiModules([
     __test__.PRIVATE_API_MODULES.lessonSearch,
     __test__.PRIVATE_API_MODULES.semanticLayer,
+    __test__.PRIVATE_API_MODULES.commercialOffer,
   ], async () => {
     assert.equal(__test__.loadPrivateApiModule('lessonSearch'), null);
     assert.equal(__test__.loadPrivateApiModule('semanticLayer'), null);
+    assert.equal(__test__.loadPrivateApiModule('commercialOffer'), null);
   });
 });
 
@@ -2347,6 +2349,7 @@ test('private-core API endpoints return 503 when hosted/private modules are abse
     __test__.PRIVATE_API_MODULES.workflowSprintIntake,
     __test__.PRIVATE_API_MODULES.lessonSearch,
     __test__.PRIVATE_API_MODULES.semanticLayer,
+    __test__.PRIVATE_API_MODULES.commercialOffer,
   ];
 
   await withMissingPrivateApiModules(modulePaths, async () => {
@@ -2397,6 +2400,17 @@ test('private-core API endpoints return 503 when hosted/private modules are abse
     const semanticRes = await fetch(apiUrl('/v1/semantic/describe?type=Customer'), { headers: authHeader });
     assert.equal(semanticRes.status, 503);
     assert.match(await semanticRes.text(), /private core|hosted runtime/i);
+
+    const checkoutRes = await fetch(apiUrl('/v1/billing/checkout'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        customerEmail: 'buyer@example.com',
+        installId: 'inst_private_offer_boundary',
+      }),
+    });
+    assert.equal(checkoutRes.status, 503);
+    assert.match(await checkoutRes.text(), /private core|hosted runtime/i);
   });
 });
 


### PR DESCRIPTION
## Summary
- move commercial-offer helpers behind the private API module loader
- keep hosted checkout behavior when the module exists and return the standard private-core 503 when it does not
- add API coverage for the unavailable commercial-offer path and a changeset for later retargeting to main

## Verification
- node --test tests/api-server.test.js
- npm run test:deployment
- npm pack --dry-run --json --ignore-scripts
- npm run changeset:check

## Stack
- base: #1153
