### PR TITLE
marketing(cpc-ads): ChatGPT CPC ads campaign content

### DIFF
--- a/docs/marketing/cpc-ads-linkedin.md
+++ b/docs/marketing/cpc-ads-linkedin.md
@@ -1,0 +1,23 @@
+# LinkedIn Post: ChatGPT CPC Ads as a Price Signal
+
+**Body:**
+OpenAI turned on CPC ads inside ChatGPT yesterday. Advertisers bid $3–$5 per click. The CPM rate they launched in February collapsed from $60 to $25 in ten weeks, and a leaked StackAdapt deck shows the real floor is closer to $15.
+
+For the first time, a single LLM turn has an explicit dollar price on the open market.
+
+Your coding agent has had one for months. It just shows up on the Anthropic or OpenAI invoice at the end of the month, not as a line item with a story.
+
+The ones that fund that line item:
+- the same failing tool call retried three times in one session
+- a file regenerated from scratch because the agent lost the edit it just made
+- a mistake from last session repeating today because the context window reset
+
+None of these are exotic. They are the ordinary cost of an agent without persistent correction. The fix is not a longer system prompt. System prompts are suggestions. Agents ignore suggestions under complex reasoning chains.
+
+The fix is enforcement at the tool-call boundary. Pre-action gates fire before the agent executes a tool, check whether the pattern has been flagged as bad, and block it before the API round-trip happens. Fix it once, your bill stops seeing it.
+
+ThumbGate does this for Claude Code, Cursor, and Codex. Local-first lesson DB, PreToolUse hooks, Thompson Sampling on which gates are worth keeping. Open source.
+
+OpenAI priced attention at $3–$5 a click. Price your agent's repeat mistakes before someone else does.
+
+thumbgate.ai

--- a/docs/marketing/cpc-ads-short.md
+++ b/docs/marketing/cpc-ads-short.md
@@ -1,0 +1,12 @@
+# Bluesky + Threads: ChatGPT CPC Ads Short
+
+**Body:**
+OpenAI turned on CPC ads in ChatGPT yesterday. $3–$5 per click.
+
+Every chat turn now has an explicit dollar price on the open market.
+
+Your coding agent has had one for months — it just shows up on your Anthropic invoice, not a line item. Same failing tool call, three retries, all billed.
+
+ThumbGate catches the repeat before the call fires. Fix it once, your bill stops seeing it.
+
+thumbgate.ai

--- a/docs/marketing/reddit-posts/r-claudeai-cpc-ads.md
+++ b/docs/marketing/reddit-posts/r-claudeai-cpc-ads.md
@@ -1,0 +1,27 @@
+# Reddit Post: r/ClaudeAI
+
+**Subreddit:** r/ClaudeAI
+
+**Title:** OpenAI priced a single ChatGPT turn at $3–$5. What is a single wrong Claude retry costing you?
+
+**Body:**
+OpenAI went live with CPC bidding on ChatGPT yesterday. $3–$5 per click. That is how much an advertiser is willing to pay for a single user eyeball on a single chat response. The CPM model they launched in February already collapsed from $60 to $25, and a leaked StackAdapt deck shows the real floor is closer to $15.
+
+The useful framing for anyone running agents: a chat turn now has an explicit dollar value on the open market.
+
+A wrong Claude Code turn has one too. It just never shows up as a line item.
+
+The ones that eat my bill:
+- the same tool call retried three times in one session because the agent did not absorb why it failed
+- a file regenerated from scratch because the agent lost the edit it just made
+- a mistake from last session repeating today because the session boundary wiped memory
+
+At the team level these are not small.
+
+The approach that actually moved the number for me was pre-action gates. PreToolUse hooks that fire before the agent executes a tool call, check whether this exact pattern was previously flagged as bad, and block it before the API round-trip happens. Not a warning in the system prompt. A block.
+
+I have been building this into a local tool called ThumbGate. Thumbs-down captures the context, the tool call, the conversation state. That distills into a lesson in a local SQLite + FTS5 lesson DB. The next time an agent tries the same tool call pattern, the hook blocks it. Works with Claude Code, Cursor, Codex, any MCP-compatible agent. Local-first, MIT licensed.
+
+Not pretending this is the only solution. Curious what the r/ClaudeAI crowd is doing to cut repeat-failure cost — are you tracking it, eating it, or solving it differently?
+
+Repo: https://github.com/IgorGanapolsky/ThumbGate


### PR DESCRIPTION
## Summary
- Archive the content files shipped live 2026-04-22 to LinkedIn, Reddit r/ClaudeAI, Bluesky, and Threads (via Zernio).
- Angle: OpenAI's new \$3-\$5 CPC for ChatGPT priced a single chat turn. A wrong Claude Code retry costs similar tokens but no one sends you a receipt. ThumbGate is the pre-action gate that keeps the repeat mistake off the bill.
- Sources: Digiday (2026-04-21), Search Engine Journal (StackAdapt \$15 leak), TechCrunch (Feb 9 ad rollout).

Zernio post IDs (already live):
- LinkedIn: \`69e947d7b268a62306992f76\`
- Reddit:   \`69e947e3b268a6230699317e\`
- Bluesky:  \`69e947b0a49ea78cdb3b8329\`
- Threads:  \`69e947b28b0554dae72cf69b\`

## Test plan
- [x] Quality gate PASS on all three files (\`node scripts/post-everywhere.js <file> --platforms=... --dry-run\`)
- [x] All four posts confirmed published by Zernio
- [ ] CI green
- [ ] 0 unresolved review threads

## Notes
- Files are content-only, not imported by any runtime code, not bundled in the npm package.
- A separate spawned task will fix three dispatcher bugs in \`scripts/post-everywhere.js\` that forced us to bypass the unified CLI and call Zernio directly (LinkedIn/Threads/Bluesky method-name mismatches). Not blocking this PR.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>