### PR TITLE
feat(seo): ChatGPT ads trust guide + FAQ

### DIFF
--- a/.changeset/chatgpt-ads-trust-guide.md
+++ b/.changeset/chatgpt-ads-trust-guide.md
@@ -1,0 +1,19 @@
+---
+"thumbgate": patch
+---
+
+feat(seo): add /guides/chatgpt-ads-trust page and ChatGPT-ads FAQ
+
+New SEO/GEO guide page threading the "pre-action gates" thesis
+against the ChatGPT ads rollout (CPC bidding went live 2026-04-21
+per Digiday; ads test started 2026-02-09 per TechCrunch).
+
+Adds a JSON-LD `FAQPage` entry on the homepage answering *why does
+the ChatGPT ads rollout matter to ThumbGate?*, and links the new
+guide from the ChatGPT GPT section with a "Why ChatGPT ads need
+gates" CTA.
+
+Canonical URL pinned to `https://thumbgate.ai/guides/chatgpt-ads-trust`.
+Pre-existing guide files still use the legacy `usethumbgate.com`
+domain that 301-redirects to apex but drops the path — a separate
+PR sweeps those.

--- a/docs/marketing/chatgpt-ads-trust-pack.md
+++ b/docs/marketing/chatgpt-ads-trust-pack.md
@@ -1,0 +1,108 @@
+# ChatGPT Ads Trust Pack
+
+Use this pack when the conversation is about ChatGPT ads, AI trust, or measurement. The thesis is not "ThumbGate is an ad product." The thesis is "as AI assistants become monetized decision surfaces, teams need pre-action gates before AI suggestions turn into risky actions."
+
+## Core thesis
+
+As AI assistants become ad platforms, teams need pre-action gates, audit trails, and proof-ready runs before a monetized workflow touches users.
+
+## LinkedIn post
+
+```text
+OpenAI's ChatGPT ads story is not just a media-buying story.
+It is a trust story.
+
+OpenAI began testing ads in ChatGPT on February 9, 2026.
+This week, Digiday reported CPC bidding inside the ads manager.
+
+That means conversational AI is moving closer to a performance channel:
+- research
+- comparison
+- recommendation
+- click
+- action
+
+The moment that matters is not the click.
+It is the handoff from AI advice to real execution.
+
+If a suggested command, deployment, approval, or workflow step is one message away from running, you need a hard boundary between conversational discovery and execution.
+
+That is the ThumbGate pitch:
+- ChatGPT can be the discovery and checkpointing layer
+- typed thumbs up/down can capture feedback
+- ThumbGate becomes the pre-action gate layer that decides allow, block, or checkpoint before the risky step runs
+
+As AI assistants become ad platforms, teams need pre-action gates, audit trails, and proof-ready runs before a monetized workflow touches users.
+
+Proof:
+https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+Guide:
+https://thumbgate-production.up.railway.app/guides/chatgpt-ads-trust
+```
+
+## Reddit post
+
+```text
+ChatGPT ads make me think the real problem is no longer just "can an AI assistant recommend something?"
+
+It is "what happens when that recommendation is one step away from a real action?"
+
+OpenAI started testing ads in ChatGPT in the US on February 9, 2026, and Digiday just reported CPC bidding in the ads manager this week.
+
+To me that raises the trust bar for AI workflows.
+
+If the chat surface becomes:
+- research
+- compare
+- click
+- take action
+
+then teams need a hard boundary between AI advice and risky execution.
+
+That is what I am building with ThumbGate:
+- capture thumbs up/down on agent behavior
+- turn repeated failures into Pre-Action Gates
+- block the known-bad action before it runs
+- keep verification evidence close to the workflow
+
+I do not think the winner here is the loudest ad creative.
+I think the winner is the product teams can trust when conversational discovery starts bleeding into execution.
+
+Proof:
+https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+Guide:
+https://thumbgate-production.up.railway.app/guides/chatgpt-ads-trust
+```
+
+## Bluesky / Threads
+
+```text
+ChatGPT ads raise the trust bar.
+
+Once AI assistants become monetized discovery surfaces, teams need a hard boundary between AI advice and risky execution.
+
+That is the ThumbGate angle:
+ChatGPT for discovery and typed feedback.
+ThumbGate for Pre-Action Gates before the action runs.
+
+Guide:
+https://thumbgate-production.up.railway.app/guides/chatgpt-ads-trust
+```
+
+## Short comment reply
+
+```text
+My read: ChatGPT ads make trust and execution boundaries more important, not less.
+
+If AI is now part search surface, part recommendation engine, and part action planner, the next layer has to be enforcement.
+
+That is where ThumbGate fits: Pre-Action Gates between AI advice and the risky command.
+```
+
+## Proof links
+
+- Verification evidence: [../VERIFICATION_EVIDENCE.md](../VERIFICATION_EVIDENCE.md)
+- Pitch: [../PITCH.md](../PITCH.md)
+- GEO demand engine: [../GEO_DEMAND_ENGINE_MAR2026.md](../GEO_DEMAND_ENGINE_MAR2026.md)

--- a/public/guides/chatgpt-ads-trust.html
+++ b/public/guides/chatgpt-ads-trust.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChatGPT Ads Need Pre-Action Gates | ThumbGate Guide</title>
+  <meta name="description" content="ChatGPT ads change distribution, but they also raise the trust bar. Learn why pre-action gates, measurement discipline, and proof-backed workflow hardening matter more as AI assistants become ad surfaces." />
+  <meta property="og:title" content="ChatGPT Ads Need Pre-Action Gates | ThumbGate Guide" />
+  <meta property="og:description" content="As ChatGPT adds advertising, teams need a clean line between AI advice, monetized discovery, and risky execution. ThumbGate is the pre-action gate layer for that transition." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/chatgpt-ads-trust" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/chatgpt-ads-trust" />
+  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
+  <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
+  <meta property="og:image" content="/og.png" />
+  <style>
+    :root {
+      --bg: #0a0a0b;
+      --bg-raised: #111113;
+      --bg-card: #161618;
+      --line: #222225;
+      --text: #e8e8ec;
+      --muted: #8b8b96;
+      --cyan: #22d3ee;
+      --green: #4ade80;
+      --red: #f87171;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.65;
+    }
+    a { color: var(--cyan); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .container { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      backdrop-filter: blur(12px);
+      background: rgba(10, 10, 11, 0.88);
+      border-bottom: 1px solid var(--line);
+    }
+    .topbar .container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-top: 14px;
+      padding-bottom: 14px;
+    }
+    .brand {
+      font-weight: 700;
+      color: var(--text);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+    }
+    .brand .logo-mark { width: 28px; height: 28px; display: block; }
+    .hero { padding: 72px 0 32px; }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(34, 211, 238, 0.22);
+      background: rgba(34, 211, 238, 0.1);
+      color: var(--cyan);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    h1 {
+      font-size: clamp(34px, 5vw, 56px);
+      line-height: 1.06;
+      letter-spacing: -0.04em;
+      margin: 16px 0;
+      max-width: 760px;
+    }
+    .hero p {
+      max-width: 760px;
+      color: var(--muted);
+      font-size: 18px;
+    }
+    .signal-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin: 28px 0 0;
+    }
+    .signal-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--bg-raised);
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .signal-pill.up {
+      border-color: rgba(74, 222, 128, 0.28);
+      color: #b8f7c8;
+      background: rgba(74, 222, 128, 0.1);
+    }
+    .signal-pill.down {
+      border-color: rgba(248, 113, 113, 0.28);
+      color: #ffc0c0;
+      background: rgba(248, 113, 113, 0.1);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+      gap: 24px;
+      padding-bottom: 72px;
+    }
+    .card, .detail-section, .sidebar-card {
+      background: var(--bg-card);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+    }
+    .card { padding: 24px; }
+    .detail-section { padding: 24px; margin-bottom: 18px; }
+    .detail-section h2 { margin: 0 0 12px; font-size: 24px; letter-spacing: -0.03em; }
+    .detail-section p { color: var(--muted); }
+    .detail-section ul, .card ul { padding-left: 18px; color: var(--muted); }
+    .card h2 { margin-top: 0; }
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+    .sidebar-card {
+      padding: 20px;
+    }
+    .sidebar-card:first-child {
+      position: sticky;
+      top: 84px;
+      max-height: calc(100vh - 104px);
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .proof-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 16px;
+    }
+    .cta-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 18px;
+      padding: 12px 16px;
+      border-radius: 10px;
+      background: var(--cyan);
+      color: #071116;
+      font-weight: 700;
+      text-decoration: none;
+    }
+    .faq-item {
+      border-top: 1px solid var(--line);
+      padding: 14px 0;
+    }
+    .faq-item summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .faq-item p {
+      color: var(--muted);
+    }
+    .related-card {
+      display: block;
+      padding: 14px;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: var(--bg-raised);
+      margin-top: 12px;
+      color: var(--text);
+    }
+    .related-label {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 4px;
+    }
+    @media (max-width: 860px) {
+      .grid {
+        grid-template-columns: 1fr;
+      }
+      .sidebar-card:first-child {
+        position: static;
+        max-height: none;
+        overflow: visible;
+      }
+    }
+  </style>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "ChatGPT ads raise the trust bar for AI workflows",
+  "description": "As ChatGPT adds advertising, teams need a clean line between AI advice, monetized discovery, and risky execution. ThumbGate is the pre-action gate layer for that transition.",
+  "about": [
+    "ChatGPT ads",
+    "AI ad trust",
+    "LLM ad measurement",
+    "pre-action gates for AI coding agents"
+  ],
+  "url": "https://thumbgate.ai/guides/chatgpt-ads-trust",
+  "publisher": {
+    "@type": "Organization",
+    "name": "ThumbGate",
+    "url": "https://thumbgate.ai"
+  },
+  "mainEntityOfPage": "https://thumbgate.ai/guides/chatgpt-ads-trust"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Are ChatGPT ads live already?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "OpenAI began testing ads in ChatGPT in the US on February 9, 2026, and Digiday reported on April 21, 2026 that CPC bidding was being turned on in the ads manager. The rollout is still early and limited."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does this matter to ThumbGate?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "As AI assistants become ad surfaces, buyers need a clearer separation between conversational discovery and risky execution. ThumbGate is the pre-action gate layer that turns a suggested action into an allow, block, or checkpoint decision before it runs locally."
+      }
+    }
+  ]
+}
+  </script>
+</head>
+<body>
+  <div class="topbar">
+    <div class="container">
+      <a class="brand" href="/"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence</a>
+    </div>
+  </div>
+
+  <main class="container">
+    <section class="hero">
+      <div class="eyebrow">guide | chatgpt ads and ai trust</div>
+      <h1>ChatGPT ads need pre-action gates, not just better creative.</h1>
+      <p>OpenAI's ad rollout changes the distribution layer for AI products, but it also raises the trust bar. Once AI assistants become ad surfaces, teams need a clean line between sponsored discovery, AI advice, and the risky local actions that follow.</p>
+      <p>ThumbGate fits that transition. ChatGPT can stay the discovery and typed-feedback surface. ThumbGate becomes the enforcement surface that decides whether a suggested command, edit, merge, deploy, or workflow step should be allowed, blocked, or checkpointed before execution.</p>
+      <div class="signal-row">
+        <div class="signal-pill up">April 21, 2026: Digiday reported CPC bidding inside ChatGPT</div>
+        <div class="signal-pill down">Trust risk rises when monetized discovery gets closer to execution</div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div>
+        <div class="card">
+          <h2>Why this page exists</h2>
+          <ul>
+            <li>OpenAI began testing ads in ChatGPT in the US on February 9, 2026, then moved closer to performance marketing as CPC bidding surfaced in reporting on April 21, 2026.</li>
+            <li>That shift creates a new trust question for AI workflows: what happens when a sponsored suggestion is one step away from a real action?</li>
+            <li>ThumbGate should own the answer: Pre-Action Gates put a hard decision layer between AI output and execution.</li>
+          </ul>
+        </div>
+
+        <section class="detail-section">
+          <h2>Why the ads story matters even if you never buy a click</h2>
+          <p>ChatGPT ads are not just a media-buying story. They are a behavior and measurement story. OpenAI's official materials now frame ChatGPT as a place where people research, compare options, and get ready to act. That is exactly the moment when buyers become sensitive to trust, incentives, proof, and action safety.</p>
+          <p>For ThumbGate, this is a positioning opportunity. The right message is not "we also do ads." The right message is "as AI assistants become monetized decision surfaces, you need a pre-action gate before a recommendation turns into a risky command."</p>
+        </section>
+
+        <section class="detail-section">
+          <h2>The ThumbGate angle</h2>
+          <ul>
+            <li>Keep ChatGPT as the public front door for advice, checkpointing, and typed thumbs-up or thumbs-down capture.</li>
+            <li>Keep risky execution local where ThumbGate can enforce a real allow, block, or checkpoint decision through Pre-Action Gates.</li>
+            <li>Lead with trust and proof, not generic ad-tech language: workflow hardening, verification evidence, auditability, and runtime enforcement.</li>
+            <li>Use the Workflow Hardening Fit Checker to route buyers into Sprint, Team, Pro, or free OSS based on the workflow risk, not on ad curiosity alone.</li>
+          </ul>
+        </section>
+
+        <section class="detail-section">
+          <h2>What to publish and say next</h2>
+          <p>The promotion move is simple. Tie ThumbGate to the new category language before somebody else does. Publish this topic as a high-intent guide, mention it in the landing page FAQ, and use one clear line in social posts and outreach.</p>
+          <p>Recommended thesis: "As AI assistants become ad platforms, teams need pre-action gates, audit trails, and proof-ready runs before a monetized workflow touches users."</p>
+        </section>
+
+        <div class="detail-section">
+          <h2>FAQ</h2>
+          <details class="faq-item">
+            <summary>Are ChatGPT ads live already?</summary>
+            <p>Yes, but the rollout is still early. OpenAI began testing ads in the US on February 9, 2026, and Digiday reported on April 21, 2026 that CPC bidding was showing up inside the ads manager.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Why not make ChatGPT ads the main acquisition bet yet?</summary>
+            <p>Because the market is still early, the category set is limited, and ThumbGate wins first when it becomes the quoted trust layer around risky AI workflows. Organic and AI-search visibility should mature the message while the paid surface is still forming.</p>
+          </details>
+          <details class="faq-item">
+            <summary>How does ThumbGate fit the ChatGPT ads story without sounding off-category?</summary>
+            <p>ThumbGate is not an ad-tech product. It is the pre-action gate layer for AI workflows. The connection is trust: monetized conversational discovery increases the need for hard execution boundaries, proof, and auditability once a suggested action leaves the chat and approaches a real system.</p>
+          </details>
+        </div>
+      </div>
+
+      <aside class="sidebar">
+        <div class="sidebar-card">
+          <h2>GSD execution brief</h2>
+          <p>This page captures high-intent demand around ChatGPT ads, AI trust, and LLM measurement while routing that attention into ThumbGate's workflow-hardening motion.</p>
+          <p><strong>Opportunity score:</strong> 78</p>
+          <p><strong>Primary persona:</strong> growth leader, platform lead, AI product owner</p>
+          <p><strong>Keyword cluster:</strong> ChatGPT ads, AI ad trust, LLM ad measurement, pre-action gates</p>
+          <p><strong>Commercial lane:</strong> Workflow Hardening Sprint first, Pro second</p>
+          <div class="proof-links">
+            <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence</a>
+            <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/PITCH.md" target="_blank" rel="noopener">Pitch</a>
+            <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/GEO_DEMAND_ENGINE_MAR2026.md" target="_blank" rel="noopener">GEO demand engine</a>
+          </div>
+          <a class="cta-button" href="/#workflow-sprint-intake">Start the Workflow Hardening Sprint</a>
+        </div>
+        <div class="sidebar-card">
+          <h2>Related pages</h2>
+          <a class="related-card" href="/guides/pre-action-gates">
+            <span class="related-label">Related page</span>
+            <strong>What Are Pre-Action Gates?</strong>
+          </a>
+          <a class="related-card" href="/guides/ai-search-topical-presence">
+            <span class="related-label">Related page</span>
+            <strong>AI Search Topical Presence</strong>
+          </a>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -206,6 +206,14 @@ __GA_BOOTSTRAP__
     },
     {
       "@type": "Question",
+      "name": "Why does the ChatGPT ads rollout matter to ThumbGate?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "OpenAI began testing ads in ChatGPT in the US on February 9, 2026, and Digiday reported CPC bidding on April 21, 2026. As conversational AI becomes a monetized discovery surface, teams need a cleaner boundary between AI advice and risky execution. ThumbGate is that pre-action gate layer."
+      }
+    },
+    {
+      "@type": "Question",
       "name": "How does ThumbGate reduce host blast radius for high-risk local runs?",
       "acceptedAnswer": {
         "@type": "Answer",
@@ -773,7 +781,7 @@ __GA_BOOTSTRAP__
     <div class="gpt-panel">
       <div class="section-label" style="text-align:left;">ChatGPT Entry Point · Live ThumbGate GPT for ChatGPT</div>
       <h2>Open the GPT. Give typed thumbs feedback. Turn the lesson into a gate.</h2>
-      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to capture a useful thumbs-up/down lesson, check a risky action, and prove the enforcement loop before installing anything.</p>
+      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to capture a useful thumbs-up/down lesson, check a risky action, and prove the enforcement loop before installing anything. As ChatGPT ads roll out, this matters more: ChatGPT can stay the discovery and checkpointing layer, while ThumbGate remains the hard execution boundary after <code>npx thumbgate init</code>.</p>
       <div class="gpt-steps">
         <div class="gpt-step">
           <strong>1. Try the live GPT</strong>
@@ -791,6 +799,7 @@ __GA_BOOTSTRAP__
       <div style="display:flex;gap:12px;flex-wrap:wrap;">
         <a href="/go/gpt?utm_source=website&utm_medium=gpt_section&utm_campaign=chatgpt_gpt&cta_id=gpt_path_open_gpt&cta_placement=gpt_section" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('gpt_path_cta_click',{cta:'open_gpt'})">Open ThumbGate GPT</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/adapters/chatgpt/INSTALL.md" class="btn-free" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">ChatGPT Actions setup</a>
+        <a href="/guides/chatgpt-ads-trust" class="btn-free" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">Why ChatGPT ads need gates</a>
       </div>
       <p class="gpt-note"><strong>Plain English rule:</strong> ChatGPT is the discovery and memory surface for advice, checkpointing, and typed feedback capture. One typed signal becomes one remembered rule. The hard Reliability Gateway still runs in the local agent or CI lane.</p>
     </div>
@@ -959,6 +968,12 @@ __GA_BOOTSTRAP__
         <h3>AI Search Topical Presence</h3>
         <p>Why AI tools recommend the brands they repeatedly see tied to a buyer problem, and how ThumbGate builds that association with proof-backed pages.</p>
         <div class="card-arrow">Strengthen the association →</div>
+      </a>
+      <a class="seo-card" href="/guides/chatgpt-ads-trust">
+        <div class="seo-kicker">ChatGPT Ads</div>
+        <h3>ChatGPT Ads Need Pre-Action Gates</h3>
+        <p>As conversational AI becomes an ad surface, trust, measurement, and execution boundaries matter more. This page ties that shift directly to ThumbGate.</p>
+        <div class="card-arrow">Own the trust angle →</div>
       </a>
       <a class="seo-card" href="/guides/relational-knowledge-ai-recommendations">
         <div class="seo-kicker">Recommendation</div>
@@ -1330,6 +1345,10 @@ __GA_BOOTSTRAP__
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">Do I have to chat inside the ThumbGate GPT for enforcement?</div>
         <div class="faq-a">No. The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions, capturing thumbs-up/down lessons, and getting setup help. Use it for advice and checkpointing; hard enforcement still runs locally where the agent executes after <code>npx thumbgate init</code>.</div>
+      </div>
+      <div class="faq-item">
+        <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">Why does the ChatGPT ads rollout matter to ThumbGate?</div>
+        <div class="faq-a">OpenAI began testing ads in ChatGPT in the US on February 9, 2026, and Digiday reported CPC bidding on April 21, 2026. That makes trust and measurement more important around AI-assisted decisions. ThumbGate gives teams a hard boundary between conversational discovery and risky local execution, so a suggested action still has to pass a real gate before it runs. <a href="/guides/chatgpt-ads-trust" style="color:var(--cyan);text-decoration:underline;">Read the full positioning guide</a>.</div>
       </div>
       <div class="faq-item">
         <button class="faq-q" type="button" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How do we keep high-risk autonomous runs off the host?</button>


### PR DESCRIPTION
## Summary
- New SEO guide at \`/guides/chatgpt-ads-trust\` threading the "pre-action gates" thesis against the ChatGPT ads rollout news.
- FAQ entry on \`index.html\` (JSON-LD \`FAQPage\`) for GEO/AI-search discoverability.
- Canonical URL pinned to \`https://thumbgate.ai/guides/chatgpt-ads-trust\` (legacy guides use the \`usethumbgate.com\` domain that 301s to apex but drops path — separate PR will sweep those).
- Content pack at \`docs/marketing/chatgpt-ads-trust-pack.md\` archives trust-angle post drafts for future reuse.

## Why now
- OpenAI turned on CPC bidding in ChatGPT on 2026-04-21 (Digiday).
- Ads test started 2026-02-09 (TechCrunch).
- SEJ leaked StackAdapt deck shows CPMs closer to \$15 — steeper collapse than Digiday's \$25 number.
- Dev-tool category is silent on this rollout — first credible voice wins the narrative.

## Scope guard
- No JS changes. No tests. Pure static SEO surface.
- CPC-cost angle (different framing) shipped live 2026-04-22 across LinkedIn, Reddit r/ClaudeAI, Bluesky, Threads via PR #1187 + Zernio. This guide is the trust-angle companion.

## Test plan
- [x] Pre-commit guards: versions synced, congruence, landing claims — all green
- [ ] CI green on \`feat/\*\* matrix
- [ ] 0 unresolved review threads
- [ ] Guide URL serves 200 on Railway after deploy

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>