### PR TITLE
fix(post-everywhere): route linkedin/threads/bluesky through zernio.publishToAllPlatforms

### DIFF
--- a/.changeset/post-everywhere-dispatcher-contracts.md
+++ b/.changeset/post-everywhere-dispatcher-contracts.md
@@ -1,0 +1,20 @@
+---
+'thumbgate': patch
+---
+
+Fix three post-everywhere dispatcher contract mismatches discovered live
+2026-04-22 during the ChatGPT CPC ads campaign:
+
+- `postToLinkedIn` called `linkedin.publishPost({text})`; the module exports
+  `publishTextPost(token, personUrn, text)`.
+- `postToThreads` called `threads.publishPost({text})`; no such export (real
+  entry is `postTextThread({text, token, userId})`).
+- `postToBluesky` called `zernio.publishPost({text, platform})`; the real
+  signature is `publishPost(content, platforms[], options)` with `accountId`
+  required on each platform entry.
+
+All three now route through `zernio.publishToAllPlatforms(content,
+{platforms:[<name>]})` — single code path, account discovery handled by
+Zernio. Contract tests in `tests/post-everywhere-channels.test.js` spy on
+`publishToAllPlatforms` and pin the call shape so this bug class cannot land
+again.

--- a/scripts/post-everywhere.js
+++ b/scripts/post-everywhere.js
@@ -51,12 +51,13 @@ function getPublisher(platform) {
   return loader();
 }
 
-// Zernio covers a subset of channels with a single OAuth bundle. When
-// ZERNIO_API_KEY is set we prefer it for those channels, collapsing per-platform
-// token rotations to one. Channels whose content shape Zernio can't match
-// (Reddit subreddit+title, Instagram media, YouTube video, Dev.to articles) stay
-// on direct-API dispatchers regardless. THUMBGATE_USE_DIRECT_PUBLISHERS=1 forces
-// the direct-API path even when the Zernio key is present (emergency fallback).
+// Zernio covers linkedin/threads/bluesky with a single OAuth bundle. These three
+// dispatchers route unconditionally through publishToAllPlatforms — direct-API
+// paths were removed 2026-04-22 after they were discovered to be calling
+// non-existent / mismatched signatures (linkedin.publishPost, threads.publishPost,
+// zernio.publishPost({text, platform})) during the ChatGPT CPC ads campaign.
+// Channels whose content shape Zernio can't match (Reddit subreddit+title,
+// Instagram media, YouTube video, Dev.to articles) stay on direct-API dispatchers.
 const ZERNIO_ELIGIBLE_PLATFORMS = new Set(['linkedin', 'threads', 'bluesky']);
 
 function shouldUseZernio(platform) {
@@ -185,12 +186,8 @@ async function postToLinkedIn(parsed, dryRun) {
     return { dryRun: true };
   }
 
-  if (shouldUseZernio('linkedin')) {
-    const zernio = require('./social-analytics/publishers/zernio');
-    return zernio.publishPost({ text, platform: 'linkedin' });
-  }
-  const linkedin = getPublisher('linkedin');
-  return linkedin.publishPost({ text });
+  const zernio = require('./social-analytics/publishers/zernio');
+  return zernio.publishToAllPlatforms(text, { platforms: ['linkedin'] });
 }
 
 async function postToDevTo(parsed, dryRun) {
@@ -277,12 +274,8 @@ async function postToThreads(parsed, dryRun) {
     return { dryRun: true };
   }
 
-  if (shouldUseZernio('threads')) {
-    const zernio = require('./social-analytics/publishers/zernio');
-    return zernio.publishPost({ text, platform: 'threads' });
-  }
-  const threads = getPublisher('threads');
-  return threads.publishPost({ text });
+  const zernio = require('./social-analytics/publishers/zernio');
+  return zernio.publishToAllPlatforms(text, { platforms: ['threads'] });
 }
 
 async function postToBluesky(parsed, dryRun) {
@@ -294,9 +287,8 @@ async function postToBluesky(parsed, dryRun) {
     return { dryRun: true };
   }
 
-  // Bluesky posts route through Zernio's aggregator.
   const zernio = getPublisher('bluesky');
-  return zernio.publishPost({ text, platform: 'bluesky' });
+  return zernio.publishToAllPlatforms(text, { platforms: ['bluesky'] });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/post-everywhere-channels.test.js
+++ b/tests/post-everywhere-channels.test.js
@@ -166,6 +166,103 @@ test('Bluesky dispatcher truncates to 300 chars', async () => {
   assert.deepEqual(result, { dryRun: true });
 });
 
+// ---------------------------------------------------------------------------
+// Dispatcher contract assertions
+//
+// On 2026-04-22 the ChatGPT CPC ads campaign hit three dead dispatchers:
+//   - postToLinkedIn → linkedin.publishPost({text})  (module exports publishTextPost(token, urn, text))
+//   - postToThreads  → threads.publishPost({text})   (no such export)
+//   - postToBluesky  → zernio.publishPost({text, platform})  (publishPost takes (content, platforms[], options))
+// All three are now routed through zernio.publishToAllPlatforms(content, {platforms:[<name>]}).
+// These tests spy on publishToAllPlatforms to pin the wire contract — any future
+// refactor that re-introduces a mismatched call will fail here before shipping.
+// ---------------------------------------------------------------------------
+
+function withZernioSpy(fn) {
+  const zernio = require('../scripts/social-analytics/publishers/zernio');
+  const original = zernio.publishToAllPlatforms;
+  const calls = [];
+  zernio.publishToAllPlatforms = async (content, options) => {
+    calls.push({ content, options });
+    return { published: [{ platform: options?.platforms?.[0], result: { id: 'spy' } }], errors: [] };
+  };
+  return Promise.resolve(fn(calls)).finally(() => {
+    zernio.publishToAllPlatforms = original;
+  });
+}
+
+test('postToLinkedIn routes through zernio.publishToAllPlatforms with {platforms:["linkedin"]}', async () => {
+  await withZernioSpy(async (calls) => {
+    await DISPATCHERS.linkedin({ body: 'Hello from LinkedIn.' }, false);
+    assert.equal(calls.length, 1, 'publishToAllPlatforms must be called exactly once');
+    assert.equal(calls[0].content, 'Hello from LinkedIn.');
+    assert.deepEqual(calls[0].options, { platforms: ['linkedin'] });
+  });
+});
+
+test('postToThreads routes through zernio.publishToAllPlatforms with {platforms:["threads"]}', async () => {
+  await withZernioSpy(async (calls) => {
+    await DISPATCHERS.threads({ title: 'T', body: 'Short threads body.' }, false);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].content.includes('Short threads body.'));
+    assert.deepEqual(calls[0].options, { platforms: ['threads'] });
+  });
+});
+
+test('postToBluesky routes through zernio.publishToAllPlatforms with {platforms:["bluesky"]}', async () => {
+  await withZernioSpy(async (calls) => {
+    await DISPATCHERS.bluesky({ title: 'B', body: 'Short bluesky body.' }, false);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].content.includes('Short bluesky body.'));
+    assert.deepEqual(calls[0].options, { platforms: ['bluesky'] });
+  });
+});
+
+test('postToThreads truncates content to 500 chars before handing to Zernio', async () => {
+  await withZernioSpy(async (calls) => {
+    const long = 'x'.repeat(1000);
+    await DISPATCHERS.threads({ title: 'T', body: long }, false);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].content.length <= 500, `content length ${calls[0].content.length} must be ≤ 500`);
+  });
+});
+
+test('postToBluesky truncates content to 300 chars before handing to Zernio', async () => {
+  await withZernioSpy(async (calls) => {
+    const long = 'x'.repeat(1000);
+    await DISPATCHERS.bluesky({ title: 'B', body: long }, false);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].content.length <= 300, `content length ${calls[0].content.length} must be ≤ 300`);
+  });
+});
+
+test('zernio module exports publishToAllPlatforms (the single-call contract)', () => {
+  const zernio = require('../scripts/social-analytics/publishers/zernio');
+  assert.equal(typeof zernio.publishToAllPlatforms, 'function',
+    'publishToAllPlatforms must stay exported — three dispatchers depend on it');
+});
+
+test('linkedin publisher module does not export a {text}-options-bag publishPost', () => {
+  // Regression guard for the 2026-04-22 discovery: the direct-API call
+  // linkedin.publishPost({text}) was shipped but the module actually exports
+  // publishTextPost(token, personUrn, text). If a future refactor re-adds
+  // a publishPost({text}) export, that's fine — but the dispatcher must not
+  // rely on it without also fixing the signature.
+  const linkedin = require('../scripts/social-analytics/publishers/linkedin');
+  assert.equal(typeof linkedin.publishTextPost, 'function',
+    'publishTextPost(token, personUrn, text) is the canonical direct-API entry');
+});
+
+test('threads publisher module exposes postTextThread, not publishPost', () => {
+  // Regression guard for the 2026-04-22 discovery: threads.publishPost({text})
+  // was called but does not exist. The real entry is postTextThread({text, token, userId}).
+  const threads = require('../scripts/social-analytics/publishers/threads');
+  assert.equal(typeof threads.postTextThread, 'function',
+    'postTextThread is the canonical threads direct-API entry');
+  assert.equal(typeof threads.publishPost, 'undefined',
+    'threads.publishPost must not exist — it was an invented name that broke silently');
+});
+
 test('marketing-autopilot workflow default platforms match focus channels', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'marketing-autopilot.yml'),

--- a/tests/post-everywhere-zernio-default.test.js
+++ b/tests/post-everywhere-zernio-default.test.js
@@ -92,7 +92,10 @@ test('THUMBGATE_USE_DIRECT_PUBLISHERS with any value other than "1" does not tri
   });
 });
 
-test('DISPATCHERS.linkedin and DISPATCHERS.threads route through Zernio publisher when ZERNIO_API_KEY is set', async () => {
+test('DISPATCHERS.linkedin and DISPATCHERS.threads route through zernio.publishToAllPlatforms', async () => {
+  // Dispatchers now unconditionally route through publishToAllPlatforms (single
+  // code path, account discovery handled by Zernio). The prior stub targeted a
+  // broken publishPost({text, platform}) contract that never existed.
   const zernioPath = require.resolve('../scripts/social-analytics/publishers/zernio');
   const peModulePath = require.resolve('../scripts/post-everywhere');
   const calls = [];
@@ -104,10 +107,12 @@ test('DISPATCHERS.linkedin and DISPATCHERS.threads route through Zernio publishe
     filename: zernioPath,
     loaded: true,
     exports: {
-      publishPost: async (args) => {
-        calls.push(args);
-        return { via: 'zernio-stub', args };
+      publishToAllPlatforms: async (content, options) => {
+        calls.push({ content, options });
+        return { via: 'zernio-stub', content, options };
       },
+      isDuplicate: () => false,
+      recordPost: () => {},
     },
   };
   delete require.cache[peModulePath];
@@ -120,8 +125,10 @@ test('DISPATCHERS.linkedin and DISPATCHERS.threads route through Zernio publishe
     assert.equal(linkedinResult.via, 'zernio-stub');
     assert.equal(threadsResult.via, 'zernio-stub');
     assert.equal(calls.length, 2);
-    assert.equal(calls[0].platform, 'linkedin');
-    assert.equal(calls[1].platform, 'threads');
+    assert.deepEqual(calls[0].options, { platforms: ['linkedin'] });
+    assert.deepEqual(calls[1].options, { platforms: ['threads'] });
+    assert.equal(calls[0].content, 'hello-linkedin');
+    assert.ok(calls[1].content.includes('hello-threads'));
   } finally {
     if (prevKey === undefined) delete process.env.ZERNIO_API_KEY;
     else process.env.ZERNIO_API_KEY = prevKey;


### PR DESCRIPTION
## Summary
- Three dispatchers in `scripts/post-everywhere.js` were calling non-existent or mismatched-signature methods. Discovered live 2026-04-22 while shipping the ChatGPT CPC ads campaign (Zernio post id `69e947d7b268a62306992f76` confirmed the working path).
- All three now route through `zernio.publishToAllPlatforms(content, {platforms:[<name>]})` — single code path, account discovery handled by Zernio.
- Added contract tests that spy on `publishToAllPlatforms` and pin the call shape so this bug class can't land again.

## Contract mismatches fixed
| Dispatcher | Broken call | Real signature |
|---|---|---|
| `postToLinkedIn` | `linkedin.publishPost({text})` | exports `publishTextPost(token, personUrn, text)` |
| `postToThreads`  | `threads.publishPost({text})`  | no such export (real entry: `postTextThread({text, token, userId})`) |
| `postToBluesky`  | `zernio.publishPost({text, platform})` | `publishPost(content, platforms[], options)` — `platforms` must be array of `{platform, accountId}` |

## Test plan
- [x] `npm run test:post-everywhere-channels` — 21/21 pass (7 new contract assertions)
- [x] `npm run test:post-everywhere-zernio-default` — 7/7 pass (updated stub to the new contract)
- [x] `npm run test:post-everywhere-instagram` — 6/6 pass
- [x] `npm run test:zernio` — 28/28 pass
- [x] `npm run test:weekly-auto-post`, `test:social-post-hourly`, `test:publish-thumbgate-launch`, `test:reconcile-thumbgate-campaign` — all green
- [ ] CI full suite (runs on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)