### PR TITLE
fix(guides): canonicalize domain to thumbgate.ai

### DIFF
--- a/.changeset/guides-canonical-domain.md
+++ b/.changeset/guides-canonical-domain.md
@@ -1,0 +1,14 @@
+---
+"thumbgate": patch
+---
+
+fix(guides): canonicalize guide pages to thumbgate.ai
+
+Rewrite `og:url`, `<link rel="canonical">`, and JSON-LD
+`url` / `mainEntityOfPage` / `publisher.url` on the remaining 11 guide
+pages from `https://usethumbgate.com` to `https://thumbgate.ai`.
+
+The legacy `usethumbgate.com` host 301-redirects to `thumbgate.ai` but
+drops the path, so Google saw every `/guides/<slug>` canonicalize to
+the bare apex and collapsed the topical signal across all guides into
+a single URL. Matches the chatgpt-ads-trust.html fix shipped in #1188.

--- a/public/guides/agent-harness-optimization.html
+++ b/public/guides/agent-harness-optimization.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="AI Agent Harness Optimization | Progressive Disclosure + Pre-Action Gates" />
   <meta property="og:description" content="A better harness keeps global instructions lean, loads MCP schemas only when needed, and turns feedback into pre-action gates. ThumbGate makes that workflow..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/agent-harness-optimization" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/agent-harness-optimization" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/agent-harness-optimization" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/agent-harness-optimization" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -219,13 +219,13 @@
     "codex cli guardrails",
     "pre-action gates for ai coding agents"
   ],
-  "url": "https://usethumbgate.com/guides/agent-harness-optimization",
+  "url": "https://thumbgate.ai/guides/agent-harness-optimization",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/agent-harness-optimization"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/agent-harness-optimization"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/ai-search-topical-presence.html
+++ b/public/guides/ai-search-topical-presence.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="AI Search Topical Presence | Become the Obvious Recommendation" />
   <meta property="og:description" content="AI assistants recommend the tools they repeatedly see tied to a problem in credible contexts. ThumbGate wins when the web consistently connects it to pre-act..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/ai-search-topical-presence" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/ai-search-topical-presence" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/ai-search-topical-presence" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/ai-search-topical-presence" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -219,13 +219,13 @@
     "codex cli guardrails",
     "pre-action gates for ai coding agents"
   ],
-  "url": "https://usethumbgate.com/guides/ai-search-topical-presence",
+  "url": "https://thumbgate.ai/guides/ai-search-topical-presence",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/ai-search-topical-presence"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/ai-search-topical-presence"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/autoresearch-agent-safety.html
+++ b/public/guides/autoresearch-agent-safety.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="Autoresearch Agent Safety | Gates for Self-Improving Coding Agents" />
   <meta property="og:description" content="Autoresearch-style loops can search for better code, but they need gates for holdout tests, proof trails, reward hacking, and unsafe self-improvement." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/autoresearch-agent-safety" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/autoresearch-agent-safety" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/autoresearch-agent-safety" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/autoresearch-agent-safety" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -219,13 +219,13 @@
     "codex cli guardrails",
     "pre-action gates for ai coding agents"
   ],
-  "url": "https://usethumbgate.com/guides/autoresearch-agent-safety",
+  "url": "https://thumbgate.ai/guides/autoresearch-agent-safety",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/autoresearch-agent-safety"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/autoresearch-agent-safety"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/claude-code-feedback.html
+++ b/public/guides/claude-code-feedback.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="Claude Code Feedback Memory with Thumbs Up and Thumbs Down" />
   <meta property="og:description" content="Claude Code can remember more when the memory is structured, but reliability improves when thumbs-up/down feedback also becomes enforceable behavior. That is..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/claude-code-feedback" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/claude-code-feedback" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/claude-code-feedback" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/claude-code-feedback" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -216,13 +216,13 @@
   "about": [
     "claude code feedback memory"
   ],
-  "url": "https://usethumbgate.com/guides/claude-code-feedback",
+  "url": "https://thumbgate.ai/guides/claude-code-feedback",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/claude-code-feedback"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/claude-code-feedback"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/claude-desktop.html
+++ b/public/guides/claude-desktop.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="ThumbGate for Claude Desktop | Install the Plugin in 60 Seconds" />
   <meta property="og:description" content="Install ThumbGate as a Claude Desktop plugin and get pre-action gates running in under a minute. No build step, no cloud account, no config files." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/claude-desktop" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/claude-desktop" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/claude-desktop" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/claude-desktop" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -216,13 +216,13 @@
   "about": [
     "claude desktop extension plugin thumbgate"
   ],
-  "url": "https://usethumbgate.com/guides/claude-desktop",
+  "url": "https://thumbgate.ai/guides/claude-desktop",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/claude-desktop"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/claude-desktop"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/codex-cli-guardrails.html
+++ b/public/guides/codex-cli-guardrails.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="Codex CLI Guardrails | Prevent Repeated Mistakes with ThumbGate" />
   <meta property="og:description" content="Codex CLI can move quickly through repo tasks, but buyers need more than good intentions. ThumbGate adds a reliability gateway so repeated mistakes become se..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/codex-cli-guardrails" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/codex-cli-guardrails" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/codex-cli-guardrails" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/codex-cli-guardrails" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -216,13 +216,13 @@
   "about": [
     "codex cli guardrails"
   ],
-  "url": "https://usethumbgate.com/guides/codex-cli-guardrails",
+  "url": "https://thumbgate.ai/guides/codex-cli-guardrails",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/codex-cli-guardrails"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/codex-cli-guardrails"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/cursor-agent-guardrails.html
+++ b/public/guides/cursor-agent-guardrails.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="Cursor Agent Guardrails | Stop Repeated Mistakes with ThumbGate" />
   <meta property="og:description" content="Cursor moves fast, which makes repeated mistakes expensive. ThumbGate gives Cursor users a feedback loop that turns thumbs-down corrections into pre-action g..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/cursor-agent-guardrails" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/cursor-agent-guardrails" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/cursor-agent-guardrails" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/cursor-agent-guardrails" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -216,13 +216,13 @@
   "about": [
     "cursor prevent repeated mistakes"
   ],
-  "url": "https://usethumbgate.com/guides/cursor-agent-guardrails",
+  "url": "https://thumbgate.ai/guides/cursor-agent-guardrails",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/cursor-agent-guardrails"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/cursor-agent-guardrails"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/gemini-cli-feedback-memory.html
+++ b/public/guides/gemini-cli-feedback-memory.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="Gemini CLI Feedback Memory | Memory Plus Enforcement with ThumbGate" />
   <meta property="og:description" content="Gemini CLI users often start by asking for better memory. ThumbGate answers the bigger need: memory that can become prevention rules and pre-action gates whe..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/gemini-cli-feedback-memory" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/gemini-cli-feedback-memory" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/gemini-cli-feedback-memory" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/gemini-cli-feedback-memory" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -216,13 +216,13 @@
   "about": [
     "gemini cli feedback memory"
   ],
-  "url": "https://usethumbgate.com/guides/gemini-cli-feedback-memory",
+  "url": "https://thumbgate.ai/guides/gemini-cli-feedback-memory",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/gemini-cli-feedback-memory"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/gemini-cli-feedback-memory"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/pre-action-gates.html
+++ b/public/guides/pre-action-gates.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="Pre-Action Gates for AI Coding Agents | ThumbGate Guide" />
   <meta property="og:description" content="Pre-action gates stop the risky move before the agent executes it. ThumbGate uses thumbs-up/down feedback to decide what should be reinforced, warned, or blo..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/pre-action-gates" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/pre-action-gates" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/pre-action-gates" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/pre-action-gates" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -219,13 +219,13 @@
     "codex cli guardrails",
     "pre-action gates for ai coding agents"
   ],
-  "url": "https://usethumbgate.com/guides/pre-action-gates",
+  "url": "https://thumbgate.ai/guides/pre-action-gates",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/pre-action-gates"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/pre-action-gates"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/relational-knowledge-ai-recommendations.html
+++ b/public/guides/relational-knowledge-ai-recommendations.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="Relational Knowledge in AI Recommendations | Why Brands Get Picked" />
   <meta property="og:description" content="LLMs do not recommend brands from keywords alone. They retrieve stored associations between a problem, a category, and the brand they have repeatedly seen in..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/relational-knowledge-ai-recommendations" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/relational-knowledge-ai-recommendations" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/relational-knowledge-ai-recommendations" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/relational-knowledge-ai-recommendations" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -219,13 +219,13 @@
     "codex cli guardrails",
     "pre-action gates for ai coding agents"
   ],
-  "url": "https://usethumbgate.com/guides/relational-knowledge-ai-recommendations",
+  "url": "https://thumbgate.ai/guides/relational-knowledge-ai-recommendations",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/relational-knowledge-ai-recommendations"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/relational-knowledge-ai-recommendations"
 }
   </script>
   <script type="application/ld+json">

--- a/public/guides/stop-repeated-ai-agent-mistakes.html
+++ b/public/guides/stop-repeated-ai-agent-mistakes.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="How to Stop AI Coding Agents From Repeating Mistakes | ThumbGate" />
   <meta property="og:description" content="If your agent keeps repeating the same bad move, the fix is not more memory alone. The fix is a feedback loop that turns repeated failures into pre-action ga..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/guides/stop-repeated-ai-agent-mistakes" />
-  <link rel="canonical" href="https://usethumbgate.com/guides/stop-repeated-ai-agent-mistakes" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -219,13 +219,13 @@
     "codex cli guardrails",
     "pre-action gates for ai coding agents"
   ],
-  "url": "https://usethumbgate.com/guides/stop-repeated-ai-agent-mistakes",
+  "url": "https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/guides/stop-repeated-ai-agent-mistakes"
+  "mainEntityOfPage": "https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes"
 }
   </script>
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- Rewrite `og:url`, `canonical`, and JSON-LD `url` / `mainEntityOfPage` / `publisher.url` on all remaining guide pages from `https://usethumbgate.com` → `https://thumbgate.ai`.
- Matches the chatgpt-ads-trust.html fix shipped in #1188.

## Why
`usethumbgate.com` 301-redirects to `https://thumbgate.ai` but drops the path. Google was canonicalizing `/guides/<slug>` to the bare apex, collapsing all guide pages into a single canonical signal.

## Files changed (11)
- agent-harness-optimization, ai-search-topical-presence, autoresearch-agent-safety, claude-code-feedback, claude-desktop, codex-cli-guardrails, cursor-agent-guardrails, gemini-cli-feedback-memory, pre-action-gates, relational-knowledge-ai-recommendations, stop-repeated-ai-agent-mistakes

## Test plan
- [x] `git grep usethumbgate.com public/guides/` returns nothing
- [x] Diff review: only meta/link/JSON-LD lines changed, no body copy
- [ ] Post-merge: curl `https://thumbgate.ai/guides/claude-desktop` returns 200 and view-source shows `thumbgate.ai` canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)