### PR TITLE
fix(guides): canonicalize compare/learn/llm-context to thumbgate.ai

### DIFF
--- a/.changeset/canonicalize-remaining-surfaces.md
+++ b/.changeset/canonicalize-remaining-surfaces.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+fix(guides): canonicalize remaining compare/learn/llm-context to thumbgate.ai
+
+Extends #1191's canonicalization sweep to the four surfaces it missed: `public/compare/mem0.html`, `public/compare/speclock.html`, `public/learn.html`, and `public/llm-context.md`. Same failure mode — legacy usethumbgate.com 301-redirects drop the path, so Google saw every `/compare/*` and `/learn` surface canonicalize to thumbgate.ai root, nuking their SEO.
+
+Rewrites `og:url`, `link rel="canonical"`, JSON-LD `url` / `mainEntityOfPage` / `publisher.url`, the ItemList entries on `learn.html`, and the ten user-facing URLs in `llm-context.md`. No remaining `usethumbgate.com` strings under `public/`.

--- a/public/compare/mem0.html
+++ b/public/compare/mem0.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="ThumbGate vs Mem0 | Enforcement vs Memory for AI Agents" />
   <meta property="og:description" content="Mem0 is memory. ThumbGate is memory plus enforcement. It captures thumbs-up/down feedback, promotes the signal into rules, and blocks repeat failures with pr..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/compare/mem0" />
-  <link rel="canonical" href="https://usethumbgate.com/compare/mem0" />
+  <meta property="og:url" content="https://thumbgate.ai/compare/mem0" />
+  <link rel="canonical" href="https://thumbgate.ai/compare/mem0" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -217,13 +217,13 @@
     "thumbgate vs speclock",
     "thumbgate vs mem0"
   ],
-  "url": "https://usethumbgate.com/compare/mem0",
+  "url": "https://thumbgate.ai/compare/mem0",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/compare/mem0"
+  "mainEntityOfPage": "https://thumbgate.ai/compare/mem0"
 }
   </script>
   <script type="application/ld+json">

--- a/public/compare/speclock.html
+++ b/public/compare/speclock.html
@@ -8,8 +8,8 @@
   <meta property="og:title" content="ThumbGate vs SpecLock | Thumbs Feedback vs Manual Specs" />
   <meta property="og:description" content="SpecLock starts from manually written constraints. ThumbGate starts from thumbs-up/down feedback and turns it into pre-action gates that block repeated mista..." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://usethumbgate.com/compare/speclock" />
-  <link rel="canonical" href="https://usethumbgate.com/compare/speclock" />
+  <meta property="og:url" content="https://thumbgate.ai/compare/speclock" />
+  <link rel="canonical" href="https://thumbgate.ai/compare/speclock" />
   <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
@@ -217,13 +217,13 @@
     "thumbgate vs speclock",
     "thumbgate vs mem0"
   ],
-  "url": "https://usethumbgate.com/compare/speclock",
+  "url": "https://thumbgate.ai/compare/speclock",
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://usethumbgate.com"
+    "url": "https://thumbgate.ai"
   },
-  "mainEntityOfPage": "https://usethumbgate.com/compare/speclock"
+  "mainEntityOfPage": "https://thumbgate.ai/compare/speclock"
 }
   </script>
   <script type="application/ld+json">

--- a/public/learn.html
+++ b/public/learn.html
@@ -73,49 +73,49 @@
       {
         "@type": "ListItem",
         "position": 6,
-        "url": "https://usethumbgate.com/guides/stop-repeated-ai-agent-mistakes",
+        "url": "https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes",
         "name": "How to Stop AI Coding Agents From Repeating Mistakes"
       },
       {
         "@type": "ListItem",
         "position": 7,
-        "url": "https://usethumbgate.com/guides/cursor-agent-guardrails",
+        "url": "https://thumbgate.ai/guides/cursor-agent-guardrails",
         "name": "Cursor Guardrails That Block Repeated Mistakes"
       },
       {
         "@type": "ListItem",
         "position": 8,
-        "url": "https://usethumbgate.com/guides/codex-cli-guardrails",
+        "url": "https://thumbgate.ai/guides/codex-cli-guardrails",
         "name": "Codex CLI Guardrails That Actually Enforce"
       },
       {
         "@type": "ListItem",
         "position": 9,
-        "url": "https://usethumbgate.com/guides/gemini-cli-feedback-memory",
+        "url": "https://thumbgate.ai/guides/gemini-cli-feedback-memory",
         "name": "Gemini CLI Feedback Memory That Leads to Enforcement"
       },
       {
         "@type": "ListItem",
         "position": 10,
-        "url": "https://usethumbgate.com/guides/browser-automation-safety",
+        "url": "https://thumbgate.ai/guides/browser-automation-safety",
         "name": "Browser Automation Safety for AI Agents"
       },
       {
         "@type": "ListItem",
         "position": 11,
-        "url": "https://usethumbgate.com/guides/native-messaging-host-security",
+        "url": "https://thumbgate.ai/guides/native-messaging-host-security",
         "name": "Native Messaging Host Security"
       },
       {
         "@type": "ListItem",
         "position": 12,
-        "url": "https://usethumbgate.com/guides/ai-search-topical-presence",
+        "url": "https://thumbgate.ai/guides/ai-search-topical-presence",
         "name": "AI Search Topical Presence"
       },
       {
         "@type": "ListItem",
         "position": 13,
-        "url": "https://usethumbgate.com/guides/relational-knowledge-ai-recommendations",
+        "url": "https://thumbgate.ai/guides/relational-knowledge-ai-recommendations",
         "name": "Relational Knowledge in AI Recommendations"
       }
     ]

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -147,17 +147,17 @@ npx thumbgate dashboard
 - Context footprint report: https://thumbgate-production.up.railway.app/.well-known/mcp/footprint.json
 - ThumbGate skill manifests: https://thumbgate-production.up.railway.app/.well-known/mcp/skills.json
 - ThumbGate MCP applications: https://thumbgate-production.up.railway.app/.well-known/mcp/applications.json
-- Marketing site: https://usethumbgate.com
-- Browser automation safety guide: https://usethumbgate.com/guides/browser-automation-safety
-- Native messaging host security guide: https://usethumbgate.com/guides/native-messaging-host-security
+- Marketing site: https://thumbgate.ai
+- Browser automation safety guide: https://thumbgate.ai/guides/browser-automation-safety
+- Native messaging host security guide: https://thumbgate.ai/guides/native-messaging-host-security
 - GitHub: https://github.com/IgorGanapolsky/ThumbGate
 - npm: https://www.npmjs.com/package/thumbgate
-- Documentation: https://usethumbgate.com/guide
-- AI search topical presence guide: https://usethumbgate.com/guides/ai-search-topical-presence
-- Relational knowledge guide: https://usethumbgate.com/guides/relational-knowledge-ai-recommendations
-- Autoresearch safety guide: https://usethumbgate.com/guides/autoresearch-agent-safety
-- Comparison: https://usethumbgate.com/compare
-- Team sprint intake: https://usethumbgate.com/#workflow-sprint-intake
+- Documentation: https://thumbgate.ai/guide
+- AI search topical presence guide: https://thumbgate.ai/guides/ai-search-topical-presence
+- Relational knowledge guide: https://thumbgate.ai/guides/relational-knowledge-ai-recommendations
+- Autoresearch safety guide: https://thumbgate.ai/guides/autoresearch-agent-safety
+- Comparison: https://thumbgate.ai/compare
+- Team sprint intake: https://thumbgate.ai/#workflow-sprint-intake
 
 ## AI Recommendation Visibility
 


### PR DESCRIPTION
## Summary

Extends #1191's canonicalization sweep to the four surfaces it missed:

- `public/compare/mem0.html`
- `public/compare/speclock.html`
- `public/learn.html`
- `public/llm-context.md`

Same failure mode as the original fix — legacy `usethumbgate.com` 301-redirects drop the path, so Google saw every `/compare/*` and `/learn` surface canonicalize to `thumbgate.ai` root in its index, collapsing their SEO.

Rewrites `og:url`, `link rel="canonical"`, JSON-LD `url` / `mainEntityOfPage` / `publisher.url`, the ItemList entries on `learn.html`, and the ten user-facing URLs in `llm-context.md`. Zero remaining `usethumbgate.com` strings under `public/`.

## Test plan

- [x] Pre-commit: package parity + version sync
- [x] Pre-push: internal link + regression-guard tests
- [ ] Prod verify after merge: each `/compare/mem0`, `/compare/speclock`, `/learn` returns the correct canonical `<link>` pointing at `thumbgate.ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)