### PR TITLE
fix(decision-journal): pin clock in metrics test to remove day-boundary flake

### DIFF
--- a/.changeset/fix-decision-journal-day-boundary-flake.md
+++ b/.changeset/fix-decision-journal-day-boundary-flake.md
@@ -2,6 +2,6 @@
 "thumbgate": patch
 ---
 
-fix(tests): anchor decision-journal metric test timestamps to now-3d
+fix(decision-journal): pin clock in metrics test to remove day-boundary flake
 
-The `computeDecisionMetrics` test used hard-coded `2026-04-09T...` timestamps while the metric aggregates over a rolling 14-day window anchored at wall-clock time. Two weeks later the fixed timestamps fell off the window and the `metrics.days.some((day) => day.evaluations > 0)` assertion failed, blocking every open PR. Switched to a `now - 3 days` base with preserved hour-offset latencies so the test is date-agnostic.
+`computeDecisionMetrics` now accepts an optional `options.now` and threads it into `initializeDaySeries`, so the rolling 14-day window is driven by an injectable clock rather than a fresh `new Date()` at aggregation time. The metrics test pins both the synthetic event base and the aggregator clock to the same reference timestamp, removing the race where CI crossing UTC midnight between event inserts and aggregation dropped events out of the window and failed `metrics.days.some((day) => day.evaluations > 0)`.

--- a/scripts/decision-journal.js
+++ b/scripts/decision-journal.js
@@ -192,8 +192,18 @@ function collapseDecisionTimeline(records) {
   });
 }
 
-function initializeDaySeries(dayCount) {
-  const today = new Date();
+function resolveNow(now) {
+  if (now instanceof Date) return new Date(now.getTime());
+  if (typeof now === 'number' && Number.isFinite(now)) return new Date(now);
+  if (typeof now === 'string' && now) {
+    const parsed = new Date(now);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return new Date();
+}
+
+function initializeDaySeries(dayCount, now) {
+  const today = resolveNow(now);
   today.setHours(0, 0, 0, 0);
   const days = [];
   for (let offset = dayCount - 1; offset >= 0; offset -= 1) {
@@ -224,7 +234,7 @@ function computeDecisionMetrics(feedbackDir, options = {}) {
   const dayCount = Number.isInteger(options.dayCount) ? options.dayCount : DEFAULT_DAY_COUNT;
   const records = readDecisionLog(getDecisionLogPath(feedbackDir));
   const actions = collapseDecisionTimeline(records).filter((entry) => entry.evaluation);
-  const series = initializeDaySeries(dayCount);
+  const series = initializeDaySeries(dayCount, options.now);
   const dayMap = new Map(series.map((day) => [day.dayKey, day]));
   const outcomeCounts = {
     accepted: 0,

--- a/tests/decision-journal.test.js
+++ b/tests/decision-journal.test.js
@@ -119,10 +119,12 @@ test('collapseDecisionTimeline groups records by actionId', () => {
 
 test('computeDecisionMetrics summarizes fast-path, overrides, rollbacks, and latency', () => {
   withTempDir(() => {
-    // Anchor timestamps 3 days ago so events land inside the rolling 14-day
-    // window regardless of when CI runs. Hour offsets preserve the exact
-    // latency deltas the assertions below depend on.
-    const baseDate = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+    // Pin a synthetic "now" and anchor events three days earlier so both the
+    // day-series window and the event timestamps share a single clock. This
+    // removes the day-boundary flake where CI crossing UTC midnight between
+    // event inserts and metrics aggregation dropped events out of the window.
+    const pinnedNow = new Date('2026-06-15T12:00:00.000Z');
+    const baseDate = new Date(pinnedNow.getTime() - 3 * 24 * 60 * 60 * 1000);
     baseDate.setUTCHours(0, 0, 0, 0);
     const baseMs = baseDate.getTime();
     const iso = (hours, minutes = 0, seconds = 0) =>
@@ -226,7 +228,7 @@ test('computeDecisionMetrics summarizes fast-path, overrides, rollbacks, and lat
       timestamp: iso(11, 3),
     });
 
-    const metrics = computeDecisionMetrics();
+    const metrics = computeDecisionMetrics(undefined, { now: pinnedNow });
     assert.equal(metrics.evaluationCount, 3);
     assert.equal(metrics.fastPathCount, 1);
     assert.equal(metrics.overrideCount, 1);


### PR DESCRIPTION
## Summary
- `computeDecisionMetrics` now accepts `options.now` and threads it into `initializeDaySeries`, so the rolling 14-day window is driven by an injectable clock instead of a fresh `new Date()` at aggregation time.
- Metrics test pins both the synthetic event base (`baseMs`) and the aggregator clock to the same reference timestamp (`2026-06-15T12:00:00.000Z`), so event day-keys and day-series buckets are produced from a single instant — no more race when CI crosses UTC midnight between event inserts and aggregation.
- Assertion stays strict (`metrics.days.some((day) => day.evaluations > 0)`) — no weakening.

## Why
Three open PRs in the trunk queue tripped `tests/decision-journal.test.js:230` at `2026-04-23T00:05:06Z`. The prior "anchor to now-3d" fix ([a0517d17](https://github.com/IgorGanapolsky/ThumbGate/commit/a0517d17)) still read `Date.now()` twice (once in the test, once inside `computeDecisionMetrics → initializeDaySeries`), leaving a day-boundary race. Clock injection closes it at the seam the window actually depends on.

## Test plan
- [x] `node --test tests/decision-journal.test.js` — 3/3 pass
- [x] Same suite with a frozen clock at `2026-04-23T00:00:03Z` (the exact failure moment) — 3/3 pass
- [x] `TZ=UTC`, `TZ=Pacific/Kiritimati` (UTC+14), `TZ=Pacific/Pago_Pago` (UTC-11) — all green
- [x] `npm test` — pre-existing unrelated flakes in `social-analytics store` and `require_evidence_for_claim` remain, but decision-journal suite is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)