### PR TITLE
feat(eval): turn feedback into prompt eval proof

### DIFF
--- a/.changeset/feedback-prompt-evals.md
+++ b/.changeset/feedback-prompt-evals.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add feedback-derived prompt/workflow evaluation so real thumbs-up/down signals can become reusable eval suites, CLI proof reports, and buyer-ready evidence artifacts.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Before any agent action executes, ThumbGate's `PreToolUse` hook intercepts the c
 ### Layer 4: Multi-Agent Distribution
 Checks are distributed across all connected agents via MCP stdio protocol. One correction in Claude Code protects Cursor, Codex, Gemini CLI, Cline, and any MCP-compatible agent.
 
-Prompt engineering still matters, but it is only the starting point. ThumbGate adds prompt evaluation on top: proof lanes, benchmarks, and self-heal checks tell you whether your prompt and workflow actually held up under execution instead of leaving you to guess from vibes.
+Prompt engineering still matters, but it is only the starting point. ThumbGate adds prompt evaluation on top: proof lanes, benchmarks, and self-heal checks tell you whether your prompt and workflow actually held up under execution instead of leaving you to guess from vibes. Run `npx thumbgate eval --from-feedback --write-report=.thumbgate/prompt-eval-proof.md` to turn real thumbs-up/down feedback into reusable eval cases and a buyer-ready proof report.
 
 ![Feedback Pipeline](docs/diagrams/feedback_pipeline.png)
 
@@ -180,7 +180,7 @@ ThumbGate sells three concrete outcomes:
 - **Prevent expensive AI mistakes** — catch bad commands, destructive database actions, unsafe publishes, and risky API calls before they run.
 - **Make AI stop repeating mistakes** — fix it once, turn the lesson into a rule, and block the repeat before the next tool call lands.
 - **Turn AI into a reliable operator** — move from a smart assistant that apologizes after damage to a production-ready operator with checkpoints, proof, and enforcement.
-- **Measure prompts instead of rewriting them blindly** — use proof lanes, ThumbGate Bench, and `self-heal:check` to evaluate whether prompts and workflows actually improved behavior.
+- **Measure prompts instead of rewriting them blindly** — use `thumbgate eval --from-feedback`, proof lanes, ThumbGate Bench, and `self-heal:check` to evaluate whether prompts and workflows actually improved behavior.
 
 ---
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,6 +11,7 @@
  *   npx thumbgate import-doc    # import a local policy/runbook document and propose gates
  *   npx thumbgate export-dpo    # export DPO training pairs
  *   npx thumbgate export-databricks   # export Databricks-ready analytics bundle
+ *   npx thumbgate eval --from-feedback # turn feedback into reusable prompt evals
  *   npx thumbgate stats         # feedback analytics + Revenue-at-Risk
  *   npx thumbgate cfo           # local operational billing summary
  *   npx thumbgate pro           # solo dashboard + exports side lane
@@ -1809,6 +1810,60 @@ function gateStats() {
   console.log('\n' + formatStats(stats) + '\n');
 }
 
+function evalCmd() {
+  syncActiveProjectContext();
+  const args = parseArgs(process.argv.slice(3));
+  const {
+    formatProofReport,
+    runFeedbackEvalSuite,
+    runSuite,
+    loadSuite,
+  } = require(path.join(PKG_ROOT, 'scripts', 'prompt-eval'));
+  const minScore = args['min-score'] === undefined ? 80 : Number(args['min-score']);
+  const maxCases = args['max-cases'] === undefined ? 25 : Number(args['max-cases']);
+  const suitePath = args.suite ? path.resolve(CWD, args.suite) : null;
+  const fromFeedback = Boolean(args['from-feedback'] || !suitePath);
+  const evalRun = fromFeedback
+    ? runFeedbackEvalSuite({
+        feedbackDir: args['feedback-dir'] ? path.resolve(CWD, args['feedback-dir']) : undefined,
+        feedbackLog: args['feedback-log'] ? path.resolve(CWD, args['feedback-log']) : undefined,
+        maxCases,
+        minScore,
+      })
+    : {
+        suite: loadSuite(suitePath),
+        report: runSuite(suitePath, { minScore }),
+      };
+  const { suite, report } = evalRun;
+
+  if (args['write-suite']) {
+    const outputPath = path.resolve(CWD, args['write-suite']);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${JSON.stringify(suite, null, 2)}\n`, 'utf8');
+  }
+
+  if (args['write-report']) {
+    const outputPath = path.resolve(CWD, args['write-report']);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, `${formatProofReport(report, suite)}\n`, 'utf8');
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({ ...report, suiteDefinition: fromFeedback ? suite : undefined }, null, 2));
+    process.exit(report.pass ? 0 : 1);
+  }
+
+  console.log(`\nPrompt Evaluation: ${report.suite}`);
+  console.log('─'.repeat(50));
+  console.log(`  Score      : ${report.score}% (min ${report.minScore}%)`);
+  console.log(`  Cases      : ${report.passed}/${report.total} passing`);
+  console.log(`  Failures   : ${report.failed}`);
+  console.log(`  Errors     : ${report.errors}`);
+  console.log(`  Source     : ${fromFeedback ? 'feedback-derived' : suitePath}`);
+  console.log(report.pass ? '\n✅ PASS\n' : '\n❌ FAIL\n');
+  process.exit(report.pass ? 0 : 1);
+}
+
 function startApi() {
   const serverPath = path.join(PKG_ROOT, 'src', 'api', 'server.js');
   try {
@@ -1825,13 +1880,13 @@ function help() {
   const GROUP_LABELS = {
     capture:   'Feedback capture',
     discovery: 'Discovery & inspection',
-    gates:     'Gates & rules',
+    gates:     'Checks & rules',
     export:    'Export',
     ops:       'Operations',
     advanced:  'Advanced',
   };
 
-  console.log(`thumbgate v${v}  — pre-action gates for AI coding agents`);
+  console.log(`thumbgate v${v}  — pre-action checks for AI coding agents`);
   console.log('');
 
   for (const [groupKey, label] of Object.entries(GROUP_LABELS)) {
@@ -1862,7 +1917,8 @@ function help() {
   console.log('  north-star            Show proof-backed workflow-run progress toward the North Star');
   console.log('  model-fit             Detect local embedding profile and write evidence report');
   console.log('  risk                  Train or query the boosted local risk scorer');
-  console.log('  optimize              [PRO] Prune CLAUDE.md and migrate rules to Pre-Action Gates');
+  console.log('  eval                  Turn feedback into reusable prompt/workflow eval proof');
+  console.log('  optimize              [PRO] Prune CLAUDE.md and migrate rules to Pre-Action Checks');
   console.log('  prove [--target=X]    Run proof harness (adapters|automation|...)');
   console.log('  watch                 Watch .thumbgate/ for external signals');
   console.log('  status                Approval trend + failure domain dashboard');
@@ -1893,6 +1949,7 @@ function help() {
   console.log('  npx thumbgate explore gates --json');
   console.log('  npx thumbgate demo');
   console.log('  npx thumbgate stats --json');
+  console.log('  npx thumbgate eval --from-feedback --json');
   console.log('  npx thumbgate lessons "force push" --json');
   console.log('  npx thumbgate lessons --query="deploy" --remote');
   console.log('  npx thumbgate gate-stats --json');
@@ -2172,6 +2229,10 @@ switch (COMMAND) {
   }
   case 'gate-stats':
     gateStats();
+    break;
+  case 'eval':
+  case 'prompt-eval':
+    evalCmd();
     break;
   case 'explore': {
     const subCmd = process.argv[3];

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -9,6 +9,7 @@
 | **Pre-action checks** | Block known mistakes before tool use — tested with real feedback patterns |
 | **Feedback capture** | Up/down signals with context, tags, rubric scores — schema-validated |
 | **Prevention rules** | Auto-promoted from repeated failures — regression-tested |
+| **Prompt/workflow evals** | Feedback-derived eval suites prove whether prompt and workflow behavior improved |
 | **Filesystem search** | ContextFS files searchable without embeddings — regression-tested |
 | **Social analytics** | Multi-platform polling pipeline — regression-tested |
 | **ThumbGate search** | Two-tier search (MCP tool + REST API) — regression-tested |
@@ -24,6 +25,7 @@ cd thumbgate && npm ci
 npm test                    # full repository suite
 npm run prove:adapters      # Adapter compatibility proof
 npm run prove:automation    # Automation proof harness
+npm run eval:feedback       # Feedback-derived prompt/workflow eval proof
 npm run test:coverage       # Coverage report
 ```
 

--- a/package.json
+++ b/package.json
@@ -250,6 +250,7 @@
     "test:dashboard-insights": "node --test tests/dashboard-insights.test.js",
     "test:telemetry-tracked-link-slug": "node --test tests/telemetry-tracked-link-slug.test.js",
     "test:prompt-eval": "node --test tests/prompt-eval.test.js",
+    "eval:feedback": "node scripts/prompt-eval.js --from-feedback",
     "test:decision-trace": "node --test tests/decision-trace.test.js",
     "test:feedback-fallback": "node --test tests/feedback-fallback.test.js",
     "test:metaclaw": "node --test tests/metaclaw-features.test.js",

--- a/scripts/cli-schema.js
+++ b/scripts/cli-schema.js
@@ -92,7 +92,7 @@ const CLI_COMMANDS = [
   },
   {
     name: 'gate-stats',
-    description: 'Gate engine statistics — active checks, blocks, warns, time saved',
+    description: 'Check engine statistics — active checks, blocks, warns, time saved',
     group: 'discovery',
     flags: [
       { name: 'json', type: 'boolean', description: 'Output as JSON' },
@@ -128,10 +128,26 @@ const CLI_COMMANDS = [
   discoveryCommand({
     name: 'harness-audit',
     aliases: ['harness'],
-    description: 'Score global docs, MCP discovery, and specialized gate harnesses',
+    description: 'Score global docs, MCP discovery, and specialized check harnesses',
     flags: [
       jsonFlag(),
       { name: 'doc-token-budget', type: 'number', description: 'Global docs budget (default 9000)' },
+    ],
+  }),
+  discoveryCommand({
+    name: 'eval',
+    aliases: ['prompt-eval'],
+    description: 'Turn feedback into reusable prompt/workflow eval proof',
+    flags: [
+      jsonFlag(),
+      { name: 'from-feedback', type: 'boolean', description: 'Generate eval cases from feedback-log.jsonl' },
+      { name: 'feedback-log', type: 'string', description: 'Explicit feedback-log.jsonl path' },
+      { name: 'feedback-dir', type: 'string', description: 'Explicit ThumbGate feedback directory' },
+      { name: 'suite', type: 'string', description: 'Run an existing prompt eval suite' },
+      { name: 'write-suite', type: 'string', description: 'Write generated suite JSON' },
+      { name: 'write-report', type: 'string', description: 'Write Markdown proof report' },
+      { name: 'min-score', type: 'number', description: 'Minimum passing score (default 80)' },
+      { name: 'max-cases', type: 'number', description: 'Maximum feedback-derived cases (default 25)' },
     ],
   }),
   discoveryCommand({

--- a/scripts/prompt-eval.js
+++ b/scripts/prompt-eval.js
@@ -250,9 +250,14 @@ function stableCaseId(value, index = 0) {
   const slug = String(value || '')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 48);
-  return `${slug || 'entry'}-${index + 1}`;
+    .slice(0, 64);
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug[start] === '-') start += 1;
+  while (end > start && slug[end - 1] === '-') end -= 1;
+  const trimmed = slug.slice(start, end);
+  const normalized = trimmed.slice(0, 48);
+  return `${normalized || 'entry'}-${index + 1}`;
 }
 
 function normalizeSignal(entry = {}) {

--- a/scripts/prompt-eval.js
+++ b/scripts/prompt-eval.js
@@ -17,7 +17,6 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const crypto = require('node:crypto');
 
 const ROOT = path.join(__dirname, '..');
 const DEFAULT_SUITE = path.join(ROOT, 'bench', 'prompt-eval-suite.json');
@@ -247,8 +246,13 @@ function readJsonl(filePath) {
   }
 }
 
-function hashId(value) {
-  return crypto.createHash('sha1').update(String(value)).digest('hex').slice(0, 10);
+function stableCaseId(value, index = 0) {
+  const slug = String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  return `${slug || 'entry'}-${index + 1}`;
 }
 
 function normalizeSignal(entry = {}) {
@@ -294,8 +298,8 @@ function feedbackEntryToEvalCase(entry = {}, index = 0) {
   const tags = Array.isArray(entry.tags)
     ? entry.tags.map(String).filter(Boolean)
     : String(entry.tags || '').split(',').map((tag) => tag.trim()).filter(Boolean);
-  const rawId = entry.id || entry.feedbackId || `${signal}:${context}:${whatWentWrong}:${whatToChange}:${whatWorked}:${index}`;
-  const id = `feedback-${signal}-${hashId(rawId)}`;
+  const rawId = entry.id || entry.feedbackId || `${signal}:${context}:${whatWentWrong}:${whatToChange}:${whatWorked}`;
+  const id = `feedback-${signal}-${stableCaseId(rawId, index)}`;
   const actionableText = signal === 'negative'
     ? compactText(whatToChange, whatWentWrong, context)
     : compactText(context, whatWorked);

--- a/scripts/prompt-eval.js
+++ b/scripts/prompt-eval.js
@@ -17,9 +17,11 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const crypto = require('node:crypto');
 
 const ROOT = path.join(__dirname, '..');
 const DEFAULT_SUITE = path.join(ROOT, 'bench', 'prompt-eval-suite.json');
+const DEFAULT_MAX_FEEDBACK_CASES = 25;
 
 // ---------------------------------------------------------------------------
 // Prompt simulators — run ThumbGate's actual logic against eval inputs
@@ -224,6 +226,219 @@ function gradeOutput(output, expected) {
 }
 
 // ---------------------------------------------------------------------------
+// Feedback -> eval conversion
+// ---------------------------------------------------------------------------
+
+function readJsonl(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8')
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function hashId(value) {
+  return crypto.createHash('sha1').update(String(value)).digest('hex').slice(0, 10);
+}
+
+function normalizeSignal(entry = {}) {
+  const raw = String(entry.signal || entry.feedback || entry.rating || '').toLowerCase();
+  if (['down', 'negative', 'thumbs_down', 'thumbs-down', '-1'].includes(raw)) return 'negative';
+  if (['up', 'positive', 'thumbs_up', 'thumbs-up', '+1'].includes(raw)) return 'positive';
+  return null;
+}
+
+function compactText(...values) {
+  return values
+    .filter((value) => typeof value === 'string' && value.trim())
+    .map((value) => value.trim().replace(/\s+/g, ' '))
+    .join(' ')
+    .trim();
+}
+
+function keywordTerms(text, limit = 3) {
+  const stopWords = new Set([
+    'about', 'after', 'again', 'agent', 'because', 'before', 'being', 'change',
+    'could', 'from', 'have', 'into', 'should', 'that', 'their', 'there', 'this',
+    'touch', 'when', 'where', 'with', 'work', 'would',
+  ]);
+  const seen = new Set();
+  const terms = [];
+  for (const token of String(text || '').toLowerCase().match(/[a-z][a-z0-9_-]{3,}/g) || []) {
+    if (stopWords.has(token) || seen.has(token)) continue;
+    seen.add(token);
+    terms.push(token);
+    if (terms.length >= limit) break;
+  }
+  return terms;
+}
+
+function feedbackEntryToEvalCase(entry = {}, index = 0) {
+  const signal = normalizeSignal(entry);
+  if (!signal) return null;
+
+  const context = compactText(entry.context, entry.summary, entry.message, entry.userText);
+  const whatWentWrong = compactText(entry.whatWentWrong, entry.rootCause, entry.failure, entry.error);
+  const whatToChange = compactText(entry.whatToChange, entry.correctiveAction, entry.fix, entry.recommendation);
+  const whatWorked = compactText(entry.whatWorked, entry.success, entry.outcome);
+  const tags = Array.isArray(entry.tags)
+    ? entry.tags.map(String).filter(Boolean)
+    : String(entry.tags || '').split(',').map((tag) => tag.trim()).filter(Boolean);
+  const rawId = entry.id || entry.feedbackId || `${signal}:${context}:${whatWentWrong}:${whatToChange}:${whatWorked}:${index}`;
+  const id = `feedback-${signal}-${hashId(rawId)}`;
+  const actionableText = signal === 'negative'
+    ? compactText(whatToChange, whatWentWrong, context)
+    : compactText(context, whatWorked);
+  const terms = keywordTerms(actionableText, 2);
+  const vague = actionableText.length < 24 || /^thumbs?\s*(up|down)$/i.test(actionableText);
+
+  return {
+    id,
+    prompt: 'lesson-distillation',
+    source: {
+      type: 'feedback',
+      feedbackId: entry.id || entry.feedbackId || null,
+      timestamp: entry.timestamp || null,
+    },
+    input: {
+      signal,
+      context,
+      whatWentWrong,
+      whatToChange,
+      whatWorked,
+      tags,
+    },
+    expectedOutput: vague
+      ? { shouldReject: true, rejectReason: 'vague-feedback' }
+      : {
+          hasTitle: true,
+          hasContent: signal === 'negative',
+          ...(terms.length > 0 && signal === 'negative' ? { contentContains: terms } : {}),
+          category: signal === 'negative' ? 'error' : 'learning',
+        },
+  };
+}
+
+function buildEvalSuiteFromFeedback(entries = [], options = {}) {
+  const maxCases = Number.isFinite(Number(options.maxCases))
+    ? Math.max(1, Number(options.maxCases))
+    : DEFAULT_MAX_FEEDBACK_CASES;
+  const cases = [];
+  const seen = new Set();
+
+  for (const [index, entry] of entries.entries()) {
+    const evalCase = feedbackEntryToEvalCase(entry, index);
+    if (!evalCase || seen.has(evalCase.id)) continue;
+    seen.add(evalCase.id);
+    cases.push(evalCase);
+    if (cases.length >= maxCases) break;
+  }
+
+  return {
+    version: 1,
+    name: options.name || 'ThumbGate Feedback-Derived Prompt Evaluation',
+    description: 'Reusable eval cases generated from thumbs-up/down feedback. These cases prove whether a feedback-derived behavior now passes instead of relying on prompt vibes.',
+    generatedAt: new Date().toISOString(),
+    source: {
+      type: 'feedback-log',
+      path: options.sourcePath || null,
+      totalEntries: entries.length,
+      selectedCases: cases.length,
+    },
+    evaluations: cases,
+  };
+}
+
+function runSuiteObject(suite, options = {}) {
+  if (!suite || !Array.isArray(suite.evaluations) || (!options.allowEmpty && suite.evaluations.length === 0)) {
+    throw new Error('Suite must define a non-empty evaluations array');
+  }
+
+  const results = suite.evaluations.map(runEvaluation);
+  const passed = results.filter((r) => r.status === 'pass').length;
+  const failed = results.filter((r) => r.status === 'fail').length;
+  const errors = results.filter((r) => r.status === 'error').length;
+  const skipped = results.filter((r) => r.status === 'skip').length;
+  const totalScore = results.length > 0
+    ? Math.round(results.reduce((s, r) => s + r.score, 0) / results.length)
+    : 100;
+  const minScore = options.minScore ?? 80;
+
+  return {
+    suite: suite.name,
+    total: results.length,
+    passed,
+    failed,
+    errors,
+    skipped,
+    score: totalScore,
+    minScore,
+    pass: totalScore >= minScore,
+    noCases: results.length === 0,
+    feedbackDerived: suite.source && suite.source.type === 'feedback-log',
+    generatedAt: new Date().toISOString(),
+    results,
+  };
+}
+
+function runFeedbackEvalSuite(options = {}) {
+  const feedbackLog = options.feedbackLog || (() => {
+    const { resolveFeedbackDir } = require('./feedback-paths');
+    return path.join(resolveFeedbackDir({ feedbackDir: options.feedbackDir }), 'feedback-log.jsonl');
+  })();
+  const entries = readJsonl(feedbackLog);
+  const suite = buildEvalSuiteFromFeedback(entries, {
+    maxCases: options.maxCases,
+    name: options.name,
+    sourcePath: feedbackLog,
+  });
+  const report = runSuiteObject(suite, { minScore: options.minScore, allowEmpty: true });
+  return { suite, report };
+}
+
+function formatProofReport(report, suite) {
+  const feedbackSource = suite && suite.source ? suite.source : {};
+  const lines = [
+    '# ThumbGate Prompt Evaluation Proof',
+    '',
+    `Generated: ${report.generatedAt}`,
+    `Suite: ${report.suite}`,
+    `Score: ${report.score}% (minimum ${report.minScore}%)`,
+    `Result: ${report.pass ? 'PASS' : 'FAIL'}`,
+    '',
+    '## Feedback-Derived Coverage',
+    '',
+    `- Feedback entries scanned: ${feedbackSource.totalEntries || 0}`,
+    `- Reusable eval cases generated: ${feedbackSource.selectedCases || report.total}`,
+    `- Passing cases: ${report.passed}/${report.total}`,
+    `- Failing cases: ${report.failed}`,
+    `- Errors: ${report.errors}`,
+    `- Skipped: ${report.skipped}`,
+    '',
+    '## Case Results',
+    '',
+  ];
+
+  for (const result of report.results) {
+    lines.push(`- ${result.status.toUpperCase()} ${result.id}: ${result.score}%`);
+  }
+
+  lines.push('', '## Buyer Proof', '');
+  lines.push('Every row above started as real operator feedback, became a reusable eval, and now gives a repeatable before/after proof lane for prompt or workflow changes.');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
 
@@ -281,32 +496,7 @@ function runEvaluation(evalCase) {
 
 function runSuite(suitePath = DEFAULT_SUITE, options = {}) {
   const suite = loadSuite(suitePath);
-  const results = [];
-
-  for (const evalCase of suite.evaluations) {
-    results.push(runEvaluation(evalCase));
-  }
-
-  const passed = results.filter((r) => r.status === 'pass').length;
-  const failed = results.filter((r) => r.status === 'fail').length;
-  const errors = results.filter((r) => r.status === 'error').length;
-  const skipped = results.filter((r) => r.status === 'skip').length;
-  const totalScore = results.length > 0
-    ? Math.round(results.reduce((s, r) => s + r.score, 0) / results.length)
-    : 0;
-
-  return {
-    suite: suite.name,
-    total: results.length,
-    passed,
-    failed,
-    errors,
-    skipped,
-    score: totalScore,
-    minScore: options.minScore || 80,
-    pass: totalScore >= (options.minScore || 80),
-    results,
-  };
+  return runSuiteObject(suite, options);
 }
 
 // ---------------------------------------------------------------------------
@@ -328,17 +518,41 @@ if (isCliInvocation()) {
   let suitePath = DEFAULT_SUITE;
   let json = false;
   let minScore = 80;
+  let fromFeedback = false;
+  let feedbackLog = null;
+  let feedbackDir = null;
+  let writeSuite = null;
+  let writeReport = null;
+  let maxCases = DEFAULT_MAX_FEEDBACK_CASES;
 
   for (const arg of args) {
     if (arg.startsWith('--suite=')) suitePath = path.resolve(arg.slice(8));
     if (arg === '--json') json = true;
     if (arg.startsWith('--min-score=')) minScore = Number(arg.slice(12));
+    if (arg === '--from-feedback') fromFeedback = true;
+    if (arg.startsWith('--feedback-log=')) feedbackLog = path.resolve(arg.slice(15));
+    if (arg.startsWith('--feedback-dir=')) feedbackDir = path.resolve(arg.slice(15));
+    if (arg.startsWith('--write-suite=')) writeSuite = path.resolve(arg.slice(14));
+    if (arg.startsWith('--write-report=')) writeReport = path.resolve(arg.slice(15));
+    if (arg.startsWith('--max-cases=')) maxCases = Number(arg.slice(12));
   }
 
-  const report = runSuite(suitePath, { minScore });
+  const evalRun = fromFeedback
+    ? runFeedbackEvalSuite({ feedbackLog, feedbackDir, minScore, maxCases })
+    : { suite: loadSuite(suitePath), report: runSuite(suitePath, { minScore }) };
+  const { suite, report } = evalRun;
+
+  if (writeSuite) {
+    fs.mkdirSync(path.dirname(writeSuite), { recursive: true });
+    fs.writeFileSync(writeSuite, `${JSON.stringify(suite, null, 2)}\n`, 'utf8');
+  }
+  if (writeReport) {
+    fs.mkdirSync(path.dirname(writeReport), { recursive: true });
+    fs.writeFileSync(writeReport, `${formatProofReport(report, suite)}\n`, 'utf8');
+  }
 
   if (json) {
-    console.log(JSON.stringify(report, null, 2));
+    console.log(JSON.stringify({ ...report, suiteDefinition: fromFeedback ? suite : undefined }, null, 2));
   } else {
     console.log(`\n${report.suite}`);
     console.log('='.repeat(50));
@@ -360,4 +574,15 @@ if (isCliInvocation()) {
   process.exit(report.pass ? 0 : 1);
 }
 
-module.exports = { runSuite, runEvaluation, gradeOutput, loadSuite };
+module.exports = {
+  buildEvalSuiteFromFeedback,
+  feedbackEntryToEvalCase,
+  formatProofReport,
+  gradeOutput,
+  loadSuite,
+  readJsonl,
+  runEvaluation,
+  runFeedbackEvalSuite,
+  runSuite,
+  runSuiteObject,
+};

--- a/scripts/prompt-eval.js
+++ b/scripts/prompt-eval.js
@@ -247,10 +247,24 @@ function readJsonl(filePath) {
 }
 
 function stableCaseId(value, index = 0) {
-  const slug = String(value || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .slice(0, 64);
+  const source = String(value || '').toLowerCase();
+  let slug = '';
+  let previousWasDash = false;
+  for (const ch of source) {
+    const isDigit = ch >= '0' && ch <= '9';
+    const isLower = ch >= 'a' && ch <= 'z';
+    if (isDigit || isLower) {
+      slug += ch;
+      previousWasDash = false;
+      if (slug.length >= 64) break;
+      continue;
+    }
+    if (!previousWasDash && slug.length > 0) {
+      slug += '-';
+      previousWasDash = true;
+      if (slug.length >= 64) break;
+    }
+  }
   let start = 0;
   let end = slug.length;
   while (start < end && slug[start] === '-') start += 1;

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -551,6 +551,7 @@ describe('bin/cli.js', () => {
     assert.ok(result.stdout.includes('lessons'), 'Help should mention lessons');
     assert.ok(result.stdout.includes('stats'), 'Help should mention stats');
     assert.ok(result.stdout.includes('north-star'), 'Help should mention north-star');
+    assert.ok(result.stdout.includes('eval'), 'Help should mention eval');
     assert.ok(result.stdout.includes('rules'), 'Help should mention rules');
     assert.ok(result.stdout.includes('self-heal'), 'Help should mention self-heal');
     assert.ok(result.stdout.includes('prove'), 'Help should mention prove');
@@ -559,6 +560,33 @@ describe('bin/cli.js', () => {
     assert.ok(result.stdout.includes('analytics'), 'Help should mention analytics');
     assert.ok(result.stdout.includes('gate-check'), 'Help should mention gate-check');
     assert.ok(result.stdout.includes('statusline-render'), 'Help should mention statusline-render');
+  });
+
+  test('eval command turns local feedback into reusable proof JSON', () => {
+    const feedbackDir = makeTmpDir();
+    fs.writeFileSync(path.join(feedbackDir, 'feedback-log.jsonl'), `${JSON.stringify({
+      id: 'fb_cli_eval_1',
+      signal: 'down',
+      context: 'Skipped checkout verification and claimed the fix was live',
+      whatWentWrong: 'Reported completion before running focused tests',
+      whatToChange: 'Run focused verification before claiming completion',
+      tags: ['verification'],
+    })}\n`);
+
+    const result = runCliSync(['eval', '--from-feedback', '--json', '--min-score=0'], {
+      env: {
+        THUMBGATE_FEEDBACK_DIR: feedbackDir,
+        THUMBGATE_NO_NUDGE: '1',
+      },
+    });
+
+    assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\n${result.stderr}`);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.feedbackDerived, true);
+    assert.equal(payload.suiteDefinition.source.selectedCases, 1);
+    assert.equal(payload.total, 1);
+
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
   });
 
   test('gate-check allows ordinary edits when no task scope is declared', () => {

--- a/tests/prompt-eval.test.js
+++ b/tests/prompt-eval.test.js
@@ -147,6 +147,15 @@ test('feedbackEntryToEvalCase turns vague thumbs-down into a rejection eval', ()
   });
 });
 
+test('feedbackEntryToEvalCase builds regex-free stable ids from noisy context', () => {
+  const evalCase = feedbackEntryToEvalCase({
+    signal: 'down',
+    context: '--- Ship!!! broken $$$ checkout /// path ??? ',
+  }, 2);
+
+  assert.equal(evalCase.id, 'feedback-negative-negative-ship-broken-checkout-path-3');
+});
+
 test('buildEvalSuiteFromFeedback creates bounded reusable eval suites', () => {
   const suite = buildEvalSuiteFromFeedback([
     { id: 'fb_1', signal: 'down', context: 'Skipped tests before merge', whatToChange: 'Run tests first' },

--- a/tests/prompt-eval.test.js
+++ b/tests/prompt-eval.test.js
@@ -1,8 +1,19 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
-const { runSuite, runEvaluation, gradeOutput, loadSuite } = require('../scripts/prompt-eval');
+const {
+  buildEvalSuiteFromFeedback,
+  feedbackEntryToEvalCase,
+  formatProofReport,
+  runFeedbackEvalSuite,
+  runSuite,
+  runEvaluation,
+  gradeOutput,
+  loadSuite,
+} = require('../scripts/prompt-eval');
 
 const SUITE_PATH = path.join(__dirname, '..', 'bench', 'prompt-eval-suite.json');
 
@@ -110,4 +121,86 @@ test('runSuite: runs full suite and returns aggregate report', () => {
   assert.ok(typeof report.score === 'number', 'should compute aggregate score');
   assert.ok(typeof report.pass === 'boolean', 'should have pass/fail boolean');
   assert.equal(report.total, report.passed + report.failed + report.errors + report.skipped, 'counts should add up');
+});
+
+test('feedbackEntryToEvalCase converts negative feedback into a lesson eval', () => {
+  const evalCase = feedbackEntryToEvalCase({
+    id: 'fb_1',
+    signal: 'down',
+    context: 'Skipped verification and shipped a broken checkout flow',
+    whatWentWrong: 'Claimed the flow worked before running tests',
+    whatToChange: 'Always run focused checkout tests before claiming success',
+    tags: ['verification'],
+  });
+
+  assert.equal(evalCase.prompt, 'lesson-distillation');
+  assert.equal(evalCase.input.signal, 'negative');
+  assert.equal(evalCase.expectedOutput.category, 'error');
+  assert.equal(evalCase.expectedOutput.hasContent, true);
+});
+
+test('feedbackEntryToEvalCase turns vague thumbs-down into a rejection eval', () => {
+  const evalCase = feedbackEntryToEvalCase({ signal: 'down', context: 'thumbs down' });
+  assert.deepEqual(evalCase.expectedOutput, {
+    shouldReject: true,
+    rejectReason: 'vague-feedback',
+  });
+});
+
+test('buildEvalSuiteFromFeedback creates bounded reusable eval suites', () => {
+  const suite = buildEvalSuiteFromFeedback([
+    { id: 'fb_1', signal: 'down', context: 'Skipped tests before merge', whatToChange: 'Run tests first' },
+    { id: 'fb_2', signal: 'up', context: 'Verified the adapter parity before pushing', whatWorked: 'Ran parity tests' },
+  ], { maxCases: 1, sourcePath: '/tmp/feedback-log.jsonl' });
+
+  assert.equal(suite.source.totalEntries, 2);
+  assert.equal(suite.source.selectedCases, 1);
+  assert.equal(suite.evaluations.length, 1);
+  assert.equal(suite.source.type, 'feedback-log');
+});
+
+test('runFeedbackEvalSuite reads feedback-log.jsonl and returns proof report data', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-prompt-eval-'));
+  const feedbackLog = path.join(tmpDir, 'feedback-log.jsonl');
+  fs.writeFileSync(feedbackLog, [
+    JSON.stringify({
+      id: 'fb_eval_1',
+      signal: 'down',
+      context: 'Exited the worktree and modified the main checkout',
+      whatWentWrong: 'Touched the wrong branch after creating a worktree',
+      whatToChange: 'Stay inside the assigned worktree until the PR is opened',
+      tags: ['git'],
+    }),
+    JSON.stringify({
+      id: 'fb_eval_2',
+      signal: 'up',
+      context: 'Ran the focused tests before reporting completion',
+      whatWorked: 'Verification was evidence-backed',
+      tags: ['testing'],
+    }),
+  ].join('\n') + '\n');
+
+  const { suite, report } = runFeedbackEvalSuite({ feedbackLog, minScore: 0 });
+  const proof = formatProofReport(report, suite);
+
+  assert.equal(suite.evaluations.length, 2);
+  assert.equal(report.feedbackDerived, true);
+  assert.match(proof, /Feedback-Derived Coverage/);
+  assert.match(proof, /Buyer Proof/);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('runFeedbackEvalSuite handles empty feedback logs as bootstrapping proof', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-empty-prompt-eval-'));
+  const feedbackLog = path.join(tmpDir, 'feedback-log.jsonl');
+  fs.writeFileSync(feedbackLog, '', 'utf8');
+
+  const { suite, report } = runFeedbackEvalSuite({ feedbackLog, minScore: 0 });
+
+  assert.equal(suite.evaluations.length, 0);
+  assert.equal(report.noCases, true);
+  assert.equal(report.pass, true);
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- Turn real thumbs-up/down feedback into reusable prompt/workflow eval suites.
- Add `thumbgate eval --from-feedback` plus `npm run eval:feedback` for JSON and Markdown proof output.
- Update README and verification evidence so buyers/operators can see the feedback -> eval -> proof loop.

## Verification
- npm run test:prompt-eval
- node --test tests/cli.test.js tests/cli-schema.test.js tests/high-roi.test.js
- npm run eval:feedback -- --feedback-dir=.thumbgate --min-score=0 --json
- npm run test:public-core-boundary
- node --test tests/package-boundary.test.js tests/public-package-parity.test.js
- npm run test:sync-version
- npm run test:public-static-assets
- npm run test:landing-page-claims
- git diff --check
- pre-commit guards: package parity, version sync, congruence
- pre-push guards: npm pack dry-run, public HTML internal links, regression-guard tests
