### PR TITLE
fix(ci): retry verify-changeset git fetch to survive GitHub 500s

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -30,7 +30,27 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Fetch base branch for changeset diff
-        run: git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'
+        # Retry the fetch to ride through transient GitHub infra 500s.
+        # Without retry, a single HTTP 500 on `git fetch` (e.g. during a
+        # GitHub Actions incident) fails the required status check and
+        # blocks the Trunk merge queue. Five attempts with exponential
+        # backoff (1s, 2s, 4s, 8s) cap at ~15s of wait time.
+        run: |
+          set -euo pipefail
+          delay=1
+          for attempt in 1 2 3 4 5; do
+            if git fetch --no-tags --prune origin '+refs/heads/main:refs/remotes/origin/main'; then
+              echo "Fetched origin/main on attempt ${attempt}"
+              exit 0
+            fi
+            if [ "${attempt}" -eq 5 ]; then
+              echo "git fetch origin main failed after 5 attempts" >&2
+              exit 1
+            fi
+            echo "git fetch attempt ${attempt} failed; retrying in ${delay}s" >&2
+            sleep "${delay}"
+            delay=$(( delay * 2 ))
+          done
 
       - name: Install release-check dependencies
         run: npm ci --ignore-scripts --onnxruntime-node-install-cuda=skip


### PR DESCRIPTION
## Summary

- Harden `.github/workflows/changeset-check.yml` so a single transient HTTP 500 from GitHub doesn't fail the required status check and block the Trunk merge queue
- Replaces the naked `git fetch origin main` with a 5-attempt exponential-backoff loop (1s, 2s, 4s, 8s; ~15s wait cap)

## Triggered by

The 2026-04-23 GitHub Actions critical incident: three consecutive Trunk merge-test PRs for #1238 (#1242 #1243 #1244) all failed on this step with `remote: Internal Server Error` on the fetch, blocking the PR from merging even though the PR itself is fine.

## Why no changeset

`.github/` paths are explicitly excluded from release-relevance in `scripts/changeset-check.js` (see `isReleaseRelevantFile`, line 56–61), so this workflow-only change does not require a changeset.

## Test plan

- [ ] CI runs this new Verify changeset workflow on the PR itself
- [ ] On success, land it and observe Trunk merge-test PRs for future merges ride through 1–2 transient 500s instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)