### PR TITLE
feat: add machine-speed ROI surfaces

### DIFF
--- a/.changeset/machine-speed-roi-dashboard.md
+++ b/.changeset/machine-speed-roi-dashboard.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add machine-speed ROI surfaces to ThumbGate's public shell. The dashboard now exposes actionable remediations and agent surface inventory, the PreToolUse reminder adds action-profile and safer-next-move context, and the landing/meta copy is aligned to position ThumbGate as pre-action defense for AI coding agents without hardcoded token-savings claims.

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -2,8 +2,8 @@
   "repo": "IgorGanapolsky/ThumbGate",
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
   "homepageUrl": "https://thumbgate-production.up.railway.app",
-  "githubDescription": "Machine-speed pre-action defense for AI agents: 👍/👎 become checks that block repeat mistakes before code, money, or customer systems change.",
-  "metaDescription": "Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI agents: 👍 thumbs up and 👎 thumbs down become history-aware lessons, background-agent checkpoints, economic action gates, policy-origin proof, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
+  "githubDescription": "Agent governance for ThumbGate: 👍/👎 become Pre-Action Checks that block repeat mistakes before code, money, or customer systems change.",
+  "metaDescription": "Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI coding agents: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, actionable remediations, agent surface inventory, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
   "topics": [
     "thumbgate",
     "pre-action-checks",

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -3,7 +3,7 @@
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
   "homepageUrl": "https://thumbgate-production.up.railway.app",
   "githubDescription": "Self-improving agent governance: 👍/👎 → Pre-Action Checks that block repeat AI mistakes. Stop paying for the same mistake twice.",
-  "metaDescription": "Stop paying for the same AI mistake twice. ThumbGate is the enforcement layer for AI agent orchestration: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, plus Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
+  "metaDescription": "Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI coding agents: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, actionable remediations, agent surface inventory, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
   "topics": [
     "thumbgate",
     "pre-action-checks",

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -2,8 +2,8 @@
   "repo": "IgorGanapolsky/ThumbGate",
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
   "homepageUrl": "https://thumbgate-production.up.railway.app",
-  "githubDescription": "Self-improving agent governance: 👍/👎 → Pre-Action Checks that block repeat AI mistakes. Stop paying for the same mistake twice.",
-  "metaDescription": "Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI coding agents: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, actionable remediations, agent surface inventory, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
+  "githubDescription": "Machine-speed pre-action defense for AI agents: 👍/👎 become checks that block repeat mistakes before code, money, or customer systems change.",
+  "metaDescription": "Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI agents: 👍 thumbs up and 👎 thumbs down become history-aware lessons, background-agent checkpoints, economic action gates, policy-origin proof, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
   "topics": [
     "thumbgate",
     "pre-action-checks",

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -17,7 +17,7 @@
 
 ### GitHub Repo About
 **Canonical source:** `config/github-about.json`
-> Self-improving agent governance: 👍/👎 → Pre-Action Checks that block repeat AI mistakes. Stop paying for the same mistake twice.
+> Agent governance for ThumbGate: 👍/👎 become Pre-Action Checks that block repeat mistakes before code, money, or customer systems change.
 
 **Canonical topics:** `thumbgate`, `pre-action-checks`, `mcp`, `mcp-server`, `ai-agents`, `agent-reliability`, `guardrails`, `ai-safety`, `developer-tools`, `feedback-loop`, `claude-code`, `cursor`, `codex`, `gemini`, `amp`, `opencode`, `thompson-sampling`
 

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -10,7 +10,7 @@
 > Pre-action checks that block AI agents from repeating known mistakes. Captures feedback, auto-generates prevention rules, and enforces them via PreToolUse hooks.
 
 ### Public Landing Page (thumbgate-production.up.railway.app)
-> Stop paying for the same AI mistake twice. ThumbGate is the enforcement layer for AI agent orchestration: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, plus Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.
+> Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI coding agents: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, actionable remediations, agent surface inventory, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.
 
 ### NPM package.json
 > Pre-action checks that block AI coding agents from repeating known mistakes. Captures feedback, auto-promotes failures into prevention rules, and enforces them via PreToolUse hooks.

--- a/docs/gpt-store-submission.md
+++ b/docs/gpt-store-submission.md
@@ -28,7 +28,7 @@ ThumbGate
 ## Short Description (max 50 characters)
 
 ```
-Preflight risky AI actions before they run
+Stop your AI agent from repeating mistakes
 ```
 
 ---

--- a/docs/gpt-store-submission.md
+++ b/docs/gpt-store-submission.md
@@ -28,7 +28,7 @@ ThumbGate
 ## Short Description (max 50 characters)
 
 ```
-Stop your AI agent from repeating mistakes
+Preflight risky AI actions before they run
 ```
 
 ---
@@ -36,7 +36,7 @@ Stop your AI agent from repeating mistakes
 ## Full Description (max 300 characters)
 
 ```
-Paste any AI action before it runs: commands, edits, merges, deploys. ThumbGate tells you whether to allow, block, or checkpoint — and remembers every thumbs-down so your agent stops repeating the same mistakes. No more "why did it do that again?"
+Stop costly AI mistakes before they run. Paste a risky command, deploy, refund, PR action, or file edit before it executes. ThumbGate tells you whether to allow, block, or checkpoint it, then turns typed thumbs-up/down feedback into Pre-Action Checks so repeated mistakes stop coming back.
 ```
 
 ---
@@ -55,7 +55,7 @@ Lead with jobs, not explanations. When the user is not specific, offer these six
 6. Export evidence: feedback summary, prevention rules, DPO pairs, or verification links.
 
 Default first response:
-"Paste the risky AI action before it runs, or tell me what went right/wrong. I can prevent costly mistakes, save the lesson, write a prevention rule, or show what ThumbGate already remembers."
+"Paste the risky AI action before it runs, or tell me what went right/wrong. I can preflight risky commands, deploys, refunds, PR actions, and file edits, save the lesson, write a prevention rule, or show what ThumbGate already remembers."
 
 Mode routing:
 - Action check mode: if the user asks whether an agent should run a command, file edit, merge, deploy, payment, API call, email, or publish step, call `evaluateDecision` (`POST /v1/decisions/evaluate`) before giving approval. If the action dispatches a GitHub Actions workflow, include `workflowDispatch` evidence with the requested environment, expected workflow, ref, HEAD SHA, and expected job. If `decisionControl.executionMode` is `blocked`, say it is blocked and why. If it is `checkpoint_required`, ask for explicit confirmation. If it is `auto_execute`, say it is allowed and summarize the evidence.
@@ -101,10 +101,10 @@ Authentication: Bearer token configured once by the GPT owner in GPT Builder. Re
 Outcome-led, named-pain starters that match what developers actually type into search:
 
 ```
-1. "Check: git push --force --tags"
-2. "Stop my agent from editing generated files"
-3. "This answer was wrong — save the lesson"
-4. "What mistakes has my agent repeated this week?"
+1. "Check this agent action before it runs: git push --force --tags"
+2. "Should this background agent run a customer refund or invoice send?"
+3. "Turn this mistake into a ThumbGate rule: the agent edited generated files again."
+4. "Install ThumbGate for Claude Code or Codex in this repo."
 ```
 
 > **Why these four:** each one opens with a verb a developer would type mid-frustration, and each maps 1:1 to an API action (evaluateDecision, generatePreventionRules, captureFeedback, getFeedbackSummary). Avoid proprietary terms ("Pre-Action Checks", "Reliability Gateway") in the starters — those belong in the instructions for the model, not the discovery surface.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "scripts/audit-trail.js",
     "scripts/auto-promote-gates.js",
     "scripts/auto-wire-hooks.js",
+    "scripts/background-agent-governance.js",
     "scripts/bayes-optimal-gate.js",
     "scripts/belief-update.js",
     "scripts/billing.js",

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -354,6 +354,36 @@
           </div>
         </div>
       </div>
+      <div class="panel" style="margin-top:16px;">
+        <h3>Background Agent Mode</h3>
+        <p class="template-summary">Queued and scheduled agents need explicit checkpoints before they touch code, money, or customer systems.</p>
+        <div class="inventory-grid" id="backgroundAgentSummaryCards"><div class="loading">Loading background-agent mode...</div></div>
+        <div class="team-columns" style="margin-top:16px;">
+          <div class="panel">
+            <h3>Governance Pressure</h3>
+            <div class="inventory-tools" id="backgroundAgentHighlights"><div class="loading">Loading background-agent governance...</div></div>
+          </div>
+          <div class="panel">
+            <h3>Run Types</h3>
+            <div class="inventory-sources" id="backgroundAgentRunTypes"><div class="loading">Loading background-agent run types...</div></div>
+          </div>
+        </div>
+      </div>
+      <div class="panel" style="margin-top:16px;">
+        <h3>Regulated Buyer Proof</h3>
+        <p class="template-summary">Show where policy came from, how many runs were reviewed, and which proof artifacts are ready when buyers ask for auditability.</p>
+        <div class="inventory-grid" id="regulatedProofSummaryCards"><div class="loading">Loading proof posture...</div></div>
+        <div class="team-columns" style="margin-top:16px;">
+          <div class="panel">
+            <h3>Policy Origin Proof</h3>
+            <div class="inventory-tools" id="regulatedProofDetails"><div class="loading">Loading policy origin proof...</div></div>
+          </div>
+          <div class="panel">
+            <h3>Latest Replay Artifacts</h3>
+            <div class="inventory-sources" id="regulatedProofArtifacts"><div class="loading">Loading replay artifacts...</div></div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -939,9 +969,11 @@ function renderDashboardData(data) {
 
   renderTeam(data.team || {}, data.analytics || {});
   renderAgentInventory(data.agentSurfaceInventory || {});
+  renderBackgroundAgents(data.backgroundAgents || {});
   renderReviewDelta(data.reviewDelta || {});
   renderPredictive(data.predictive || {});
   renderSettingsStatus(data.settingsStatus || {});
+  renderRegulatedProof(data.regulatedProof || {});
   renderTemplates(data.templateLibrary || {});
   renderInsights(data);
 }
@@ -1275,6 +1307,92 @@ function renderAgentInventory(inventory) {
       return '<div class="inventory-row"><div><div class="inventory-name">' + escHtml(source.source || 'unknown') + '</div><div class="inventory-subtitle">Runtime policy source</div></div><span class="generated-badge">' + escHtml(String(source.count || 0) + ' events') + '</span></div>';
     }).join('')
     : '<div class="empty" style="padding:20px 0;">No policy sources recorded yet.</div>';
+}
+
+function renderBackgroundAgents(backgroundAgents) {
+  var cards = [
+    {
+      label: 'Background runs',
+      value: String(backgroundAgents.total || 0),
+      note: 'last ' + String(backgroundAgents.periodHours || 24) + ' hours',
+    },
+    {
+      label: 'Pass rate',
+      value: String(backgroundAgents.passRate || 0) + '%',
+      note: String(backgroundAgents.completed || 0) + ' completed / ' + String(backgroundAgents.failed || 0) + ' failed',
+    },
+    {
+      label: 'Gate pressure',
+      value: String(backgroundAgents.gatesBlocked || 0),
+      note: String(backgroundAgents.gatesChecked || 0) + ' checkpoints evaluated',
+    },
+    {
+      label: 'Checkpoint coverage',
+      value: String(Math.round((backgroundAgents.checkpointCoverage || 0) * 100)) + '%',
+      note: String(backgroundAgents.reviewedRuns || 0) + ' reviewed proof-backed runs',
+    }
+  ];
+
+  document.getElementById('backgroundAgentSummaryCards').innerHTML = cards.map(function(card) {
+    return '<div class="inventory-card"><div class="team-kicker">' + escHtml(card.label) + '</div><div class="inventory-value">' + escHtml(card.value) + '</div><div class="inventory-note">' + escHtml(card.note) + '</div></div>';
+  }).join('');
+
+  var highlights = [];
+  if (backgroundAgents.topFailingAgent) {
+    highlights.push('<div class="inventory-row"><div><div class="inventory-name">Top failing agent</div><div class="inventory-subtitle">' + escHtml(backgroundAgents.topFailingAgent.agentId || 'unknown') + '</div></div><span class="generated-badge">' + escHtml(String(backgroundAgents.topFailingAgent.passRate || 0) + '% pass') + '</span></div>');
+  }
+  highlights.push('<div class="inventory-row"><div><div class="inventory-name">Recommended operating mode</div><div class="inventory-subtitle">Use ' + escHtml(backgroundAgents.recommendedMode || 'bootstrapping') + ' when background agents queue code, money, or customer actions.</div></div><span class="generated-badge">' + escHtml(String(backgroundAgents.blocked || 0) + ' blocked') + '</span></div>');
+  document.getElementById('backgroundAgentHighlights').innerHTML = highlights.join('');
+
+  var runTypes = Object.keys(backgroundAgents.byType || {});
+  document.getElementById('backgroundAgentRunTypes').innerHTML = runTypes.length
+    ? runTypes.map(function(runType) {
+      return '<div class="inventory-row"><div><div class="inventory-name">' + escHtml(runType) + '</div><div class="inventory-subtitle">Observed background workflow type</div></div><span class="generated-badge">' + escHtml(String(backgroundAgents.byType[runType] || 0) + ' runs') + '</span></div>';
+    }).join('')
+    : '<div class="empty" style="padding:20px 0;">No background-agent runs recorded yet.</div>';
+}
+
+function renderRegulatedProof(regulatedProof) {
+  var cards = [
+    {
+      label: 'Policy origins',
+      value: String(regulatedProof.policyOriginCount || 0),
+      note: String(regulatedProof.activeLayerCount || 0) + ' active settings layers',
+    },
+    {
+      label: 'Reviewed runs',
+      value: String(regulatedProof.reviewedRuns || 0),
+      note: String(regulatedProof.proofBackedRuns || 0) + ' proof-backed runs tracked',
+    },
+    {
+      label: 'Decision records',
+      value: String(regulatedProof.decisionEvaluations || 0),
+      note: regulatedProof.appendOnlyAuditReady ? 'append-only audit trail live' : 'no decision audit yet',
+    },
+    {
+      label: 'Runtime isolation',
+      value: regulatedProof.runtimeIsolation ? 'on' : 'off',
+      note: 'containerized execution posture',
+    }
+  ];
+
+  document.getElementById('regulatedProofSummaryCards').innerHTML = cards.map(function(card) {
+    return '<div class="inventory-card"><div class="team-kicker">' + escHtml(card.label) + '</div><div class="inventory-value">' + escHtml(card.value) + '</div><div class="inventory-note">' + escHtml(card.note) + '</div></div>';
+  }).join('');
+
+  var details = [];
+  if (regulatedProof.latestPolicyOrigin) {
+    details.push('<div class="inventory-row"><div><div class="inventory-name">' + escHtml(regulatedProof.latestPolicyOrigin.path || 'latest setting') + '</div><div class="inventory-subtitle">' + escHtml(regulatedProof.latestPolicyOrigin.sourcePath || 'built-in defaults') + '</div></div><span class="generated-badge">' + escHtml(String(regulatedProof.latestPolicyOrigin.scope || 'default')) + '</span></div>');
+  }
+  details.push('<div class="inventory-row"><div><div class="inventory-name">Checkpoint coverage</div><div class="inventory-subtitle">Reviewed proof-backed runs divided by total proof-backed workflow runs.</div></div><span class="generated-badge">' + escHtml(String(Math.round((regulatedProof.checkpointCoverage || 0) * 100)) + '%') + '</span></div>');
+  document.getElementById('regulatedProofDetails').innerHTML = details.join('');
+
+  var artifacts = Array.isArray(regulatedProof.latestProofArtifacts) ? regulatedProof.latestProofArtifacts : [];
+  document.getElementById('regulatedProofArtifacts').innerHTML = artifacts.length
+    ? artifacts.map(function(artifact) {
+      return '<div class="inventory-row"><div><div class="inventory-name">' + escHtml(artifact) + '</div><div class="inventory-subtitle">Proof artifact from ' + escHtml(regulatedProof.latestWorkflowName || 'latest workflow run') + '</div></div><span class="generated-badge">replay-ready</span></div>';
+    }).join('')
+    : '<div class="empty" style="padding:20px 0;">No workflow replay artifacts recorded yet.</div>';
 }
 
 function renderTemplates(templateLibrary) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>ThumbGate Dashboard — Gate Stats, Approval Rate, Prevention Impact</title>
-<meta name="description" content="Live dashboard showing gate enforcement stats, approval rate trends, prevention impact, and system health for ThumbGate pre-action checks.">
+<title>ThumbGate Dashboard — Gate Stats, Agent Inventory, Remediations</title>
+<meta name="description" content="Live ThumbGate dashboard showing gate enforcement stats, agent surface inventory, actionable remediations, prevention impact, and system health for pre-action checks.">
 <link rel="canonical" href="https://thumbgate-production.up.railway.app/dashboard">
 <link rel="icon" type="image/png" href="/thumbgate-icon.png">
 <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
@@ -123,6 +123,16 @@
   .team-note { font-size: 13px; color: var(--text-muted); margin-top: 6px; }
   .team-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
   .risk-row, .blocked-row, .template-meta { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; }
+  .inventory-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px; margin-top: 16px; }
+  .inventory-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 18px; }
+  .inventory-value { font-size: 22px; font-weight: 700; color: var(--cyan); letter-spacing: -0.03em; }
+  .inventory-note { font-size: 12px; color: var(--text-muted); margin-top: 6px; line-height: 1.5; }
+  .inventory-tools, .inventory-sources, .remediation-list { display: flex; flex-direction: column; gap: 10px; }
+  .inventory-row, .remediation-row { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; padding: 10px 0; border-bottom: 1px solid var(--border); }
+  .inventory-row:last-child, .remediation-row:last-child { border-bottom: none; }
+  .inventory-name, .remediation-name { font-size: 14px; font-weight: 600; }
+  .inventory-subtitle, .remediation-subtitle { font-size: 12px; color: var(--text-muted); line-height: 1.55; margin-top: 4px; }
+  .remediation-action { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; border-radius: 999px; padding: 4px 10px; background: var(--bg-raised); color: var(--text-muted); border: 1px solid var(--border); white-space: nowrap; }
   .risk-row, .blocked-row { padding: 10px 0; border-bottom: 1px solid var(--border); }
   .risk-row:last-child, .blocked-row:last-child { border-bottom: none; }
   .risk-name, .blocked-name { font-size: 14px; font-weight: 600; }
@@ -183,7 +193,7 @@
   @media (max-width: 700px) {
     .stats-grid { grid-template-columns: repeat(2, 1fr); }
     .search-filters { flex-wrap: wrap; }
-    .team-grid, .template-grid, .team-columns, .settings-grid, .generated-grid { grid-template-columns: 1fr; }
+    .team-grid, .template-grid, .team-columns, .settings-grid, .generated-grid, .inventory-grid { grid-template-columns: 1fr; }
   }
 </style>
 </head>
@@ -329,6 +339,21 @@
         <h3>Predictive Watchlist</h3>
         <div id="predictiveAnomalies"><div class="loading">Loading predictive watchlist...</div></div>
       </div>
+      <div class="panel" style="margin-top:16px;">
+        <h3>Agent Surface Inventory</h3>
+        <p class="template-summary">See which tools, policy sources, and MCP surfaces are actually active before you widen rollout.</p>
+        <div class="inventory-grid" id="inventorySummaryCards"><div class="loading">Loading inventory...</div></div>
+        <div class="team-columns" style="margin-top:16px;">
+          <div class="panel">
+            <h3>Observed Tools</h3>
+            <div class="inventory-tools" id="inventoryObservedTools"><div class="loading">Loading observed tools...</div></div>
+          </div>
+          <div class="panel">
+            <h3>Policy Sources</h3>
+            <div class="inventory-sources" id="inventoryPolicySources"><div class="loading">Loading policy sources...</div></div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -426,6 +451,12 @@
         <div style="position:relative;height:280px;margin-top:12px;">
           <canvas id="gateAuditChart"></canvas>
         </div>
+      </div>
+
+      <div class="panel" style="margin-bottom:24px;">
+        <h3>Highest-ROI Next Actions</h3>
+        <p class="template-summary">These recommendations come from real feedback, risk patterns, and delegation pressure in your current runtime.</p>
+        <div class="remediation-list" id="actionableRemediations"><div class="loading">Loading next actions...</div></div>
       </div>
 
       <!-- How It Works -->
@@ -907,6 +938,7 @@ function renderDashboardData(data) {
   }
 
   renderTeam(data.team || {}, data.analytics || {});
+  renderAgentInventory(data.agentSurfaceInventory || {});
   renderReviewDelta(data.reviewDelta || {});
   renderPredictive(data.predictive || {});
   renderSettingsStatus(data.settingsStatus || {});
@@ -1202,6 +1234,49 @@ function renderPredictive(predictive) {
     : '<div class="empty" style="padding:20px 0;">No predictive anomalies right now.</div>';
 }
 
+function renderAgentInventory(inventory) {
+  var cards = [
+    {
+      label: 'MCP profile',
+      value: inventory.profile || 'unknown',
+      note: (inventory.tier || 'custom') + ' tier',
+    },
+    {
+      label: 'Observed tools',
+      value: String(inventory.observedToolCount || 0),
+      note: 'from decision + audit logs',
+    },
+    {
+      label: 'Policy sources',
+      value: String((inventory.policySources || []).length),
+      note: 'gates, scanners, or routers firing now',
+    },
+    {
+      label: 'Configured MCP servers',
+      value: String(inventory.configuredServerCount || 0),
+      note: 'from local .mcp.json',
+    }
+  ];
+
+  document.getElementById('inventorySummaryCards').innerHTML = cards.map(function(card) {
+    return '<div class="inventory-card"><div class="team-kicker">' + escHtml(card.label) + '</div><div class="inventory-value">' + escHtml(card.value) + '</div><div class="inventory-note">' + escHtml(card.note) + '</div></div>';
+  }).join('');
+
+  var tools = Array.isArray(inventory.observedTools) ? inventory.observedTools : [];
+  document.getElementById('inventoryObservedTools').innerHTML = tools.length
+    ? tools.map(function(tool) {
+      return '<div class="inventory-row"><div><div class="inventory-name">' + escHtml(tool.toolName || 'unknown') + '</div><div class="inventory-subtitle">' + escHtml((tool.evaluations || 0) + ' evals · ' + (tool.intercepted || 0) + ' intercepted · ' + (tool.allow || 0) + ' allowed') + '</div></div><span class="generated-badge">' + escHtml(String((tool.deny || 0) + ' deny / ' + (tool.warn || 0) + ' warn')) + '</span></div>';
+    }).join('')
+    : '<div class="empty" style="padding:20px 0;">No observed tools yet.</div>';
+
+  var sources = Array.isArray(inventory.policySources) ? inventory.policySources : [];
+  document.getElementById('inventoryPolicySources').innerHTML = sources.length
+    ? sources.map(function(source) {
+      return '<div class="inventory-row"><div><div class="inventory-name">' + escHtml(source.source || 'unknown') + '</div><div class="inventory-subtitle">Runtime policy source</div></div><span class="generated-badge">' + escHtml(String(source.count || 0) + ' events') + '</span></div>';
+    }).join('')
+    : '<div class="empty" style="padding:20px 0;">No policy sources recorded yet.</div>';
+}
+
 function renderTemplates(templateLibrary) {
   const templates = Array.isArray(templateLibrary.templates) ? templateLibrary.templates : [];
   const categories = templateLibrary.categories || {};
@@ -1370,6 +1445,39 @@ function loadDemo() {
       { type: 'creator_underperformance', message: 'Creator reach_vb is generating intent without revenue conversion.', severity: 'warning' }
     ]
   });
+  renderAgentInventory({
+    profile: 'default',
+    tier: 'builder',
+    configuredServerCount: 3,
+    observedToolCount: 4,
+    observedTools: [
+      { toolName: 'Bash', evaluations: 120, intercepted: 19, allow: 101, deny: 12, warn: 7 },
+      { toolName: 'Edit', evaluations: 64, intercepted: 6, allow: 58, deny: 2, warn: 4 },
+      { toolName: 'Read', evaluations: 42, intercepted: 0, allow: 42, deny: 0, warn: 0 }
+    ],
+    policySources: [
+      { source: 'gates-engine', count: 23 },
+      { source: 'secret-guard', count: 6 },
+      { source: 'workflow-sentinel', count: 4 }
+    ]
+  });
+  renderActionableRemediations([
+    {
+      title: 'tighten verification before response · recent-signals',
+      rationale: 'Recent approval rate has dropped below the lifetime baseline, so fast completion claims need tighter proof.',
+      action: 'tighten-verification-before-response',
+    },
+    {
+      title: 'audit domain failures · git-workflow',
+      rationale: 'Git workflow events are overrepresented in high-risk outcomes and deserve a stronger pre-action gate.',
+      action: 'audit-domain-failures',
+    },
+    {
+      title: 'review and update skill · github',
+      rationale: 'GitHub-related failures have crossed the negative-rate threshold, so the skill needs a correction pass.',
+      action: 'review-and-update-skill',
+    }
+  ]);
   renderSettingsStatus({
     activeLayers: [
       { scope: 'defaults', exists: true, leafCount: 7, sourcePath: null },
@@ -1412,6 +1520,58 @@ function loadDemo() {
     ]
   });
   renderGeneratedView(buildDemoGeneratedViewSpec(currentGeneratedView));
+  renderInsights({
+    gateStats: { blocked: 180 },
+    tokenSavings: {
+      dollarsSaved: 0,
+      dollarsSavedDisplay: '$0.00',
+      tokensSavedDisplay: '0',
+      blockedCalls: 0,
+      modelMix: { 'sonnet-4.5': 0.8, 'opus-4.6': 0.15, 'haiku-4.5': 0.05 },
+      blendedPricePer1M: { input: 6.2, output: 24.1 }
+    },
+    lessonPipeline: {
+      stages: [
+        { id: 'feedback', label: 'Feedback Signals', count: 297, detail: '37 up / 260 down' },
+        { id: 'lessons', label: 'Lessons Distilled', count: 94, detail: '72 mistakes / 22 good patterns' },
+        { id: 'gates', label: 'Gates Promoted', count: 21, detail: '22% of lessons become gates' },
+        { id: 'blocked', label: 'Actions Blocked', count: 180, detail: 'Repeat mistakes prevented' }
+      ],
+      rates: { feedbackToLesson: 32, lessonToGate: 22 }
+    },
+    feedbackTimeSeries: {
+      days: Array.from({ length: 30 }, function(_, index) {
+        return {
+          dayKey: '2026-04-' + String(index + 1).padStart(2, '0'),
+          up: index % 6 === 0 ? 2 : (index % 4 === 0 ? 1 : 0),
+          down: 3 + (index % 5),
+          lessons: index % 3 === 0 ? 2 : 1
+        };
+      })
+    },
+    gateAudit: {
+      days: Array.from({ length: 14 }, function(_, index) {
+        return {
+          dayKey: '2026-04-' + String(index + 10).padStart(2, '0'),
+          allow: 8 + (index % 3),
+          deny: 2 + (index % 2),
+          warn: index % 3
+        };
+      })
+    },
+    actionableRemediations: [
+      {
+        title: 'tighten verification before response · recent-signals',
+        rationale: 'Recent approval rate has dropped below the lifetime baseline, so fast completion claims need tighter proof.',
+        action: 'tighten-verification-before-response'
+      },
+      {
+        title: 'audit domain failures · git-workflow',
+        rationale: 'Git workflow events are overrepresented in high-risk outcomes and deserve a stronger pre-action gate.',
+        action: 'audit-domain-failures'
+      }
+    ]
+  });
 }
 
 // Auto-load demo on first visit so visitors see the product immediately
@@ -1461,6 +1621,23 @@ function renderInsights(data) {
   renderFeedbackTrendChart(data.feedbackTimeSeries || {});
   renderLessonTrendChart(data.feedbackTimeSeries || {});
   renderGateAuditChartFromData(data.gateAudit || {});
+  renderActionableRemediations(data.actionableRemediations || []);
+}
+
+function renderActionableRemediations(remediations) {
+  var list = document.getElementById('actionableRemediations');
+  if (!list) return;
+  if (!Array.isArray(remediations) || !remediations.length) {
+    list.innerHTML = '<div class="empty" style="padding:20px 0;">No remediation pressure yet. As feedback accumulates, ThumbGate will rank the next highest-ROI fixes here.</div>';
+    return;
+  }
+
+  list.innerHTML = remediations.map(function(item) {
+    var title = item.title || ((item.action || 'review') + ' · ' + (item.target || 'system'));
+    var subtitle = item.rationale || '';
+    var action = item.action || 'review';
+    return '<div class="remediation-row"><div><div class="remediation-name">' + escHtml(title) + '</div><div class="remediation-subtitle">' + escHtml(subtitle) + '</div></div><span class="remediation-action">' + escHtml(String(action).replace(/-/g, ' ')) + '</span></div>';
+  }).join('');
 }
 
 /**

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
 <meta property="og:image" content="/og.png">
 <title>ThumbGate — Stop paying for the same AI mistake twice</title>
-<meta name="description" content="Stop paying for the same AI mistake twice. ThumbGate is the enforcement layer for AI agent orchestration: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, plus Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.">
+<meta name="description" content="Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI coding agents: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, actionable remediations, agent surface inventory, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.">
 <meta property="og:title" content="ThumbGate — Stop paying for the same AI mistake twice">
 <meta property="og:description" content="Frontier LLMs are expensive, opaque, and unreliable in production. ThumbGate gates risky agent actions before they run: workflow shape, inspection evidence, token budget, and repeated-failure memory in one pre-action check.">
 <meta property="og:type" content="website">
@@ -53,7 +53,7 @@ __GA_BOOTSTRAP__
   "@type": "SoftwareApplication",
   "name": "ThumbGate",
   "alternateName": "thumbgate",
-  "description": "ThumbGate stops you from paying for the same AI mistake twice. Frontier LLMs are expensive, opaque, and unreliable in production — every repeated hallucination, retry loop, or known-bad tool call burns more tokens. ThumbGate's Pre-Action Checks inspect workflow shape, environment evidence, budget, and repeated-failure memory before the action runs. Works with Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and any MCP-compatible agent.",
+  "description": "ThumbGate stops you from paying for the same AI mistake twice. It is machine-speed pre-action defense for coding agents: thumbs-up/down feedback becomes history-aware lessons, shared lessons and org visibility, actionable remediations, agent surface inventory, and Pre-Action Checks that inspect workflow shape, environment evidence, budget, and repeated-failure memory before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and any MCP-compatible agent.",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
   "license": "https://opensource.org/licenses/MIT",
@@ -70,6 +70,8 @@ __GA_BOOTSTRAP__
     "Prevent expensive AI mistakes — catch bad commands, destructive database actions, unsafe publishes, and risky API calls before execution",
     "Make AI stop repeating mistakes — thumbs-down feedback becomes history-aware lessons and Pre-Action Checks",
     "Turn AI into a reliable operator — checkpoint risky actions, enforce safe patterns, and keep proof of what changed",
+    "Agent surface inventory — see which tools, MCP surfaces, and policy sources are actually active before rollout",
+    "Actionable remediations — rank the next highest-ROI fixes from real feedback and risk pressure",
     "ThumbGate GPT for ChatGPT — check proposed agent actions, capture thumbs-up/down lessons, and route users into local enforcement",
     "Workflow Sentinel — score blast radius before PR, merge, release, and publish actions fire",
     "Workflow architecture checks — distinguish predefined workflows, parallel fan-out, and open-ended agents before execution",
@@ -572,9 +574,9 @@ __GA_BOOTSTRAP__
 <section class="hero">
   <div class="container">
     <div class="hero-thumbs">👍👎</div>
-    <div class="hero-badge">● Your AI coding bill has a leak</div>
+    <div class="hero-badge">● Machine-speed pre-action defense for coding agents</div>
     <h1>Stop paying $ for the same AI mistake.</h1>
-    <p style="font-size:18px;color:var(--text-muted);max-width:720px;margin:0 auto 20px;line-height:1.6;">Every retry loop, every hallucinated import, every "let me try a different approach" — those are billable tokens on every LLM vendor's bill. Thumbs-down once; ThumbGate blocks that exact mistake on every future call. Across Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — any MCP-compatible agent, forever, including fast-moving vibe coding workflows.</p>
+    <p style="font-size:18px;color:var(--text-muted);max-width:720px;margin:0 auto 20px;line-height:1.6;">Every retry loop, every hallucinated import, every "let me try a different approach" — those are billable tokens on every LLM vendor's bill. ThumbGate is machine-speed pre-action defense: thumbs-down once, block that exact mistake on every future call, surface the next highest-ROI remediation, and show which agent surfaces are actually active before rollout. Across Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — any MCP-compatible agent, forever, including fast-moving vibe coding workflows.</p>
     <p style="font-size:15px;color:var(--text-dim);max-width:760px;margin:0 auto 24px;line-height:1.6;">As desktop agents move into parallel sessions, terminals, and production workflows, ThumbGate checks the thing benchmarks miss: is this next action a known workflow, an open-ended agent, a costly fan-out, or a blind tool call with no way to verify it worked?</p>
 
     <!-- HERO PRICING CARD — visible in first viewport so $19/mo and $149/yr never get buried -->
@@ -611,12 +613,12 @@ __GA_BOOTSTRAP__
         <span style="display:inline-flex;align-items:center;gap:6px;color:#4ade80;"><span style="width:6px;height:6px;border-radius:50%;background:#4ade80;box-shadow:0 0 8px #4ade80;animation:pulse 1.6s ease-in-out infinite;"></span>enforcing</span>
       </div>
       <div style="font-size:13px;color:var(--text-muted);margin-bottom:4px;">💸 Tokens saved — since install (Sonnet-blended, conservative)</div>
-      <div id="hero-savings-counter" data-target="1247.82" style="font-size:44px;font-weight:700;color:#4ade80;letter-spacing:-0.02em;line-height:1;margin-bottom:18px;">$0.00</div>
+      <div id="hero-savings-counter" data-target="0" style="font-size:44px;font-weight:700;color:#4ade80;letter-spacing:-0.02em;line-height:1;margin-bottom:18px;">$0.00</div>
       <div style="font-size:12px;line-height:1.8;border-top:1px solid rgba(255,255,255,0.06);padding-top:12px;">
         <div style="color:#4ade80;">✅ check:no-force-push — blocked 12×</div>
         <div style="color:#4ade80;">✅ check:no-hallucinated-import — blocked 8×</div>
         <div style="color:#f87171;">❌ check:no-drop-prod — FIRED · saved ~$3.40</div>
-        <div style="color:var(--text-muted);font-size:11px;margin-top:8px;">Sample shown. Your own dashboard tracks live feedback log + blocked calls from day one. <span style="color:var(--cyan);">Open dashboard →</span></div>
+        <div style="color:var(--text-muted);font-size:11px;margin-top:8px;">Sample shown. Your own dashboard tracks live feedback log, actionable remediations, and agent surface inventory from day one. <span style="color:var(--cyan);">Open dashboard →</span></div>
       </div>
     </a>
     <style>@keyframes pulse{0%,100%{opacity:1}50%{opacity:0.4}}</style>
@@ -632,7 +634,8 @@ __GA_BOOTSTRAP__
     </script>
     <div class="hero-signals">
       <a class="signal-pill signal-down" href="#how-it-works" title="See how check interception works">Block repeat hallucinations before the model sees them</a>
-      <a class="signal-pill signal-up" href="#how-it-works" title="See the one-thumbs-down enforcement loop">Thumbs-down once, blocked forever, across every agent</a>
+      <a class="signal-pill signal-up" href="/dashboard" title="See the remediation and inventory dashboard">Thumbs-down once, blocked forever</a>
+      <a class="signal-pill" href="/dashboard" title="See the remediation and inventory dashboard">Actionable remediations + agent surface inventory</a>
       <a class="signal-pill" href="#install" title="Install the CLI">CLI-first workflow governance with a live tokens-saved counter</a>
     </div>
     <p class="hero-persona" style="display:none">For consultancies, platform teams, and AI product teams with one workflow owner, one repeated failure, and one buyer who needs proof before a wider rollout.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -72,7 +72,7 @@ __GA_BOOTSTRAP__
     "Turn AI into a reliable operator — checkpoint risky actions, enforce safe patterns, and keep proof of what changed",
     "Agent surface inventory — see which tools, MCP surfaces, and policy sources are actually active before rollout",
     "Actionable remediations — rank the next highest-ROI fixes from real feedback and risk pressure",
-    "ThumbGate GPT for ChatGPT — check proposed agent actions, capture thumbs-up/down lessons, and route users into local enforcement",
+    "ThumbGate GPT for ChatGPT — preflight risky commands, refunds, deploys, and PR actions, capture typed thumbs-up/down lessons, and route users into local enforcement",
     "Workflow Sentinel — score blast radius before PR, merge, release, and publish actions fire",
     "Workflow architecture checks — distinguish predefined workflows, parallel fan-out, and open-ended agents before execution",
     "Environment inspection evidence — require read-before-write, screenshots, API response checks, tests, or output validation for open-ended agent loops",
@@ -787,15 +787,15 @@ __GA_BOOTSTRAP__
   <div class="container">
     <div class="gpt-panel">
       <div class="section-label" style="text-align:left;">ChatGPT Entry Point · Live ThumbGate GPT for ChatGPT</div>
-      <h2>Open the GPT. Give typed thumbs feedback. Turn the lesson into a check.</h2>
-      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the lowest-friction way to capture a useful thumbs-up/down lesson, check a risky action, and prove the enforcement loop before installing anything. As ChatGPT ads roll out, this matters more: ChatGPT can stay the discovery and checkpointing layer, while ThumbGate remains the hard execution boundary after <code>npx thumbgate init</code>.</p>
+      <h2>Use the GPT as a preflight desk for risky commands, refunds, deploys, and PR actions.</h2>
+      <p>ThumbGate should meet users where they already ask AI for help. The live GPT is the fastest way to preflight a risky action, capture a typed thumbs-up/down lesson, and prove the enforcement loop before installing anything. As ChatGPT ads roll out, this matters more: ChatGPT can stay the discovery and checkpointing layer, while ThumbGate remains the hard execution boundary after <code>npx thumbgate init</code>.</p>
       <div class="gpt-steps">
         <div class="gpt-step">
-          <strong>1. Try the live GPT</strong>
-          <p>Paste a proposed command, file edit, merge, deploy, or API call and ask whether to allow, block, or checkpoint it.</p>
+          <strong>1. Open the live GPT</strong>
+          <p>Paste a proposed command, file edit, merge, deploy, refund, invoice, or API call and ask whether to allow, block, or checkpoint it.</p>
         </div>
         <div class="gpt-step">
-          <strong>2. Save the signal</strong>
+          <strong>2. Save the typed signal</strong>
           <p>Reply in chat with <code>thumbs up:</code> or <code>thumbs down:</code> plus one concrete sentence. Do not rely on ChatGPT's native rating buttons for ThumbGate memory.</p>
         </div>
         <div class="gpt-step">
@@ -808,7 +808,7 @@ __GA_BOOTSTRAP__
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/adapters/chatgpt/INSTALL.md" class="btn-free" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">ChatGPT Actions setup</a>
         <a href="/guides/chatgpt-ads-trust" class="btn-free" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">Why ChatGPT ads need checks</a>
       </div>
-      <p class="gpt-note"><strong>Plain English rule:</strong> ChatGPT is the discovery and memory surface for advice, checkpointing, and typed feedback capture. One typed signal becomes one remembered rule. The hard Reliability Gateway still runs in the local agent or CI lane.</p>
+      <p class="gpt-note"><strong>Find it fast:</strong> if the direct link does not open, go to <strong>Explore GPTs</strong>, search <code>ThumbGate</code>, and choose the GPT by Igor Ganapolsky in <strong>Programming</strong>. <strong>Plain English rule:</strong> ChatGPT is the discovery and memory surface for advice, checkpointing, and typed feedback capture. One typed signal becomes one remembered rule. The hard Reliability Gateway still runs in the local agent or CI lane.</p>
     </div>
   </div>
 </section>
@@ -860,7 +860,7 @@ __GA_BOOTSTRAP__
       </a>
       <a class="compat-card" href="/go/gpt?utm_source=website&utm_medium=compatibility&utm_campaign=chatgpt_gpt&cta_id=compat_open_gpt&cta_placement=compatibility" target="_blank" rel="noopener">
         <h3>💬 ChatGPT GPT Actions</h3>
-        <p>Open the ThumbGate GPT to check proposed AI actions, capture thumbs-up/down lessons, and get setup guidance. Real blocking for coding agents still runs locally after <code>npx thumbgate init</code>.</p>
+        <p>Open the ThumbGate GPT to preflight risky commands, deploys, refunds, PR actions, and setup steps, capture thumbs-up/down lessons, and save typed signals. Real blocking for coding agents still runs locally after <code>npx thumbgate init</code>.</p>
         <div class="card-arrow">Open ThumbGate GPT →</div>
       </a>
     </div>

--- a/scripts/background-agent-governance.js
+++ b/scripts/background-agent-governance.js
@@ -20,8 +20,8 @@ const { ensureParentDir, readJsonl } = require('./fs-utils');
 
 const RUNS_FILE = 'agent-runs.jsonl';
 
-function getFeedbackDir() { return resolveFeedbackDir(); }
-function getRunsPath() { return path.join(getFeedbackDir(), RUNS_FILE); }
+function getFeedbackDir(feedbackDir) { return resolveFeedbackDir({ feedbackDir }); }
+function getRunsPath(feedbackDir) { return path.join(getFeedbackDir(feedbackDir), RUNS_FILE); }
 
 // ---------------------------------------------------------------------------
 // 1. Run Tracking
@@ -31,8 +31,8 @@ function getRunsPath() { return path.join(getFeedbackDir(), RUNS_FILE); }
  * Record a background agent run.
  * Called when a background agent starts or completes a task.
  */
-function recordAgentRun({ agentId, runType, source, branch, prNumber, status, gatesChecked, gatesBlocked, filesChanged, ciPassed, duration, metadata } = {}) {
-  const runsPath = getRunsPath();
+function recordAgentRun({ agentId, runType, source, branch, prNumber, status, gatesChecked, gatesBlocked, filesChanged, ciPassed, duration, metadata } = {}, feedbackDir) {
+  const runsPath = getRunsPath(feedbackDir);
   ensureParentDir(runsPath);
   const run = {
     id: `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
@@ -62,8 +62,8 @@ function recordAgentRun({ agentId, runType, source, branch, prNumber, status, ga
  * Check if a background agent run should proceed based on governance rules.
  * Returns { allowed, blockers, warnings, governanceScore }.
  */
-function checkRunGovernance({ agentId, runType, branch, filesChanged } = {}) {
-  const runs = readJsonl(getRunsPath());
+function checkRunGovernance({ agentId, runType, branch, filesChanged } = {}, feedbackDir) {
+  const runs = readJsonl(getRunsPath(feedbackDir));
   const blockers = [];
   const warnings = [];
 
@@ -109,7 +109,7 @@ function checkRunGovernance({ agentId, runType, branch, filesChanged } = {}) {
  * Auto-capture feedback from a completed background agent run.
  * Converts CI pass/fail into structured feedback for the learning loop.
  */
-function auditCompletedRun({ runId, agentId, ciPassed, ciOutput, prNumber, branch, filesChanged } = {}) {
+function auditCompletedRun({ runId, agentId, ciPassed, ciOutput, prNumber, branch, filesChanged } = {}, feedbackDir) {
   const signal = ciPassed ? 'positive' : 'negative';
   const context = ciPassed
     ? `Background agent run ${runId || 'unknown'} completed successfully. PR #${prNumber || '?'} on ${branch || '?'}. ${filesChanged || 0} files changed. CI passed.`
@@ -127,7 +127,7 @@ function auditCompletedRun({ runId, agentId, ciPassed, ciOutput, prNumber, branc
     status: ciPassed ? 'completed' : 'failed',
     filesChanged,
     ciPassed,
-  });
+  }, feedbackDir);
 
   // Auto-capture feedback
   let feedbackResult = null;
@@ -153,8 +153,8 @@ function auditCompletedRun({ runId, agentId, ciPassed, ciOutput, prNumber, branc
  * Generate a governance report for background agent runs.
  * Shows: total runs, blocked, pass rate, top failing agents, lessons learned.
  */
-function generateGovernanceReport({ periodHours = 24 } = {}) {
-  const runs = readJsonl(getRunsPath());
+function generateGovernanceReport({ periodHours = 24, feedbackDir } = {}) {
+  const runs = readJsonl(getRunsPath(feedbackDir));
   const cutoff = Date.now() - periodHours * 60 * 60 * 1000;
   const recent = runs.filter((r) => new Date(r.timestamp).getTime() > cutoff);
 

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -39,6 +39,7 @@ const { buildPredictiveInsights } = loadOptionalModule('./predictive-insights', 
 const { routeProfile } = require('./profile-router');
 const { getSettingsStatus } = require('./settings-hierarchy');
 const { summarizeWorkflowRuns } = require('./workflow-runs');
+const { generateGovernanceReport } = require('./background-agent-governance');
 const { searchLessons } = require('./lesson-search');
 const { getInterventionPolicySummary } = require('./intervention-policy');
 const {
@@ -1438,6 +1439,58 @@ function computeAgentSurfaceInventory(feedbackDir, options = {}) {
   };
 }
 
+function computeBackgroundAgentMode(feedbackDir, options = {}) {
+  const governance = generateGovernanceReport({
+    periodHours: options.periodHours || 24,
+    feedbackDir,
+  });
+  const workflowSummary = options.workflowSummary || summarizeWorkflowRuns(feedbackDir);
+  const topRunType = Object.entries(governance.byType || {})
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))[0] || null;
+  const latestRun = workflowSummary.latestRun || null;
+  const checkpointCoverage = safeRate(workflowSummary.reviewedRuns || 0, workflowSummary.proofBackedRuns || 0);
+
+  return {
+    ...governance,
+    checkpointCoverage,
+    reviewedRuns: workflowSummary.reviewedRuns || 0,
+    proofBackedRuns: workflowSummary.proofBackedRuns || 0,
+    latestRun,
+    topRunType: topRunType ? { runType: topRunType[0], count: topRunType[1] } : null,
+    recommendedMode: governance.blocked > 0 || governance.failed > 0
+      ? 'checkpoint-heavy'
+      : governance.total > 0
+        ? 'operator-light'
+        : 'bootstrapping',
+  };
+}
+
+function computeRegulatedBuyerProof(settingsStatus, workflowSummary, decisions, readiness) {
+  const origins = Array.isArray(settingsStatus && settingsStatus.origins) ? settingsStatus.origins : [];
+  const activeLayers = Array.isArray(settingsStatus && settingsStatus.activeLayers)
+    ? settingsStatus.activeLayers.filter((layer) => layer && layer.exists)
+    : [];
+  const latestRun = workflowSummary && workflowSummary.latestRun ? workflowSummary.latestRun : null;
+  const proofArtifacts = latestRun && Array.isArray(latestRun.proofArtifacts) ? latestRun.proofArtifacts : [];
+
+  return {
+    policyOriginCount: origins.length,
+    activeLayerCount: activeLayers.length,
+    reviewedRuns: workflowSummary && workflowSummary.reviewedRuns || 0,
+    proofBackedRuns: workflowSummary && workflowSummary.proofBackedRuns || 0,
+    checkpointCoverage: safeRate(
+      workflowSummary && workflowSummary.reviewedRuns || 0,
+      workflowSummary && workflowSummary.proofBackedRuns || 0
+    ),
+    decisionEvaluations: decisions && decisions.evaluationCount || 0,
+    appendOnlyAuditReady: Boolean(decisions && decisions.evaluationCount > 0),
+    runtimeIsolation: Boolean(readiness && readiness.articleAlignment && readiness.articleAlignment.runtimeIsolation),
+    latestWorkflowName: latestRun ? (latestRun.workflowName || latestRun.workflowId) : null,
+    latestProofArtifacts: proofArtifacts.slice(0, 3),
+    latestPolicyOrigin: origins[0] || null,
+  };
+}
+
 function resolveTeamWindowHours(analyticsWindow) {
   const window = analyticsWindow && analyticsWindow.window;
   if (window === 'today') return 24;
@@ -1573,6 +1626,16 @@ function generateDashboard(feedbackDir, options = {}) {
       settingsOptions: { projectRoot: PROJECT_ROOT },
     }),
   };
+  const workflowSummary = summarizeWorkflowRuns(feedbackDir);
+  const backgroundAgents = computeBackgroundAgentMode(feedbackDir, {
+    workflowSummary,
+  });
+  const regulatedProof = computeRegulatedBuyerProof(
+    settingsStatus,
+    workflowSummary,
+    decisions,
+    readiness,
+  );
 
   // Live metrics — gate hit rate, lesson effectiveness, error trend
   const now = Date.now();
@@ -1663,6 +1726,8 @@ function generateDashboard(feedbackDir, options = {}) {
     feedbackAnalysis,
     actionableRemediations,
     agentSurfaceInventory,
+    backgroundAgents,
+    regulatedProof,
     interventionPolicy,
     decisions,
     settingsStatus,

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -41,7 +41,12 @@ const { getSettingsStatus } = require('./settings-hierarchy');
 const { summarizeWorkflowRuns } = require('./workflow-runs');
 const { searchLessons } = require('./lesson-search');
 const { getInterventionPolicySummary } = require('./intervention-policy');
-const { computeDecisionMetrics } = require('./decision-journal');
+const {
+  DECISION_LOG_FILENAME,
+  computeDecisionMetrics,
+  readDecisionLog,
+} = require('./decision-journal');
+const { analyzeFeedback } = require('./feedback-loop');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 const DEFAULT_GATES_PATH = path.join(PROJECT_ROOT, 'config', 'gates', 'default.json');
@@ -1308,6 +1313,131 @@ function computeHarnessOverview(feedbackDir, entries) {
   };
 }
 
+function remediationPriority(type) {
+  const priorities = {
+    'trend-declining': 90,
+    'trend-degrading': 85,
+    'high-risk-domain': 80,
+    'high-risk-tag': 78,
+    'skill-improve': 72,
+    'delegation-reduce': 68,
+    'delegation-policy-review': 66,
+    'diagnose-failure-category': 62,
+    'pattern-reuse': 58,
+  };
+  return priorities[type] || 40;
+}
+
+function summarizeActionableRemediations(items, limit = 6) {
+  if (!Array.isArray(items)) return [];
+  return items
+    .slice()
+    .sort((left, right) => {
+      const delta = remediationPriority(right && right.type) - remediationPriority(left && left.type);
+      if (delta !== 0) return delta;
+      const rightCount = Number(right && right.evidence && (right.evidence.count || right.evidence.total || right.evidence.highRisk || 0));
+      const leftCount = Number(left && left.evidence && (left.evidence.count || left.evidence.total || left.evidence.highRisk || 0));
+      if (rightCount !== leftCount) return rightCount - leftCount;
+      return String((left && left.target) || '').localeCompare(String((right && right.target) || ''));
+    })
+    .slice(0, limit)
+    .map((item) => ({
+      ...item,
+      priority: remediationPriority(item.type),
+      title: `${String(item.action || 'review').replace(/-/g, ' ')} · ${item.target || 'system'}`,
+      badge: String(item.type || 'remediation').replace(/-/g, ' '),
+    }));
+}
+
+function summarizeMcpServerInventory(projectRoot = PROJECT_ROOT) {
+  const configPath = path.join(projectRoot, '.mcp.json');
+  const parsed = readJsonFile(configPath);
+  const mcpServers = parsed && parsed.mcpServers && typeof parsed.mcpServers === 'object'
+    ? Object.keys(parsed.mcpServers).sort()
+    : [];
+  return {
+    configPath: fs.existsSync(configPath) ? configPath : null,
+    configuredServers: mcpServers,
+    configuredServerCount: mcpServers.length,
+  };
+}
+
+function computeAgentSurfaceInventory(feedbackDir, options = {}) {
+  const readiness = options.readiness || generateAgentReadinessReport({ projectRoot: PROJECT_ROOT });
+  const auditEntries = Array.isArray(options.auditEntries)
+    ? options.auditEntries
+    : readJSONL(path.join(feedbackDir, AUDIT_LOG_FILENAME));
+  const decisionRecords = Array.isArray(options.decisionRecords)
+    ? options.decisionRecords
+    : readDecisionLog(path.join(feedbackDir, DECISION_LOG_FILENAME));
+  const toolBuckets = new Map();
+  const sourceBuckets = new Map();
+  const toolNames = new Set();
+
+  function getToolBucket(toolName) {
+    const key = normalizeText(toolName) || 'unknown';
+    toolNames.add(key);
+    if (!toolBuckets.has(key)) {
+      toolBuckets.set(key, {
+        toolName: key,
+        evaluations: 0,
+        allow: 0,
+        warn: 0,
+        deny: 0,
+        intercepted: 0,
+      });
+    }
+    return toolBuckets.get(key);
+  }
+
+  for (const record of decisionRecords) {
+    if (!record || record.recordType !== 'evaluation') continue;
+    getToolBucket(record.toolName).evaluations += 1;
+  }
+
+  for (const entry of auditEntries) {
+    if (!entry) continue;
+    const bucket = getToolBucket(entry.toolName);
+    if (entry.decision === 'allow') bucket.allow += 1;
+    if (entry.decision === 'warn') {
+      bucket.warn += 1;
+      bucket.intercepted += 1;
+    }
+    if (entry.decision === 'deny') {
+      bucket.deny += 1;
+      bucket.intercepted += 1;
+    }
+    const sourceKey = normalizeText(entry.source) || 'unknown';
+    sourceBuckets.set(sourceKey, (sourceBuckets.get(sourceKey) || 0) + 1);
+  }
+
+  const observedTools = [...toolBuckets.values()]
+    .sort((left, right) => {
+      if (right.intercepted !== left.intercepted) return right.intercepted - left.intercepted;
+      if (right.evaluations !== left.evaluations) return right.evaluations - left.evaluations;
+      return left.toolName.localeCompare(right.toolName);
+    })
+    .slice(0, 8);
+  const policySources = [...sourceBuckets.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .map(([source, count]) => ({ source, count }))
+    .slice(0, 6);
+  const mcpInventory = summarizeMcpServerInventory(PROJECT_ROOT);
+
+  return {
+    profile: readiness.permissions.profile,
+    tier: readiness.permissions.tier,
+    configuredServerCount: mcpInventory.configuredServerCount,
+    configuredServers: mcpInventory.configuredServers,
+    observedToolCount: toolNames.size,
+    observedTools,
+    policySources,
+    writeCapableTools: readiness.permissions.writeCapableTools.slice(0, 8),
+    activeBootstrapFiles: readiness.bootstrap.requiredPresent,
+    requiredBootstrapFiles: readiness.bootstrap.requiredCount,
+  };
+}
+
 function resolveTeamWindowHours(analyticsWindow) {
   const window = analyticsWindow && analyticsWindow.window;
   if (window === 'today') return 24;
@@ -1416,9 +1546,19 @@ function generateDashboard(feedbackDir, options = {}) {
       availability: 'private_core',
     };
   const readiness = generateAgentReadinessReport({ projectRoot: PROJECT_ROOT });
+  const feedbackAnalysis = analyzeFeedback(path.join(feedbackDir, 'feedback-log.jsonl'));
   const harness = computeHarnessOverview(feedbackDir, entries);
   const interventionPolicy = getInterventionPolicySummary(feedbackDir);
+  const decisionRecords = readDecisionLog(path.join(feedbackDir, DECISION_LOG_FILENAME));
   const decisions = computeDecisionMetrics(feedbackDir);
+  const actionableRemediations = summarizeActionableRemediations(
+    feedbackAnalysis && feedbackAnalysis.actionableRemediations
+  );
+  const agentSurfaceInventory = computeAgentSurfaceInventory(feedbackDir, {
+    readiness,
+    auditEntries,
+    decisionRecords,
+  });
   const settingsStatus = getSettingsStatus({ projectRoot: PROJECT_ROOT });
   settingsStatus.routingPreview = {
     dashboardTool: routeProfile({
@@ -1520,6 +1660,9 @@ function generateDashboard(feedbackDir, options = {}) {
     observability,
     instrumentation,
     readiness,
+    feedbackAnalysis,
+    actionableRemediations,
+    agentSurfaceInventory,
     interventionPolicy,
     decisions,
     settingsStatus,

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -1354,7 +1354,7 @@ function summarizeMcpServerInventory(projectRoot = PROJECT_ROOT) {
   const configPath = path.join(projectRoot, '.mcp.json');
   const parsed = readJsonFile(configPath);
   const mcpServers = parsed && parsed.mcpServers && typeof parsed.mcpServers === 'object'
-    ? Object.keys(parsed.mcpServers).sort()
+    ? Object.keys(parsed.mcpServers).sort((left, right) => left.localeCompare(right))
     : [];
   return {
     configPath: fs.existsSync(configPath) ? configPath : null,

--- a/scripts/hook-pre-tool-use.js
+++ b/scripts/hook-pre-tool-use.js
@@ -295,8 +295,87 @@ function formatLessonsAsReminder(lessons, extras) {
       'You MUST satisfy this gate (show gh pr view output with 0 unresolved threads) before merging.'
     );
   }
+  const riskContext = summarizeActionRiskContext(extras?.toolName, extras?.toolInput, lessons);
+  if (riskContext.surfaceSignals.length > 0) {
+    lines.push('', `ACTION PROFILE: ${riskContext.surfaceSignals.join(' · ')}`);
+  }
+  if (riskContext.hotSignals.length > 0) {
+    lines.push(`HOT RISK SIGNALS: ${riskContext.hotSignals.join(' · ')}`);
+  }
+  const saferMove = buildSaferNextMove(lessons);
+  if (saferMove) {
+    lines.push(`SAFER NEXT MOVE: ${saferMove}`);
+  }
   lines.push('</system-reminder>');
   return lines.join('\n');
+}
+
+function summarizeActionRiskContext(toolName, toolInput, lessons) {
+  const actionContext = extractActionContext(toolName, toolInput).toLowerCase();
+  const surfaceSignals = [];
+  if (toolName === 'Bash') {
+    if (/\bgit\s+push\b/.test(actionContext)) surfaceSignals.push('remote git write');
+    if (/\bgh\s+pr\s+(?:create|merge|close|edit|ready)\b/.test(actionContext)) surfaceSignals.push('pull-request mutation');
+    if (/\b(?:npm|pnpm|yarn)\s+publish\b/.test(actionContext)) surfaceSignals.push('package publish');
+    if (/\brm\s+-rf\b/.test(actionContext)) surfaceSignals.push('destructive shell');
+  }
+  if ((toolName === 'Edit' || toolName === 'Write') && /(^|\/)(agents\.md|claude(\.local)?\.md|gemini\.md|readme\.md|skill\.md)$|^config\/gates\//i.test(String(toolInput && toolInput.file_path || ''))) {
+    surfaceSignals.push('protected policy file');
+  }
+
+  let summary = null;
+  try {
+    const pkgRoot = path.resolve(__dirname, '..');
+    const { getRiskSummary } = require(path.join(pkgRoot, 'scripts', 'risk-scorer'));
+    summary = getRiskSummary();
+  } catch (err) {
+    failOpen(err);
+  }
+
+  const lessonTags = new Set();
+  for (const lesson of lessons || []) {
+    for (const tag of tagsForLesson(lesson)) lessonTags.add(String(tag).toLowerCase());
+  }
+
+  const hotSignals = [];
+  if (summary) {
+    const highRiskTags = Array.isArray(summary.highRiskTags) ? summary.highRiskTags : [];
+    for (const bucket of highRiskTags) {
+      const key = String(bucket && bucket.key || '').toLowerCase();
+      if (!key) continue;
+      if (actionContext.includes(key) || lessonTags.has(key)) {
+        hotSignals.push(`${key} (${Math.round(Number(bucket.riskRate || 0) * 100)}% risk)`);
+      }
+      if (hotSignals.length >= 2) break;
+    }
+    const highRiskDomains = Array.isArray(summary.highRiskDomains) ? summary.highRiskDomains : [];
+    for (const bucket of highRiskDomains) {
+      const key = String(bucket && bucket.key || '').toLowerCase();
+      if (!key) continue;
+      if ((key === 'git-workflow' && /\bgit\b|\bgh\s+pr\b/.test(actionContext))
+        || (key === 'security' && /\bsecret|token|credential|key\b/.test(actionContext))
+        || (key === 'testing' && /\btest|coverage|verify\b/.test(actionContext))) {
+        hotSignals.push(`${key} domain (${Math.round(Number(bucket.riskRate || 0) * 100)}% risk)`);
+      }
+      if (hotSignals.length >= 3) break;
+    }
+  }
+
+  return {
+    surfaceSignals: [...new Set(surfaceSignals)].slice(0, 3),
+    hotSignals: [...new Set(hotSignals)].slice(0, 3),
+  };
+}
+
+function buildSaferNextMove(lessons) {
+  for (const lesson of lessons || []) {
+    const text = lesson && (lesson.whatToChange || lesson.howToAvoid || lesson.content || lesson.title);
+    if (!text) continue;
+    const safeText = String(text).trim().replace(/\s+/g, ' ');
+    if (!safeText) continue;
+    return safeText.slice(0, MAX_LESSON_TEXT_LEN);
+  }
+  return null;
 }
 
 function resolveEffectiveInput(rawToolInput) {
@@ -439,7 +518,11 @@ function main() {
   const autogate = maybeRegisterPrCommitGate(toolName, effectiveInput);
 
   if (lessons.length > 0 || autogate) {
-    return allowWithContext(formatLessonsAsReminder(lessons, { autogate }));
+    return allowWithContext(formatLessonsAsReminder(lessons, {
+      autogate,
+      toolName,
+      toolInput: effectiveInput,
+    }));
   }
 
   return allow();
@@ -486,6 +569,8 @@ module.exports = {
   currentGitBranch,
   maybeRegisterPrCommitGate,
   formatLessonsAsReminder,
+  summarizeActionRiskContext,
+  buildSaferNextMove,
   resolveEffectiveInput,
   maybeBlockOnRisk,
   maybeBlockViaBayesOptimal,

--- a/scripts/workflow-sentinel.js
+++ b/scripts/workflow-sentinel.js
@@ -39,6 +39,9 @@ const DEFAULT_PROTECTED_FILE_GLOBS = [
 ];
 const EDIT_LIKE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit']);
 const HIGH_RISK_BASH_PATTERN = /\b(?:git\s+(?:add|commit|push)|gh\s+(?:pr\s+(?:create|merge)|workflow\s+run|release\s+create)|npm\s+publish|yarn\s+publish|pnpm\s+publish|rm\s+-rf)\b/i;
+const BACKGROUND_AGENT_PATTERN = /\b(?:async(?:-job|-task)?|autonomous|background|cron|dispatch|heartbeat|job runner|job-runner|queue|queued|schedule|scheduled|worker|workflow run)\b/i;
+const ECONOMIC_ACTION_PATTERN = /\b(?:billing|charge|credit memo|invoice|payment(?: link|s)?|payout|refund|stripe|subscription(?:s| creation| update| cancel| delete)?|top-?up)\b/i;
+const CUSTOMER_SYSTEM_PATTERN = /\b(?:crm|customer|email|hubspot|intercom|mailgun|resend|salesforce|support|zendesk)\b/i;
 
 const SURFACE_RULES = [
   { key: 'policy', pattern: /^(?:AGENTS\.md|CLAUDE(?:\.local)?\.md|GEMINI\.md|config\/gates\/|config\/mcp-allowlists\.json|scripts\/tool-registry\.js)/ },
@@ -234,6 +237,38 @@ function isHighRiskAction(toolName, toolInput = {}, affectedFiles = []) {
   return HIGH_RISK_BASH_PATTERN.test(String(toolInput.command || ''));
 }
 
+function classifyActionProfile(toolInput = {}) {
+  const command = String(toolInput.command || '');
+  const metadata = toolInput && typeof toolInput.metadata === 'object' ? toolInput.metadata : {};
+  const source = String(toolInput.source || metadata.source || '');
+  const runType = String(toolInput.runType || metadata.runType || '');
+  const combined = [command, source, runType, metadata.context || ''].filter(Boolean).join(' ');
+
+  const backgroundAgent = Boolean(
+    toolInput.backgroundAgent === true
+      || toolInput.scheduled === true
+      || metadata.backgroundAgent === true
+      || metadata.scheduled === true
+      || BACKGROUND_AGENT_PATTERN.test(combined)
+  );
+  const economicAction = Boolean(
+    toolInput.economicAction === true
+      || metadata.economicAction === true
+      || ECONOMIC_ACTION_PATTERN.test(combined)
+  );
+  const customerSystemAction = Boolean(
+    toolInput.customerSystemAction === true
+      || metadata.customerSystemAction === true
+      || CUSTOMER_SYSTEM_PATTERN.test(combined)
+  );
+
+  return {
+    backgroundAgent,
+    economicAction,
+    customerSystemAction,
+  };
+}
+
 function isProtectedApprovalRelevant(toolName, toolInput = {}) {
   if (EDIT_LIKE_TOOLS.has(toolName)) return true;
   if (toolName !== 'Bash') return false;
@@ -399,12 +434,28 @@ function scoreRisk({
   protectedSurface,
   costControl,
   workflowControl,
+  actionProfile,
 }) {
   const drivers = [];
   const commandInfo = classifyCommand(toolInput.command || '');
 
   if (isHighRiskAction(toolName, toolInput, affectedFiles)) {
     addDriver(drivers, 'high_risk_action', 0.18, 'Command or edit pattern is classified as high risk.');
+  }
+  if (actionProfile && actionProfile.backgroundAgent) {
+    addDriver(drivers, 'background_agent', 0.18, 'Background or scheduled agent context reduces real-time human supervision.');
+  }
+  if (actionProfile && actionProfile.economicAction) {
+    addDriver(drivers, 'economic_action', 0.24, 'Action appears to touch billing, refunds, invoices, payouts, or subscriptions.');
+  }
+  if (actionProfile && actionProfile.customerSystemAction) {
+    addDriver(drivers, 'customer_system_action', 0.14, 'Action appears to touch customer-facing systems or communications.');
+  }
+  if (actionProfile && actionProfile.backgroundAgent && actionProfile.economicAction) {
+    addDriver(drivers, 'background_economic_combo', 0.08, 'Background autonomy plus money movement needs a tighter checkpoint.');
+  }
+  if (actionProfile && actionProfile.backgroundAgent && actionProfile.customerSystemAction) {
+    addDriver(drivers, 'background_customer_combo', 0.06, 'Background autonomy plus customer systems raises downstream trust risk.');
   }
   if (commandInfo.isPrCreate
     || commandInfo.isPrMerge
@@ -612,6 +663,7 @@ function buildEvidence({
   normalizedAction,
   costControl,
   workflowControl,
+  actionProfile,
 }) {
   const evidence = [];
   if (normalizedAction && normalizedAction.provider !== 'unknown') {
@@ -630,6 +682,15 @@ function buildEvidence({
     if (workflowControl.mode !== 'allow') {
       evidence.push(`Workflow control ${workflowControl.mode}: ${workflowControl.reasons.join(' ')}`);
     }
+  }
+  if (actionProfile && actionProfile.backgroundAgent) {
+    evidence.push('Background or scheduled agent context detected for this action.');
+  }
+  if (actionProfile && actionProfile.economicAction) {
+    evidence.push('Economic action keywords detected (billing, refunds, payouts, invoices, or subscriptions).');
+  }
+  if (actionProfile && actionProfile.customerSystemAction) {
+    evidence.push('Customer-system keywords detected (email, CRM, or support surface).');
   }
   if (memoryGuard && memoryGuard.mode && memoryGuard.mode !== 'allow') {
     evidence.push(`Memory guard predicted ${memoryGuard.mode}: ${memoryGuard.reason}`);
@@ -740,6 +801,7 @@ function buildRemediations({
   executionSurface,
   costControl,
   workflowControl,
+  actionProfile,
 }) {
   const remediations = [];
   const seen = new Set();
@@ -767,6 +829,30 @@ function buildRemediations({
     );
   }
   addIntegrityRemediations(push, integrity);
+  if (actionProfile && actionProfile.backgroundAgent) {
+    push(
+      'background_agent_checkpoint',
+      'Add an operator checkpoint',
+      'Pause the background run at a review step before it continues into code, deploy, money, or customer actions.',
+      'Queued autonomy needs an explicit approval boundary before irreversible work proceeds.'
+    );
+  }
+  if (actionProfile && actionProfile.economicAction) {
+    push(
+      'economic_action_approval',
+      'Require operator approval for money movement',
+      'Require an explicit operator checkpoint before refunds, payouts, invoice sends, or subscription changes execute.',
+      'Money-touching actions are costly to reverse and need a clear human owner.'
+    );
+  }
+  if (actionProfile && actionProfile.customerSystemAction) {
+    push(
+      'customer_system_guardrail',
+      'Add a customer-system hold point',
+      'Review customer-facing email, CRM, or support actions before sending or mutating external state.',
+      'Customer-facing actions can create trust damage even when the underlying code path is correct.'
+    );
+  }
   if (memoryGuard && memoryGuard.mode && memoryGuard.mode !== 'allow') {
     push(
       'retrieve_lessons',
@@ -850,6 +936,16 @@ function buildReasoning(report) {
       lines.push(`Deliberation policy: ${report.decisionControl.deliberation.mode} before final approval.`);
     }
   }
+  if (report.actionProfile) {
+    const activeFlags = [
+      report.actionProfile.backgroundAgent ? 'background agent' : null,
+      report.actionProfile.economicAction ? 'economic action' : null,
+      report.actionProfile.customerSystemAction ? 'customer system' : null,
+    ].filter(Boolean);
+    if (activeFlags.length) {
+      lines.push(`Action profile: ${activeFlags.join(', ')}.`);
+    }
+  }
   if (report.learnedPolicy && report.learnedPolicy.enabled && report.learnedPolicy.prediction) {
     lines.push(
       `Learned policy predicted ${report.learnedPolicy.prediction.label} (${report.learnedPolicy.prediction.confidence}).`
@@ -885,7 +981,7 @@ function getSentinelActionType(toolName) {
   return '';
 }
 
-function classifyReversibility({ command, blastRadius, integrity, protectedSurface }) {
+function classifyReversibility({ command, blastRadius, integrity, protectedSurface, actionProfile }) {
   const text = String(command || '');
   const blockers = integrity && Array.isArray(integrity.blockers) ? integrity.blockers : [];
   const destructiveCommand = /\bgit\s+push\b.*(?:--force|-f)\b/i.test(text)
@@ -901,9 +997,15 @@ function classifyReversibility({ command, blastRadius, integrity, protectedSurfa
     ? protectedSurface.unapprovedProtectedFiles.length > 0
     : false;
   const hardBlockers = blockers.some((blocker) => /publish|merge|release|protected/i.test(String(blocker.code || '')));
+  const economicAction = Boolean(actionProfile && actionProfile.economicAction);
+  const customerSystemAction = Boolean(actionProfile && actionProfile.customerSystemAction);
+  const backgroundAgent = Boolean(actionProfile && actionProfile.backgroundAgent);
 
-  if (destructiveCommand || releaseSensitive || unapprovedProtected || hardBlockers) {
+  if (destructiveCommand || releaseSensitive || unapprovedProtected || hardBlockers || economicAction) {
     return 'one_way_door';
+  }
+  if ((backgroundAgent && customerSystemAction) || customerSystemAction) {
+    return 'reviewable';
   }
   if ((blastRadius && blastRadius.fileCount >= 4) || (blastRadius && blastRadius.surfaceCount >= 2)) {
     return 'reviewable';
@@ -966,12 +1068,14 @@ function buildDecisionControl({
   protectedSurface,
   costControl,
   workflowControl,
+  actionProfile,
 }) {
   const reversibility = classifyReversibility({
     command,
     blastRadius,
     integrity,
     protectedSurface,
+    actionProfile,
   });
   const hasOperationalBlockers = Boolean(integrity && Array.isArray(integrity.blockers) && integrity.blockers.length > 0);
   const hasCostWarning = Boolean(costControl && costControl.mode === 'warn');
@@ -1020,7 +1124,7 @@ function buildDecisionControl({
   };
 }
 
-function chooseDecision({ riskScore, integrity, memoryGuard, learnedPolicy, blastRadius, command, costControl, workflowControl }) {
+function chooseDecision({ riskScore, integrity, memoryGuard, learnedPolicy, blastRadius, command, costControl, workflowControl, actionProfile }) {
   const hasOperationalBlockers = Boolean(integrity && Array.isArray(integrity.blockers) && integrity.blockers.length > 0);
   if (costControl && costControl.mode === 'block') {
     return 'deny';
@@ -1067,12 +1171,18 @@ function chooseDecision({ riskScore, integrity, memoryGuard, learnedPolicy, blas
         || blastRadius.unapprovedProtectedFiles > 0
       )
   );
+  const economicAction = Boolean(actionProfile && actionProfile.economicAction);
+  const backgroundAgent = Boolean(actionProfile && actionProfile.backgroundAgent);
+  const customerSystemAction = Boolean(actionProfile && actionProfile.customerSystemAction);
 
   if (lowRiskHandoff) {
     return 'allow';
   }
   if (destructiveBypass || learnedHardStop || repeatedHighBlast || (hasOperationalBlockers && riskScore >= 0.72) || riskScore >= 0.86) {
     return 'deny';
+  }
+  if (economicAction || (backgroundAgent && customerSystemAction) || (backgroundAgent && riskScore >= 0.3)) {
+    return 'warn';
   }
   if ((workflowControl && workflowControl.mode === 'warn') || (costControl && costControl.mode === 'warn') || riskScore >= 0.45 || (learnedWarning && riskScore >= 0.3) || (learnedRecall && riskScore >= 0.34)) {
     return 'warn';
@@ -1112,6 +1222,7 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
   const affectedFiles = Array.isArray(options.affectedFiles)
     ? options.affectedFiles.map((filePath) => normalizePosix(filePath)).filter(Boolean)
     : collectAffectedFiles(normalizedToolName, normalizedToolInput, repoRoot);
+  const actionProfile = classifyActionProfile(normalizedToolInput);
   const highRiskAction = isHighRiskAction(normalizedToolName, normalizedToolInput, affectedFiles);
   const baseBranch = options.baseBranch
     || (governanceState.branchGovernance && governanceState.branchGovernance.baseBranch)
@@ -1174,6 +1285,7 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
     protectedSurface: protectedSurfaceForRisk,
     costControl,
     workflowControl,
+    actionProfile,
   });
   const executionSurface = buildDockerSandboxPlan({
     toolName: normalizedToolName,
@@ -1199,6 +1311,7 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
     command: normalizedToolInput.command || '',
     costControl,
     workflowControl,
+    actionProfile,
   });
   const evidence = buildEvidence({
     integrity,
@@ -1210,6 +1323,7 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
     normalizedAction,
     costControl,
     workflowControl,
+    actionProfile,
   });
   const remediations = buildRemediations({
     integrity,
@@ -1221,6 +1335,7 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
     executionSurface,
     costControl,
     workflowControl,
+    actionProfile,
   });
   const summary = decision === 'allow'
     ? 'No predictive workflow blockers detected.'
@@ -1242,6 +1357,7 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
     evidence,
     remediations,
     executionSurface,
+    actionProfile,
     memoryGuard,
     learnedPolicy,
     taskScopeViolation,
@@ -1267,6 +1383,7 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
     protectedSurface: protectedSurfaceForRisk,
     costControl,
     workflowControl,
+    actionProfile,
   });
   report.reasoning = buildReasoning(report);
   return report;
@@ -1282,6 +1399,7 @@ module.exports = {
   buildReasoning,
   buildRemediations,
   buildTaskScopeViolation,
+  classifyActionProfile,
   classifySurface,
   collectAffectedFiles,
   evaluateWorkflowSentinel,

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -62,10 +62,18 @@ test('dashboard includes team metrics and gate-template tabs powered by dashboar
   assert.match(dashboard, /id="inventorySummaryCards"/);
   assert.match(dashboard, /id="inventoryObservedTools"/);
   assert.match(dashboard, /id="inventoryPolicySources"/);
+  assert.match(dashboard, /id="backgroundAgentSummaryCards"/);
+  assert.match(dashboard, /id="backgroundAgentHighlights"/);
+  assert.match(dashboard, /id="backgroundAgentRunTypes"/);
+  assert.match(dashboard, /id="regulatedProofSummaryCards"/);
+  assert.match(dashboard, /id="regulatedProofDetails"/);
+  assert.match(dashboard, /id="regulatedProofArtifacts"/);
   assert.match(dashboard, /id="actionableRemediations"/);
   assert.match(dashboard, /function renderTeam\(team, analytics\)/);
   assert.match(dashboard, /function renderPredictive\(predictive\)/);
   assert.match(dashboard, /function renderAgentInventory\(inventory\)/);
+  assert.match(dashboard, /function renderBackgroundAgents\(backgroundAgents\)/);
+  assert.match(dashboard, /function renderRegulatedProof\(regulatedProof\)/);
   assert.match(dashboard, /function renderGeneratedView\(spec\)/);
   assert.match(dashboard, /function loadGeneratedView\(viewName\)/);
   assert.match(dashboard, /function renderSettingsStatus\(settingsStatus\)/);
@@ -76,6 +84,8 @@ test('dashboard includes team metrics and gate-template tabs powered by dashboar
   assert.match(dashboard, /Forecast revenue/);
   assert.match(dashboard, /highest-ROI guardrails/i);
   assert.match(dashboard, /Agent Surface Inventory/);
+  assert.match(dashboard, /Background Agent Mode/);
+  assert.match(dashboard, /Regulated Buyer Proof/);
   assert.match(dashboard, /Highest-ROI Next Actions/);
 });
 

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -59,16 +59,24 @@ test('dashboard includes team metrics and gate-template tabs powered by dashboar
   assert.match(dashboard, /id="templateLibrary"/);
   assert.match(dashboard, /id="predictiveSummaryCards"/);
   assert.match(dashboard, /id="predictiveAnomalies"/);
+  assert.match(dashboard, /id="inventorySummaryCards"/);
+  assert.match(dashboard, /id="inventoryObservedTools"/);
+  assert.match(dashboard, /id="inventoryPolicySources"/);
+  assert.match(dashboard, /id="actionableRemediations"/);
   assert.match(dashboard, /function renderTeam\(team, analytics\)/);
   assert.match(dashboard, /function renderPredictive\(predictive\)/);
+  assert.match(dashboard, /function renderAgentInventory\(inventory\)/);
   assert.match(dashboard, /function renderGeneratedView\(spec\)/);
   assert.match(dashboard, /function loadGeneratedView\(viewName\)/);
   assert.match(dashboard, /function renderSettingsStatus\(settingsStatus\)/);
   assert.match(dashboard, /function renderTemplates\(templateLibrary\)/);
+  assert.match(dashboard, /function renderActionableRemediations\(remediations\)/);
   assert.match(dashboard, /\/v1\/dashboard\/render-spec\?view=/);
   assert.match(dashboard, /Approved component catalog:/);
   assert.match(dashboard, /Forecast revenue/);
   assert.match(dashboard, /highest-ROI guardrails/i);
+  assert.match(dashboard, /Agent Surface Inventory/);
+  assert.match(dashboard, /Highest-ROI Next Actions/);
 });
 
 test('dashboard includes incremental review checkpoint controls', () => {

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -91,6 +91,12 @@ function writeWorkflowRuns(entries) {
   fs.writeFileSync(runsPath, lines + '\n');
 }
 
+function writeAgentRuns(entries) {
+  const runsPath = path.join(tmpDir, 'agent-runs.jsonl');
+  const lines = entries.map((e) => JSON.stringify(e)).join('\n');
+  fs.writeFileSync(runsPath, lines + '\n');
+}
+
 function writeContextPacks(entries) {
   const packsPath = path.join(tmpDir, 'contextfs', 'provenance', 'packs.jsonl');
   fs.mkdirSync(path.dirname(packsPath), { recursive: true });
@@ -148,12 +154,45 @@ test('generateDashboard handles empty state (no files)', () => {
   assert.equal(data.analytics.northStar.weeklyActiveProofBackedWorkflowRuns, 0);
   assert.equal(data.observability.diagnosticEvents, 0);
   assert.equal(typeof data.team.activeAgents, 'number');
+  assert.equal(typeof data.backgroundAgents.total, 'number');
+  assert.equal(typeof data.regulatedProof.policyOriginCount, 'number');
   assert.equal(data.predictive.anomalySummary.count, 0);
   assert.equal(data.predictive.upgradePropensity.pro.band, 'very_low');
   assert.equal(data.templateLibrary.total, 6);
   assert.equal(data.templateLibrary.categories['Git Safety'], 1);
   assert.equal(typeof data.settingsStatus.resolvedSettings.mcp.defaultProfile, 'string');
   assert.ok(Array.isArray(data.settingsStatus.origins));
+});
+
+test('generateDashboard summarizes background-agent mode and regulated proof posture', () => {
+  const now = new Date().toISOString();
+  writeAgentRuns([
+    { id: 'run_a', timestamp: now, agentId: 'bg-agent-1', runType: 'refund-review', status: 'completed', gatesChecked: 4, gatesBlocked: 1 },
+    { id: 'run_b', timestamp: now, agentId: 'bg-agent-2', runType: 'invoice-send', status: 'failed', gatesChecked: 2, gatesBlocked: 1 },
+  ]);
+  writeWorkflowRuns([
+    {
+      timestamp: now,
+      workflowId: 'wf_background',
+      workflowName: 'Background refund lane',
+      owner: 'ops',
+      runtime: 'codex',
+      status: 'passed',
+      customerType: 'paid_team',
+      reviewed: true,
+      proofBacked: true,
+      proofArtifacts: ['proof/refund-review.txt'],
+    },
+  ]);
+
+  const data = generateDashboard(tmpDir);
+
+  assert.equal(data.backgroundAgents.total, 2);
+  assert.equal(data.backgroundAgents.gatesBlocked, 2);
+  assert.equal(data.backgroundAgents.topRunType.runType, 'invoice-send');
+  assert.equal(data.regulatedProof.reviewedRuns, 1);
+  assert.equal(data.regulatedProof.proofBackedRuns, 1);
+  assert.equal(data.regulatedProof.latestProofArtifacts[0], 'proof/refund-review.txt');
 });
 
 test('generateDashboard surfaces tracking readiness and instrumentation truth', () => {

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -895,6 +895,79 @@ test('generateDashboard computes a harness score and top next fix recommendation
   assert.ok(data.harness.topRecommendations.some((recommendation) => recommendation.type === 'prevention_rule'));
 });
 
+test('generateDashboard surfaces actionable remediations and agent surface inventory', () => {
+  writeFeedbackLog([
+    {
+      id: 'fb_inv_1',
+      signal: 'negative',
+      skill: 'github',
+      context: 'Skipped verification before merge',
+      tags: ['git-workflow', 'verification'],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      id: 'fb_inv_2',
+      signal: 'negative',
+      skill: 'github',
+      context: 'Skipped verification before merge again',
+      tags: ['git-workflow', 'verification'],
+      timestamp: new Date().toISOString(),
+    },
+    {
+      id: 'fb_inv_3',
+      signal: 'negative',
+      skill: 'github',
+      context: 'Skipped verification before merge a third time',
+      tags: ['git-workflow', 'verification'],
+      timestamp: new Date().toISOString(),
+    },
+  ]);
+  writeAuditLog([
+    {
+      id: 'audit_inv_1',
+      timestamp: new Date().toISOString(),
+      toolName: 'Bash',
+      decision: 'deny',
+      gateId: 'evidence-before-done',
+      source: 'gates-engine',
+    },
+    {
+      id: 'audit_inv_2',
+      timestamp: new Date().toISOString(),
+      toolName: 'Edit',
+      decision: 'warn',
+      gateId: 'protected-policy-file',
+      source: 'secret-guard',
+    },
+  ]);
+  writeDecisionLog([
+    {
+      recordType: 'evaluation',
+      actionId: 'decision_inv_1',
+      timestamp: new Date().toISOString(),
+      toolName: 'Bash',
+      recommendation: { executionMode: 'checkpoint_required' },
+    },
+    {
+      recordType: 'evaluation',
+      actionId: 'decision_inv_2',
+      timestamp: new Date().toISOString(),
+      toolName: 'Edit',
+      recommendation: { executionMode: 'auto_execute' },
+    },
+  ]);
+
+  const data = generateDashboard(tmpDir);
+
+  assert.ok(Array.isArray(data.actionableRemediations));
+  assert.ok(data.actionableRemediations.some((item) => item.type === 'skill-improve'));
+  assert.equal(data.agentSurfaceInventory.profile, data.readiness.permissions.profile);
+  assert.ok(Array.isArray(data.agentSurfaceInventory.observedTools));
+  assert.ok(data.agentSurfaceInventory.observedTools.some((tool) => tool.toolName === 'Bash'));
+  assert.ok(Array.isArray(data.agentSurfaceInventory.policySources));
+  assert.ok(data.agentSurfaceInventory.policySources.some((source) => source.source === 'gates-engine'));
+});
+
 test('generateDashboard separates repeated CTA clicks from unique checkout starters and flags orphan revenue', () => {
   writeTelemetryLog([
     {

--- a/tests/enforcement-teeth.test.js
+++ b/tests/enforcement-teeth.test.js
@@ -353,6 +353,44 @@ test('formatLessonsAsReminder appends auto-gate notice when extras.autogate is p
   assert.match(out, /0 unresolved threads/);
 });
 
+test('formatLessonsAsReminder adds action profile, hot risk signals, and safer next move context', () => {
+  const hook = require(HOOK_PATH);
+  const riskScorerPath = path.join(REPO_ROOT, 'scripts', 'risk-scorer.js');
+  const realMod = require.cache[riskScorerPath];
+  require.cache[riskScorerPath] = {
+    id: riskScorerPath,
+    filename: riskScorerPath,
+    loaded: true,
+    exports: {
+      getRiskSummary: () => ({
+        highRiskTags: [{ key: 'force-push', risk: 8, riskRate: 0.8 }],
+        highRiskDomains: [{ key: 'git-workflow', highRisk: 3, total: 4, riskRate: 0.75 }],
+      }),
+    },
+  };
+  try {
+    const out = hook.formatLessonsAsReminder(
+      [
+        { whatToChange: 'create a branch PR instead of force-pushing', tags: ['force-push', 'git-workflow'] },
+      ],
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'git push --force origin main' },
+      }
+    );
+    assert.match(out, /ACTION PROFILE:/);
+    assert.match(out, /remote git write/);
+    assert.match(out, /HOT RISK SIGNALS:/);
+    assert.match(out, /force-push/);
+    assert.match(out, /git-workflow domain/);
+    assert.match(out, /SAFER NEXT MOVE:/);
+    assert.match(out, /branch PR instead of force-pushing/);
+  } finally {
+    if (realMod) require.cache[riskScorerPath] = realMod;
+    else delete require.cache[riskScorerPath];
+  }
+});
+
 test('resolveEffectiveInput falls back to legacy CLAUDE_TOOL_INPUT env string', () => {
   const { resolveEffectiveInput } = require(HOOK_PATH);
   assert.deepEqual(resolveEffectiveInput({ command: 'ls' }), { command: 'ls' });

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -47,6 +47,8 @@ test('public surfaces lead with outcomes instead of infrastructure abstractions'
   assert.match(readme, /Make AI stop repeating mistakes/i);
   assert.match(readme, /reliable operator/i);
   assert.match(landingPage, /Stop the same mistake before|paying Anthropic to watch/i);
+  assert.match(landingPage, /machine-speed pre-action defense/i);
+  assert.match(landingPage, /agent surface inventory/i);
   assert.match(gptInstructions, /Sell outcomes before infrastructure/i);
   assert.doesNotMatch(landingPage, /Global enforcement/i);
   assert.doesNotMatch(readme, /Behavior control system/i);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -303,10 +303,13 @@ test('public landing page includes compatibility section for AI agent surfaces',
   assert.match(landingPage, /Open ThumbGate GPT/);
   assert.match(landingPage, /Live ThumbGate GPT for ChatGPT/);
   assert.match(landingPage, /ChatGPT Entry Point/);
-  assert.match(landingPage, /Open the GPT\. Give typed thumbs feedback\. Turn the lesson into a check\./);
+  assert.match(landingPage, /Use the GPT as a preflight desk for risky commands, refunds, deploys, and PR actions\./);
   assert.match(landingPage, /No, you do not have to chat inside the GPT forever/);
   assert.match(landingPage, /ChatGPT is the discovery and memory surface/);
   assert.match(landingPage, /Do not rely on ChatGPT's native rating buttons for ThumbGate memory/);
+  assert.match(landingPage, /Explore GPTs/);
+  assert.match(landingPage, /choose the GPT by Igor Ganapolsky/i);
+  assert.match(landingPage, /Programming/);
   assert.match(landingPage, /Do I have to chat inside the ThumbGate GPT for enforcement\?/);
   assert.match(landingPage, /capture thumbs-up\/down lessons/i);
   assert.match(landingPage, /Real blocking for coding agents still runs locally/);

--- a/tests/workflow-sentinel.test.js
+++ b/tests/workflow-sentinel.test.js
@@ -133,6 +133,68 @@ test('workflow sentinel denies recurring destructive pattern with high blast rad
   assert.match(report.evidence.join('\n'), /Memory guard predicted block/);
 });
 
+test('workflow sentinel checkpoints economic actions even before code changes land', () => {
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-sentinel-economic-'));
+  const report = evaluateWorkflowSentinel('Bash', {
+    command: 'stripe refunds create re_123 --reason requested_by_customer',
+  }, {
+    feedbackDir,
+    repoPath: process.cwd(),
+    governanceState: {
+      taskScope: {
+        summary: 'finance ops',
+        allowedPaths: ['scripts/**'],
+        protectedPaths: [],
+      },
+      protectedApprovals: [],
+      branchGovernance: {
+        baseBranch: 'main',
+        prRequired: true,
+      },
+    },
+  });
+
+  assert.equal(report.decision, 'warn');
+  assert.equal(report.actionProfile.economicAction, true);
+  assert.equal(report.decisionControl.executionMode, 'checkpoint_required');
+  assert.equal(report.decisionControl.reversibility, 'one_way_door');
+  assert.ok(report.remediations.some((entry) => entry.id === 'economic_action_approval'));
+  assert.match(report.reasoning.join('\n'), /economic action/i);
+});
+
+test('workflow sentinel checkpoints background customer-system actions', () => {
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-sentinel-background-'));
+  const report = evaluateWorkflowSentinel('Bash', {
+    command: 'node scripts/async-job-runner.js --task "resend customer invoice email"',
+    metadata: {
+      source: 'scheduled',
+      runType: 'invoice-send',
+    },
+  }, {
+    feedbackDir,
+    repoPath: process.cwd(),
+    governanceState: {
+      taskScope: {
+        summary: 'background invoicing',
+        allowedPaths: ['scripts/**'],
+        protectedPaths: [],
+      },
+      protectedApprovals: [],
+      branchGovernance: {
+        baseBranch: 'main',
+        prRequired: true,
+      },
+    },
+  });
+
+  assert.equal(report.decision, 'warn');
+  assert.equal(report.actionProfile.backgroundAgent, true);
+  assert.equal(report.actionProfile.customerSystemAction, true);
+  assert.equal(report.decisionControl.executionMode, 'checkpoint_required');
+  assert.ok(report.remediations.some((entry) => entry.id === 'background_agent_checkpoint'));
+  assert.ok(report.remediations.some((entry) => entry.id === 'customer_system_guardrail'));
+});
+
 test('workflow sentinel treats explicit changed files as authoritative for PR handoff', () => {
   const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-sentinel-empty-'));
   const report = evaluateWorkflowSentinel('Bash', {


### PR DESCRIPTION
## Summary
- add agent surface inventory and highest-ROI remediation sections to the dashboard
- enrich PreToolUse reminders with action profile, hot risk signals, and a safer next move
- update landing and metadata positioning to machine-speed pre-action defense, plus remove hardcoded savings samples and add a release note

## Verification
- `node --test tests/token-savings-dashboard.test.js tests/public-landing.test.js tests/dashboard-html.test.js tests/dashboard.test.js tests/enforcement-teeth.test.js tests/positioning-contract.test.js`
- `npm run test:coverage`
- `npm test`
- `npm run self-heal:check`
