### PR TITLE
fix(billing): fail loudly on hosted summary 401/403 instead of reporting $0

### DIFF
--- a/.changeset/revenue-truth-401-loud.md
+++ b/.changeset/revenue-truth-401-loud.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+fix(operational-summary): throw on 401/403 instead of silently falling back to empty local ledger
+
+The hosted billing summary client used a `try { hosted } catch { local }` pattern that swallowed auth failures. When the operator key expired, the CLI reported $0.00 revenue even though Stripe had real charges — because the local ledger was empty and the 401 was caught silently.
+
+Now 401/403 throw `hosted_summary_unauthorized` with an actionable message (re-auth the operator key). Non-auth failures (503, network) still fall back to local, but the result is tagged `source: 'local-unverified'` with `hostedStatus` so downstream consumers can distinguish verified from unverified revenue.

--- a/scripts/operational-summary.js
+++ b/scripts/operational-summary.js
@@ -150,10 +150,12 @@ async function getOperationalBillingSummary(options = {}) {
     // Non-auth failure (network, 5xx, config) — local fallback is still
     // useful for dev workflows, but tag the source so downstream renderers
     // and agents do not mistake it for verified hosted truth.
+    //
+    // Log only the status code (trusted) — the full reason contains upstream
+    // response text and is only returned structurally via fallbackReason.
     console.warn(
       `[operational-summary] Hosted billing unreachable (status=${status ?? 'network'}); ` +
-      `falling back to LOCAL-UNVERIFIED state. Numbers below may not reflect ` +
-      `actual Stripe revenue. Reason: ${reason}`
+      `falling back to LOCAL-UNVERIFIED state. Numbers below may not reflect actual Stripe revenue.`
     );
     return {
       source: 'local-unverified',

--- a/scripts/operational-summary.js
+++ b/scripts/operational-summary.js
@@ -113,6 +113,18 @@ async function getOperationalBillingSummary(options = {}) {
   } catch (err) {
     const reason = err && err.message ? err.message : 'hosted_summary_unavailable';
     const status = err && typeof err.status === 'number' ? err.status : null;
+    const code = err && err.code ? err.code : null;
+
+    // Hosted deliberately disabled or never configured — local fallback is
+    // intentional, not a degraded state. Tag as plain 'local'.
+    if (code === 'hosted_summary_disabled' || code === 'hosted_summary_unconfigured') {
+      return {
+        source: 'local',
+        summary: await getBillingSummaryLive(analyticsWindow),
+        fallbackReason: reason,
+        hostedStatus: null,
+      };
+    }
 
     // Auth failure is the most dangerous case: if hosted Stripe data says
     // we have paid customers and local ledgers are empty, silently returning

--- a/scripts/operational-summary.js
+++ b/scripts/operational-summary.js
@@ -108,14 +108,46 @@ async function getOperationalBillingSummary(options = {}) {
       source: 'hosted',
       summary,
       fallbackReason: null,
+      hostedStatus: 200,
     };
   } catch (err) {
     const reason = err && err.message ? err.message : 'hosted_summary_unavailable';
-    console.warn(`[operational-summary] Hosted billing unavailable — falling back to local state. Reason: ${reason}`);
+    const status = err && typeof err.status === 'number' ? err.status : null;
+
+    // Auth failure is the most dangerous case: if hosted Stripe data says
+    // we have paid customers and local ledgers are empty, silently returning
+    // "$0.00" is a lie that hides actual revenue. Refuse to guess — surface
+    // an actionable error so the operator fixes the key before any
+    // downstream report renders wrong numbers.
+    if (status === 401 || status === 403) {
+      const authErr = new Error(
+        `Hosted billing summary rejected credentials (HTTP ${status}). ` +
+        `The operator key on this machine does not match the one on the ` +
+        `hosted deployment. Fix: set THUMBGATE_OPERATOR_KEY in this shell, ` +
+        `or update the operatorKey field in ~/.config/thumbgate/operator.json, ` +
+        `to match Railway's THUMBGATE_OPERATOR_KEY. ` +
+        `Running this command without hosted auth would report local-only ` +
+        `data as ground truth, which may not reflect actual Stripe revenue. ` +
+        `Original response: ${reason}`
+      );
+      authErr.code = 'hosted_summary_unauthorized';
+      authErr.status = status;
+      throw authErr;
+    }
+
+    // Non-auth failure (network, 5xx, config) — local fallback is still
+    // useful for dev workflows, but tag the source so downstream renderers
+    // and agents do not mistake it for verified hosted truth.
+    console.warn(
+      `[operational-summary] Hosted billing unreachable (status=${status ?? 'network'}); ` +
+      `falling back to LOCAL-UNVERIFIED state. Numbers below may not reflect ` +
+      `actual Stripe revenue. Reason: ${reason}`
+    );
     return {
-      source: 'local',
+      source: 'local-unverified',
       summary: await getBillingSummaryLive(analyticsWindow),
       fallbackReason: reason,
+      hostedStatus: status,
     };
   }
 }

--- a/tests/operational-summary.test.js
+++ b/tests/operational-summary.test.js
@@ -10,6 +10,7 @@ const {
   resolveHostedSummaryConfig,
   shouldPreferHostedSummary,
   fetchHostedBillingSummary,
+  getOperationalBillingSummary,
 } = require('../scripts/operational-summary');
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -175,6 +176,97 @@ describe('operational-summary', () => {
           () => fetchHostedBillingSummary({}, { apiBaseUrl: null, apiKey: 'tg_op_k' }),
           (err) => err.code === 'hosted_summary_unconfigured'
         );
+      });
+    });
+  });
+
+  // ── getOperationalBillingSummary auth-failure contract ──────────────────────
+  //
+  // Regression test for the silent-lie bug: prior to 2026-04-24, a 401 from
+  // the hosted summary endpoint was swallowed into a `source: 'local'` empty
+  // summary, which reports $0.00 even when Stripe has real paid revenue.
+  // The contract is now: 401/403 must throw loudly; other failures fall back
+  // to local but tag `source: 'local-unverified'` so downstream surfaces can
+  // distinguish verified hosted data from unverified fallback.
+
+  describe('getOperationalBillingSummary', () => {
+    const ORIGINAL_FETCH = global.fetch;
+
+    after(() => {
+      global.fetch = ORIGINAL_FETCH;
+    });
+
+    it('throws hosted_summary_unauthorized on 401 instead of silently returning $0', async () => {
+      global.fetch = async () => ({
+        ok: false,
+        status: 401,
+        text: async () => '{"detail":"A valid API key is required to access this endpoint."}',
+      });
+      await withEnv({
+        THUMBGATE_METRICS_SOURCE: undefined,
+        THUMBGATE_OPERATOR_KEY: 'tg_op_stale',
+        THUMBGATE_BILLING_API_BASE_URL: 'https://fake.example.com',
+      }, async () => {
+        await assert.rejects(
+          () => getOperationalBillingSummary({ window: 'lifetime' }),
+          (err) => {
+            assert.strictEqual(err.code, 'hosted_summary_unauthorized');
+            assert.strictEqual(err.status, 401);
+            assert.match(err.message, /THUMBGATE_OPERATOR_KEY/);
+            assert.match(err.message, /operator\.json/);
+            return true;
+          }
+        );
+      });
+    });
+
+    it('also throws on 403', async () => {
+      global.fetch = async () => ({
+        ok: false,
+        status: 403,
+        text: async () => '',
+      });
+      await withEnv({
+        THUMBGATE_METRICS_SOURCE: undefined,
+        THUMBGATE_OPERATOR_KEY: 'tg_op_forbidden',
+        THUMBGATE_BILLING_API_BASE_URL: 'https://fake.example.com',
+      }, async () => {
+        await assert.rejects(
+          () => getOperationalBillingSummary({ window: 'lifetime' }),
+          (err) => err.code === 'hosted_summary_unauthorized' && err.status === 403
+        );
+      });
+    });
+
+    it('falls back to local-unverified on 503 (non-auth failure)', async () => {
+      global.fetch = async () => ({
+        ok: false,
+        status: 503,
+        text: async () => 'Service Unavailable',
+      });
+      await withEnv({
+        THUMBGATE_METRICS_SOURCE: undefined,
+        THUMBGATE_OPERATOR_KEY: 'tg_op_ok',
+        THUMBGATE_BILLING_API_BASE_URL: 'https://fake.example.com',
+      }, async () => {
+        const result = await getOperationalBillingSummary({ window: 'lifetime' });
+        assert.strictEqual(result.source, 'local-unverified');
+        assert.strictEqual(result.hostedStatus, 503);
+        assert.ok(result.fallbackReason);
+        assert.ok(result.summary, 'summary object should still be returned from local fallback');
+      });
+    });
+
+    it('falls back to local-unverified on network error (no status)', async () => {
+      global.fetch = async () => { throw new Error('ECONNREFUSED'); };
+      await withEnv({
+        THUMBGATE_METRICS_SOURCE: undefined,
+        THUMBGATE_OPERATOR_KEY: 'tg_op_ok',
+        THUMBGATE_BILLING_API_BASE_URL: 'https://fake.example.com',
+      }, async () => {
+        const result = await getOperationalBillingSummary({ window: 'lifetime' });
+        assert.strictEqual(result.source, 'local-unverified');
+        assert.strictEqual(result.hostedStatus, null);
       });
     });
   });


### PR DESCRIPTION
## Summary

- `getOperationalBillingSummary()` silently swallowed hosted 401/403 and returned a `source: 'local'` fallback with $0.00, masking real Stripe revenue when the operator key on disk had diverged from Railway's.
- Now: 401/403 throws `hosted_summary_unauthorized` with an actionable message (points at `THUMBGATE_OPERATOR_KEY` and `~/.config/thumbgate/operator.json`). CLI exits non-zero instead of rendering a lie.
- Non-auth failures (network, 5xx) still fall back to local, but tag `source: 'local-unverified'` + `hostedStatus` so downstream renderers and agents can distinguish verified hosted truth from unverified fallback.

## Why this matters

A revenue dashboard that silently says **\$0** is worse than one that refuses to render — the first is a lie the operator acts on, the second is a bug the operator fixes. The $149 April 20 Stripe payment was invisible on this machine because of this silent-fallback path.

## Root cause

The operator key in `~/.config/thumbgate/operator.json` diverged from the one set as `THUMBGATE_OPERATOR_KEY` on Railway. When `cfo`/`north-star` ran locally, the hosted endpoint returned 401, the try/catch swallowed it, and the fallback ran against an empty local ledger. Nothing surfaced the auth failure.

Key rotation is a separate operator action (rotate both to match), but the client should never silently convert \"I have no credentials\" into \"there is no revenue.\"

## Test plan

- [x] Added 4 regression tests covering 401/403 throw paths and 503/network fallback paths
- [x] 18/18 pass (`node --test tests/operational-summary.test.js`)
- [x] Verified end-to-end: `node bin/cli.js cfo --json` against a stale key now throws an actionable error and exits 1, instead of printing `$0.00` (verified in the worktree before copy).
- [ ] Follow-up: `scripts/operational-dashboard.js` north-star command uses `getBillingSummaryLive` directly, bypassing the hosted path entirely — separate PR.
- [ ] Follow-up: rotate operator key on Railway to match `~/.config/thumbgate/operator.json` (or regenerate both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)