### PR TITLE
feat(newsletter): send welcome email on signup (was a silent black hole)

### DIFF
--- a/.changeset/newsletter-welcome-email.md
+++ b/.changeset/newsletter-welcome-email.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": minor
+---
+
+feat(newsletter): send welcome email via Resend on subscription
+
+New subscribers to the ThumbGate newsletter now receive an immediate welcome email with the "one AI mistake prevented per email" framing and a CTA to thumbgate.ai/pro.
+
+The `/api/newsletter` endpoint fires the send in the background (Promise-then pattern) so the HTTP response stays fast and never fails on mailer errors. Missing RESEND_API_KEY degrades gracefully to a logged warning; the subscriber is still recorded.

--- a/scripts/mailer/resend-mailer.js
+++ b/scripts/mailer/resend-mailer.js
@@ -503,10 +503,121 @@ async function sendTrialWelcomeEmail({ to, licenseKey, customerId, customerName,
   return sendEmail({ to, subject, html, text, replyTo: getReplyTo(), fetchImpl, dnsResolver });
 }
 
+function renderNewsletterWelcomeBodies() {
+  const supportEmail = getSupportEmail();
+  const unsubscribeEmail = getUnsubscribeEmail();
+  const businessName = getBusinessName();
+  const businessAddress = getBusinessAddress();
+  const unsubscribeMailto = `mailto:${unsubscribeEmail}?subject=unsubscribe&body=Please%20remove%20me%20from%20ThumbGate%20emails.`;
+  const headline = 'Welcome to ThumbGate.';
+  const subhead =
+    'One concrete AI coding failure prevented per email. No theory, no fluff.';
+  const firstLesson =
+    'First lesson: the most expensive AI mistake is the one it repeats. ' +
+    'ThumbGate turns thumbs up/down signals into Pre-Action Checks that stop ' +
+    'the next recurrence before the tool call runs.';
+  const ctaLink = 'https://thumbgate.ai/pro';
+
+  const text = [
+    'Welcome to ThumbGate.',
+    '',
+    subhead,
+    '',
+    firstLesson,
+    '',
+    `Want the full stop-repeating-mistakes loop locally? ${ctaLink}`,
+    '',
+    `Questions? Reply to this email or write ${supportEmail}.`,
+    '',
+    '— Igor, founder of ThumbGate',
+    '',
+    '---',
+    `You're getting this because you signed up on thumbgate.ai. Unsubscribe: ${unsubscribeEmail}`,
+    `${businessName} · ${businessAddress}`,
+  ].join('\n');
+
+  const safeHeadline = escapeHtml(headline);
+  const safeSubhead = escapeHtml(subhead);
+  const safeFirstLesson = escapeHtml(firstLesson);
+  const safeSupportEmail = escapeHtml(supportEmail);
+  const safeBusinessName = escapeHtml(businessName);
+  const safeBusinessAddress = escapeHtml(businessAddress);
+  const safeUnsubscribeEmail = escapeHtml(unsubscribeEmail);
+  const safeUnsubscribeMailto = escapeHtml(unsubscribeMailto);
+
+  const html = `<!doctype html>
+<html>
+  <body style="margin:0;background:#f5f7fb;padding:28px 12px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;color:#17212b;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;max-width:640px;background:#ffffff;border:1px solid #d8e2ea;border-radius:10px;overflow:hidden;">
+            <tr>
+              <td style="background:#071115;padding:24px 28px;color:#e7fbff;">
+                <div style="font-size:13px;font-weight:700;letter-spacing:0.02em;text-transform:uppercase;color:#73d4e9;">ThumbGate</div>
+                <h1 style="margin:10px 0 6px;font-size:24px;line-height:1.25;color:#ffffff;">${safeHeadline}</h1>
+                <p style="margin:0;font-size:14px;line-height:1.5;color:#9cbac4;">${safeSubhead}</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 28px 10px;">
+                <p style="margin:0 0 18px;font-size:15px;line-height:1.6;color:#344451;">${safeFirstLesson}</p>
+                <p style="margin:0 0 22px;">
+                  <a href="${ctaLink}" style="display:inline-block;background:#45bfd8;color:#061015;text-decoration:none;font-weight:700;padding:12px 22px;border-radius:6px;font-size:15px;">See the full Pro loop</a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 28px 22px;">
+                <p style="margin:0 0 4px;font-size:14px;line-height:1.6;color:#17212b;">— Igor, founder of ThumbGate</p>
+                <p style="margin:0;font-size:13px;line-height:1.55;color:#526273;">
+                  Questions? Reply or write
+                  <a href="mailto:${safeSupportEmail}" style="color:#087a91;">${safeSupportEmail}</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 28px 22px;border-top:1px solid #e2e8ec;background:#fafbfc;">
+                <p style="margin:0 0 6px;font-size:12px;line-height:1.5;color:#7a8790;">
+                  You signed up on thumbgate.ai.
+                  <a href="${safeUnsubscribeMailto}" style="color:#7a8790;text-decoration:underline;">Unsubscribe</a>
+                  (${safeUnsubscribeEmail}).
+                </p>
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#7a8790;">
+                  ${safeBusinessName} &middot; ${safeBusinessAddress}
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  return { html, text };
+}
+
+async function sendNewsletterWelcomeEmail({ to, fetchImpl, dnsResolver } = {}) {
+  if (!isNonEmptyString(to)) throw new Error('sendNewsletterWelcomeEmail: `to` is required');
+  const { html, text } = renderNewsletterWelcomeBodies();
+  return sendEmail({
+    to,
+    subject: 'Welcome to ThumbGate — one AI mistake prevented per email',
+    html,
+    text,
+    replyTo: getReplyTo(),
+    fetchImpl,
+    dnsResolver,
+  });
+}
+
 module.exports = {
   sendEmail,
   sendTrialWelcomeEmail,
+  sendNewsletterWelcomeEmail,
   renderTrialWelcomeBodies,
+  renderNewsletterWelcomeBodies,
   _resolveSenderAddress: resolveSenderAddress,
   _hasResendSenderDns: hasResendSenderDns,
   _recordsHaveResendDns: recordsHaveResendDns,

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -181,6 +181,7 @@ const {
 } = require('../../scripts/rate-limiter');
 const { sendProblem, PROBLEM_TYPES } = require('../../scripts/problem-detail');
 const { TOOLS: MCP_TOOLS } = require('../../scripts/tool-registry');
+const resendMailer = require('../../scripts/mailer/resend-mailer');
 const {
   buildContextFootprintReport,
 } = require('../../scripts/context-footprint');
@@ -3480,6 +3481,19 @@ function createApiServer() {
               landingPath,
               attribution,
             }) + '\n');
+            // Fire-and-forget welcome email. Never blocks the 200 response, never
+            // throws — the mailer returns a structured result even on failure, so
+            // the signup still succeeds if Resend is down or RESEND_API_KEY is unset.
+            Promise.resolve()
+              .then(() => resendMailer.sendNewsletterWelcomeEmail({ to: email }))
+              .then((result) => {
+                if (!result || result.sent !== true) {
+                  console.warn('[newsletter] welcome email not sent:', email, result && result.reason);
+                }
+              })
+              .catch((err) => {
+                console.warn('[newsletter] welcome email threw:', email, err && err.message);
+              });
           }
           const journeyState = resolveJourneyState(req, parsed);
           appendBestEffortTelemetry(getFeedbackPaths().FEEDBACK_DIR, {


### PR DESCRIPTION
## Summary

The \`/api/newsletter\` endpoint was a silent sink: it appended the email to a jsonl file and returned 200, but never sent the subscriber anything. From the user's perspective: signed up and got nothing.

This wires the existing Resend mailer (\`scripts/mailer/resend-mailer.js\`) to send a short welcome email on first signup.

## Behavior

- **Signup still returns 200 immediately** — email is fire-and-forget, non-blocking
- **RESEND_API_KEY unset** → mailer logs a warn, skips, signup succeeds (matches existing trial-email behavior)
- **Resend 4xx/5xx** → mailer logs, signup succeeds
- **Network exception** → caught in .catch(), signup succeeds
- **Duplicate signup** → no email re-sent (existing dedup logic is ahead of the mail call)

## Email content

- Subject: \"Welcome to ThumbGate — one AI mistake prevented per email\"
- Single punchy lesson + single CTA to \`thumbgate.ai/pro\`
- CAN-SPAM compliant (business name, physical address, unsubscribe mailto — all from the existing mailer helpers)

## Why this matters

Acquiring an email address and sending nothing is worse than not asking — it teaches the subscriber we can't execute on promises. Small change, proportional risk, immediately-felt on the next signup.

## Test plan

- [x] 108/108 existing api-server tests pass
- [x] Smoke: \`renderNewsletterWelcomeBodies()\` produces 3.1K of valid HTML + 400-char text
- [ ] Post-merge verify: \`RESEND_API_KEY\` is set on Railway (separate ops check — if unset, sends skip silently, same as trial emails do today)

## Follow-up (separate PRs)

- Add a boot-time warning when \`RESEND_API_KEY\` is unset in production so silent-skip becomes visible
- Add a scheduled newsletter sender (this PR only handles the welcome, not ongoing sends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)