### PR TITLE
docs(gpt-store): sharpen GPT listing copy (3 conversations is not a product problem, it's a discovery problem)

### DIFF
--- a/.changeset/gpt-store-v3-copy.md
+++ b/.changeset/gpt-store-v3-copy.md
@@ -1,0 +1,11 @@
+---
+"thumbgate": patch
+---
+
+docs(gpt-store): sharpen GPT listing copy for discovery
+
+The live GPT listing had 3 conversations — not a product problem, a discovery problem. Description was jargon-heavy ("proof-backed Reliability Gateway workflows") and conversation starters buried the pain behind branded terminology.
+
+New short/full descriptions lead with the named pain ("Stop your AI agent from repeating mistakes") and starters match what developers type mid-frustration. Also adds an ACTION REQUIRED banner reminding the operator that the live listing needs a publish bump in GPT Builder for updated copy to appear.
+
+Version-metadata test assertions updated to match the new copy (starter text + short description).

--- a/docs/gpt-store-submission.md
+++ b/docs/gpt-store-submission.md
@@ -1,7 +1,7 @@
 ---
 title: GPT Store Submission — ThumbGate
 created: 2026-03-04T00:00:00Z
-updated: 2026-04-14T00:00:00Z
+updated: 2026-04-24T00:00:00Z
 status: published-user-confirmed
 ---
 
@@ -10,6 +10,8 @@ status: published-user-confirmed
 ThumbGate was user-confirmed as published to GPT Store in the Programming category on April 13, 2026. Direct URL: https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate. If that URL is unavailable for a user's account, point them to **Explore GPTs -> search ThumbGate -> choose the GPT by Igor Ganapolsky**.
 
 This page remains the canonical copy-paste submission packet for updating the GPT in ChatGPT GPT Builder (https://chat.openai.com/gpts/editor).
+
+> **ACTION REQUIRED (operator):** the live GPT listing currently shows earlier copy. Sync by opening https://chat.openai.com/gpts/editor → ThumbGate → Configure, and pasting the sections below into Name, Description, Instructions, and Conversation Starters. A publish bump is required for the updated copy to show in Explore GPTs.
 
 ---
 
@@ -24,7 +26,7 @@ ThumbGate
 ## Short Description (max 50 characters)
 
 ```
-Stop costly AI mistakes before they run
+Stop your AI agent from repeating mistakes
 ```
 
 ---
@@ -32,7 +34,7 @@ Stop costly AI mistakes before they run
 ## Full Description (max 300 characters)
 
 ```
-Paste a risky AI action before it runs. ThumbGate tells you whether to allow, block, or checkpoint it, then turns thumbs-up/down feedback into Pre-Action Checks so repeated mistakes stop coming back.
+Paste any AI action before it runs: commands, edits, merges, deploys. ThumbGate tells you whether to allow, block, or checkpoint — and remembers every thumbs-down so your agent stops repeating the same mistakes. No more "why did it do that again?"
 ```
 
 ---
@@ -89,12 +91,16 @@ Authentication: Bearer token configured once by the GPT owner in GPT Builder. Re
 
 ## Conversation Starters
 
+Outcome-led, named-pain starters that match what developers actually type into search:
+
 ```
-1. "Check this agent action before it runs: git push --force --tags"
-2. "Turn this mistake into a ThumbGate rule: the agent edited generated files again."
-3. "Install ThumbGate for Claude Code or Codex in this repo."
-4. "Search my saved lessons before you answer."
+1. "Check: git push --force --tags"
+2. "Stop my agent from editing generated files"
+3. "This answer was wrong — save the lesson"
+4. "What mistakes has my agent repeated this week?"
 ```
+
+> **Why these four:** each one opens with a verb a developer would type mid-frustration, and each maps 1:1 to an API action (evaluateDecision, generatePreventionRules, captureFeedback, getFeedbackSummary). Avoid proprietary terms ("Pre-Action Checks", "Reliability Gateway") in the starters — those belong in the instructions for the model, not the discovery surface.
 
 ---
 

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -148,7 +148,7 @@ test('public docs render the current package version', () => {
   assert.match(gptStoreSubmission, /https:\/\/chatgpt\.com\/g\/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate/);
   assert.doesNotMatch(gptStoreSubmission, /URL has not been captured/i);
   assert.match(gptStoreSubmission, /Explore GPTs -> search ThumbGate/i);
-  assert.match(gptStoreSubmission, /Stop costly AI mistakes before they run/);
+  assert.match(gptStoreSubmission, /Stop your AI agent from repeating mistakes/);
   assert.match(gptStoreSubmission, /Reliability Gateway/i);
   assert.match(gptStoreSubmission, /one signal becomes one remembered rule/i);
   assert.match(gptStoreSubmission, /prevent expensive AI mistakes/i);
@@ -164,7 +164,7 @@ test('public docs render the current package version', () => {
   assert.match(gptStoreSubmission, /Only show feedback IDs when the user asks for technical details/i);
   assert.match(gptStoreSubmission, /https:\/\/thumbgate-production\.up\.railway\.app\/privacy/);
   assert.match(gptStoreSubmission, /Category set to Programming \/ Productivity/);
-  assert.match(gptStoreSubmission, /Turn this mistake into a ThumbGate rule/i);
+  assert.match(gptStoreSubmission, /Stop my agent from editing generated files/i);
   assert.match(claudePluginReadme, new RegExp(getClaudePluginLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.match(claudePluginReadme, new RegExp(getClaudePluginReviewLatestDownloadUrl(PROJECT_ROOT).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   assert.match(claudeCodexBridgeReadme, /claude --plugin-dir/i);


### PR DESCRIPTION
## Summary

The live ThumbGate GPT on ChatGPT has 3 conversations. That's not a product problem — it's a discovery problem. The Explore-GPTs surface copy uses proprietary jargon (\"Pre-Action Checks\", \"Reliability Gateway\") that nobody searches for, and the conversation starters read like documentation rather than mid-frustration queries.

This PR sharpens the copy. The GPT itself still needs to be re-published in ChatGPT's GPT Builder for the new copy to show — this repo is the source of truth, not the delivery vehicle.

## Changes

**Short description** (42/50 char): \`Stop your AI agent from repeating mistakes\`
- Names the loop, outcome-focused, no jargon.

**Full description** (244/300 char): opens with the concrete action (\"paste any AI action\"), lists the four verbs developers already recognize (commands, edits, merges, deploys), closes with the \"why did it do that again?\" hook developers know too well.

**Conversation starters**: replaced instructional phrasings with mid-frustration verbs. Each maps 1:1 to an API action. None contain proprietary terms:
1. \`\"Check: git push --force --tags\"\`
2. \`\"Stop my agent from editing generated files\"\`
3. \`\"This answer was wrong — save the lesson\"\`
4. \`\"What mistakes has my agent repeated this week?\"\`

**ACTION REQUIRED banner**: added a callout so whoever reads this doc next doesn't assume merging this PR propagates to Explore GPTs. The live GPT must be re-published through https://chat.openai.com/gpts/editor for the new copy to appear.

## Out of scope (follow-ups)

- **Landing pages** (\`public/index.html\`, \`public/pro.html\`) still use \"Reliability Gateway\" and \"Pre-Action Checks\" prominently — same jargon issue on the highest-intent surface. Worth its own audit.
- **GPT category** is \"Programming\" — crowded. Worth testing a secondary \"Productivity\" tag once the re-publish lands and we have a clean measurement baseline.

## Test plan

- [x] Char budgets respected (short 42/50, full 244/300)
- [ ] Operator action post-merge: update the GPT in ChatGPT GPT Builder and re-publish
- [ ] After re-publish, wait 7 days and compare conversation count vs baseline of 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)