### PR TITLE
fix(pricing): correct stale $99/seat Team price in llms.txt + CI guard

### DIFF
--- a/.changeset/team-price-99-stale-reference.md
+++ b/.changeset/team-price-99-stale-reference.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+fix(pricing): correct stale $99/seat Team price in .well-known/llms.txt and extend parity guard
+
+AI crawlers reading `.well-known/llms.txt` were being served the retired `$99/seat/mo` Team anchor. The canonical anchor per `docs/COMMERCIAL_TRUTH.md` has been `$49/seat/mo with a 3-seat minimum` since mid-April 2026; every HTML surface, server-side constant (`TEAM_MONTHLY_PRICE_DOLLARS`), and README already uses $49. The llms.txt leak was the last unguarded public surface.
+
+Also extends `tests/public-package-parity.test.js` to scan `.well-known/` text surfaces in addition to HTML, so this class of leak is caught in CI next time.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -42,7 +42,7 @@ npx thumbgate init --agent claude-code
 - Free GPT: advice, checkpointing, and setup help in ChatGPT
 - Free local CLI: 3 feedback captures/day, 5 lesson searches/day, recall, and local Pre-Action Checks after install
 - Pro: $19/mo or $149/yr — personal enforcement proof, local dashboard, check debugger, DPO export, and review-ready exports
-- Team: $99/seat/mo, 3-seat minimum after intake — shared lessons, org visibility, approval boundaries, and rollout proof
+- Team: $49/seat/mo, 3-seat minimum after intake — shared lessons, org visibility, approval boundaries, and rollout proof
 
 ## Links
 

--- a/tests/public-package-parity.test.js
+++ b/tests/public-package-parity.test.js
@@ -70,4 +70,18 @@ describe('public/ package parity', () => {
       );
     }
   });
+
+  test('.well-known text surfaces have correct pricing', () => {
+    const wellKnownFiles = ['.well-known/llms.txt'];
+    for (const rel of wellKnownFiles) {
+      const filePath = path.join(ROOT, rel);
+      if (!fs.existsSync(filePath)) continue;
+      const content = fs.readFileSync(filePath, 'utf8');
+      const stripped = content.replace(/Previously \$99\/seat/g, '');
+      assert.ok(
+        !/\$99\s*\/?\s*seat/i.test(stripped),
+        `${rel} contains stale $99/seat pricing — Team is now $49/seat (AI crawlers read this)`,
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- `.well-known/llms.txt` still served the retired `$99/seat/mo` Team anchor to AI crawlers. Corrected to `$49/seat/mo` to match `docs/COMMERCIAL_TRUTH.md`, server constants (`TEAM_MONTHLY_PRICE_DOLLARS`), and every HTML surface.
- Extended `tests/public-package-parity.test.js` to scan `.well-known/` text files, not just HTML — that's how this leak slipped past the existing guard.

## Context

Spotted while describing the two Stripe Team prices ($49 current, $99 retired packaging experiment from `docs/MONETIZATION_EXEC_SUMMARY_2026-04-08.md`). No subscriptions on either price in Stripe, so no grandfathering risk. Recommended Stripe-side actions (archive the $99 price, paste description text on the $49) are for the operator to do in the Stripe dashboard — that part is not code.

## Test plan

- [x] `node --test tests/public-package-parity.test.js` passes locally (4/4)
- [ ] CI green