### PR TITLE
fix(chatgpt): harden published GPT feedback capture

### DIFF
--- a/.changeset/chatgpt-published-gpt-repair.md
+++ b/.changeset/chatgpt-published-gpt-repair.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+fix(chatgpt): harden the published GPT feedback-capture repair packet
+
+The ChatGPT GPT setup guide now fails closed when `captureFeedback` is unauthenticated or unavailable: it must say "Not saved in ThumbGate yet" instead of implying a reusable lesson was saved. The GPT Store packet also pins the canonical ThumbGate avatar and records a live audit of the published GPT drift so the wrong icon, stale Action instructions, and Bearer-auth setup issue can be repaired from evidence.

--- a/adapters/chatgpt/INSTALL.md
+++ b/adapters/chatgpt/INSTALL.md
@@ -23,6 +23,8 @@ The GPT should feel like a feedback button that remembers.
 
 Do not imply ChatGPT's built-in thumbs buttons save ThumbGate lessons. The reliable public capture path is a typed message inside the GPT.
 
+Critical failure rule: if the `captureFeedback` Action fails with `401`, `403`, `5xx`, timeout, missing action, or any setup/auth error, the GPT must not say it saved the lesson, will remember the lesson, or can still apply it going forward. It must say: "Not saved in ThumbGate yet." Then it should state the setup failure and point the GPT owner to the Action auth repair steps below. Do not ask the user whether to turn failed feedback into a hard rule.
+
 ## GPT Store path
 
 1. Open the direct GPT URL: https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate
@@ -64,6 +66,14 @@ Conversation starters:
 4. `Turn this mistake into a ThumbGate rule: the agent edited generated files again.`
 
 Use typed chat replies. ChatGPT's native feedback buttons may send feedback to OpenAI, but they should not be described as the ThumbGate capture path unless OpenAI exposes them to GPT Actions.
+
+GPT avatar:
+
+```text
+public/assets/brand/thumbgate-icon-512.png
+```
+
+Upload the canonical dark rounded-square TG gate monogram above. Do not use `docs/logo-400x400.png`, `.claude-plugin/bundle/icon.png`, a generic cube, emoji thumbs, or a generated image. Expected SHA-256: `6f0290f7fe50de9a82c18be2299deafba4c686df46b3b5309e363a7d589d89dc`.
 
 ## Pre-action check flow
 
@@ -162,6 +172,12 @@ Before publishing or re-publishing the GPT, keep it private and verify these thr
 3. `Check this: git push --force`
 
 All three should call the action layer without a `401 Unauthorized` response. If any action test returns `401`, the GPT Builder secret is missing, stale, pasted with an extra `Bearer ` prefix, or pointed at a different backend key than Railway's `THUMBGATE_API_KEY`.
+
+Expected user-facing failure copy when an Action is unhealthy:
+
+```text
+Not saved in ThumbGate yet. The GPT Action is not authenticated, so I cannot persist this lesson. The GPT owner needs to update Actions auth to API Key -> Bearer with the raw THUMBGATE_API_KEY, re-import https://thumbgate-production.up.railway.app/openapi.yaml, and retest captureFeedback.
+```
 
 ## Available Actions
 

--- a/docs/chatgpt-gpt-instructions.md
+++ b/docs/chatgpt-gpt-instructions.md
@@ -42,6 +42,9 @@ User experience rules:
 - Do not imply ChatGPT's native rating buttons automatically save ThumbGate lessons. The reliable capture path is a typed message such as "thumbs up: this worked" or "thumbs down: this missed the point."
 - Do not claim hard enforcement from plain feedback alone. Hard enforcement requires an applied saved lesson, generated prevention rule, or decision evaluation.
 - Confirm every saved lesson with the exact future behavior it changes.
+- Never say "I saved this", "I'll remember this", "I'll keep doing this", or "I can still apply it going forward" unless the `captureFeedback` action returned a successful promoted/accepted result.
+- If `captureFeedback` fails with `401`, `403`, `5xx`, timeout, missing action, or any setup/auth error, say exactly: "Not saved in ThumbGate yet." Then state the setup failure in one sentence and give the owner fix: update the GPT Builder Action authentication to API Key -> Bearer with the raw `THUMBGATE_API_KEY`, re-import `https://thumbgate-production.up.railway.app/openapi.yaml`, and retest `captureFeedback`.
+- Do not ask the user whether to turn failed feedback into a hard rule after a save failure. The only next step is repair the Action setup or retry capture after the Action is healthy.
 - Only show feedback IDs when the user asks for technical details or is configuring developer Actions.
 - Keep confirmations short. The product feeling is: one signal becomes one remembered rule.
 
@@ -90,4 +93,4 @@ Import the full action schema from `adapters/chatgpt/openapi.yaml`, then configu
 
 ## GPT Avatar
 
-Use the existing ThumbGate logo/icon.
+Use `public/assets/brand/thumbgate-icon-512.png` as the GPT avatar. It is the canonical dark rounded-square TG gate monogram. Expected SHA-256: `6f0290f7fe50de9a82c18be2299deafba4c686df46b3b5309e363a7d589d89dc`. Do not use `docs/logo-400x400.png`, the Claude plugin icon, a generic cube, emoji thumbs, or an auto-generated ChatGPT image.

--- a/docs/chatgpt-live-audit-2026-04-24.md
+++ b/docs/chatgpt-live-audit-2026-04-24.md
@@ -1,0 +1,57 @@
+# ChatGPT GPT Live Audit - 2026-04-24
+
+Public GPT URL: https://chatgpt.com/g/g-69dcfd1cd5f881918ae31874631d6f08-thumbgate
+
+This audit records the live published GPT state visible from the public ChatGPT page on 2026-04-24. It exists to make the repair path concrete: the GPT Builder configuration is stale even though the production ThumbGate API is online.
+
+## Confirmed Live Drift
+
+- The published GPT still exposes `thumbgate-production.up.railway.app` as the Actions domain.
+- The published Action metadata includes `authorization_type: bearer`, so feedback capture depends on GPT Builder's saved Bearer secret.
+- The public page includes the `captureFeedback` route (`/v1/feedback/capture`) and `evaluateDecision` route (`/v1/decisions/evaluate`).
+- The Action metadata shows empty custom Action instructions (`instructions: ""` in the embedded action block).
+- The GPT profile image fields are present but not populated with a usable ThumbGate asset in the public metadata.
+- The GPT is showing ChatGPT's built-in `ember` emoji/theme state instead of the canonical ThumbGate icon.
+
+## Production API Check
+
+Production health endpoint:
+
+```text
+GET https://thumbgate-production.up.railway.app/healthz
+HTTP 200
+{"status":"ok","feedbackLogPath":"/data/feedback/feedback-log.jsonl","memoryLogPath":"/data/feedback/memory-log.jsonl"}
+```
+
+Unauthenticated feedback capture check:
+
+```text
+POST https://thumbgate-production.up.railway.app/v1/feedback/capture
+HTTP 401
+{"type":"urn:thumbgate:error:unauthorized","title":"Unauthorized","status":401,"detail":"A valid API key is required to access this endpoint."}
+```
+
+This means the backend is correctly requiring a Bearer key. The screenshot failure is consistent with the published GPT Action not having a valid owner-managed Bearer secret configured in GPT Builder, not with the production API being down.
+
+## Required GPT Builder Repair
+
+Use the canonical update packet in `docs/gpt-store-submission.md` and `docs/chatgpt-gpt-instructions.md`.
+
+Minimum live repair checklist:
+
+- Re-import `https://thumbgate-production.up.railway.app/openapi.yaml`.
+- Configure Actions authentication as API Key -> Bearer with the raw owner-managed `THUMBGATE_API_KEY`.
+- Test `captureFeedback` in GPT Builder until it returns `200 OK` with `accepted: true`.
+- Upload `public/assets/brand/thumbgate-icon-512.png` as the GPT avatar.
+- Confirm the avatar SHA-256 is `6f0290f7fe50de9a82c18be2299deafba4c686df46b3b5309e363a7d589d89dc`.
+- Do not use `docs/logo-400x400.png`, `.claude-plugin/bundle/icon.png`, a generic cube, emoji thumbs, or a generated ChatGPT image.
+
+## User-Facing Failure Copy
+
+If the Action cannot save feedback, the GPT must say:
+
+```text
+Not saved in ThumbGate yet.
+```
+
+It must not say "I saved this", "I'll remember this", "I'll keep doing this", or "I can still apply it going forward" unless `captureFeedback` returned a successful accepted/promoted result.

--- a/docs/gpt-store-submission.md
+++ b/docs/gpt-store-submission.md
@@ -13,6 +13,8 @@ This page remains the canonical copy-paste submission packet for updating the GP
 
 > **ACTION REQUIRED (operator):** the live GPT listing currently shows earlier copy. Sync by opening https://chat.openai.com/gpts/editor → ThumbGate → Configure, and pasting the sections below into Name, Description, Instructions, and Conversation Starters. A publish bump is required for the updated copy to show in Explore GPTs.
 
+Live repair audit: `docs/chatgpt-live-audit-2026-04-24.md` records the current published GPT drift: empty profile image metadata, built-in `ember` emoji/theme state, stale Action instructions, and feedback capture behavior consistent with a missing or stale GPT Builder Bearer secret.
+
 ---
 
 ## GPT Name

--- a/docs/gpt-store-submission.md
+++ b/docs/gpt-store-submission.md
@@ -70,6 +70,9 @@ User experience rules:
 - Sell outcomes before infrastructure: prevent expensive AI mistakes, make AI stop repeating mistakes, and turn a smart assistant into a reliable operator.
 - Be precise about scope: this GPT provides advice, checkpointing, and memory capture; hard blocking applies to actions routed through ThumbGate locally, in CI, or through the decision endpoint.
 - Confirm every saved lesson with the exact future behavior it changes.
+- Never say "I saved this", "I'll remember this", "I'll keep doing this", or "I can still apply it going forward" unless the `captureFeedback` action returned a successful promoted/accepted result.
+- If `captureFeedback` fails with `401`, `403`, `5xx`, timeout, missing action, or any setup/auth error, say exactly: "Not saved in ThumbGate yet." Then state the setup failure in one sentence and give the owner fix: update the GPT Builder Action authentication to API Key -> Bearer with the raw `THUMBGATE_API_KEY`, re-import `https://thumbgate-production.up.railway.app/openapi.yaml`, and retest `captureFeedback`.
+- Do not ask the user whether to turn failed feedback into a hard rule after a save failure. The only next step is repair the Action setup or retry capture after the Action is healthy.
 - Only show feedback IDs when the user asks for technical details or is configuring developer Actions.
 - Keep confirmations short. The product feeling is: one signal becomes one remembered rule.
 
@@ -231,7 +234,19 @@ components:
 
 ## Profile Image Suggestion
 
-A simple icon: blue feedback loop arrow (circular) with a thumbs-up/thumbs-down overlay. Or use the GitHub social preview image from the repo.
+Use the canonical ThumbGate GPT avatar:
+
+```
+public/assets/brand/thumbgate-icon-512.png
+```
+
+Expected SHA-256:
+
+```
+6f0290f7fe50de9a82c18be2299deafba4c686df46b3b5309e363a7d589d89dc
+```
+
+This is the dark rounded-square TG gate monogram. Do not use `docs/logo-400x400.png`, `.claude-plugin/bundle/icon.png`, a generic cube, emoji thumbs, or a generated image.
 
 ---
 
@@ -251,8 +266,9 @@ https://thumbgate-production.up.railway.app/privacy
 - [ ] Conversation starters added
 - [ ] OpenAPI schema imported (Actions tab)
 - [ ] API key authentication configured
+- [ ] `captureFeedback` tested after publish settings change; it returns `200 OK` with `accepted: true`
 - [ ] Category set to Programming / Productivity
-- [ ] Profile image uploaded
+- [ ] Profile image uploaded from `public/assets/brand/thumbgate-icon-512.png` and visually checked in ChatGPT mobile/desktop
 - [ ] Privacy policy URL added
 - [ ] Test: send a capture feedback message and verify API call succeeds
 - [ ] Submit for review

--- a/tests/brand-assets.test.js
+++ b/tests/brand-assets.test.js
@@ -9,7 +9,9 @@ const markPath = path.join(repoRoot, 'public', 'assets', 'brand', 'thumbgate-mar
 // Transparent full-bleed mark — correct for site-header inline use next to the wordmark
 const inlineMarkPath = path.join(repoRoot, 'public', 'assets', 'brand', 'thumbgate-mark-inline.svg');
 const faviconPngPath = path.join(repoRoot, 'public', 'thumbgate-icon.png');
+const canonicalGptIconPath = path.join(repoRoot, 'public', 'assets', 'brand', 'thumbgate-icon-512.png');
 const ogPngPath = path.join(repoRoot, 'public', 'og.png');
+const CANONICAL_GPT_ICON_SHA256 = '6f0290f7fe50de9a82c18be2299deafba4c686df46b3b5309e363a7d589d89dc';
 
 test('ThumbGate app-icon mark SVG exists at /assets/brand (for apple-touch-icon / PWA)', () => {
   assert.equal(fs.existsSync(markPath), true, 'public/assets/brand/thumbgate-mark.svg must exist');
@@ -60,6 +62,38 @@ test('ThumbGate favicon PNG exists for crisp tab and bookmark rendering', () => 
   assert.equal(buf[1], 0x50);
   assert.equal(buf[2], 0x4e);
   assert.equal(buf[3], 0x47);
+});
+
+test('ChatGPT GPT submission uses the canonical TG gate monogram avatar', () => {
+  assert.equal(
+    fs.existsSync(canonicalGptIconPath),
+    true,
+    'public/assets/brand/thumbgate-icon-512.png must exist for the GPT avatar',
+  );
+
+  const crypto = require('node:crypto');
+  const canonicalIcon = fs.readFileSync(canonicalGptIconPath);
+  assert.equal(crypto.createHash('sha256').update(canonicalIcon).digest('hex'), CANONICAL_GPT_ICON_SHA256);
+
+  const publicIcon = fs.readFileSync(faviconPngPath);
+  assert.equal(
+    crypto.createHash('sha256').update(publicIcon).digest('hex'),
+    CANONICAL_GPT_ICON_SHA256,
+    'public/thumbgate-icon.png must stay byte-identical to the canonical GPT avatar',
+  );
+
+  const chatgptInstructions = fs.readFileSync(path.join(repoRoot, 'docs', 'chatgpt-gpt-instructions.md'), 'utf8');
+  const gptStoreSubmission = fs.readFileSync(path.join(repoRoot, 'docs', 'gpt-store-submission.md'), 'utf8');
+  const chatgptInstall = fs.readFileSync(path.join(repoRoot, 'adapters', 'chatgpt', 'INSTALL.md'), 'utf8');
+
+  for (const content of [chatgptInstructions, gptStoreSubmission, chatgptInstall]) {
+    assert.match(content, /public\/assets\/brand\/thumbgate-icon-512\.png/);
+    assert.match(content, new RegExp(CANONICAL_GPT_ICON_SHA256));
+    assert.match(content, /generic cube|emoji thumbs|generated image|auto-generated ChatGPT image/i);
+  }
+
+  assert.doesNotMatch(gptStoreSubmission, /blue feedback loop arrow \(circular\)/i);
+  assert.doesNotMatch(gptStoreSubmission, /GitHub social preview image/i);
 });
 
 test('ThumbGate og-image PNG exists for link previews', () => {

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -121,6 +121,12 @@ test('public docs render the current package version', () => {
   assert.match(chatgptInstall, /Thumbs up: this answer gave file paths, commands, and tests/i);
   assert.match(chatgptInstall, /Paste the risky AI action before it runs, or tell me what went right\/wrong/i);
   assert.match(chatgptInstall, /native feedback buttons may send feedback to OpenAI/i);
+  assert.match(chatgptInstall, /Not saved in ThumbGate yet/i);
+  assert.match(chatgptInstall, /must not say it saved the lesson/i);
+  assert.match(chatgptInstall, /API Key -> Bearer with the raw THUMBGATE_API_KEY/i);
+  assert.match(chatgptInstall, /public\/assets\/brand\/thumbgate-icon-512\.png/);
+  assert.match(chatgptInstall, /6f0290f7fe50de9a82c18be2299deafba4c686df46b3b5309e363a7d589d89dc/);
+  assert.doesNotMatch(chatgptInstall, /blue feedback loop arrow \(circular\)/i);
   assert.match(chatgptInstall, /Regular GPT users should not need an API key, JSON payload, OpenAPI knowledge, or developer setup/i);
   assert.match(chatgptInstall, /Users do \*\*not\*\* have to keep chatting inside the ThumbGate GPT for enforcement/i);
   assert.match(chatgptInstall, /every landing page, README, social post, and plugin listing should point to the live GPT/i);
@@ -142,6 +148,11 @@ test('public docs render the current package version', () => {
   assert.match(chatgptInstructions, /public front door for ThumbGate/i);
   assert.match(chatgptInstructions, /Hard enforcement runs locally after `npx thumbgate init` where your agent actually executes/i);
   assert.match(chatgptInstructions, /Regular users should never need an API key, JSON payload, OpenAPI knowledge, or developer setup/i);
+  assert.match(chatgptInstructions, /Never say "I saved this", "I'll remember this", "I'll keep doing this", or "I can still apply it going forward"/);
+  assert.match(chatgptInstructions, /Not saved in ThumbGate yet/i);
+  assert.match(chatgptInstructions, /API Key -> Bearer with the raw `THUMBGATE_API_KEY`/);
+  assert.match(chatgptInstructions, /public\/assets\/brand\/thumbgate-icon-512\.png/);
+  assert.match(chatgptInstructions, /Do not use `docs\/logo-400x400\.png`, the Claude plugin icon, a generic cube, emoji thumbs, or an auto-generated ChatGPT image/);
   assert.doesNotMatch(chatgptInstructions, /Setup Concierge/i);
   assert.doesNotMatch(chatgptInstructions, /AI safety gate/i);
   assert.match(gptStoreSubmission, /published-user-confirmed/);
@@ -162,6 +173,13 @@ test('public docs render the current package version', () => {
   assert.match(gptStoreSubmission, /Never make regular users write JSON/);
   assert.match(gptStoreSubmission, /Regular users should never be asked for API keys/);
   assert.match(gptStoreSubmission, /Only show feedback IDs when the user asks for technical details/i);
+  assert.match(gptStoreSubmission, /Never say "I saved this", "I'll remember this", "I'll keep doing this", or "I can still apply it going forward"/);
+  assert.match(gptStoreSubmission, /Not saved in ThumbGate yet/i);
+  assert.match(gptStoreSubmission, /API Key -> Bearer with the raw `THUMBGATE_API_KEY`/);
+  assert.match(gptStoreSubmission, /public\/assets\/brand\/thumbgate-icon-512\.png/);
+  assert.match(gptStoreSubmission, /6f0290f7fe50de9a82c18be2299deafba4c686df46b3b5309e363a7d589d89dc/);
+  assert.match(gptStoreSubmission, /Do not use `docs\/logo-400x400\.png`, `.claude-plugin\/bundle\/icon\.png`, a generic cube, emoji thumbs, or a generated image/);
+  assert.doesNotMatch(gptStoreSubmission, /blue feedback loop arrow \(circular\)/i);
   assert.match(gptStoreSubmission, /https:\/\/thumbgate-production\.up\.railway\.app\/privacy/);
   assert.match(gptStoreSubmission, /Category set to Programming \/ Productivity/);
   assert.match(gptStoreSubmission, /Stop my agent from editing generated files/i);


### PR DESCRIPTION
## Summary
- harden ChatGPT GPT instructions so failed `captureFeedback` calls say "Not saved in ThumbGate yet" instead of implying memory was saved
- pin the canonical ThumbGate GPT avatar to `public/assets/brand/thumbgate-icon-512.png` and forbid stale/generic icon sources
- add a live 2026-04-24 audit documenting published GPT drift: empty profile image metadata, ember theme state, stale action instructions, and auth behavior consistent with a missing/stale GPT Builder Bearer secret

## Verification
- `node --test tests/version-metadata.test.js tests/brand-assets.test.js`
- `git diff --check`
- production `/healthz` returned HTTP 200
- unauthenticated `POST /v1/feedback/capture` returned HTTP 401 as expected because production requires a Bearer key

## Operational notes
- branch was rebased onto current `origin/main` and now contains only the ChatGPT repair commits
- PR creation required switching `gh` from the restricted `ganapolsky-i_subway` account to the personal `IgorGanapolsky` keyring account