### PR TITLE
feat(gtm): harden evidence-backed revenue assets

### DIFF
--- a/.changeset/evidence-backed-revenue-assets.md
+++ b/.changeset/evidence-backed-revenue-assets.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Harden the GTM revenue loop with evidence-based target scoring, operator-ready CSV prospect queues, and a discovery-first launch checklist that prioritizes validated outreach over stale broadcast playbooks.

--- a/LAUNCH_NOW.md
+++ b/LAUNCH_NOW.md
@@ -1,120 +1,132 @@
-# LAUNCH NOW — Revenue Ignition Checklist
+# LAUNCH NOW — Discovery-First Revenue Checklist
 
-**Status as of 2026-04-14:** $0 lifetime revenue. 0 signups. Funnel is wired, product is shipped, copy is written. **Nothing has been posted.** This file is the single-page launch trigger.
+**Status as of 2026-04-25:** local revenue status shows `0` lifetime revenue, `0` paid orders, `0` tracked leads, and `0` checkout starts. Treat this file as an operator playbook for creating qualified conversations, not as proof of traction.
 
-Every line is a copy-paste action. Do them in order. Total time: ~45 minutes.
+Every line below is evidence-backed and channel-current. Do them in order.
 
 ---
 
-## Pre-flight (5 min) — verify the funnel is actually alive
+## Pre-flight (5 min) — verify the funnel is alive
 
 ```bash
 # 1. Landing page loads
-curl -sS https://thumbgate-production.up.railway.app/ | grep -q 'ThumbGate' && echo "✅ landing up" || echo "❌ landing DOWN"
+curl -sS https://thumbgate-production.up.railway.app/ | grep -q 'ThumbGate' && echo "landing up" || echo "landing down"
 
-# 2. Checkout endpoint responds
-curl -sS -o /dev/null -w "%{http_code}\n" https://thumbgate-production.up.railway.app/checkout/pro
+# 2. Workflow sprint intake is reachable
+curl -sS https://thumbgate-production.up.railway.app/ | grep -q 'workflow-sprint-intake' && echo "sprint intake linked" || echo "sprint intake missing"
 
-# 3. Health endpoint returns current version
-curl -sS https://thumbgate-production.up.railway.app/health | head -c 200
+# 3. Current commercial snapshot is explicit
+npm run revenue:status:local
 ```
 
-If any of those fail: STOP and fix before posting. You do not want to land traffic on a broken funnel.
+If any of those fail, stop and fix the funnel before outreach.
 
 ---
 
-## Step 1 — Show HN  (window: Sun 9 PM ET or Tue 7 AM ET)
-
-**Submit at:** https://news.ycombinator.com/submit
-
-- **Title** (paste exactly): `Show HN: ThumbGate – Persistent memory for AI coding agents`
-- **URL:** `https://github.com/IgorGanapolsky/ThumbGate`
-- **Text** (leave blank — HN prefers URL-only for Show HN if you have a GitHub link; or paste the body from [docs/marketing/show-hn.md](docs/marketing/show-hn.md) if you want a text post)
-
-**After posting:**
-- Post first comment immediately with the 30-sec demo + `npx thumbgate init` command.
-- Stay at the keyboard for 2 hours. Every comment gets a reply within 5 minutes. HN ranking decays fast.
-
----
-
-## Step 2 — X/Twitter thread  (fire 30 min after Show HN goes live)
-
-Source: [docs/marketing/x-launch-thread.md](docs/marketing/x-launch-thread.md) (10 tweets, pre-written)
-
-- Paste Tweet 1 → schedule the rest as a thread reply chain.
-- Quote-tweet the Show HN link in tweet 10.
-- Attach: [docs/marketing/assets/ai-reliability-system-x-card.svg](docs/marketing/assets/ai-reliability-system-x-card.svg)
-
----
-
-## Step 3 — Reddit seeding  (90 min after Show HN, one sub per hour)
-
-Post order (rate-limit yourself — Reddit bans burst cross-posting):
-
-| Order | Subreddit | Source file | Status |
-|-------|-----------|-------------|--------|
-| 1 | r/ClaudeAI | [docs/marketing/reddit-posts/r-claudeai.md](docs/marketing/reddit-posts/r-claudeai.md) | [ ] |
-| 2 | r/LocalLLaMA | [docs/marketing/reddit-posts/r-locallama.md](docs/marketing/reddit-posts/r-locallama.md) | [ ] |
-| 3 | r/ChatGPTCoding | [docs/marketing/reddit-posts/r-chatgptcoding.md](docs/marketing/reddit-posts/r-chatgptcoding.md) | [ ] |
-| 4 | r/node | [docs/marketing/reddit-posts/r-node.md](docs/marketing/reddit-posts/r-node.md) | [ ] |
-| 5 | r/webdev | [docs/marketing/reddit-posts/r-webdev.md](docs/marketing/reddit-posts/r-webdev.md) | [ ] |
-
-After each post, tick the STATUS.md file.
-
-**Rule:** Do not paste a store link or `/checkout/pro` in Reddit posts. Reddit kills vendor posts. Link to the GitHub repo only. The README converts from there.
-
----
-
-## Step 4 — LinkedIn / dev.to  (day 2)
-
-- LinkedIn reliability post: [docs/marketing/linkedin-ai-reliability-post.md](docs/marketing/linkedin-ai-reliability-post.md)
-- dev.to article: [docs/marketing/devto-article.md](docs/marketing/devto-article.md)
-- Cross-post to hashnode + medium (same body).
-
----
-
-## Step 5 — Product Hunt  (next Tuesday 12:01 AM PT)
-
-Kit: [docs/marketing/product-hunt-launch-kit.md](docs/marketing/product-hunt-launch-kit.md)
-
-PH wants you to line up 10+ hunters in advance. Start DMing today.
-
----
-
-## Step 6 — Outbound (parallel to launch)
-
-- Cold outreach (20 targets/day): [docs/marketing/cold-outreach-sequence.md](docs/marketing/cold-outreach-sequence.md)
-- Target list: [docs/OUTREACH_TARGETS.md](docs/OUTREACH_TARGETS.md) — List A (consulting firms) first, highest ACV.
-- Team intake is your highest-value funnel at $49/seat/mo × 3-seat minimum = $147 MRR per close.
-
----
-
-## Kill switches — stop immediately if these happen
-
-- Railway returns 5xx on `/` or `/checkout/pro` → pull the launch, post a stickied comment, fix, relaunch.
-- Show HN gets downvoted to page 3 inside 30 min → don't amplify with paid, reassess post title and resubmit next cycle.
-- Stripe checkout fails → you lose every visitor who clicked. Verify with `curl` BEFORE posting HN.
-
----
-
-## What success looks like (48h targets)
-
-| Metric | Target | Measure via |
-|---|---|---|
-| Landing page visits | 500+ | PostHog funnel |
-| npm installs | 30+ | `npm view thumbgate` download count |
-| GitHub stars | 50+ | repo page |
-| Paid Pro conversions | 3+ | `node bin/cli.js cfo --today` |
-| Show HN points | 30+ | HN front page |
-
-If 48h hits <100 visits: the problem is the post timing/title, not the product. Rewrite the hook and retry next cycle.
-
----
-
-## After first sale
+## Step 1 — generate the target queue
 
 ```bash
-node bin/cli.js cfo --today   # verify the ledger saw it
+REPORT_DIR="reports/gtm/$(date +%F)-selling-now"
+npm run gtm:revenue-loop -- --report-dir "$REPORT_DIR" --max-targets=12
 ```
 
-Screenshot. Post it publicly ("first dollar"). That screenshot is more conversion fuel than any ad.
+Review three files before sending anything:
+
+- `gtm-revenue-loop.md` for the current commercial truth and directive
+- `gtm-revenue-loop.json` for the machine-readable queue
+- `gtm-target-queue.csv` for operator copy/paste into a tracker or CRM
+
+Rule: if a target has weak workflow evidence, do not contact them just because they are recent.
+
+---
+
+## Step 2 — import the queue into the local sales ledger
+
+```bash
+npm run sales:pipeline -- import \
+  --source "$REPORT_DIR/gtm-revenue-loop.json" \
+  --out "$REPORT_DIR/sales-pipeline.md"
+```
+
+The lead only exists after it is in the ledger. A repo URL or social profile alone is not pipeline state.
+
+---
+
+## Step 3 — send the warm discovery messages first
+
+Start with the warm targets in [docs/marketing/team-outreach-messages.md](docs/marketing/team-outreach-messages.md). The first-touch offer stays:
+
+> I will harden one AI-agent workflow for you.
+
+Do not lead with Pro.
+Do not lead with the proof pack.
+Do not count a sent message as progress until the lead is advanced to `contacted`.
+
+---
+
+## Step 4 — contact the strongest cold targets from the report
+
+Use only the targets with clear workflow evidence, operator ownership, or production-system integration. Move each lead explicitly:
+
+```bash
+npm run sales:pipeline -- advance \
+  --lead <lead-id> \
+  --stage contacted \
+  --channel github \
+  --note "Sent workflow hardening outreach from the 2026-04-25 revenue loop"
+```
+
+Advance stages only when the real-world event happened:
+
+`targeted -> contacted -> replied -> call_booked -> checkout_started or sprint_intake -> paid`
+
+---
+
+## Step 5 — use public channels only after direct outreach is running
+
+Current active channels are Reddit, LinkedIn, Threads, Bluesky, Instagram, and YouTube.
+X/Twitter is retired from active distribution.
+
+Public posting is support for the direct pipeline, not the primary motion:
+
+- Reddit: reply where the workflow pain is explicit, then route qualified leads into DM or intake.
+- LinkedIn: post proof-backed workflow hardening content once buyer language is current.
+- Threads, Bluesky, Instagram, YouTube: repurpose only after the direct offer and landing copy match what buyers actually said.
+
+Do not treat generic posting as sales progress.
+
+---
+
+## Step 6 — update marketplace and proof assets only when they match reality
+
+Before refreshing listing copy or directory submissions, make sure these remain aligned:
+
+- [docs/COMMERCIAL_TRUTH.md](docs/COMMERCIAL_TRUTH.md)
+- [docs/VERIFICATION_EVIDENCE.md](docs/VERIFICATION_EVIDENCE.md)
+- [.claude-plugin/marketplace.json](.claude-plugin/marketplace.json)
+- [.agents/plugins/marketplace.json](.agents/plugins/marketplace.json)
+- [plugins/cursor-marketplace/.cursor-plugin/plugin.json](plugins/cursor-marketplace/.cursor-plugin/plugin.json)
+
+If the direct outreach language changes, update the listings to match. Never invent installs, customers, or revenue.
+
+---
+
+## Kill switches
+
+- Landing page or intake is down: pause all outreach.
+- Queue is full of weak or low-signal targets: improve targeting before sending messages.
+- Public copy drifts from `COMMERCIAL_TRUTH.md`: fix the source copy before posting.
+- Proof pack is used before pain is confirmed: stop and rewrite the outreach.
+
+---
+
+## What success looks like for the next 7 days
+
+- `12` evidence-backed targets generated and imported
+- `4` warm leads contacted
+- `8` cold leads contacted
+- `3` replies
+- `2` discovery calls or sprint-intake starts
+- `1` paid sprint or named pilot agreement
+
+The operating goal is not awareness. The goal is the first booked Workflow Hardening Sprint.

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -10,6 +10,34 @@ const { ensureDir } = require('./fs-utils');
 const GITHUB_API_BASE_URL = 'https://api.github.com/';
 const COMMERCIAL_TRUTH_LINK = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md';
 const VERIFICATION_EVIDENCE_LINK = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md';
+const TARGET_SEARCH_QUERIES = [
+  'search/repositories?q=Model+Context+Protocol+workflow+automation+sort:updated',
+  'search/repositories?q=Model+Context+Protocol+production+security+sort:stars',
+  'search/repositories?q=Claude+Code+review+automation+sort:updated',
+];
+const SELF_SERVE_ONLY_SIGNALS = /\b(awesome|list|example|template|demo|tutorial|course|personal|dotfiles|toy|boilerplate)\b/;
+const TARGET_SIGNAL_RULES = [
+  {
+    label: 'workflow control surface',
+    pattern: /\b(workflow|approval|review|handoff|governance|gate|guardrail|policy|audit|proof)\b/,
+    weight: 4,
+  },
+  {
+    label: 'production or platform workflow',
+    pattern: /\b(production|platform|deploy|deployment|incident|sre|ci|cd|release|security|compliance)\b/,
+    weight: 4,
+  },
+  {
+    label: 'business-system integration',
+    pattern: /\b(jira|github|gitlab|microsoft ?365|office|google drive|calendar|slack|salesforce|crm|analytics)\b/,
+    weight: 3,
+  },
+  {
+    label: 'agent infrastructure',
+    pattern: /\b(mcp|model context protocol|agent|automation|memory|context|tool use|orchestrator)\b/,
+    weight: 2,
+  },
+];
 
 function getGoogleGenAI() {
   try {
@@ -101,6 +129,20 @@ function clampTargetCount(value) {
 function normalizeText(value) {
   if (value === undefined || value === null) return '';
   return String(value).trim();
+}
+
+function dedupeList(values = []) {
+  const seen = new Set();
+  const deduped = [];
+  for (const value of values) {
+    const normalized = normalizeText(value);
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(normalized);
+  }
+  return deduped;
 }
 
 function buildRevenueLinks(config = resolveHostedBillingConfig({
@@ -268,15 +310,69 @@ function dedupeTargets(targets) {
   return unique;
 }
 
-async function prospectTargets(maxTargets = 6, { fetchImpl = globalThis.fetch } = {}) {
-  const queries = [
-    'search/repositories?q=MCP+Model+Context+Protocol+sort:updated',
-    'search/repositories?q=Claude+Code+MCP+sort:updated',
-  ];
+function hasCredibleRepoIdentity(target) {
+  const repoName = normalizeText(target.repoName);
+  const normalized = repoName.replace(/[^a-z0-9]/gi, '');
+  return normalized.length >= 4;
+}
 
+function analyzeTargetEvidence(target) {
+  const haystack = `${normalizeText(target.repoName)} ${normalizeText(target.description)}`.toLowerCase();
+  const evidence = [];
+  let score = 0;
+
+  for (const rule of TARGET_SIGNAL_RULES) {
+    if (!rule.pattern.test(haystack)) continue;
+    score += rule.weight;
+    evidence.push(rule.label);
+  }
+
+  if (target.stars >= 100) {
+    score += 4;
+    evidence.push(`${target.stars} GitHub stars`);
+  } else if (target.stars >= 25) {
+    score += 3;
+    evidence.push(`${target.stars} GitHub stars`);
+  } else if (target.stars >= 5) {
+    score += 2;
+    evidence.push(`${target.stars} GitHub stars`);
+  }
+
+  const updatedAt = normalizeText(target.updatedAt);
+  if (updatedAt) {
+    const ageMs = Date.now() - Date.parse(updatedAt);
+    if (Number.isFinite(ageMs) && ageMs >= 0) {
+      const ageDays = ageMs / (24 * 60 * 60 * 1000);
+      if (ageDays <= 7) {
+        score += 2;
+        evidence.push('updated in the last 7 days');
+      } else if (ageDays <= 30) {
+        score += 1;
+        evidence.push('updated in the last 30 days');
+      }
+    }
+  }
+
+  let outreachAngle = 'Pitch one repeated workflow failure, then offer proof-backed hardening instead of a generic tool trial.';
+  if (/\b(jira|github|gitlab|microsoft ?365|office|google drive|calendar|slack|salesforce|crm|analytics)\b/.test(haystack)) {
+    outreachAngle = 'Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.';
+  } else if (/\b(production|platform|deploy|deployment|incident|sre|ci|cd|release|security|compliance)\b/.test(haystack)) {
+    outreachAngle = 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.';
+  } else if (/\b(memory|context|agent|orchestrator|tool use)\b/.test(haystack)) {
+    outreachAngle = 'Lead with context-drift hardening for one workflow before proposing any broader agent platform story.';
+  }
+
+  return {
+    score,
+    evidence: dedupeList(evidence),
+    outreachAngle,
+  };
+}
+
+async function prospectTargets(maxTargets = 6, { fetchImpl = globalThis.fetch } = {}) {
   const combined = [];
   const errors = [];
-  for (const endpoint of queries) {
+  for (const endpoint of TARGET_SEARCH_QUERIES) {
     const response = await fetchGitHubJson(endpoint, { fetchImpl });
     if (!response.ok) {
       errors.push(response.error);
@@ -296,36 +392,71 @@ async function prospectTargets(maxTargets = 6, { fetchImpl = globalThis.fetch } 
     }
   }
 
+  const ranked = dedupeTargets(combined)
+    .filter(hasCredibleRepoIdentity)
+    .map((target) => {
+      const evidence = analyzeTargetEvidence(target);
+      return {
+        ...target,
+        evidence,
+      };
+    })
+    .filter((target) => {
+      if (SELF_SERVE_ONLY_SIGNALS.test(`${target.repoName} ${target.description}`.toLowerCase())) {
+        return target.evidence.score >= 6;
+      }
+      return target.evidence.score >= 5;
+    })
+    .sort((left, right) => {
+      if (right.evidence.score !== left.evidence.score) {
+        return right.evidence.score - left.evidence.score;
+      }
+      if (right.stars !== left.stars) {
+        return right.stars - left.stars;
+      }
+      return String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''));
+    });
+
   return {
-    targets: dedupeTargets(combined).slice(0, maxTargets),
+    targets: ranked.slice(0, maxTargets),
     errors,
   };
 }
 
 function selectOutreachMotion(target, motionCatalog = buildMotionCatalog()) {
   const haystack = `${normalizeText(target.repoName)} ${normalizeText(target.description)}`.toLowerCase();
-  const proOnlySignals = /(awesome|list|example|template|demo|tutorial|course|personal|dotfiles|toy)/;
-  if (proOnlySignals.test(haystack)) {
+  if (SELF_SERVE_ONLY_SIGNALS.test(haystack)) {
     return {
       key: motionCatalog.pro.key,
       label: motionCatalog.pro.label,
-      reason: 'Target looks like a low-urgency self-serve/tooling fit, so Pro is the fallback CTA.',
+      reason: 'Target looks like a self-serve tooling surface, so Pro is the cleaner CTA unless a concrete workflow pain is confirmed.',
+    };
+  }
+
+  if ((target.evidence?.score || 0) >= 8) {
+    return {
+      key: motionCatalog.sprint.key,
+      label: motionCatalog.sprint.label,
+      reason: target.evidence.outreachAngle,
     };
   }
 
   return {
     key: motionCatalog.sprint.key,
     label: motionCatalog.sprint.label,
-    reason: 'Target can be approached with one concrete workflow-hardening offer before any generic Pro pitch.',
+    reason: target.evidence?.outreachAngle
+      || 'Target can be approached with one concrete workflow-hardening offer before any generic Pro pitch.',
   };
 }
 
 function buildFallbackMessage(target, selectedMotion, motionCatalog = buildMotionCatalog()) {
   const motion = motionCatalog[selectedMotion.key];
   const repoRef = `\`${target.repoName}\``;
+  const angle = normalizeText(target.evidence?.outreachAngle);
   if (selectedMotion.key === motionCatalog.sprint.key) {
     return [
       `Hey @${target.username}, saw you're shipping ${repoRef}. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run.`,
+      angle ? `${angle}` : '',
       `If ${repoRef} has one workflow that keeps breaking or losing context, I can harden that workflow for you: ${motion.cta}`
     ].join(' ');
   }
@@ -441,6 +572,9 @@ function buildRevenueLoopReport({ source, fallbackReason, summary, motionCatalog
       description: target.description,
       stars: target.stars,
       updatedAt: target.updatedAt,
+      evidenceScore: target.evidence?.score || 0,
+      evidence: target.evidence?.evidence || [],
+      outreachAngle: target.evidence?.outreachAngle || '',
       motion: target.selectedMotion.key,
       motionLabel: target.selectedMotion.label,
       motionReason: target.selectedMotion.reason,
@@ -458,6 +592,9 @@ function renderRevenueTargetMarkdown(target) {
     `- Pipeline stage: ${target.pipelineStage}`,
     `- Offer: ${target.offer}`,
     `- Repo: ${target.repoUrl || 'n/a'}`,
+    `- Evidence score: ${target.evidenceScore}`,
+    `- Evidence: ${target.evidence.length ? target.evidence.join(', ') : 'n/a'}`,
+    `- Outreach angle: ${target.outreachAngle || 'n/a'}`,
     `- Motion: ${target.motionLabel}`,
     `- Why: ${target.motionReason}`,
     `- CTA: ${target.cta}`,
@@ -511,10 +648,51 @@ function renderRevenueLoopMarkdown(report) {
   return `${lines.join('\n').trim()}\n`;
 }
 
+function escapeCsvValue(value) {
+  const text = normalizeText(value);
+  if (!text) return '';
+  const escaped = text.replace(/"/g, '""');
+  return /[",\n]/.test(escaped) ? `"${escaped}"` : escaped;
+}
+
+function renderRevenueLoopCsv(report) {
+  const rows = [
+    [
+      'username',
+      'repoName',
+      'repoUrl',
+      'offer',
+      'pipelineStage',
+      'evidenceScore',
+      'evidence',
+      'outreachAngle',
+      'motionLabel',
+      'cta',
+      'message',
+    ],
+    ...report.targets.map((target) => ([
+      target.username,
+      target.repoName,
+      target.repoUrl,
+      target.offer,
+      target.pipelineStage,
+      String(target.evidenceScore),
+      target.evidence.join('; '),
+      target.outreachAngle,
+      target.motionLabel,
+      target.cta,
+      target.message,
+    ])),
+  ];
+
+  return `${rows.map((row) => row.map(escapeCsvValue).join(',')).join('\n')}\n`;
+}
+
 function writeRevenueLoopOutputs(report, options = {}) {
   const repoRoot = path.resolve(__dirname, '..');
   const defaultDocsPath = path.join(repoRoot, 'docs', 'AUTONOMOUS_GITOPS.md');
   const markdown = renderRevenueLoopMarkdown(report);
+  const csv = renderRevenueLoopCsv(report);
   const reportDir = normalizeText(options.reportDir)
     ? path.resolve(repoRoot, options.reportDir)
     : '';
@@ -524,6 +702,7 @@ function writeRevenueLoopOutputs(report, options = {}) {
     ensureDir(reportDir);
     fs.writeFileSync(path.join(reportDir, 'gtm-revenue-loop.md'), markdown, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'gtm-revenue-loop.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.csv'), csv, 'utf8');
   }
 
   if (shouldWriteDocs) {
@@ -600,12 +779,14 @@ module.exports = {
   COMMERCIAL_TRUTH_LINK,
   VERIFICATION_EVIDENCE_LINK,
   buildFallbackMessage,
+  analyzeTargetEvidence,
   buildMotionCatalog,
   buildRevenueLinks,
   buildRevenueLoopReport,
   clampTargetCount,
   deriveRevenueDirective,
   fetchGitHubJson,
+  hasCredibleRepoIdentity,
   isCliInvocation,
   parseArgs,
   prospectTargets,

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -1,3 +1,6 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
@@ -5,6 +8,7 @@ const {
   analyzeTargetEvidence,
   buildFallbackMessage,
   buildMotionCatalog,
+  buildRevenueLoopReport,
   buildRevenueLinks,
   clampTargetCount,
   deriveRevenueDirective,
@@ -13,8 +17,10 @@ const {
   parseArgs,
   prospectTargets,
   renderRevenueLoopMarkdown,
+  runRevenueLoop,
   selectOutreachMotion,
   summarizeCommercialSnapshot,
+  writeRevenueLoopOutputs,
 } = require('../scripts/gtm-revenue-loop');
 
 test('motion catalog stays aligned with current commercial truth and proof links', () => {
@@ -324,4 +330,169 @@ test('first-touch outreach does not push proof before pain is confirmed', () => 
   assert.match(message, /harden/);
   assert.doesNotMatch(message, /VERIFICATION_EVIDENCE/);
   assert.doesNotMatch(message, /COMMERCIAL_TRUTH/);
+});
+
+test('revenue loop report keeps evidence metadata on each target', () => {
+  const links = buildRevenueLinks();
+  const catalog = buildMotionCatalog(links);
+  const report = buildRevenueLoopReport({
+    source: 'local',
+    fallbackReason: '',
+    summary: {
+      revenue: { paidOrders: 0, bookedRevenueCents: 0 },
+      trafficMetrics: {},
+      signups: {},
+      pipeline: {},
+    },
+    motionCatalog: catalog,
+    directive: {
+      state: 'cold-start',
+      objective: 'First 10 paying customers',
+      headline: 'No verified revenue and no active pipeline.',
+      primaryMotion: 'sprint',
+      secondaryMotion: 'pro',
+      actions: ['Lead with one workflow.'],
+    },
+    targets: [{
+      username: 'builder',
+      repoName: 'production-mcp-server',
+      repoUrl: 'https://github.com/example/production-mcp-server',
+      description: 'Production workflow automation with GitHub integrations.',
+      stars: 42,
+      updatedAt: '2026-04-20T00:00:00.000Z',
+      evidence: {
+        score: 9,
+        evidence: ['workflow control surface', '42 GitHub stars'],
+        outreachAngle: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+      },
+      selectedMotion: {
+        key: 'sprint',
+        label: catalog.sprint.label,
+        reason: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+      },
+      message: 'I can harden one production workflow for you this week.',
+    }],
+  });
+
+  assert.equal(report.targets[0].evidenceScore, 9);
+  assert.deepEqual(report.targets[0].evidence, ['workflow control surface', '42 GitHub stars']);
+  assert.match(report.targets[0].outreachAngle, /rollout proof/);
+  assert.equal(report.targets[0].offer, 'workflow_hardening_sprint');
+});
+
+test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for operator import', () => {
+  const links = buildRevenueLinks();
+  const catalog = buildMotionCatalog(links);
+  const report = {
+    generatedAt: '2026-04-25T00:00:00.000Z',
+    source: 'local',
+    fallbackReason: 'Hosted operational summary is not configured.',
+    currentTruth: {
+      publicSelfServeOffer: catalog.pro.label,
+      teamPilotOffer: catalog.sprint.label,
+      commercialTruthLink: catalog.pro.truth,
+      verificationEvidenceLink: catalog.pro.proof,
+    },
+    directive: {
+      state: 'cold-start',
+      objective: 'First 10 paying customers',
+      headline: 'No verified revenue and no active pipeline.',
+      primaryMotion: 'sprint',
+      secondaryMotion: 'pro',
+      actions: ['Lead with one workflow.'],
+    },
+    snapshot: {
+      paidOrders: 0,
+      bookedRevenueCents: 0,
+      checkoutStarts: 0,
+      uniqueLeads: 0,
+      sprintLeads: 0,
+      qualifiedSprintLeads: 0,
+    },
+    targets: [{
+      username: 'builder',
+      repoName: 'production-mcp-server',
+      repoUrl: 'https://github.com/example/production-mcp-server',
+      offer: 'workflow_hardening_sprint',
+      pipelineStage: 'targeted',
+      evidenceScore: 9,
+      evidence: ['workflow control surface', '42 GitHub stars'],
+      outreachAngle: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+      motionLabel: catalog.sprint.label,
+      motionReason: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+      cta: catalog.sprint.cta,
+      message: 'I can harden one workflow, then prove it.',
+    }],
+  };
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-gtm-'));
+
+  try {
+    const written = writeRevenueLoopOutputs(report, { reportDir });
+    const csvPath = path.join(reportDir, 'gtm-target-queue.csv');
+    const csv = fs.readFileSync(csvPath, 'utf8');
+
+    assert.equal(written.reportDir, reportDir);
+    assert.equal(written.docsPath, null);
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-revenue-loop.md')));
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-revenue-loop.json')));
+    assert.ok(fs.existsSync(csvPath));
+    assert.match(csv, /^username,repoName,repoUrl,offer,pipelineStage,evidenceScore,evidence,outreachAngle,motionLabel,cta,message/m);
+    assert.match(csv, /"I can harden one workflow, then prove it\."/);
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});
+
+test('runRevenueLoop writes an evidence-backed target queue with discovery warnings when GitHub search fails', async () => {
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-revenue-loop-'));
+  const originalGeminiKey = process.env.GEMINI_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+
+  try {
+    const { report, written } = await runRevenueLoop({
+      maxTargets: 2,
+      reportDir,
+      fetchImpl: async (url) => {
+        if (String(url).includes('Claude+Code+review+automation')) {
+          return {
+            ok: false,
+            status: 503,
+            async text() {
+              return 'search temporarily unavailable';
+            },
+          };
+        }
+
+        return {
+          ok: true,
+          async text() {
+            return JSON.stringify({
+              items: [{
+                owner: { login: 'builder' },
+                name: 'production-mcp-server',
+                html_url: 'https://github.com/example/production-mcp-server',
+                description: 'Production workflow automation with GitHub integrations.',
+                stargazers_count: 42,
+                updated_at: '2026-04-20T00:00:00.000Z',
+              }],
+            });
+          },
+        };
+      },
+    });
+
+    assert.equal(report.targets.length, 1);
+    assert.ok(Array.isArray(report.discoveryWarnings));
+    assert.equal(report.discoveryWarnings.length, 1);
+    assert.match(report.discoveryWarnings[0], /temporarily unavailable/);
+    assert.equal(written.reportDir, reportDir);
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.csv')));
+  } finally {
+    if (originalGeminiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiKey;
+    }
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
 });

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -2,12 +2,14 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+  analyzeTargetEvidence,
   buildFallbackMessage,
   buildMotionCatalog,
   buildRevenueLinks,
   clampTargetCount,
   deriveRevenueDirective,
   fetchGitHubJson,
+  hasCredibleRepoIdentity,
   parseArgs,
   prospectTargets,
   renderRevenueLoopMarkdown,
@@ -116,6 +118,10 @@ test('target classification leads with sprint unless target is clearly self-serv
   const sprintTarget = selectOutreachMotion({
     repoName: 'deployment-governance-agent',
     description: 'Production workflow governance and compliance gates for platform teams.',
+    evidence: {
+      score: 10,
+      outreachAngle: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+    },
   }, catalog);
   const proTarget = selectOutreachMotion({
     repoName: 'mcp-demo-template',
@@ -126,7 +132,31 @@ test('target classification leads with sprint unless target is clearly self-serv
   assert.equal(proTarget.key, 'pro');
 });
 
-test('prospects GitHub targets via REST search and dedupes repeated repos', async () => {
+test('target evidence favors production workflows over generic fresh repos', () => {
+  const strong = analyzeTargetEvidence({
+    repoName: 'jira-workflow-guardian',
+    description: 'Production Jira workflow governance with approval gates and audit proof for platform teams.',
+    stars: 84,
+    updatedAt: new Date().toISOString(),
+  });
+  const weak = analyzeTargetEvidence({
+    repoName: 'mcp-playground-demo',
+    description: 'Template demo for trying MCP quickly.',
+    stars: 0,
+    updatedAt: new Date().toISOString(),
+  });
+
+  assert.ok(strong.score > weak.score);
+  assert.ok(strong.evidence.some((entry) => /workflow control surface/i.test(entry)));
+  assert.match(strong.outreachAngle, /rollout proof|approval boundaries/i);
+});
+
+test('repo identity filter drops obviously weak identifiers', () => {
+  assert.equal(hasCredibleRepoIdentity({ repoName: '-L-' }), false);
+  assert.equal(hasCredibleRepoIdentity({ repoName: 'mcp-jira-stdio' }), true);
+});
+
+test('prospects GitHub targets via REST search, filters low-signal repos, and dedupes repeated repos', async () => {
   const requestedUrls = [];
   const fetchImpl = async (url, options) => {
     requestedUrls.push(String(url));
@@ -140,9 +170,9 @@ test('prospects GitHub targets via REST search and dedupes repeated repos', asyn
               owner: { login: 'builder' },
               name: 'production-mcp-server',
               html_url: 'https://github.com/builder/production-mcp-server',
-              description: 'Production MCP server',
+              description: 'Production MCP server for deployment workflow approvals and audit proof.',
               stargazers_count: 42,
-              updated_at: '2026-04-14T00:00:00Z',
+              updated_at: new Date().toISOString(),
             },
             {
               owner: { login: 'builder' },
@@ -150,7 +180,15 @@ test('prospects GitHub targets via REST search and dedupes repeated repos', asyn
               html_url: 'https://github.com/builder/production-mcp-server',
               description: 'Duplicate target',
               stargazers_count: 42,
-              updated_at: '2026-04-14T00:00:00Z',
+              updated_at: new Date().toISOString(),
+            },
+            {
+              owner: { login: 'builder' },
+              name: 'mcp-demo-template',
+              html_url: 'https://github.com/builder/mcp-demo-template',
+              description: 'Template demo for Claude Code builders.',
+              stargazers_count: 0,
+              updated_at: new Date().toISOString(),
             },
           ],
         });
@@ -163,7 +201,8 @@ test('prospects GitHub targets via REST search and dedupes repeated repos', asyn
   assert.equal(result.errors.length, 0);
   assert.equal(result.targets.length, 1);
   assert.equal(result.targets[0].username, 'builder');
-  assert.equal(requestedUrls.length, 2);
+  assert.ok(result.targets[0].evidence.score >= 5);
+  assert.equal(requestedUrls.length, 3);
   assert.ok(requestedUrls.every((url) => url.startsWith('https://api.github.com/search/repositories')));
 });
 
@@ -201,7 +240,7 @@ test('GitHub discovery reports API and parser failures as non-fatal warnings', a
   assert.equal(invalid.ok, false);
   assert.equal(unavailable.ok, false);
   assert.equal(prospects.targets.length, 0);
-  assert.equal(prospects.errors.length, 2);
+  assert.equal(prospects.errors.length, 3);
 });
 
 test('rendered revenue loop markdown anchors every target to truth and proof', () => {
@@ -247,6 +286,9 @@ test('rendered revenue loop markdown anchors every target to truth and proof', (
       username: 'builder',
       repoName: 'mcp-solo-helper',
       repoUrl: 'https://github.com/example/mcp-solo-helper',
+      evidenceScore: 8,
+      evidence: ['agent infrastructure', 'updated in the last 7 days'],
+      outreachAngle: 'Lead with context-drift hardening for one workflow before proposing any broader agent platform story.',
       motion: selectedMotion.key,
       motionLabel: selectedMotion.label,
       motionReason: selectedMotion.reason,
@@ -261,6 +303,8 @@ test('rendered revenue loop markdown anchors every target to truth and proof', (
   assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
   assert.match(markdown, /Workflow Hardening Sprint/);
   assert.match(markdown, /Pipeline stage: targeted/);
+  assert.match(markdown, /Evidence score: 8/);
+  assert.match(markdown, /Outreach angle:/);
   assert.doesNotMatch(markdown, /founding users today/i);
 });
 

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -182,6 +182,18 @@ test('launch-content variants align with reliability-over-orchestration position
   assert.doesNotMatch(launchContent, /persistent memory layer that fixes this/i);
 });
 
+test('launch-now playbook stays discovery-first and avoids retired broadcast channels', () => {
+  const launchNow = readText('LAUNCH_NOW.md');
+
+  assert.match(launchNow, /npm run gtm:revenue-loop/i);
+  assert.match(launchNow, /sales:pipeline -- import/i);
+  assert.match(launchNow, /Workflow Hardening Sprint/i);
+  assert.match(launchNow, /X\/Twitter is retired/i);
+  assert.match(launchNow, /Do not lead with Pro/i);
+  assert.doesNotMatch(launchNow, /Show HN/i);
+  assert.doesNotMatch(launchNow, /X\/Twitter thread/i);
+});
+
 test('public landing copy stays vendor-neutral and honest about editor support', () => {
   const congruence = readText(path.join('docs', 'MARKETING_COPY_CONGRUENCE.md'));
   const landingPage = readText(path.join('public', 'index.html'));


### PR DESCRIPTION
## Summary
- score and filter GTM revenue-loop targets using workflow, production, and business-system evidence instead of recency alone
- emit richer operator artifacts, including evidence-backed outreach angles and a CSV queue for direct outreach
- replace the stale launch playbook with the current discovery-first revenue motion and pin it with positioning tests

## Verification
- `npm ci`
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`
