### PR TITLE
feat(gtm): track Aiventyx marketplace attribution

### DIFF
--- a/.changeset/aiventyx-attribution-assets.md
+++ b/.changeset/aiventyx-attribution-assets.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add tracked Aiventyx marketplace CTAs and operator-ready listing export assets.

--- a/docs/marketing/aiventyx-marketplace-revenue-pack.md
+++ b/docs/marketing/aiventyx-marketplace-revenue-pack.md
@@ -1,77 +1,70 @@
 # Aiventyx Marketplace Revenue Pack
 
-Status: current
-Updated: April 25, 2026
+Updated: 2026-04-25T15:49:39.939Z
+Dashboard: https://aiventyx.com/dashboard
 
-This is the operator pack for turning the Aiventyx opportunity into tracked ThumbGate revenue. It is not proof of revenue, sent messages, or marketplace approval.
+This is a sales operator artifact. It is not proof of revenue, sent messages, or marketplace approval.
 
 ## Objective
 
-Use Aiventyx as a distribution-first lane for paid conversion:
+Turn existing marketplace visibility into tracked Pro conversions and qualified team conversations.
 
-- Primary signal: Pro paid conversions
-- Secondary signal: qualified team conversations for the Workflow Hardening Sprint
-- Non-signal: views, likes, or comments that do not become a tracked pipeline stage
-
-Dashboard: https://aiventyx.com/dashboard
-
-## Dashboard Entries
+## Listings To Submit
 
 ### ThumbGate Free
-
-- Status: keep existing free listing live
+- Dashboard status: keep existing free listing live
 - Category: AI Coding
 - Pricing model: Free
 - API endpoint: https://thumbgate-production.up.railway.app
-- Primary CTA: https://www.npmjs.com/package/thumbgate
+- Primary CTA: https://thumbgate-production.up.railway.app/go/install?utm_source=aiventyx&utm_medium=marketplace&utm_campaign=aiventyx_free_listing&utm_content=dashboard&campaign_variant=free&offer_code=AIVENTYX-FREE&cta_id=aiventyx_free_listing&cta_placement=marketplace_listing&landing_path=%2F
 - Conversion goal: install_or_free_usage
-- Buyer: solo builders evaluating local AI coding reliability
+- Buyer: Solo builders evaluating local AI coding reliability.
 - Headline: Turn AI-agent feedback into reusable pre-action gates.
-
-Description:
+- Attribution: utm_source=aiventyx, utm_medium=marketplace, utm_campaign=aiventyx_free_listing, offer_code=AIVENTYX-FREE
 
 ThumbGate captures thumbs up/down style corrections from AI coding sessions, turns them into searchable lessons, and regenerates pre-action gates so agents check known failure patterns before they act. Use the free package when you want local feedback capture, memory search, and CLI-first reliability checks for a single operator.
 
-### ThumbGate Pro
+Proof: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md | https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
-- Status: submit as paid listing
+### ThumbGate Pro
+- Dashboard status: submit as paid listing
 - Category: AI Coding
 - Pricing model: $19/mo or $149/yr
 - API endpoint: https://thumbgate-production.up.railway.app
-- Primary CTA: https://thumbgate-production.up.railway.app/checkout/pro
+- Primary CTA: https://thumbgate-production.up.railway.app/go/pro?utm_source=aiventyx&utm_medium=marketplace&utm_campaign=aiventyx_pro_listing&utm_content=dashboard&campaign_variant=pro&offer_code=AIVENTYX-PRO&cta_id=aiventyx_pro_listing&cta_placement=marketplace_listing&plan_id=pro&landing_path=%2F
 - Conversion goal: paid_pro_conversion
-- Buyer: solo operators and small teams with repeated AI coding mistakes but no team rollout yet
+- Buyer: Solo operators and small teams with repeated AI coding mistakes but no team rollout yet.
 - Headline: Personal AI reliability memory with proof-ready exports.
-
-Description:
+- Attribution: utm_source=aiventyx, utm_medium=marketplace, utm_campaign=aiventyx_pro_listing, offer_code=AIVENTYX-PRO
 
 ThumbGate Pro is for builders who want a personal reliability layer across AI coding sessions: synced lessons, feedback-to-gate enforcement, local dashboard views, DPO/KTO-ready exports, and evidence checks before completion claims. It keeps the free local loop intact while giving serious operators the paid path for durable memory and proof artifacts.
 
-### ThumbGate Teams
+Proof: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md | https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
-- Status: submit as team/service listing
+### ThumbGate Teams
+- Dashboard status: submit as team/service listing
 - Category: AI Coding
 - Pricing model: Workflow Hardening Sprint, then Team at $49/seat/mo with 3-seat minimum after qualification
 - API endpoint: https://thumbgate-production.up.railway.app
-- Primary CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Primary CTA: https://thumbgate-production.up.railway.app/?utm_source=aiventyx&utm_medium=marketplace&utm_campaign=aiventyx_teams_listing&utm_content=dashboard&campaign_variant=teams&offer_code=AIVENTYX-TEAMS&cta_id=aiventyx_teams_listing&cta_placement=marketplace_listing&landing_path=%2F#workflow-sprint-intake
 - Conversion goal: qualified_team_conversation
-- Buyer: teams with one valuable AI-agent workflow that keeps repeating the same mistake or losing operational context
+- Buyer: Teams with one valuable AI-agent workflow that keeps repeating the same mistake or losing operational context.
 - Headline: Harden one AI-agent workflow before scaling it team-wide.
-
-Description:
+- Attribution: utm_source=aiventyx, utm_medium=marketplace, utm_campaign=aiventyx_teams_listing, offer_code=AIVENTYX-TEAMS
 
 ThumbGate Teams starts with a Workflow Hardening Sprint: one workflow, one owner, one repeated failure, one proof review. The sprint turns repeated AI-agent mistakes into shared prevention gates, audit-ready evidence, and a rollout path for teams that need approvals, compliance, and repeatability.
+
+Proof: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md | https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
 ## 90-Day Measurement Plan
 
 - North star: paid_conversion
-- Fee position: accept the standard Aiventyx marketplace fee for the first listing phase
-- Integration position: defer pre-action review integration until 60-90 days of listing distribution data exists
+- Fee position: Accept the standard Aiventyx marketplace fee for the first listing phase.
+- Integration position: Defer pre-action review integration until 60-90 days of listing distribution data exists.
 - Minimum useful signal: one paid Pro conversion or one qualified team conversation
 - Strong signal: three paid conversions or three qualified team conversations
 
-Track these fields:
-
+Tracked metrics:
 - listing_views
 - cta_clicks
 - free_installs
@@ -80,18 +73,22 @@ Track these fields:
 - team_sprint_intake_submissions
 - qualified_team_conversations
 
-## Milestones
+Attribution contract:
+- Use only the tracked first-party CTAs below so Aiventyx clicks land with explicit source, medium, campaign, and offer metadata.
+- Free routes through `/go/install`, Pro routes through `/go/pro`, and Teams routes to the sprint intake with Aiventyx UTMs attached.
 
-- Days 0-30: get Pro and Teams listings live, baseline listing views, and record every CTA click with UTM attribution.
-- Days 31-60: optimize headline, screenshots, and CTA order around the listing that produces the highest paid-intent rate.
-- Days 61-90: decide whether Aiventyx deserves deeper integration, bundles, or partner-specific onboarding.
+Milestones:
+- days_0_30: Get Pro and Teams listings live, baseline listing views, and record every CTA click with UTM attribution.
+  Decision rule: Keep copy unchanged unless click-through is clearly below marketplace average.
+- days_31_60: Optimize headline, screenshots, and CTA order around the listing that produces the highest paid-intent rate.
+  Decision rule: If free installs happen without paid intent, move Pro proof and sprint qualification higher in the listing.
+- days_61_90: Decide whether Aiventyx deserves deeper integration, bundles, or partner-specific onboarding.
+  Decision rule: Only revisit pre-action review integration or rev-share bundles after paid conversions or qualified team conversations exist.
 
-Only revisit pre-action review integration or rev-share bundles after paid conversions or qualified team conversations exist.
-
-## Proof Links
-
-- Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
-- Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+Do not count as success:
+- views without CTA clicks
+- likes or comments without a tracked lead stage
+- unverified revenue claims
 
 ## Follow-Up Draft
 

--- a/scripts/aiventyx-marketplace-plan.js
+++ b/scripts/aiventyx-marketplace-plan.js
@@ -4,6 +4,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { ensureDir } = require('./fs-utils');
+const { buildUTMLink } = require('./social-analytics/utm');
 const {
   COMMERCIAL_TRUTH_LINK,
   VERIFICATION_EVIDENCE_LINK,
@@ -13,9 +14,58 @@ const {
 const DASHBOARD_URL = 'https://aiventyx.com/dashboard';
 const AI_CODING_CATEGORY = 'AI Coding';
 const STANDARD_MARKETPLACE_FEE = 'Accept the standard Aiventyx marketplace fee for the first listing phase.';
+const AIVENTYX_SOURCE = 'aiventyx';
+const AIVENTYX_MEDIUM = 'marketplace';
+const AIVENTYX_CONTENT = 'dashboard';
 
 function normalizeText(value) {
   return value === undefined || value === null ? '' : String(value).trim();
+}
+
+function csvCell(value) {
+  const text = normalizeText(value);
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function buildTrackedMarketplaceLink(baseUrl, tracking = {}) {
+  const url = new URL(buildUTMLink(baseUrl, {
+    source: tracking.utmSource,
+    medium: tracking.utmMedium,
+    campaign: tracking.utmCampaign,
+    content: tracking.utmContent,
+  }));
+
+  const extras = {
+    campaign_variant: tracking.campaignVariant,
+    offer_code: tracking.offerCode,
+    cta_id: tracking.ctaId,
+    cta_placement: tracking.ctaPlacement,
+    plan_id: tracking.planId,
+    landing_path: tracking.landingPath,
+  };
+  for (const [key, value] of Object.entries(extras)) {
+    if (normalizeText(value)) {
+      url.searchParams.set(key, normalizeText(value));
+    }
+  }
+
+  return url.toString();
+}
+
+function buildAiventyxTrackingMetadata(key) {
+  const normalizedKey = normalizeText(key).toLowerCase();
+  const upperKey = normalizedKey.toUpperCase();
+  return {
+    utmSource: AIVENTYX_SOURCE,
+    utmMedium: AIVENTYX_MEDIUM,
+    utmCampaign: `aiventyx_${normalizedKey}_listing`,
+    utmContent: AIVENTYX_CONTENT,
+    campaignVariant: normalizedKey,
+    offerCode: `AIVENTYX-${upperKey}`,
+    ctaPlacement: 'marketplace_listing',
+    ctaId: `aiventyx_${normalizedKey}_listing`,
+    landingPath: '/',
+  };
 }
 
 function parseArgs(argv = []) {
@@ -44,6 +94,13 @@ function parseArgs(argv = []) {
 }
 
 function buildAiventyxListings(links = buildRevenueLinks()) {
+  const freeTracking = buildAiventyxTrackingMetadata('free');
+  const proTracking = {
+    ...buildAiventyxTrackingMetadata('pro'),
+    planId: 'pro',
+  };
+  const teamsTracking = buildAiventyxTrackingMetadata('teams');
+
   return [
     {
       key: 'free',
@@ -52,7 +109,7 @@ function buildAiventyxListings(links = buildRevenueLinks()) {
       category: AI_CODING_CATEGORY,
       pricingModel: 'Free',
       APIEndpoint: links.appOrigin,
-      primaryCTA: 'https://www.npmjs.com/package/thumbgate',
+      primaryCTA: buildTrackedMarketplaceLink(`${links.appOrigin}/go/install`, freeTracking),
       headline: 'Turn AI-agent feedback into reusable pre-action gates.',
       description: [
         'ThumbGate captures thumbs up/down style corrections from AI coding sessions, turns them into searchable lessons, and regenerates pre-action gates so agents check known failure patterns before they act.',
@@ -60,6 +117,7 @@ function buildAiventyxListings(links = buildRevenueLinks()) {
       ].join(' '),
       buyer: 'Solo builders evaluating local AI coding reliability.',
       conversionGoal: 'install_or_free_usage',
+      attribution: freeTracking,
       proofLinks: [COMMERCIAL_TRUTH_LINK, VERIFICATION_EVIDENCE_LINK],
     },
     {
@@ -69,7 +127,7 @@ function buildAiventyxListings(links = buildRevenueLinks()) {
       category: AI_CODING_CATEGORY,
       pricingModel: '$19/mo or $149/yr',
       APIEndpoint: links.appOrigin,
-      primaryCTA: links.proCheckoutLink,
+      primaryCTA: buildTrackedMarketplaceLink(`${links.appOrigin}/go/pro`, proTracking),
       headline: 'Personal AI reliability memory with proof-ready exports.',
       description: [
         'ThumbGate Pro is for builders who want a personal reliability layer across AI coding sessions: synced lessons, feedback-to-gate enforcement, local dashboard views, DPO/KTO-ready exports, and evidence checks before completion claims.',
@@ -77,6 +135,7 @@ function buildAiventyxListings(links = buildRevenueLinks()) {
       ].join(' '),
       buyer: 'Solo operators and small teams with repeated AI coding mistakes but no team rollout yet.',
       conversionGoal: 'paid_pro_conversion',
+      attribution: proTracking,
       proofLinks: [COMMERCIAL_TRUTH_LINK, VERIFICATION_EVIDENCE_LINK],
     },
     {
@@ -86,7 +145,7 @@ function buildAiventyxListings(links = buildRevenueLinks()) {
       category: AI_CODING_CATEGORY,
       pricingModel: 'Workflow Hardening Sprint, then Team at $49/seat/mo with 3-seat minimum after qualification',
       APIEndpoint: links.appOrigin,
-      primaryCTA: links.sprintLink,
+      primaryCTA: buildTrackedMarketplaceLink(links.sprintLink, teamsTracking),
       headline: 'Harden one AI-agent workflow before scaling it team-wide.',
       description: [
         'ThumbGate Teams starts with a Workflow Hardening Sprint: one workflow, one owner, one repeated failure, one proof review.',
@@ -94,6 +153,7 @@ function buildAiventyxListings(links = buildRevenueLinks()) {
       ].join(' '),
       buyer: 'Teams with one valuable AI-agent workflow that keeps repeating the same mistake or losing operational context.',
       conversionGoal: 'qualified_team_conversation',
+      attribution: teamsTracking,
       proofLinks: [COMMERCIAL_TRUTH_LINK, VERIFICATION_EVIDENCE_LINK],
     },
   ];
@@ -177,12 +237,63 @@ function renderListingMarkdown(listing) {
     `- Conversion goal: ${listing.conversionGoal}`,
     `- Buyer: ${listing.buyer}`,
     `- Headline: ${listing.headline}`,
+    `- Attribution: utm_source=${listing.attribution.utmSource}, utm_medium=${listing.attribution.utmMedium}, utm_campaign=${listing.attribution.utmCampaign}, offer_code=${listing.attribution.offerCode}`,
     '',
     listing.description,
     '',
     `Proof: ${listing.proofLinks.join(' | ')}`,
     '',
   ];
+}
+
+function renderAiventyxMarketplaceCsv(plan) {
+  const header = [
+    'key',
+    'name',
+    'dashboardStatus',
+    'category',
+    'pricingModel',
+    'primaryCTA',
+    'conversionGoal',
+    'buyer',
+    'headline',
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_content',
+    'campaign_variant',
+    'offer_code',
+    'cta_id',
+    'cta_placement',
+    'plan_id',
+    'landing_path',
+    'proof_links',
+  ];
+
+  const rows = plan.listings.map((listing) => ([
+    listing.key,
+    listing.name,
+    listing.dashboardStatus,
+    listing.category,
+    listing.pricingModel,
+    listing.primaryCTA,
+    listing.conversionGoal,
+    listing.buyer,
+    listing.headline,
+    listing.attribution.utmSource,
+    listing.attribution.utmMedium,
+    listing.attribution.utmCampaign,
+    listing.attribution.utmContent,
+    listing.attribution.campaignVariant,
+    listing.attribution.offerCode,
+    listing.attribution.ctaId,
+    listing.attribution.ctaPlacement,
+    listing.attribution.planId,
+    listing.attribution.landingPath,
+    listing.proofLinks.join(' | '),
+  ]));
+
+  return `${[header, ...rows].map((row) => row.map(csvCell).join(',')).join('\n')}\n`;
 }
 
 function renderAiventyxMarketplaceMarkdown(plan) {
@@ -212,6 +323,10 @@ function renderAiventyxMarketplaceMarkdown(plan) {
     'Tracked metrics:',
     ...plan.ninetyDayPlan.metrics.map((metric) => `- ${metric}`),
     '',
+    'Attribution contract:',
+    '- Use only the tracked first-party CTAs below so Aiventyx clicks land with explicit source, medium, campaign, and offer metadata.',
+    '- Free routes through `/go/install`, Pro routes through `/go/pro`, and Teams routes to the sprint intake with Aiventyx UTMs attached.',
+    '',
     'Milestones:',
     ...plan.ninetyDayPlan.milestones.flatMap((milestone) => [
       `- ${milestone.window}: ${milestone.goal}`,
@@ -233,6 +348,7 @@ function renderAiventyxMarketplaceMarkdown(plan) {
 function writeAiventyxMarketplaceOutputs(plan, options = {}) {
   const repoRoot = path.resolve(__dirname, '..');
   const markdown = renderAiventyxMarketplaceMarkdown(plan);
+  const csv = renderAiventyxMarketplaceCsv(plan);
   const reportDir = normalizeText(options.reportDir)
     ? path.resolve(repoRoot, options.reportDir)
     : '';
@@ -242,6 +358,7 @@ function writeAiventyxMarketplaceOutputs(plan, options = {}) {
     ensureDir(reportDir);
     fs.writeFileSync(path.join(reportDir, 'aiventyx-marketplace-plan.md'), markdown, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'aiventyx-marketplace-plan.json'), `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'aiventyx-marketplace-listings.csv'), csv, 'utf8');
   }
 
   if (options.writeDocs) {
@@ -288,14 +405,18 @@ if (isCliInvocation()) {
 
 module.exports = {
   AI_CODING_CATEGORY,
+  AIVENTYX_CONTENT,
   DASHBOARD_URL,
   STANDARD_MARKETPLACE_FEE,
   buildAiventyxFollowUp,
   buildAiventyxListings,
   buildAiventyxMarketplacePlan,
   buildAiventyxNinetyDayPlan,
+  buildAiventyxTrackingMetadata,
+  buildTrackedMarketplaceLink,
   isCliInvocation,
   parseArgs,
+  renderAiventyxMarketplaceCsv,
   renderAiventyxMarketplaceMarkdown,
   writeAiventyxMarketplaceOutputs,
 };

--- a/tests/aiventyx-marketplace-plan.test.js
+++ b/tests/aiventyx-marketplace-plan.test.js
@@ -6,14 +6,18 @@ const path = require('node:path');
 
 const {
   AI_CODING_CATEGORY,
+  AIVENTYX_CONTENT,
   DASHBOARD_URL,
   STANDARD_MARKETPLACE_FEE,
   buildAiventyxFollowUp,
   buildAiventyxListings,
   buildAiventyxMarketplacePlan,
   buildAiventyxNinetyDayPlan,
+  buildAiventyxTrackingMetadata,
+  buildTrackedMarketplaceLink,
   isCliInvocation,
   parseArgs,
+  renderAiventyxMarketplaceCsv,
   renderAiventyxMarketplaceMarkdown,
   writeAiventyxMarketplaceOutputs,
 } = require('../scripts/aiventyx-marketplace-plan');
@@ -32,10 +36,32 @@ test('Aiventyx listings cover free, Pro, and Teams without inventing traction', 
   assert.deepEqual(listings.map((listing) => listing.key), ['free', 'pro', 'teams']);
   assert.ok(listings.every((listing) => listing.category === AI_CODING_CATEGORY));
   assert.equal(listings.find((listing) => listing.key === 'pro').pricingModel, '$19/mo or $149/yr');
-  assert.match(listings.find((listing) => listing.key === 'pro').primaryCTA, /\/checkout\/pro$/);
-  assert.match(listings.find((listing) => listing.key === 'teams').primaryCTA, /#workflow-sprint-intake$/);
+  assert.match(listings.find((listing) => listing.key === 'free').primaryCTA, /\/go\/install\?/);
+  assert.match(listings.find((listing) => listing.key === 'pro').primaryCTA, /\/go\/pro\?/);
+  assert.match(listings.find((listing) => listing.key === 'teams').primaryCTA, /#workflow-sprint-intake/);
+  assert.ok(listings.every((listing) => /utm_source=aiventyx/.test(listing.primaryCTA)));
+  assert.ok(listings.every((listing) => /utm_medium=marketplace/.test(listing.primaryCTA)));
+  assert.ok(listings.every((listing) => listing.attribution.utmContent === AIVENTYX_CONTENT));
   assert.ok(listings.every((listing) => listing.proofLinks.some((link) => /COMMERCIAL_TRUTH\.md/.test(link))));
   assert.ok(listings.every((listing) => !/guaranteed|partnered with|approved by/i.test(listing.description)));
+});
+
+test('tracked marketplace links and metadata stay machine-readable for attribution', () => {
+  const tracking = buildAiventyxTrackingMetadata('pro');
+  const tracked = new URL(buildTrackedMarketplaceLink('https://thumbgate-production.up.railway.app/go/pro', {
+    ...tracking,
+    planId: 'pro',
+  }));
+
+  assert.equal(tracking.utmSource, 'aiventyx');
+  assert.equal(tracking.utmMedium, 'marketplace');
+  assert.equal(tracking.utmCampaign, 'aiventyx_pro_listing');
+  assert.equal(tracking.offerCode, 'AIVENTYX-PRO');
+  assert.equal(tracked.searchParams.get('utm_source'), 'aiventyx');
+  assert.equal(tracked.searchParams.get('utm_medium'), 'marketplace');
+  assert.equal(tracked.searchParams.get('utm_campaign'), 'aiventyx_pro_listing');
+  assert.equal(tracked.searchParams.get('offer_code'), 'AIVENTYX-PRO');
+  assert.equal(tracked.searchParams.get('plan_id'), 'pro');
 });
 
 test('90-day plan keeps paid conversion as the north star and defers deeper integration', () => {
@@ -75,7 +101,22 @@ test('rendered pack is dashboard-ready and anchored to proof links', () => {
   assert.match(rendered, /ThumbGate Teams/);
   assert.match(rendered, /paid_conversion/);
   assert.match(rendered, /VERIFICATION_EVIDENCE\.md/);
+  assert.match(rendered, /Attribution contract/);
+  assert.match(rendered, /utm_source=aiventyx, utm_medium=marketplace/);
   assert.doesNotMatch(rendered, /guaranteed revenue|approved partner/i);
+});
+
+test('CSV export keeps listing submission fields and attribution in one operator file', () => {
+  const csv = renderAiventyxMarketplaceCsv(buildAiventyxMarketplacePlan({
+    appOrigin: 'https://thumbgate-production.up.railway.app',
+    proCheckoutLink: 'https://thumbgate-production.up.railway.app/checkout/pro',
+    sprintLink: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+  }));
+
+  assert.match(csv, /^key,name,dashboardStatus,category,pricingModel,primaryCTA,/);
+  assert.match(csv, /ThumbGate Pro/);
+  assert.match(csv, /aiventyx_pro_listing/);
+  assert.match(csv, /AIVENTYX-TEAMS/);
 });
 
 test('CLI options and report writing produce markdown and JSON artifacts', () => {
@@ -96,10 +137,12 @@ test('CLI options and report writing produce markdown and JSON artifacts', () =>
   assert.equal(written.docsPath, null);
   assert.equal(fs.existsSync(path.join(tempDir, 'aiventyx-marketplace-plan.md')), true);
   assert.equal(fs.existsSync(path.join(tempDir, 'aiventyx-marketplace-plan.json')), true);
+  assert.equal(fs.existsSync(path.join(tempDir, 'aiventyx-marketplace-listings.csv')), true);
 
   const json = JSON.parse(fs.readFileSync(path.join(tempDir, 'aiventyx-marketplace-plan.json'), 'utf8'));
   assert.equal(json.listings.length, 3);
   assert.equal(json.ninetyDayPlan.northStar, 'paid_conversion');
+  assert.match(fs.readFileSync(path.join(tempDir, 'aiventyx-marketplace-listings.csv'), 'utf8'), /utm_source/);
 });
 
 test('CLI entrypoint detection is path based for importer safety', () => {


### PR DESCRIPTION
## Summary
- add first-party tracked Aiventyx marketplace CTAs for Free, Pro, and Teams
- export an operator-ready CSV alongside the marketplace revenue pack
- document the attribution contract and lock behavior with tests

## Verification
- npm ci
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check