### PR TITLE
feat: add evidence-backed GTM prospect handoffs

### DIFF
--- a/.changeset/evidence-backed-gtm-handoff.md
+++ b/.changeset/evidence-backed-gtm-handoff.md
@@ -1,3 +1,4 @@
+---
 'thumbgate': patch
 ---
 

--- a/.changeset/evidence-backed-gtm-handoff.md
+++ b/.changeset/evidence-backed-gtm-handoff.md
@@ -1,0 +1,4 @@
+'thumbgate': patch
+---
+
+Add evidence-backed GTM handoff outputs so the revenue loop emits first-touch drafts, pain-confirmed follow-ups, proof-timing guidance, and JSONL prospect queues for operator outreach.

--- a/docs/CUSTOMER_DISCOVERY_SPRINT.md
+++ b/docs/CUSTOMER_DISCOVERY_SPRINT.md
@@ -46,6 +46,13 @@ Generate a target queue:
 npm run gtm:revenue-loop -- --report-dir reports/gtm/$(date +%F)-selling-now --max-targets=12
 ```
 
+The revenue loop now emits four operator artifacts in that folder:
+
+- `gtm-revenue-loop.md` for the human summary
+- `gtm-revenue-loop.json` for machine-readable truth
+- `gtm-target-queue.csv` for spreadsheet sorting
+- `gtm-target-queue.jsonl` for line-by-line operator handoff with first-touch and pain-confirmed follow-up drafts
+
 Import the queue into the local sales ledger:
 
 ```bash

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -467,6 +467,22 @@ function buildFallbackMessage(target, selectedMotion, motionCatalog = buildMotio
   ].join(' ');
 }
 
+function buildPainConfirmedFollowUp(target, selectedMotion, motionCatalog = buildMotionCatalog()) {
+  const motion = motionCatalog[selectedMotion.key];
+  const repoRef = `\`${target.repoName}\``;
+  if (selectedMotion.key === motionCatalog.sprint.key) {
+    return [
+      `If ${repoRef} really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: ${motion.cta}`,
+      `Commercial truth: ${motion.truth} Verification evidence: ${motion.proof}`,
+    ].join(' ');
+  }
+
+  return [
+    `If you want the self-serve path for ${repoRef}, here is the live Pro checkout: ${motion.cta}`,
+    `Commercial truth: ${motion.truth} Verification evidence: ${motion.proof}`,
+  ].join(' ');
+}
+
 function buildGeminiPrompt(target, selectedMotion, motionCatalog = buildMotionCatalog()) {
   const motion = motionCatalog[selectedMotion.key];
   return `
@@ -502,6 +518,8 @@ async function generateOutreachMessages(targets, motionCatalog = buildMotionCata
       return {
         ...target,
         selectedMotion,
+        proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+        followUpMessage: buildPainConfirmedFollowUp(target, selectedMotion, motionCatalog),
         message: buildFallbackMessage(target, selectedMotion, motionCatalog),
       };
     });
@@ -514,6 +532,8 @@ async function generateOutreachMessages(targets, motionCatalog = buildMotionCata
       return {
         ...target,
         selectedMotion,
+        proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+        followUpMessage: buildPainConfirmedFollowUp(target, selectedMotion, motionCatalog),
         message: buildFallbackMessage(target, selectedMotion, motionCatalog),
       };
     });
@@ -542,6 +562,8 @@ async function generateOutreachMessages(targets, motionCatalog = buildMotionCata
     results.push({
       ...target,
       selectedMotion,
+      proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+      followUpMessage: buildPainConfirmedFollowUp(target, selectedMotion, motionCatalog),
       message,
     });
   }
@@ -575,12 +597,16 @@ function buildRevenueLoopReport({ source, fallbackReason, summary, motionCatalog
       evidenceScore: target.evidence?.score || 0,
       evidence: target.evidence?.evidence || [],
       outreachAngle: target.evidence?.outreachAngle || '',
+      evidenceSource: target.repoUrl || '',
       motion: target.selectedMotion.key,
       motionLabel: target.selectedMotion.label,
       motionReason: target.selectedMotion.reason,
       pipelineStage: 'targeted',
       offer: target.selectedMotion.key === motionCatalog.sprint.key ? 'workflow_hardening_sprint' : 'pro_self_serve',
       cta: motionCatalog[target.selectedMotion.key].cta,
+      proofPackTrigger: target.proofPackTrigger || 'Use proof pack only after the buyer confirms pain.',
+      firstTouchDraft: target.message,
+      painConfirmedFollowUpDraft: target.followUpMessage || '',
       message: target.message,
     })),
   };
@@ -592,13 +618,16 @@ function renderRevenueTargetMarkdown(target) {
     `- Pipeline stage: ${target.pipelineStage}`,
     `- Offer: ${target.offer}`,
     `- Repo: ${target.repoUrl || 'n/a'}`,
+    `- Repo last updated: ${target.updatedAt || 'n/a'}`,
     `- Evidence score: ${target.evidenceScore}`,
     `- Evidence: ${target.evidence.length ? target.evidence.join(', ') : 'n/a'}`,
     `- Outreach angle: ${target.outreachAngle || 'n/a'}`,
     `- Motion: ${target.motionLabel}`,
     `- Why: ${target.motionReason}`,
+    `- Proof timing: ${target.proofPackTrigger || 'Use proof pack only after the buyer confirms pain.'}`,
     `- CTA: ${target.cta}`,
-    `- Outreach draft: ${target.message}`,
+    `- First-touch draft: ${target.firstTouchDraft || target.message}`,
+    `- Pain-confirmed follow-up: ${target.painConfirmedFollowUpDraft || 'n/a'}`,
     '',
   ];
 }
@@ -661,31 +690,45 @@ function renderRevenueLoopCsv(report) {
       'username',
       'repoName',
       'repoUrl',
+      'updatedAt',
       'offer',
       'pipelineStage',
       'evidenceScore',
       'evidence',
+      'evidenceSource',
       'outreachAngle',
       'motionLabel',
+      'motionReason',
+      'proofPackTrigger',
       'cta',
-      'message',
+      'firstTouchDraft',
+      'painConfirmedFollowUpDraft',
     ],
     ...report.targets.map((target) => ([
       target.username,
       target.repoName,
       target.repoUrl,
+      target.updatedAt,
       target.offer,
       target.pipelineStage,
       String(target.evidenceScore),
       target.evidence.join('; '),
+      target.evidenceSource,
       target.outreachAngle,
       target.motionLabel,
+      target.motionReason,
+      target.proofPackTrigger,
       target.cta,
-      target.message,
+      target.firstTouchDraft || target.message,
+      target.painConfirmedFollowUpDraft,
     ])),
   ];
 
   return `${rows.map((row) => row.map(escapeCsvValue).join(',')).join('\n')}\n`;
+}
+
+function renderRevenueLoopJsonl(report) {
+  return `${report.targets.map((target) => JSON.stringify(target)).join('\n')}\n`;
 }
 
 function writeRevenueLoopOutputs(report, options = {}) {
@@ -693,6 +736,7 @@ function writeRevenueLoopOutputs(report, options = {}) {
   const defaultDocsPath = path.join(repoRoot, 'docs', 'AUTONOMOUS_GITOPS.md');
   const markdown = renderRevenueLoopMarkdown(report);
   const csv = renderRevenueLoopCsv(report);
+  const jsonl = renderRevenueLoopJsonl(report);
   const reportDir = normalizeText(options.reportDir)
     ? path.resolve(repoRoot, options.reportDir)
     : '';
@@ -703,6 +747,7 @@ function writeRevenueLoopOutputs(report, options = {}) {
     fs.writeFileSync(path.join(reportDir, 'gtm-revenue-loop.md'), markdown, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'gtm-revenue-loop.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.csv'), csv, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), jsonl, 'utf8');
   }
 
   if (shouldWriteDocs) {
@@ -779,6 +824,7 @@ module.exports = {
   COMMERCIAL_TRUTH_LINK,
   VERIFICATION_EVIDENCE_LINK,
   buildFallbackMessage,
+  buildPainConfirmedFollowUp,
   analyzeTargetEvidence,
   buildMotionCatalog,
   buildRevenueLinks,

--- a/scripts/sales-pipeline.js
+++ b/scripts/sales-pipeline.js
@@ -171,6 +171,7 @@ function normalizeLeadOutbound(entry = {}) {
   const outbound = entry.outbound || {};
   return {
     draft: normalizeText(outbound.draft, 2000),
+    followUpDraft: normalizeText(outbound.followUpDraft, 2000),
     cta: normalizeUrl(outbound.cta),
     lastSentAt: normalizeText(outbound.lastSentAt, 64),
     lastSentUrl: normalizeUrl(outbound.lastSentUrl),
@@ -281,10 +282,11 @@ function buildLeadFromRevenueTarget(target = {}, { sourcePath = null } = {}) {
     qualification: {
       painHypothesis: target.motionReason || target.description,
       concreteOffer: 'I will harden one AI-agent workflow for you.',
-      proofTiming: 'Use proof pack only after the buyer confirms pain.',
+      proofTiming: target.proofPackTrigger || 'Use proof pack only after the buyer confirms pain.',
     },
     outbound: {
-      draft: target.message,
+      draft: target.firstTouchDraft || target.message,
+      followUpDraft: target.painConfirmedFollowUpDraft,
       cta: target.cta,
     },
     attribution: {
@@ -471,6 +473,7 @@ function renderLeadQueueEntry(lead) {
     `- Concrete offer: ${lead.qualification.concreteOffer}`,
     `- Proof rule: ${lead.qualification.proofTiming}`,
     `- Outreach draft: ${lead.outbound.draft || 'n/a'}`,
+    `- Pain-confirmed follow-up: ${lead.outbound.followUpDraft || 'n/a'}`,
     '',
   ];
 }

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -351,6 +351,25 @@ test('pain-confirmed follow-up adds proof links only after the buyer confirms pa
   assert.match(message, /Workflow Hardening Sprint/i);
 });
 
+test('pain-confirmed follow-up supports self-serve Pro targets', () => {
+  const catalog = buildMotionCatalog(buildRevenueLinks());
+  const selectedMotion = selectOutreachMotion({
+    username: 'builder',
+    repoName: 'mcp-demo-template',
+    description: 'Tutorial and demo template for Claude Code builders.',
+  }, catalog);
+  const message = buildPainConfirmedFollowUp({
+    username: 'builder',
+    repoName: 'mcp-demo-template',
+  }, selectedMotion, catalog);
+
+  assert.equal(selectedMotion.key, 'pro');
+  assert.match(message, /checkout\/pro/);
+  assert.match(message, /self-serve path/);
+  assert.match(message, /VERIFICATION_EVIDENCE/);
+  assert.match(message, /COMMERCIAL_TRUTH/);
+});
+
 test('revenue loop report keeps evidence metadata on each target', () => {
   const links = buildRevenueLinks();
   const catalog = buildMotionCatalog(links);
@@ -459,6 +478,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     const written = writeRevenueLoopOutputs(report, { reportDir });
     const csvPath = path.join(reportDir, 'gtm-target-queue.csv');
     const csv = fs.readFileSync(csvPath, 'utf8');
+    const jsonl = fs.readFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), 'utf8');
 
     assert.equal(written.reportDir, reportDir);
     assert.equal(written.docsPath, null);
@@ -469,6 +489,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.match(csv, /^username,repoName,repoUrl,updatedAt,offer,pipelineStage,evidenceScore,evidence,evidenceSource,outreachAngle,motionLabel,motionReason,proofPackTrigger,cta,firstTouchDraft,painConfirmedFollowUpDraft/m);
     assert.match(csv, /"I can harden one workflow, then prove it\."/);
     assert.match(csv, /"If the workflow pain is real, I can send the proof pack\."/);
+    assert.equal(JSON.parse(jsonl.trim()).repoName, 'production-mcp-server');
   } finally {
     fs.rmSync(reportDir, { recursive: true, force: true });
   }

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -8,6 +8,7 @@ const {
   analyzeTargetEvidence,
   buildFallbackMessage,
   buildMotionCatalog,
+  buildPainConfirmedFollowUp,
   buildRevenueLoopReport,
   buildRevenueLinks,
   clampTargetCount,
@@ -332,6 +333,24 @@ test('first-touch outreach does not push proof before pain is confirmed', () => 
   assert.doesNotMatch(message, /COMMERCIAL_TRUTH/);
 });
 
+test('pain-confirmed follow-up adds proof links only after the buyer confirms pain', () => {
+  const catalog = buildMotionCatalog(buildRevenueLinks());
+  const selectedMotion = selectOutreachMotion({
+    username: 'builder',
+    repoName: 'production-mcp-server',
+    description: 'MCP server for production agent workflows.',
+  }, catalog);
+  const message = buildPainConfirmedFollowUp({
+    username: 'builder',
+    repoName: 'production-mcp-server',
+  }, selectedMotion, catalog);
+
+  assert.equal(selectedMotion.key, 'sprint');
+  assert.match(message, /VERIFICATION_EVIDENCE/);
+  assert.match(message, /COMMERCIAL_TRUTH/);
+  assert.match(message, /Workflow Hardening Sprint/i);
+});
+
 test('revenue loop report keeps evidence metadata on each target', () => {
   const links = buildRevenueLinks();
   const catalog = buildMotionCatalog(links);
@@ -365,19 +384,25 @@ test('revenue loop report keeps evidence metadata on each target', () => {
         evidence: ['workflow control surface', '42 GitHub stars'],
         outreachAngle: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
       },
+      proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
       selectedMotion: {
         key: 'sprint',
         label: catalog.sprint.label,
         reason: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
       },
       message: 'I can harden one production workflow for you this week.',
+      followUpMessage: 'I can send the proof pack once the buyer confirms pain.',
     }],
   });
 
   assert.equal(report.targets[0].evidenceScore, 9);
   assert.deepEqual(report.targets[0].evidence, ['workflow control surface', '42 GitHub stars']);
   assert.match(report.targets[0].outreachAngle, /rollout proof/);
+  assert.equal(report.targets[0].evidenceSource, 'https://github.com/example/production-mcp-server');
   assert.equal(report.targets[0].offer, 'workflow_hardening_sprint');
+  assert.match(report.targets[0].proofPackTrigger, /buyer confirms pain/);
+  assert.match(report.targets[0].firstTouchDraft, /harden one production workflow/);
+  assert.match(report.targets[0].painConfirmedFollowUpDraft, /proof pack/);
 });
 
 test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for operator import', () => {
@@ -413,15 +438,19 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
       username: 'builder',
       repoName: 'production-mcp-server',
       repoUrl: 'https://github.com/example/production-mcp-server',
+      updatedAt: '2026-04-20T00:00:00.000Z',
       offer: 'workflow_hardening_sprint',
       pipelineStage: 'targeted',
       evidenceScore: 9,
       evidence: ['workflow control surface', '42 GitHub stars'],
+      evidenceSource: 'https://github.com/example/production-mcp-server',
       outreachAngle: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
       motionLabel: catalog.sprint.label,
       motionReason: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+      proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
       cta: catalog.sprint.cta,
-      message: 'I can harden one workflow, then prove it.',
+      firstTouchDraft: 'I can harden one workflow, then prove it.',
+      painConfirmedFollowUpDraft: 'If the workflow pain is real, I can send the proof pack.',
     }],
   };
   const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-gtm-'));
@@ -436,8 +465,10 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-revenue-loop.md')));
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-revenue-loop.json')));
     assert.ok(fs.existsSync(csvPath));
-    assert.match(csv, /^username,repoName,repoUrl,offer,pipelineStage,evidenceScore,evidence,outreachAngle,motionLabel,cta,message/m);
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.jsonl')));
+    assert.match(csv, /^username,repoName,repoUrl,updatedAt,offer,pipelineStage,evidenceScore,evidence,evidenceSource,outreachAngle,motionLabel,motionReason,proofPackTrigger,cta,firstTouchDraft,painConfirmedFollowUpDraft/m);
     assert.match(csv, /"I can harden one workflow, then prove it\."/);
+    assert.match(csv, /"If the workflow pain is real, I can send the proof pack\."/);
   } finally {
     fs.rmSync(reportDir, { recursive: true, force: true });
   }
@@ -485,8 +516,11 @@ test('runRevenueLoop writes an evidence-backed target queue with discovery warni
     assert.ok(Array.isArray(report.discoveryWarnings));
     assert.equal(report.discoveryWarnings.length, 1);
     assert.match(report.discoveryWarnings[0], /temporarily unavailable/);
+    assert.match(report.targets[0].proofPackTrigger, /buyer confirms pain/);
+    assert.match(report.targets[0].painConfirmedFollowUpDraft, /VERIFICATION_EVIDENCE/);
     assert.equal(written.reportDir, reportDir);
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.csv')));
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.jsonl')));
   } finally {
     if (originalGeminiKey === undefined) {
       delete process.env.GEMINI_API_KEY;

--- a/tests/sales-pipeline.test.js
+++ b/tests/sales-pipeline.test.js
@@ -60,6 +60,27 @@ test('imports GTM revenue targets as workflow sprint leads without marking them 
   assert.equal(leads[0].offer, 'workflow_hardening_sprint');
   assert.match(leads[0].qualification.concreteOffer, /harden one AI-agent workflow/);
   assert.match(leads[0].outbound.draft, /harden one AI-agent workflow/);
+  assert.equal(leads[0].outbound.followUpDraft, null);
+});
+
+test('imports follow-up proof drafts from evidence-backed GTM targets', () => {
+  const tempDir = makeTempDir();
+  const statePath = path.join(tempDir, 'sales-pipeline.jsonl');
+  const report = makeReport();
+  report.targets[0].firstTouchDraft = 'I can harden one AI-agent workflow for you.';
+  report.targets[0].painConfirmedFollowUpDraft = 'If the workflow pain is real, I can send the proof pack.';
+  report.targets[0].proofPackTrigger = 'Use proof pack only after the buyer confirms pain.';
+
+  importRevenueLoopReport(report, {
+    statePath,
+    sourcePath: path.join(tempDir, 'gtm-revenue-loop.json'),
+  });
+  const leads = loadSalesLeads({ statePath });
+
+  assert.equal(leads.length, 1);
+  assert.match(leads[0].outbound.draft, /harden one AI-agent workflow/);
+  assert.match(leads[0].outbound.followUpDraft, /proof pack/);
+  assert.match(leads[0].qualification.proofTiming, /buyer confirms pain/);
 });
 
 test('deduplicates repeated GTM imports by stable lead id', () => {


### PR DESCRIPTION
## Summary
- emit evidence source, proof timing, first-touch draft, and pain-confirmed follow-up copy from the GTM revenue loop
- export the target queue as JSONL so operators can import prospect handoff artifacts directly into downstream workflow tooling
- document the new GTM loop artifacts and cover the handoff behavior in sales pipeline and revenue loop tests

## Verification
- `node --test tests/gtm-revenue-loop.test.js tests/sales-pipeline.test.js`
- `npm ci`
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`
