### PR TITLE
fix: repair warm GTM follow-up fallback copy

### DIFF
--- a/.changeset/curly-pears-repair.md
+++ b/.changeset/curly-pears-repair.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Fix warm revenue-loop follow-up drafts so operator outreach falls back to workflow language when a qualified target has no repository name.

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -487,7 +487,9 @@ function buildFallbackMessage(target, selectedMotion, motionCatalog = buildMotio
 
 function buildPainConfirmedFollowUp(target, selectedMotion, motionCatalog = buildMotionCatalog()) {
   const motion = motionCatalog[selectedMotion.key];
-  const repoRef = `\`${target.repoName}\``;
+  const repoName = normalizeText(target.repoName);
+  const repoRef = repoName ? `\`${repoName}\`` : 'your workflow';
+  const proRef = repoName ? ` for ${repoRef}` : '';
   if (selectedMotion.key === motionCatalog.sprint.key) {
     return [
       `If ${repoRef} really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: ${motion.cta}`,
@@ -496,7 +498,7 @@ function buildPainConfirmedFollowUp(target, selectedMotion, motionCatalog = buil
   }
 
   return [
-    `If you want the self-serve path for ${repoRef}, here is the live Pro checkout: ${motion.cta}`,
+    `If you want the self-serve path${proRef}, here is the live Pro checkout: ${motion.cta}`,
     `Commercial truth: ${motion.truth} Verification evidence: ${motion.proof}`,
   ].join(' ');
 }

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -425,6 +425,23 @@ test('pain-confirmed follow-up supports self-serve Pro targets', () => {
   assert.match(message, /COMMERCIAL_TRUTH/);
 });
 
+test('pain-confirmed follow-up falls back to workflow language for warm targets without a repo', () => {
+  const catalog = buildMotionCatalog(buildRevenueLinks());
+  const message = buildPainConfirmedFollowUp({
+    username: 'builder',
+    repoName: '',
+  }, {
+    key: 'sprint',
+    label: catalog.sprint.label,
+    reason: 'Warm target already named a repeated workflow failure.',
+  }, catalog);
+
+  assert.match(message, /If your workflow really has one repeated workflow failure blocking rollout/);
+  assert.doesNotMatch(message, /``/);
+  assert.match(message, /VERIFICATION_EVIDENCE/);
+  assert.match(message, /COMMERCIAL_TRUTH/);
+});
+
 test('revenue loop report keeps evidence metadata on each target', () => {
   const links = buildRevenueLinks();
   const catalog = buildMotionCatalog(links);
@@ -560,6 +577,58 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
   } finally {
     fs.rmSync(reportDir, { recursive: true, force: true });
   }
+});
+
+test('warm-target report output does not emit blank repo placeholders in follow-up drafts', () => {
+  const links = buildRevenueLinks();
+  const catalog = buildMotionCatalog(links);
+  const report = buildRevenueLoopReport({
+    source: 'local',
+    fallbackReason: '',
+    summary: {
+      revenue: { paidOrders: 0, bookedRevenueCents: 0 },
+      trafficMetrics: {},
+      signups: {},
+      pipeline: {},
+    },
+    motionCatalog: catalog,
+    directive: {
+      state: 'cold-start',
+      objective: 'First 10 paying customers',
+      headline: 'No verified revenue and no active pipeline.',
+      primaryMotion: 'sprint',
+      secondaryMotion: 'pro',
+      actions: ['Lead with one workflow.'],
+    },
+    targets: [{
+      temperature: 'warm',
+      source: 'reddit',
+      channel: 'reddit_dm',
+      username: 'builder',
+      accountName: 'r/ClaudeCode',
+      contactUrl: 'https://www.reddit.com/user/builder/',
+      repoName: '',
+      repoUrl: '',
+      description: 'Builder already named a repeated workflow blocker.',
+      stars: 0,
+      updatedAt: null,
+      evidence: {
+        score: 8,
+        evidence: ['warm inbound engagement'],
+        outreachAngle: 'Lead with one repeated workflow blocker.',
+      },
+      proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+      selectedMotion: {
+        key: 'sprint',
+        label: catalog.sprint.label,
+        reason: 'Warm target already named a repeated workflow blocker.',
+      },
+      message: 'I can harden one AI-agent workflow for you this week.',
+    }],
+  });
+
+  assert.match(report.targets[0].painConfirmedFollowUpDraft, /If your workflow really has one repeated workflow failure blocking rollout/);
+  assert.doesNotMatch(report.targets[0].painConfirmedFollowUpDraft, /``/);
 });
 
 test('runRevenueLoop writes an evidence-backed target queue with discovery warnings when GitHub search fails', async () => {


### PR DESCRIPTION
## Summary
- fix warm-target follow-up drafts when no repo name is available
- fall back to workflow language instead of emitting blank backticks in operator-ready outreach copy
- add regressions for both direct follow-up generation and report output

## Why
Warm Reddit/operator targets can be valid acquisition leads without a repo name. The revenue loop was generating broken evidence-backed follow-up copy (``) for that cohort, which degrades outreach quality right where the repo is prioritizing acquisition.

## Verification
- node --test tests/gtm-revenue-loop.test.js
- npm ci
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check