### PR TITLE
feat: emit marketplace copy pack from revenue loop

### DIFF
--- a/.changeset/marketplace-copy-pack.md
+++ b/.changeset/marketplace-copy-pack.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Emit marketplace copy pack markdown and JSON from the GTM revenue loop so launch surfaces stay aligned with current buyer signals.

--- a/LAUNCH_NOW.md
+++ b/LAUNCH_NOW.md
@@ -30,11 +30,12 @@ REPORT_DIR="reports/gtm/$(date +%F)-selling-now"
 npm run gtm:revenue-loop -- --report-dir "$REPORT_DIR" --max-targets=12
 ```
 
-Review three files before sending anything:
+Review four files before sending anything:
 
 - `gtm-revenue-loop.md` for the current commercial truth and directive
 - `gtm-revenue-loop.json` for the machine-readable queue
 - `gtm-target-queue.csv` for operator copy/paste into a tracker or CRM
+- `gtm-marketplace-copy.md` for listing-ready copy derived from the same target evidence
 
 The generated queue now includes two lanes in one artifact:
 
@@ -106,6 +107,7 @@ Do not treat generic posting as sales progress.
 
 Before refreshing listing copy or directory submissions, make sure these remain aligned:
 
+- the current `gtm-marketplace-copy.md` artifact from the revenue loop
 - [docs/COMMERCIAL_TRUTH.md](docs/COMMERCIAL_TRUTH.md)
 - [docs/VERIFICATION_EVIDENCE.md](docs/VERIFICATION_EVIDENCE.md)
 - [.claude-plugin/marketplace.json](.claude-plugin/marketplace.json)

--- a/docs/CUSTOMER_DISCOVERY_SPRINT.md
+++ b/docs/CUSTOMER_DISCOVERY_SPRINT.md
@@ -46,10 +46,12 @@ Generate a target queue:
 npm run gtm:revenue-loop -- --report-dir reports/gtm/$(date +%F)-selling-now --max-targets=12
 ```
 
-The revenue loop now emits four operator artifacts in that folder:
+The revenue loop now emits six operator artifacts in that folder:
 
 - `gtm-revenue-loop.md` for the human summary
 - `gtm-revenue-loop.json` for machine-readable truth
+- `gtm-marketplace-copy.md` for listing-ready copy based on the same target evidence
+- `gtm-marketplace-copy.json` for machine-readable listing copy and target themes
 - `gtm-target-queue.csv` for spreadsheet sorting
 - `gtm-target-queue.jsonl` for line-by-line operator handoff with first-touch and pain-confirmed follow-up drafts
 

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -48,6 +48,36 @@ const TARGET_SIGNAL_RULES = [
     weight: 2,
   },
 ];
+const MARKETPLACE_SIGNAL_THEMES = [
+  {
+    key: 'warm_discovery',
+    label: 'Warm discovery workflows',
+    summary: 'Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain.',
+    listingAngle: 'Lead with one repeated workflow failure and a founder-led diagnostic before any generic tool pitch.',
+    match: (target) => normalizeText(target.temperature).toLowerCase() === 'warm',
+  },
+  {
+    key: 'business_system_workflows',
+    label: 'Business-system workflow approvals',
+    summary: 'Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof.',
+    listingAngle: 'Lead with approval boundaries, rollback safety, and proof for one workflow.',
+    match: (target) => hasEvidenceLabel(target, 'business-system integration'),
+  },
+  {
+    key: 'production_rollout',
+    label: 'Production rollout proof',
+    summary: 'Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems.',
+    listingAngle: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+    match: (target) => hasEvidenceLabel(target, 'production or platform workflow'),
+  },
+  {
+    key: 'workflow_control',
+    label: 'Workflow control surfaces',
+    summary: 'The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive.',
+    listingAngle: 'Lead with one repeated workflow failure, then show how ThumbGate turns it into an enforceable pre-action gate.',
+    match: (target) => hasEvidenceLabel(target, 'workflow control surface'),
+  },
+];
 
 function getGoogleGenAI() {
   try {
@@ -139,6 +169,12 @@ function clampTargetCount(value) {
 function normalizeText(value) {
   if (value === undefined || value === null) return '';
   return String(value).trim();
+}
+
+function hasEvidenceLabel(target, label) {
+  const targetLabels = Array.isArray(target?.evidence) ? target.evidence : [];
+  const needle = normalizeText(label).toLowerCase();
+  return targetLabels.some((entry) => normalizeText(entry).toLowerCase() === needle);
 }
 
 function dedupeList(values = []) {
@@ -642,6 +678,106 @@ function buildRevenueLoopReport({ source, fallbackReason, summary, motionCatalog
   };
 }
 
+function resolveMotionLabel(report, motionKey) {
+  return motionKey === 'pro'
+    ? report.currentTruth.publicSelfServeOffer
+    : report.currentTruth.teamPilotOffer;
+}
+
+function resolveMotionCta(report, motionKey) {
+  const matchingTarget = Array.isArray(report.targets)
+    ? report.targets.find((target) => normalizeText(target.motion) === normalizeText(motionKey) && normalizeText(target.cta))
+    : null;
+  return matchingTarget ? matchingTarget.cta : '';
+}
+
+function buildMarketplaceCopy(report) {
+  const targets = Array.isArray(report?.targets) ? report.targets : [];
+  const signalThemes = MARKETPLACE_SIGNAL_THEMES
+    .map((theme) => {
+      const matches = targets.filter((target) => theme.match(target));
+      return {
+        key: theme.key,
+        label: theme.label,
+        summary: theme.summary,
+        listingAngle: theme.listingAngle,
+        count: matches.length,
+        examples: matches.slice(0, 3).map((target) => (
+          normalizeText(target.repoName)
+            ? `${target.username}/${target.repoName}`
+            : `@${target.username}`
+        )),
+      };
+    })
+    .filter((theme) => theme.count > 0)
+    .sort((left, right) => right.count - left.count)
+    .slice(0, 3);
+  const topTheme = signalThemes[0];
+  const primaryMotion = normalizeText(report.directive?.primaryMotion) || 'sprint';
+  const secondaryMotion = normalizeText(report.directive?.secondaryMotion) || 'pro';
+  const headline = primaryMotion === 'sprint'
+    ? 'Harden one AI-agent workflow before you roll it out.'
+    : 'Turn repeated AI-agent mistakes into pre-action checks before the next tool call.';
+  const signalSentence = signalThemes.length
+    ? signalThemes.map((theme) => theme.summary).join(' ')
+    : 'Current target evidence still points to workflow hardening and proof-first positioning.';
+  const shortDescription = [
+    report.directive?.headline || headline,
+    signalSentence,
+  ].join(' ');
+  const longDescription = [
+    'ThumbGate is a reliability gateway for AI coding workflows.',
+    'It captures repeated failures, regenerates pre-action gates, and keeps approval boundaries, rollback safety, and proof attached to the workflow before the next risky tool call.',
+    signalSentence,
+    `Primary motion: ${resolveMotionLabel(report, primaryMotion)}.`,
+    `Secondary motion: ${resolveMotionLabel(report, secondaryMotion)} after the buyer asks for the self-serve path.`,
+  ].join(' ');
+  const sampleTargets = targets
+    .slice(0, 5)
+    .map((target) => ({
+      account: normalizeText(target.repoName)
+        ? `${target.username}/${target.repoName}`
+        : `@${target.username}`,
+      temperature: target.temperature || 'cold',
+      motion: target.motionLabel || resolveMotionLabel(report, target.motion),
+      why: target.motionReason || target.outreachAngle || '',
+    }));
+
+  return {
+    generatedAt: report.generatedAt,
+    state: report.directive?.state || 'cold-start',
+    headline,
+    shortDescription,
+    longDescription,
+    proofPolicy: 'Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms pain.',
+    recommendedCtas: [
+      {
+        motion: primaryMotion,
+        label: resolveMotionLabel(report, primaryMotion),
+        cta: resolveMotionCta(report, primaryMotion),
+      },
+      {
+        motion: secondaryMotion,
+        label: resolveMotionLabel(report, secondaryMotion),
+        cta: resolveMotionCta(report, secondaryMotion),
+      },
+    ],
+    listingBullets: dedupeList([
+      'Turn repeated AI-agent mistakes into enforceable pre-action gates.',
+      topTheme ? topTheme.listingAngle : '',
+      `Primary offer: ${resolveMotionLabel(report, primaryMotion)}.`,
+      `Secondary offer: ${resolveMotionLabel(report, secondaryMotion)} after the buyer asks for the tool path.`,
+      'Keep approval boundaries, rollback safety, and proof attached to the workflow before rollout.',
+    ]),
+    topSignals: signalThemes,
+    sampleTargets,
+    proofLinks: [
+      report.currentTruth?.commercialTruthLink || '',
+      report.currentTruth?.verificationEvidenceLink || '',
+    ].filter(Boolean),
+  };
+}
+
 function renderRevenueTargetMarkdown(target) {
   return [
     `### @${target.username} — ${target.repoName || target.accountName || 'warm discovery lead'}`,
@@ -718,6 +854,55 @@ function renderRevenueLoopMarkdown(report) {
   return `${lines.join('\n').trim()}\n`;
 }
 
+function renderMarketplaceCopyMarkdown(pack) {
+  const signalLines = pack.topSignals.length
+    ? pack.topSignals.map((signal) => `- ${signal.label} (${signal.count}): ${signal.summary}${signal.examples.length ? ` Examples: ${signal.examples.join(', ')}` : ''}`)
+    : ['- No target evidence was available for this run.'];
+  const ctaLines = pack.recommendedCtas
+    .filter((entry) => entry.label || entry.cta)
+    .map((entry) => `- ${entry.label}: ${entry.cta || 'cta unavailable in this run'}`);
+  const sampleTargetLines = pack.sampleTargets.length
+    ? pack.sampleTargets.map((target) => `- ${target.account} (${target.temperature}): ${target.why}`)
+    : ['- No sample targets available in this run.'];
+  const proofLines = pack.proofLinks.length
+    ? pack.proofLinks.map((link) => `- ${link}`)
+    : ['- No proof links available in this run.'];
+
+  return [
+    '# Marketplace Copy Pack',
+    '',
+    'This pack is operator-ready listing copy derived from the current GTM revenue loop. It is not proof of sent outreach, installs, or revenue by itself.',
+    '',
+    '## Listing Headline',
+    pack.headline,
+    '',
+    '## Short Description',
+    pack.shortDescription,
+    '',
+    '## Long Description',
+    pack.longDescription,
+    '',
+    '## Listing Bullets',
+    ...pack.listingBullets.map((bullet) => `- ${bullet}`),
+    '',
+    '## Recommended CTAs',
+    ...ctaLines,
+    '',
+    '## Evidence-Backed Buyer Signals',
+    ...signalLines,
+    '',
+    '## Proof Policy',
+    `- ${pack.proofPolicy}`,
+    '',
+    '## Sample Targets Behind This Copy',
+    ...sampleTargetLines,
+    '',
+    '## Proof Links',
+    ...proofLines,
+    '',
+  ].join('\n');
+}
+
 function escapeCsvValue(value) {
   const text = normalizeText(value);
   if (!text) return '';
@@ -786,6 +971,8 @@ function writeRevenueLoopOutputs(report, options = {}) {
   const repoRoot = path.resolve(__dirname, '..');
   const defaultDocsPath = path.join(repoRoot, 'docs', 'AUTONOMOUS_GITOPS.md');
   const markdown = renderRevenueLoopMarkdown(report);
+  const marketplaceCopy = report.marketplaceCopy || buildMarketplaceCopy(report);
+  const marketplaceMarkdown = renderMarketplaceCopyMarkdown(marketplaceCopy);
   const csv = renderRevenueLoopCsv(report);
   const jsonl = renderRevenueLoopJsonl(report);
   const reportDir = normalizeText(options.reportDir)
@@ -797,6 +984,8 @@ function writeRevenueLoopOutputs(report, options = {}) {
     ensureDir(reportDir);
     fs.writeFileSync(path.join(reportDir, 'gtm-revenue-loop.md'), markdown, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'gtm-revenue-loop.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'gtm-marketplace-copy.md'), marketplaceMarkdown, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'gtm-marketplace-copy.json'), `${JSON.stringify(marketplaceCopy, null, 2)}\n`, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.csv'), csv, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), jsonl, 'utf8');
   }
@@ -807,6 +996,7 @@ function writeRevenueLoopOutputs(report, options = {}) {
 
   return {
     markdown,
+    marketplaceMarkdown,
     reportDir: reportDir || null,
     docsPath: shouldWriteDocs ? defaultDocsPath : null,
   };
@@ -830,6 +1020,7 @@ async function runRevenueLoop(options = {}) {
     directive,
     targets: warmTargets.concat(enrichedTargets),
   });
+  report.marketplaceCopy = buildMarketplaceCopy(report);
 
   if (errors.length) {
     report.discoveryWarnings = errors;
@@ -890,8 +1081,10 @@ module.exports = {
   parseArgs,
   prospectTargets,
   renderRevenueLoopMarkdown,
+  renderMarketplaceCopyMarkdown,
   runRevenueLoop,
   selectOutreachMotion,
   summarizeCommercialSnapshot,
   writeRevenueLoopOutputs,
+  buildMarketplaceCopy,
 };

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -7,6 +7,7 @@ const assert = require('node:assert/strict');
 const {
   analyzeTargetEvidence,
   buildFallbackMessage,
+  buildMarketplaceCopy,
   buildMotionCatalog,
   buildPainConfirmedFollowUp,
   buildRevenueLoopReport,
@@ -18,6 +19,7 @@ const {
   hasCredibleRepoIdentity,
   parseArgs,
   prospectTargets,
+  renderMarketplaceCopyMarkdown,
   renderRevenueLoopMarkdown,
   runRevenueLoop,
   selectOutreachMotion,
@@ -503,6 +505,125 @@ test('revenue loop report keeps evidence metadata on each target', () => {
   assert.match(report.targets[0].painConfirmedFollowUpDraft, /proof pack/);
 });
 
+test('marketplace copy pack stays tied to current revenue-loop evidence', () => {
+  const links = buildRevenueLinks();
+  const catalog = buildMotionCatalog(links);
+  const report = buildRevenueLoopReport({
+    source: 'local',
+    fallbackReason: 'Hosted operational summary is not configured.',
+    summary: {
+      revenue: { paidOrders: 0, bookedRevenueCents: 0 },
+      trafficMetrics: {},
+      signups: {},
+      pipeline: {},
+    },
+    motionCatalog: catalog,
+    directive: {
+      state: 'cold-start',
+      objective: 'First 10 paying customers',
+      headline: 'No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.',
+      primaryMotion: 'sprint',
+      secondaryMotion: 'pro',
+      actions: ['Lead with one workflow.'],
+    },
+    targets: [
+      {
+        temperature: 'warm',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        username: 'builder',
+        accountName: 'r/ClaudeCode',
+        contactUrl: 'https://www.reddit.com/user/builder/',
+        repoName: '',
+        repoUrl: '',
+        evidence: {
+          score: 8,
+          evidence: ['warm inbound engagement'],
+          outreachAngle: 'Lead with one repeated workflow failure.',
+        },
+        outreachAngle: 'Lead with one repeated workflow failure.',
+        motion: 'sprint',
+        motionLabel: catalog.sprint.label,
+        motionReason: 'Warm workflow pain already exists.',
+        selectedMotion: {
+          key: 'sprint',
+          label: catalog.sprint.label,
+          reason: 'Warm workflow pain already exists.',
+        },
+        pipelineStage: 'targeted',
+        offer: 'workflow_hardening_sprint',
+        cta: catalog.sprint.cta,
+      },
+      {
+        temperature: 'cold',
+        source: 'github',
+        channel: 'github',
+        username: 'freema',
+        accountName: 'freema',
+        contactUrl: '',
+        repoName: 'mcp-jira-stdio',
+        repoUrl: 'https://github.com/freema/mcp-jira-stdio',
+        evidence: {
+          score: 10,
+          evidence: ['workflow control surface', 'business-system integration'],
+          outreachAngle: 'Lead with approval boundaries, rollback safety, and proof.',
+        },
+        outreachAngle: 'Lead with approval boundaries, rollback safety, and proof.',
+        motion: 'sprint',
+        motionLabel: catalog.sprint.label,
+        motionReason: 'Jira workflows need approval boundaries.',
+        selectedMotion: {
+          key: 'sprint',
+          label: catalog.sprint.label,
+          reason: 'Jira workflows need approval boundaries.',
+        },
+        pipelineStage: 'targeted',
+        offer: 'workflow_hardening_sprint',
+        cta: catalog.sprint.cta,
+      },
+      {
+        temperature: 'cold',
+        source: 'github',
+        channel: 'github',
+        username: 'platform',
+        accountName: 'platform',
+        contactUrl: '',
+        repoName: 'release-governor',
+        repoUrl: 'https://github.com/example/release-governor',
+        evidence: {
+          score: 9,
+          evidence: ['production or platform workflow'],
+          outreachAngle: 'Lead with rollout proof for one production workflow.',
+        },
+        outreachAngle: 'Lead with rollout proof for one production workflow.',
+        motion: 'pro',
+        motionLabel: catalog.pro.label,
+        motionReason: 'Self-serve path is secondary.',
+        selectedMotion: {
+          key: 'pro',
+          label: catalog.pro.label,
+          reason: 'Self-serve path is secondary.',
+        },
+        pipelineStage: 'targeted',
+        offer: 'pro_self_serve',
+        cta: catalog.pro.cta,
+      },
+    ],
+  });
+  const pack = buildMarketplaceCopy(report);
+  const markdown = renderMarketplaceCopyMarkdown(pack);
+
+  assert.match(pack.headline, /Harden one AI-agent workflow/i);
+  assert.equal(pack.recommendedCtas[0].label, catalog.sprint.label);
+  assert.equal(pack.recommendedCtas[1].label, catalog.pro.label);
+  assert.ok(pack.topSignals.some((signal) => /Warm discovery workflows/.test(signal.label)));
+  assert.ok(pack.topSignals.some((signal) => /Business-system workflow approvals/.test(signal.label)));
+  assert.match(markdown, /Proof Policy/);
+  assert.match(markdown, /COMMERCIAL_TRUTH\.md/);
+  assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
+  assert.doesNotMatch(markdown, /paid customers already exist/i);
+});
+
 test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for operator import', () => {
   const links = buildRevenueLinks();
   const catalog = buildMotionCatalog(links);
@@ -562,17 +683,22 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     const written = writeRevenueLoopOutputs(report, { reportDir });
     const csvPath = path.join(reportDir, 'gtm-target-queue.csv');
     const csv = fs.readFileSync(csvPath, 'utf8');
+    const marketplaceCopy = JSON.parse(fs.readFileSync(path.join(reportDir, 'gtm-marketplace-copy.json'), 'utf8'));
     const jsonl = fs.readFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), 'utf8');
 
     assert.equal(written.reportDir, reportDir);
     assert.equal(written.docsPath, null);
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-revenue-loop.md')));
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-revenue-loop.json')));
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-marketplace-copy.md')));
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-marketplace-copy.json')));
     assert.ok(fs.existsSync(csvPath));
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.jsonl')));
     assert.match(csv, /^temperature,source,channel,username,accountName,contactUrl,repoName,repoUrl,updatedAt,offer,pipelineStage,evidenceScore,evidence,evidenceSource,outreachAngle,motionLabel,motionReason,proofPackTrigger,cta,firstTouchDraft,painConfirmedFollowUpDraft/m);
     assert.match(csv, /"I can harden one workflow, then prove it\."/);
     assert.match(csv, /"If the workflow pain is real, I can send the proof pack\."/);
+    assert.match(marketplaceCopy.headline, /workflow/i);
+    assert.ok(Array.isArray(marketplaceCopy.topSignals));
     assert.equal(JSON.parse(jsonl.trim()).repoName, 'production-mcp-server');
   } finally {
     fs.rmSync(reportDir, { recursive: true, force: true });
@@ -675,9 +801,13 @@ test('runRevenueLoop writes an evidence-backed target queue with discovery warni
     assert.ok(Array.isArray(report.discoveryWarnings));
     assert.equal(report.discoveryWarnings.length, 1);
     assert.match(report.discoveryWarnings[0], /temporarily unavailable/);
+    assert.ok(report.marketplaceCopy);
+    assert.ok(Array.isArray(report.marketplaceCopy.topSignals));
     assert.match(report.targets[0].proofPackTrigger, /buyer confirms pain/);
     assert.match(report.targets[0].painConfirmedFollowUpDraft, /VERIFICATION_EVIDENCE/);
     assert.equal(written.reportDir, reportDir);
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-marketplace-copy.md')));
+    assert.ok(fs.existsSync(path.join(reportDir, 'gtm-marketplace-copy.json')));
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.csv')));
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.jsonl')));
   } finally {


### PR DESCRIPTION
## Summary
- emit a marketplace-ready copy pack from the GTM revenue loop so listing text stays tied to the same evidence as the target queue
- persist markdown/json marketplace-copy artifacts alongside the existing GTM report outputs
- document the new operator artifact in the launch and discovery playbooks

## Verification
- `node --test tests/gtm-revenue-loop.test.js`
- `node --test tests/positioning-contract.test.js`
- `npm ci`
- `npm test`
