### PR TITLE
feat(gtm): add claude workflow hardening pack

### DIFF
--- a/.changeset/claude-workflow-hardening-pack.md
+++ b/.changeset/claude-workflow-hardening-pack.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add a Claude workflow hardening pack to the GTM automation so each revenue-loop run emits operator-ready Claude-first outbound copy, buyer lanes, and proof-linked follow-up guidance.

--- a/docs/ANTHROPIC_MARKETPLACE_STRATEGY.md
+++ b/docs/ANTHROPIC_MARKETPLACE_STRATEGY.md
@@ -151,7 +151,7 @@ Always include:
 
 1. Tighten the public landing page around the Workflow Hardening Sprint.
 2. Use the proof pack in direct outreach to consultancies, platform teams, and Claude-first engineering leaders.
-3. Support the outreach with a role-based X thread and LinkedIn post.
+3. Support the outreach with the generated Claude workflow hardening pack plus role-based LinkedIn, Reddit, or Bluesky follow-ups.
 4. Keep the ask narrow: one workflow, one pilot, one proof review.
 5. Use partner-network status only as supporting credibility once it is real.
 

--- a/docs/CUSTOMER_DISCOVERY_SPRINT.md
+++ b/docs/CUSTOMER_DISCOVERY_SPRINT.md
@@ -46,7 +46,7 @@ Generate a target queue:
 npm run gtm:revenue-loop -- --report-dir reports/gtm/$(date +%F)-selling-now --max-targets=12
 ```
 
-The revenue loop now emits nine operator artifacts in that folder:
+The revenue loop now emits eleven operator artifacts in that folder:
 
 - `gtm-revenue-loop.md` for the human summary
 - `gtm-revenue-loop.json` for machine-readable truth
@@ -54,6 +54,8 @@ The revenue loop now emits nine operator artifacts in that folder:
 - `gtm-marketplace-copy.json` for machine-readable listing copy and target themes
 - `gtm-target-queue.csv` for spreadsheet sorting
 - `gtm-target-queue.jsonl` for line-by-line operator handoff with first-touch and pain-confirmed follow-up drafts
+- `claude-workflow-hardening-pack.md` for Claude-first positioning, buyer lanes, and evidence-backed outbound copy
+- `claude-workflow-hardening-pack.json` for the same Claude-first outbound pack in machine-readable form
 - `cursor-marketplace-revenue-pack.md` for Cursor Marketplace, Cursor Directory, and Team Marketplace submission copy
 - `cursor-marketplace-revenue-pack.json` for machine-readable Cursor listing metadata and follow-on offers
 - `cursor-marketplace-surfaces.csv` for one-sheet operator submission fields

--- a/docs/marketing/claude-workflow-hardening-pack.md
+++ b/docs/marketing/claude-workflow-hardening-pack.md
@@ -1,0 +1,65 @@
+# Claude Workflow Hardening Pack
+
+Updated: 2026-04-26T02:01:28.625Z
+
+This is a sales operator artifact. It is not proof of sent outreach, partner acceptance, booked revenue, or deployment success by itself.
+
+## Objective
+Turn current Claude-first buyer signals into booked workflow-hardening diagnostics and self-serve follow-up only after pain is confirmed.
+
+## Positioning
+- State: cold-start
+- Headline: Make one Claude-first workflow safe enough to ship team-wide.
+- Summary: ThumbGate should sell Claude workflow hardening as a concrete delivery motion, not generic AI governance. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
+
+## Offer Stack
+- Primary: Workflow Hardening Sprint -> https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Secondary: Pro at $19/mo or $149/yr -> https://thumbgate-production.up.railway.app/checkout/pro
+- Proof policy: Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms workflow pain.
+
+## Evidence-Backed Signals
+### Warm Claude workflow pain already exists
+- Count: 2
+- Summary: 2 warm Claude-first signals already named review boundaries, brittle guardrails, or context-risk pain.
+- Examples: @leogodin217, @Enthu-Cutlet-1337
+
+### Production rollout proof is the strongest cold signal
+- Count: 5
+- Summary: 5 current targets touch releases, incidents, or other production-sensitive workflows that need approval boundaries and proof.
+- Examples: WagnerAgent/awesome-mcp-servers-devops, bjeans/homelab-mcp, Shashankk1907/Learning-about-MCP
+
+### Business-system approvals are present but secondary
+- Count: 1
+- Summary: 1 current targets wire agents into business systems where rollback safety and approvals matter.
+- Examples: freema/mcp-jira-stdio
+
+## Buyer Lanes
+### Claude-first builders and workflow owners
+- Evidence: 2 warm Claude-first signals already named concrete workflow pain. Examples: @leogodin217, @Enthu-Cutlet-1337.
+- Angle: Lead with one repeated workflow failure inside an already-serious Claude process. Do not open with proof.
+- First touch: You are already running a serious Claude workflow. I am looking for one Claude-first workflow to harden end-to-end this week: repeated failure, pre-action gate, and proof run. If one review boundary or brittle-guardrail failure keeps coming back, I can harden that workflow for you.
+- Pain-confirmed follow-up: If that Claude workflow really has one repeated failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence so the next step stays grounded.
+
+### Platform teams shipping agents near release, incident, or compliance surfaces
+- Evidence: 5 current targets expose production or platform workflows where proof matters before rollout. Examples: WagnerAgent/awesome-mcp-servers-devops, bjeans/homelab-mcp, Shashankk1907/Learning-about-MCP.
+- Angle: Lead with approval boundaries, rollback safety, and proof for one production workflow.
+- First touch: I am looking for one production workflow to harden end-to-end this week: repeated failure, prevention gate, and proof run. If one release, incident, or compliance-adjacent workflow keeps needing manual rescue, I can harden that workflow for you.
+- Pain-confirmed follow-up: If that production workflow is real, I can send the Workflow Hardening Sprint brief with commercial truth and verification evidence after the buyer confirms the specific blocker.
+
+### Teams wiring agents into Jira, ServiceNow, Slack, or other business systems
+- Evidence: 1 current targets touch business-system workflows where approvals and rollback safety are explicit buying triggers. Examples: freema/mcp-jira-stdio.
+- Angle: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
+- First touch: I am looking for one agent workflow touching Jira, ServiceNow, Slack, or another business system to harden end-to-end this week. If one approval or handoff failure keeps repeating, I can harden that workflow for you.
+- Pain-confirmed follow-up: Once the buyer confirms the failing business-system workflow, send the Workflow Hardening Sprint brief plus commercial truth and verification evidence. Do not lead with the proof pack.
+
+## Sample Targets Behind This Pack
+- @Deep_Ad1959 (warm): Warm Reddit engager already named a repeated workflow risk, so the fastest path is a founder-led diagnostic.
+- @game-of-kton (warm): Warm Reddit engager already works on advanced agent memory, so discovery should center on one repeated failure pattern.
+- @leogodin217 (warm): Warm Reddit engager already described a mature workflow, so the next step is a targeted diagnostic on one failure mode.
+- @Enthu-Cutlet-1337 (warm): Warm Reddit engager already understands the adaptive-gate thesis, so offer one concrete workflow hardening diagnostic.
+- freema/mcp-jira-stdio (cold): Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
+- salacoste/mcp-n8n-workflow-builder (cold): Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+
+## Proof Links
+- https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
+- https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "test:hosted-config": "node --test tests/hosted-config.test.js",
     "test:operational-summary": "node --test tests/operational-summary.test.js",
     "test:operational-dashboard": "node --test tests/operational-dashboard.test.js",
-    "test:operator-artifacts": "node --test tests/operator-artifacts.test.js",
+    "test:operator-artifacts": "node --test tests/operator-artifacts.test.js tests/claude-workflow-hardening-pack.test.js",
     "test:operator-key-auth": "node --test tests/api-operator-key-auth.test.js",
     "test:cloudflare-sandbox": "node --test tests/cloudflare-dynamic-sandbox.test.js tests/cloudflare-sandbox-api.test.js",
     "test:mcp-config": "node --test tests/mcp-config.test.js",

--- a/scripts/autonomous-sales-agent.js
+++ b/scripts/autonomous-sales-agent.js
@@ -13,6 +13,10 @@
 
 const { parseArgs, runRevenueLoop } = require('./gtm-revenue-loop');
 const {
+  buildClaudeWorkflowHardeningPack,
+  writeClaudeWorkflowHardeningPack,
+} = require('./claude-workflow-hardening-pack');
+const {
   buildCursorMarketplaceRevenuePack,
   writeCursorMarketplaceRevenuePack,
 } = require('./cursor-marketplace-revenue-pack');
@@ -20,6 +24,8 @@ const {
 async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
   const { report, written } = await runRevenueLoop(options);
+  const claudePack = buildClaudeWorkflowHardeningPack(report);
+  const claudeWritten = writeClaudeWorkflowHardeningPack(claudePack, options);
   const cursorPack = buildCursorMarketplaceRevenuePack();
   const cursorWritten = writeCursorMarketplaceRevenuePack(cursorPack, options);
 
@@ -29,6 +35,9 @@ async function main(argv = process.argv.slice(2)) {
   }
   if (written.reportDir) {
     console.log(`Artifacts written to ${written.reportDir}.`);
+  }
+  if (claudeWritten.docsPath) {
+    console.log(`Claude outbound pack updated: ${claudeWritten.docsPath}`);
   }
   if (cursorWritten.docsPath) {
     console.log(`Cursor pack updated: ${cursorWritten.docsPath}`);

--- a/scripts/claude-workflow-hardening-pack.js
+++ b/scripts/claude-workflow-hardening-pack.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { ensureDir } = require('./fs-utils');
+
+function normalizeText(value) {
+  return String(value ?? '').trim();
+}
+
+function hasEvidenceLabel(target, label) {
+  const evidence = Array.isArray(target?.evidence) ? target.evidence : [];
+  const needle = normalizeText(label).toLowerCase();
+  return evidence.some((entry) => normalizeText(entry).toLowerCase() === needle);
+}
+
+function isWarmTarget(target) {
+  return normalizeText(target?.temperature).toLowerCase() === 'warm';
+}
+
+function isClaudeTarget(target) {
+  const haystack = [
+    target?.accountName,
+    target?.repoName,
+    target?.description,
+    target?.source,
+    target?.channel,
+  ].map(normalizeText).join(' ').toLowerCase();
+  return /claude/.test(haystack);
+}
+
+function hasRepo(target) {
+  return Boolean(normalizeText(target?.repoName) && normalizeText(target?.repoUrl));
+}
+
+function summarizeExamples(targets = [], limit = 3) {
+  return targets.slice(0, limit).map((target) => {
+    if (hasRepo(target)) {
+      return `${target.username}/${target.repoName}`;
+    }
+    return `@${target.username}`;
+  });
+}
+
+function buildSignalSummary(report = {}) {
+  const targets = Array.isArray(report.targets) ? report.targets : [];
+  const warmClaudeTargets = targets.filter((target) => isWarmTarget(target) && isClaudeTarget(target));
+  const productionTargets = targets.filter((target) => hasEvidenceLabel(target, 'production or platform workflow'));
+  const businessSystemTargets = targets.filter((target) => hasEvidenceLabel(target, 'business-system integration'));
+
+  return [
+    {
+      key: 'warm_claude_workflows',
+      label: 'Warm Claude workflow pain already exists',
+      count: warmClaudeTargets.length,
+      summary: `${warmClaudeTargets.length} warm Claude-first signals already named review boundaries, brittle guardrails, or context-risk pain.`,
+      examples: summarizeExamples(warmClaudeTargets),
+    },
+    {
+      key: 'production_rollout',
+      label: 'Production rollout proof is the strongest cold signal',
+      count: productionTargets.length,
+      summary: `${productionTargets.length} current targets touch releases, incidents, or other production-sensitive workflows that need approval boundaries and proof.`,
+      examples: summarizeExamples(productionTargets),
+    },
+    {
+      key: 'business_system_approvals',
+      label: 'Business-system approvals are present but secondary',
+      count: businessSystemTargets.length,
+      summary: `${businessSystemTargets.length} current targets wire agents into business systems where rollback safety and approvals matter.`,
+      examples: summarizeExamples(businessSystemTargets),
+    },
+  ].filter((entry) => entry.count > 0);
+}
+
+function buildLaneEvidenceSentence(count, noun, examples = []) {
+  const exampleText = examples.length ? ` Examples: ${examples.join(', ')}.` : '';
+  return `${count} ${noun}.${exampleText}`;
+}
+
+function buildBuyerLanes(report = {}) {
+  const targets = Array.isArray(report.targets) ? report.targets : [];
+  const warmClaudeTargets = targets.filter((target) => isWarmTarget(target) && isClaudeTarget(target));
+  const productionTargets = targets.filter((target) => hasEvidenceLabel(target, 'production or platform workflow'));
+  const businessSystemTargets = targets.filter((target) => hasEvidenceLabel(target, 'business-system integration'));
+
+  const lanes = [];
+
+  if (warmClaudeTargets.length) {
+    lanes.push({
+      key: 'claude_first_workflow_owner',
+      audience: 'Claude-first builders and workflow owners',
+      evidence: buildLaneEvidenceSentence(
+        warmClaudeTargets.length,
+        'warm Claude-first signals already named concrete workflow pain',
+        summarizeExamples(warmClaudeTargets)
+      ),
+      angle: 'Lead with one repeated workflow failure inside an already-serious Claude process. Do not open with proof.',
+      firstTouchDraft: 'You are already running a serious Claude workflow. I am looking for one Claude-first workflow to harden end-to-end this week: repeated failure, pre-action gate, and proof run. If one review boundary or brittle-guardrail failure keeps coming back, I can harden that workflow for you.',
+      painConfirmedFollowUpDraft: 'If that Claude workflow really has one repeated failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence so the next step stays grounded.',
+    });
+  }
+
+  if (productionTargets.length) {
+    lanes.push({
+      key: 'platform_rollout_owner',
+      audience: 'Platform teams shipping agents near release, incident, or compliance surfaces',
+      evidence: buildLaneEvidenceSentence(
+        productionTargets.length,
+        'current targets expose production or platform workflows where proof matters before rollout',
+        summarizeExamples(productionTargets)
+      ),
+      angle: 'Lead with approval boundaries, rollback safety, and proof for one production workflow.',
+      firstTouchDraft: 'I am looking for one production workflow to harden end-to-end this week: repeated failure, prevention gate, and proof run. If one release, incident, or compliance-adjacent workflow keeps needing manual rescue, I can harden that workflow for you.',
+      painConfirmedFollowUpDraft: 'If that production workflow is real, I can send the Workflow Hardening Sprint brief with commercial truth and verification evidence after the buyer confirms the specific blocker.',
+    });
+  }
+
+  if (businessSystemTargets.length) {
+    lanes.push({
+      key: 'business_system_operator',
+      audience: 'Teams wiring agents into Jira, ServiceNow, Slack, or other business systems',
+      evidence: buildLaneEvidenceSentence(
+        businessSystemTargets.length,
+        'current targets touch business-system workflows where approvals and rollback safety are explicit buying triggers',
+        summarizeExamples(businessSystemTargets)
+      ),
+      angle: 'Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.',
+      firstTouchDraft: 'I am looking for one agent workflow touching Jira, ServiceNow, Slack, or another business system to harden end-to-end this week. If one approval or handoff failure keeps repeating, I can harden that workflow for you.',
+      painConfirmedFollowUpDraft: 'Once the buyer confirms the failing business-system workflow, send the Workflow Hardening Sprint brief plus commercial truth and verification evidence. Do not lead with the proof pack.',
+    });
+  }
+
+  return lanes;
+}
+
+function buildPackTargets(report = {}) {
+  const targets = Array.isArray(report.targets) ? report.targets : [];
+  return targets.slice(0, 6).map((target) => ({
+    account: hasRepo(target) ? `${target.username}/${target.repoName}` : `@${target.username}`,
+    temperature: normalizeText(target.temperature) || 'cold',
+    why: normalizeText(target.motionReason) || normalizeText(target.outreachAngle),
+    motion: normalizeText(target.motionLabel),
+  }));
+}
+
+function buildClaudeWorkflowHardeningPack(report = {}) {
+  const signals = buildSignalSummary(report);
+  const buyerLanes = buildBuyerLanes(report);
+
+  return {
+    generatedAt: normalizeText(report.generatedAt) || new Date().toISOString(),
+    objective: 'Turn current Claude-first buyer signals into booked workflow-hardening diagnostics and self-serve follow-up only after pain is confirmed.',
+    state: normalizeText(report.directive?.state) || 'cold-start',
+    headline: 'Make one Claude-first workflow safe enough to ship team-wide.',
+    summary: [
+      'ThumbGate should sell Claude workflow hardening as a concrete delivery motion, not generic AI governance.',
+      normalizeText(report.directive?.headline),
+    ].filter(Boolean).join(' '),
+    primaryOffer: {
+      label: normalizeText(report.currentTruth?.teamPilotOffer) || 'Workflow Hardening Sprint',
+      cta: normalizeText(report.targets?.find((target) => normalizeText(target.motion) === 'sprint')?.cta),
+    },
+    secondaryOffer: {
+      label: normalizeText(report.currentTruth?.publicSelfServeOffer) || 'Pro at $19/mo or $149/yr',
+      cta: normalizeText(report.targets?.find((target) => normalizeText(target.motion) === 'pro')?.cta),
+    },
+    proofPolicy: 'Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms workflow pain.',
+    signals,
+    buyerLanes,
+    sampleTargets: buildPackTargets(report),
+    proofLinks: [
+      normalizeText(report.currentTruth?.commercialTruthLink),
+      normalizeText(report.currentTruth?.verificationEvidenceLink),
+    ].filter(Boolean),
+  };
+}
+
+function renderClaudeWorkflowHardeningPackMarkdown(pack = {}) {
+  const signalLines = Array.isArray(pack.signals) && pack.signals.length
+    ? pack.signals.flatMap((signal) => ([
+      `### ${signal.label}`,
+      `- Count: ${signal.count}`,
+      `- Summary: ${signal.summary}`,
+      `- Examples: ${signal.examples.length ? signal.examples.join(', ') : 'n/a'}`,
+      '',
+    ]))
+    : ['- No evidence-backed Claude signals were available in this run.', ''];
+  const laneLines = Array.isArray(pack.buyerLanes) && pack.buyerLanes.length
+    ? pack.buyerLanes.flatMap((lane) => ([
+      `### ${lane.audience}`,
+      `- Evidence: ${lane.evidence}`,
+      `- Angle: ${lane.angle}`,
+      `- First touch: ${lane.firstTouchDraft}`,
+      `- Pain-confirmed follow-up: ${lane.painConfirmedFollowUpDraft}`,
+      '',
+    ]))
+    : ['- No buyer lanes were available in this run.', ''];
+  const sampleTargetLines = Array.isArray(pack.sampleTargets) && pack.sampleTargets.length
+    ? pack.sampleTargets.map((target) => `- ${target.account} (${target.temperature}): ${target.why}`)
+    : ['- No sample targets available in this run.'];
+  const proofLines = Array.isArray(pack.proofLinks) && pack.proofLinks.length
+    ? pack.proofLinks.map((link) => `- ${link}`)
+    : ['- No proof links available in this run.'];
+
+  return [
+    '# Claude Workflow Hardening Pack',
+    '',
+    `Updated: ${pack.generatedAt}`,
+    '',
+    'This is a sales operator artifact. It is not proof of sent outreach, partner acceptance, booked revenue, or deployment success by itself.',
+    '',
+    '## Objective',
+    pack.objective,
+    '',
+    '## Positioning',
+    `- State: ${pack.state}`,
+    `- Headline: ${pack.headline}`,
+    `- Summary: ${pack.summary}`,
+    '',
+    '## Offer Stack',
+    `- Primary: ${pack.primaryOffer?.label || 'n/a'}${pack.primaryOffer?.cta ? ` -> ${pack.primaryOffer.cta}` : ''}`,
+    `- Secondary: ${pack.secondaryOffer?.label || 'n/a'}${pack.secondaryOffer?.cta ? ` -> ${pack.secondaryOffer.cta}` : ''}`,
+    `- Proof policy: ${pack.proofPolicy}`,
+    '',
+    '## Evidence-Backed Signals',
+    ...signalLines,
+    '## Buyer Lanes',
+    ...laneLines,
+    '## Sample Targets Behind This Pack',
+    ...sampleTargetLines,
+    '',
+    '## Proof Links',
+    ...proofLines,
+    '',
+  ].join('\n');
+}
+
+function writeClaudeWorkflowHardeningPack(pack, options = {}) {
+  const repoRoot = path.resolve(__dirname, '..');
+  const markdown = renderClaudeWorkflowHardeningPackMarkdown(pack);
+  const reportDir = normalizeText(options.reportDir)
+    ? path.resolve(repoRoot, options.reportDir)
+    : '';
+  const docsPath = path.join(repoRoot, 'docs', 'marketing', 'claude-workflow-hardening-pack.md');
+
+  if (reportDir) {
+    ensureDir(reportDir);
+    fs.writeFileSync(path.join(reportDir, 'claude-workflow-hardening-pack.md'), markdown, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'claude-workflow-hardening-pack.json'), `${JSON.stringify(pack, null, 2)}\n`, 'utf8');
+  }
+
+  if (options.writeDocs) {
+    fs.writeFileSync(docsPath, markdown, 'utf8');
+  }
+
+  return {
+    markdown,
+    docsPath: options.writeDocs ? docsPath : null,
+    reportDir: reportDir || null,
+  };
+}
+
+module.exports = {
+  buildClaudeWorkflowHardeningPack,
+  buildSignalSummary,
+  buildBuyerLanes,
+  renderClaudeWorkflowHardeningPackMarkdown,
+  writeClaudeWorkflowHardeningPack,
+};

--- a/tests/claude-workflow-hardening-pack.test.js
+++ b/tests/claude-workflow-hardening-pack.test.js
@@ -1,0 +1,153 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildBuyerLanes,
+  buildClaudeWorkflowHardeningPack,
+  buildSignalSummary,
+  renderClaudeWorkflowHardeningPackMarkdown,
+  writeClaudeWorkflowHardeningPack,
+} = require('../scripts/claude-workflow-hardening-pack');
+
+function makeReportFixture() {
+  return {
+    generatedAt: '2026-04-26T02:00:00.000Z',
+    directive: {
+      state: 'cold-start',
+      headline: 'No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.',
+    },
+    currentTruth: {
+      teamPilotOffer: 'Workflow Hardening Sprint',
+      publicSelfServeOffer: 'Pro at $19/mo or $149/yr',
+      commercialTruthLink: 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md',
+      verificationEvidenceLink: 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md',
+    },
+    targets: [
+      {
+        temperature: 'warm',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        username: 'claude_builder',
+        accountName: 'r/ClaudeCode',
+        repoName: '',
+        repoUrl: '',
+        description: 'Named review boundaries and context risk in a mature Claude workflow.',
+        evidence: ['warm inbound engagement'],
+        motion: 'sprint',
+        motionLabel: 'Workflow Hardening Sprint',
+        motionReason: 'Warm Claude workflow pain is already explicit.',
+        outreachAngle: 'Lead with one repeated workflow failure inside an already-mature Claude workflow.',
+        cta: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+      },
+      {
+        temperature: 'warm',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        username: 'adaptive_guardrails',
+        accountName: 'r/ClaudeCode',
+        repoName: '',
+        repoUrl: '',
+        description: 'Called out brittle guardrails that fail under context shift.',
+        evidence: ['warm inbound engagement'],
+        motion: 'sprint',
+        motionLabel: 'Workflow Hardening Sprint',
+        motionReason: 'Warm Claude workflow pain is already explicit.',
+        outreachAngle: 'Lead with brittle-guardrail workflow pain.',
+        cta: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+      },
+      {
+        temperature: 'cold',
+        source: 'github',
+        channel: 'github',
+        username: 'freema',
+        accountName: 'freema',
+        repoName: 'mcp-jira-stdio',
+        repoUrl: 'https://github.com/freema/mcp-jira-stdio',
+        description: 'Claude-friendly Jira workflow automation with approvals and rollback safety.',
+        evidence: ['workflow control surface', 'business-system integration', 'production or platform workflow'],
+        motion: 'sprint',
+        motionLabel: 'Workflow Hardening Sprint',
+        motionReason: 'Jira workflows need approval boundaries.',
+        outreachAngle: 'Lead with approval boundaries, rollback safety, and proof.',
+        cta: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+      },
+      {
+        temperature: 'cold',
+        source: 'github',
+        channel: 'github',
+        username: 'WagnerAgent',
+        accountName: 'WagnerAgent',
+        repoName: 'awesome-mcp-servers-devops',
+        repoUrl: 'https://github.com/WagnerAgent/awesome-mcp-servers-devops',
+        description: 'Production workflow tooling for agent operators.',
+        evidence: ['production or platform workflow'],
+        motion: 'pro',
+        motionLabel: 'Pro at $19/mo or $149/yr',
+        motionReason: 'Self-serve tooling path is explicit.',
+        outreachAngle: 'Lead with rollout proof for one production workflow.',
+        cta: 'https://thumbgate-production.up.railway.app/checkout/pro',
+      },
+    ],
+  };
+}
+
+test('signal summary stays tied to Claude, production, and business-system evidence', () => {
+  const signals = buildSignalSummary(makeReportFixture());
+
+  assert.deepEqual(signals.map((entry) => entry.key), [
+    'warm_claude_workflows',
+    'production_rollout',
+    'business_system_approvals',
+  ]);
+  assert.equal(signals[0].count, 2);
+  assert.equal(signals[1].count, 2);
+  assert.equal(signals[2].count, 1);
+});
+
+test('buyer lanes stay workflow-hardening-first and do not lead with proof', () => {
+  const lanes = buildBuyerLanes(makeReportFixture());
+
+  assert.ok(lanes.some((lane) => /Claude-first builders/.test(lane.audience)));
+  assert.ok(lanes.some((lane) => /Platform teams/.test(lane.audience)));
+  assert.ok(lanes.some((lane) => /Jira, ServiceNow, Slack/.test(lane.audience)));
+  assert.ok(lanes.every((lane) => /harden/.test(lane.firstTouchDraft)));
+  assert.ok(lanes.every((lane) => !/VERIFICATION_EVIDENCE|COMMERCIAL_TRUTH/.test(lane.firstTouchDraft)));
+});
+
+test('rendered pack is operator-ready and anchored to proof links', () => {
+  const pack = buildClaudeWorkflowHardeningPack(makeReportFixture());
+  const markdown = renderClaudeWorkflowHardeningPackMarkdown(pack);
+
+  assert.match(markdown, /Claude Workflow Hardening Pack/);
+  assert.match(markdown, /Make one Claude-first workflow safe enough to ship team-wide/);
+  assert.match(markdown, /Workflow Hardening Sprint/);
+  assert.match(markdown, /Pro at \$19\/mo or \$149\/yr/);
+  assert.match(markdown, /COMMERCIAL_TRUTH\.md/);
+  assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
+  assert.doesNotMatch(markdown, /official partner|booked revenue exists/i);
+});
+
+test('writer exports markdown and JSON artifacts for the operator report folder', () => {
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-claude-pack-'));
+
+  try {
+    const written = writeClaudeWorkflowHardeningPack(
+      buildClaudeWorkflowHardeningPack(makeReportFixture()),
+      { reportDir }
+    );
+
+    assert.equal(written.reportDir, reportDir);
+    assert.equal(written.docsPath, null);
+    assert.equal(fs.existsSync(path.join(reportDir, 'claude-workflow-hardening-pack.md')), true);
+    assert.equal(fs.existsSync(path.join(reportDir, 'claude-workflow-hardening-pack.json')), true);
+
+    const json = JSON.parse(fs.readFileSync(path.join(reportDir, 'claude-workflow-hardening-pack.json'), 'utf8'));
+    assert.equal(json.signals[0].key, 'warm_claude_workflows');
+    assert.equal(json.buyerLanes[0].key, 'claude_first_workflow_owner');
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a generated Claude workflow hardening pack to the GTM automation outputs
- ship a tracked operator-ready Claude-first outbound asset plus tests
- document the new artifact in the discovery sprint and align Anthropic strategy channels

## Verification
- npm run test:operator-artifacts
- node --test tests/gtm-revenue-loop.test.js tests/cursor-marketplace-revenue-pack.test.js
- npm run pr:manage

## Evidence
- main CI on 2026-04-26 commit 2af4acbc65b7e7fd4b80473b9bc93e65fa64ee4f was green before branching
- current open PR sweep shows #1308 blocked only by one pending Trunk quality check