### PR TITLE
feat(gtm): route marketplace installs through proof guide

### DIFF
--- a/.changeset/marketplace-proof-guide-sync.md
+++ b/.changeset/marketplace-proof-guide-sync.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Route install-intent marketplace and Claude operator surfaces through the proof-backed guide so listing traffic lands on the setup path that already carries Commercial Truth, verification evidence, and clear Pro versus Workflow Hardening Sprint next steps.

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -39,6 +39,8 @@ Or use the project bootstrap:
 npx thumbgate init
 ```
 
+Full setup guide: https://thumbgate-production.up.railway.app/guide
+
 ### Direct bundle download
 
 Download the latest packaged Claude Desktop bundle from GitHub Releases:
@@ -159,6 +161,7 @@ For complete privacy information, see: https://thumbgate-production.up.railway.a
 
 - GitHub Issues: https://github.com/IgorGanapolsky/ThumbGate/issues
 - Security Advisories: https://github.com/IgorGanapolsky/ThumbGate/security
+- Full setup guide: https://thumbgate-production.up.railway.app/guide
 - Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 - Product Hunt: https://www.producthunt.com/products/thumbgate
 

--- a/docs/AUTONOMOUS_GITOPS.md
+++ b/docs/AUTONOMOUS_GITOPS.md
@@ -1,9 +1,10 @@
 # GSD Revenue Loop
 
-Status: post-first-dollar
-Updated: 2026-03-20T15:49:15.715Z
+Status: cold-start
+Updated: 2026-04-26T04:03:15.030Z
 
 This report is an operator artifact for landing the first 10 paying customers. It is not proof of sent messages or booked revenue by itself.
+Outbound rule: do not treat posts as sales. A lead only moves when it is tracked as contacted, replied, call booked, checkout/sprint, or paid.
 
 ## Current Truth
 - Public self-serve offer: Pro at $19/mo or $149/yr
@@ -11,9 +12,18 @@ This report is an operator artifact for landing the first 10 paying customers. I
 - Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
 - Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
+## Evidence Backstop
+- Source rule: Every listing, queue row, and pain-confirmed follow-up must inherit these sources before it is treated as operator-ready.
+- Do not claim revenue, installs, or marketplace approval without direct command evidence.
+- Do not lead with proof links before the buyer confirms pain.
+- Keep public pricing and traction claims aligned with COMMERCIAL_TRUTH.md.
+- Keep proof and quality claims aligned with VERIFICATION_EVIDENCE.md.
+- Proof link: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
+- Proof link: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
 ## Revenue Snapshot
-- Paid orders: 2
-- Booked revenue: $20.00
+- Paid orders: 0
+- Booked revenue: $0.00
 - Checkout starts: 0
 - Unique leads: 0
 - Workflow sprint leads: 0
@@ -21,55 +31,320 @@ This report is an operator artifact for landing the first 10 paying customers. I
 - Billing source: local (Hosted operational summary is not configured.)
 
 ## GSD Directive
-- Objective: Scale the first-10-customers loop with proof-backed self-serve follow-up.
-- Headline: Revenue is proven. Double down on the self-serve Pro CTA and use the sprint motion for expansion deals.
-- Primary motion: pro
-- Secondary motion: sprint
+- Objective: Land the first 10 paying customers with founder-led workflow hardening.
+- Headline: No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
+- Primary motion: sprint
+- Secondary motion: pro
 
 ## Immediate Actions
-- Reply to every qualified builder lead with the Pro checkout path and the proof pack.
-- Use the Workflow Hardening Sprint only when a team already has one workflow owner and a rollout blocker.
-- Publish only booked revenue and paid-order proof from the billing summary or named pilot agreements.
+- Directly contact qualified buyers with: "I will harden one AI-agent workflow for you."
+- Use Pro at $19/mo or $149/yr only as the self-serve follow-up after the buyer asks for the tool path.
+- Track every lead as contacted -> replied -> call booked -> checkout or sprint intake -> paid.
+- Treat stars, traffic, and model praise as noise until they become paid orders or named pilot agreements.
 
-## Target Queue
-### @estebamod — osmmcp
-- Repo: https://github.com/estebamod/osmmcp
-- Motion: Pro at $19/mo or $149/yr
-- Why: Target looks builder-led, so the self-serve Pro CTA is the lowest-friction path.
-- CTA: https://thumbgate-production.up.railway.app/checkout/pro
-- Outreach draft: Hey @estebamod, saw you're building around `osmmcp`. If you're hitting "Claude amnesia" or losing architectural constraints to auto-compaction between sessions, the self-serve path is compaction-safe memory with ThumbGate Pro at $19/mo or $149/yr: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md. Proof pack: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md.
-
-### @milxxyzxc — mcp-boilerplate
-- Repo: https://github.com/milxxyzxc/mcp-boilerplate
+## Warm Discovery Queue
+### @Deep_Ad1959 — r/cursor
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: https://www.reddit.com/user/Deep_Ad1959/
+- Repo: n/a
+- Repo last updated: n/a
+- Evidence score: 10
+- Evidence: warm inbound engagement, workflow pain named: rollback risk, already in DMs
+- Evidence sources: Target signal: https://www.reddit.com/user/Deep_Ad1959/; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with rollback safety and context-drift hardening for one workflow before any generic tool pitch.
 - Motion: Workflow Hardening Sprint
-- Why: Target language suggests a team workflow or production rollout problem.
+- Why: Warm Reddit engager already named a repeated workflow risk, so the fastest path is a founder-led diagnostic.
+- Proof timing: Use proof pack only after the buyer confirms pain.
 - CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
-- Outreach draft: Hey @milxxyzxc, saw you're shipping `mcp-boilerplate`. If your production workflows are losing critical architectural context to auto-compaction, I am pitching a Workflow Hardening Sprint for one workflow, one owner, and one proof review: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md. Proof pack: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md.
+- First-touch draft: Your question about rollback rates when context changes is exactly the right one. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have one workflow where context drift or rollback risk keeps showing up, I can harden that workflow for you. Worth a 15-minute diagnostic?
+- Pain-confirmed follow-up: If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
-### @skyfire-xyz — skyfire-solutions-demo
-- Repo: https://github.com/skyfire-xyz/skyfire-solutions-demo
-- Motion: Pro at $19/mo or $149/yr
-- Why: Target looks builder-led, so the self-serve Pro CTA is the lowest-friction path.
-- CTA: https://thumbgate-production.up.railway.app/checkout/pro
-- Outreach draft: Hey @skyfire-xyz, saw you're building around `skyfire-solutions-demo`. If you're hitting "Claude amnesia" or losing architectural constraints to auto-compaction between sessions, the self-serve path is compaction-safe memory with ThumbGate Pro at $19/mo or $149/yr: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md. Proof pack: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md.
-
-### @danielmonterocr — skills-integrate-mcp-with-copilot
-- Repo: https://github.com/danielmonterocr/skills-integrate-mcp-with-copilot
-- Motion: Pro at $19/mo or $149/yr
-- Why: Target looks builder-led, so the self-serve Pro CTA is the lowest-friction path.
-- CTA: https://thumbgate-production.up.railway.app/checkout/pro
-- Outreach draft: Hey @danielmonterocr, saw you're building around `skills-integrate-mcp-with-copilot`. If you're hitting "Claude amnesia" or losing architectural constraints to auto-compaction between sessions, the self-serve path is compaction-safe memory with ThumbGate Pro at $19/mo or $149/yr: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md. Proof pack: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md.
-
-### @princestf01 — skills-integrate-mcp-with-copilot
-- Repo: https://github.com/princestf01/skills-integrate-mcp-with-copilot
-- Motion: Pro at $19/mo or $149/yr
-- Why: Target looks builder-led, so the self-serve Pro CTA is the lowest-friction path.
-- CTA: https://thumbgate-production.up.railway.app/checkout/pro
-- Outreach draft: Hey @princestf01, saw you're building around `skills-integrate-mcp-with-copilot`. If you're hitting "Claude amnesia" or losing architectural constraints to auto-compaction between sessions, the self-serve path is compaction-safe memory with ThumbGate Pro at $19/mo or $149/yr: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md. Proof pack: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md.
-
-### @gunbun33 — mcp-servers
-- Repo: https://github.com/gunbun33/mcp-servers
+### @game-of-kton — r/cursor
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: https://www.reddit.com/user/game-of-kton/
+- Repo: n/a
+- Repo last updated: n/a
+- Evidence score: 9
+- Evidence: warm inbound engagement, built serious memory systems, workflow pain named: stale context and conflicting facts
+- Evidence sources: Target signal: https://www.reddit.com/user/game-of-kton/; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with one recurring memory or handoff failure that can be turned into an enforceable prevention rule.
 - Motion: Workflow Hardening Sprint
-- Why: Target language suggests a team workflow or production rollout problem.
+- Why: Warm Reddit engager already works on advanced agent memory, so discovery should center on one repeated failure pattern.
+- Proof timing: Use proof pack only after the buyer confirms pain.
 - CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
-- Outreach draft: Hey @gunbun33, saw you're shipping `mcp-servers`. If your production workflows are losing critical architectural context to auto-compaction, I am pitching a Workflow Hardening Sprint for one workflow, one owner, and one proof review: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md. Proof pack: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md.
+- First-touch draft: Your ACT-R engram work is fascinating, especially the conflict resolution for opposing facts and the decay model. I am looking for one serious AI-agent workflow to harden end-to-end this week. If your memory system has one recurring failure mode such as stale context, opposing facts, bad handoffs, or unsafe tool calls, I can turn that into a prevention rule and proof run. Open to a 15-minute diagnostic?
+- Pain-confirmed follow-up: If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @leogodin217 — r/ClaudeCode
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: https://www.reddit.com/user/leogodin217/
+- Repo: n/a
+- Repo last updated: n/a
+- Evidence score: 9
+- Evidence: warm inbound engagement, mature multi-step workflow described, workflow pain named: review boundaries and context risk
+- Evidence sources: Target signal: https://www.reddit.com/user/leogodin217/; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with one repeating failure inside an already-mature workflow and offer an enforceable Pre-Action Check plus proof run.
+- Motion: Workflow Hardening Sprint
+- Why: Warm Reddit engager already described a mature workflow, so the next step is a targeted diagnostic on one failure mode.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Your arch-create to sprint workflow is one of the most mature agent processes I have seen anyone describe. I am looking for one AI-agent workflow to harden end-to-end this week. Your workflow already has phases, review boundaries, and context risk, so it is a strong fit: pick one repeating failure and I will help turn it into an enforceable Pre-Action Check plus proof run. Worth 15 minutes?
+- Pain-confirmed follow-up: If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @Enthu-Cutlet-1337 — r/ClaudeCode
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: https://www.reddit.com/user/Enthu-Cutlet-1337/
+- Repo: n/a
+- Repo last updated: n/a
+- Evidence score: 8
+- Evidence: warm inbound engagement, responded to adaptive-gate positioning, workflow pain named: brittle guardrails
+- Evidence sources: Target signal: https://www.reddit.com/user/Enthu-Cutlet-1337/; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with one brittle-guardrail workflow and offer to harden it with adaptive gates plus a proof run.
+- Motion: Workflow Hardening Sprint
+- Why: Warm Reddit engager already understands the adaptive-gate thesis, so offer one concrete workflow hardening diagnostic.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Appreciate the kind words on the Thompson Sampling approach. You nailed the core insight: most guardrails are brittle prompt hacks that break when context shifts. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have a workflow where brittle guardrails keep failing, I can harden that workflow with you. Open to a 15-minute diagnostic?
+- Pain-confirmed follow-up: If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+
+## Cold GitHub Queue
+### @freema — mcp-jira-stdio
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/freema/mcp-jira-stdio
+- Repo last updated: 2026-04-21T14:40:45Z
+- Evidence score: 13
+- Evidence: workflow control surface, business-system integration, agent infrastructure, 11 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/freema/mcp-jira-stdio; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @freema, saw you're shipping `mcp-jira-stdio`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof. If `mcp-jira-stdio` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `mcp-jira-stdio` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @wanshuiyin — Auto-claude-code-research-in-sleep
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep
+- Repo last updated: 2026-04-26T03:43:06Z
+- Evidence score: 12
+- Evidence: workflow control surface, agent infrastructure, 7508 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @wanshuiyin, saw you're shipping `Auto-claude-code-research-in-sleep`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with context-drift hardening for one workflow before proposing any broader agent platform story. If `Auto-claude-code-research-in-sleep` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `Auto-claude-code-research-in-sleep` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @makafeli — n8n-workflow-builder
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/makafeli/n8n-workflow-builder
+- Repo last updated: 2026-04-20T13:30:14Z
+- Evidence score: 12
+- Evidence: workflow control surface, agent infrastructure, 512 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/makafeli/n8n-workflow-builder; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @makafeli, saw you're shipping `n8n-workflow-builder`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with context-drift hardening for one workflow before proposing any broader agent platform story. If `n8n-workflow-builder` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `n8n-workflow-builder` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @salacoste — mcp-n8n-workflow-builder
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/salacoste/mcp-n8n-workflow-builder
+- Repo last updated: 2026-04-22T23:45:33Z
+- Evidence score: 12
+- Evidence: workflow control surface, agent infrastructure, 221 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/salacoste/mcp-n8n-workflow-builder; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @salacoste, saw you're shipping `mcp-n8n-workflow-builder`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with context-drift hardening for one workflow before proposing any broader agent platform story. If `mcp-n8n-workflow-builder` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `mcp-n8n-workflow-builder` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @WagnerAgent — awesome-mcp-servers-devops
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: pro_self_serve
+- Contact: n/a
+- Repo: https://github.com/WagnerAgent/awesome-mcp-servers-devops
+- Repo last updated: 2026-04-25T18:23:28Z
+- Evidence score: 11
+- Evidence: production or platform workflow, agent infrastructure, 93 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/WagnerAgent/awesome-mcp-servers-devops; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Motion: Pro at $19/mo or $149/yr
+- Why: Target looks like a self-serve tooling surface, so Pro is the cleaner CTA unless a concrete workflow pain is confirmed.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/checkout/pro
+- First-touch draft: Hey @WagnerAgent, saw you're building around `awesome-mcp-servers-devops`. If you only want the self-serve path, ThumbGate Pro gives you compaction-safe memory and feedback-to-gate enforcement: https://thumbgate-production.up.railway.app/checkout/pro If you have a painful workflow instead, I can harden one concrete workflow first.
+- Pain-confirmed follow-up: If you want the self-serve path for `awesome-mcp-servers-devops`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @bjeans — homelab-mcp
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/bjeans/homelab-mcp
+- Repo last updated: 2026-04-23T15:29:47Z
+- Evidence score: 11
+- Evidence: production or platform workflow, agent infrastructure, 25 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/bjeans/homelab-mcp; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @bjeans, saw you're shipping `homelab-mcp`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes. If `homelab-mcp` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `homelab-mcp` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @Shashankk1907 — Learning-about-MCP
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/Shashankk1907/Learning-about-MCP
+- Repo last updated: 2026-04-17T11:28:44Z
+- Evidence score: 11
+- Evidence: workflow control surface, production or platform workflow, agent infrastructure, updated in the last 30 days
+- Evidence sources: Target signal: https://github.com/Shashankk1907/Learning-about-MCP; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @Shashankk1907, saw you're shipping `Learning-about-MCP`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes. If `Learning-about-MCP` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `Learning-about-MCP` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @gensecaihq — MCP-Developer-SubAgent
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/gensecaihq/MCP-Developer-SubAgent
+- Repo last updated: 2026-04-13T20:05:59Z
+- Evidence score: 10
+- Evidence: production or platform workflow, agent infrastructure, 27 GitHub stars, updated in the last 30 days
+- Evidence sources: Target signal: https://github.com/gensecaihq/MCP-Developer-SubAgent; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @gensecaihq, saw you're shipping `MCP-Developer-SubAgent`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes. If `MCP-Developer-SubAgent` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `MCP-Developer-SubAgent` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @aartiq — servicenow-mcp
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/aartiq/servicenow-mcp
+- Repo last updated: 2026-04-25T05:20:57Z
+- Evidence score: 10
+- Evidence: production or platform workflow, agent infrastructure, 21 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/aartiq/servicenow-mcp; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @aartiq, saw you're shipping `servicenow-mcp`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes. If `servicenow-mcp` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `servicenow-mcp` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @verygoodplugins — mcp-freescout
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/verygoodplugins/mcp-freescout
+- Repo last updated: 2026-04-23T13:11:30Z
+- Evidence score: 10
+- Evidence: workflow control surface, agent infrastructure, 15 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/verygoodplugins/mcp-freescout; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @verygoodplugins, saw you're shipping `mcp-freescout`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with context-drift hardening for one workflow before proposing any broader agent platform story. If `mcp-freescout` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `mcp-freescout` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @Cake-sweet — agents
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/Cake-sweet/agents
+- Repo last updated: 2026-04-26T02:16:06Z
+- Evidence score: 10
+- Evidence: workflow control surface, agent infrastructure, 6 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/Cake-sweet/agents; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Pitch one repeated workflow failure, then offer proof-backed hardening instead of a generic tool trial.
+- Motion: Workflow Hardening Sprint
+- Why: Pitch one repeated workflow failure, then offer proof-backed hardening instead of a generic tool trial.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @Cake-sweet, saw you're shipping `agents`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Pitch one repeated workflow failure, then offer proof-backed hardening instead of a generic tool trial. If `agents` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `agents` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### @ibmbpm — ibm-baw-mcp-server
+- Temperature: cold
+- Source: github / github
+- Pipeline stage: targeted
+- Offer: workflow_hardening_sprint
+- Contact: n/a
+- Repo: https://github.com/ibmbpm/ibm-baw-mcp-server
+- Repo last updated: 2026-04-23T15:06:45Z
+- Evidence score: 10
+- Evidence: workflow control surface, agent infrastructure, 6 GitHub stars, updated in the last 7 days
+- Evidence sources: Target signal: https://github.com/ibmbpm/ibm-baw-mcp-server; Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md; Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Outreach angle: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Motion: Workflow Hardening Sprint
+- Why: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Proof timing: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- First-touch draft: Hey @ibmbpm, saw you're shipping `ibm-baw-mcp-server`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with context-drift hardening for one workflow before proposing any broader agent platform story. If `ibm-baw-mcp-server` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Pain-confirmed follow-up: If `ibm-baw-mcp-server` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md

--- a/docs/CURSOR_PLUGIN_OPERATIONS.md
+++ b/docs/CURSOR_PLUGIN_OPERATIONS.md
@@ -52,5 +52,5 @@ When the feedback is a vague thumbs-down, ThumbGate can distill the lesson from 
 - Name: `ThumbGate`
 - Description: `👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.`
 - Repository URL: `https://github.com/IgorGanapolsky/ThumbGate`
-- Homepage: `https://thumbgate-production.up.railway.app`
+- Homepage: `https://thumbgate-production.up.railway.app/guide`
 - Revenue pack: `node scripts/cursor-marketplace-revenue-pack.js --write-docs`

--- a/docs/marketing/claude-workflow-hardening-pack.md
+++ b/docs/marketing/claude-workflow-hardening-pack.md
@@ -1,6 +1,6 @@
 # Claude Workflow Hardening Pack
 
-Updated: 2026-04-26T02:01:28.625Z
+Updated: 2026-04-26T04:03:15.030Z
 
 This is a sales operator artifact. It is not proof of sent outreach, partner acceptance, booked revenue, or deployment success by itself.
 
@@ -15,6 +15,7 @@ Turn current Claude-first buyer signals into booked workflow-hardening diagnosti
 ## Offer Stack
 - Primary: Workflow Hardening Sprint -> https://thumbgate-production.up.railway.app/#workflow-sprint-intake
 - Secondary: Pro at $19/mo or $149/yr -> https://thumbgate-production.up.railway.app/checkout/pro
+- Self-serve guide: Proof-backed setup guide -> https://thumbgate-production.up.railway.app/guide
 - Proof policy: Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms workflow pain.
 
 ## Evidence-Backed Signals
@@ -58,7 +59,7 @@ Turn current Claude-first buyer signals into booked workflow-hardening diagnosti
 - @leogodin217 (warm): Warm Reddit engager already described a mature workflow, so the next step is a targeted diagnostic on one failure mode.
 - @Enthu-Cutlet-1337 (warm): Warm Reddit engager already understands the adaptive-gate thesis, so offer one concrete workflow hardening diagnostic.
 - freema/mcp-jira-stdio (cold): Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
-- salacoste/mcp-n8n-workflow-builder (cold): Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- wanshuiyin/Auto-claude-code-research-in-sleep (cold): Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
 
 ## Proof Links
 - https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md

--- a/docs/marketing/cursor-marketplace-revenue-pack.md
+++ b/docs/marketing/cursor-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Cursor Marketplace Revenue Pack
 
-Updated: 2026-04-26T00:00:32.567Z
+Updated: 2026-04-26T04:03:15.038Z
 
 This is a sales operator artifact. It is not proof of installs, paid revenue, directory approval, or marketplace publication by itself.
 
@@ -25,7 +25,7 @@ Turn Cursor plugin discovery into tracked installs, Pro checkout starts, and qua
 - Buyer: Cursor users who want the fastest install path for repeated-mistake prevention.
 - Submission path: https://cursor.com/marketplace/publish
 - Repository: https://github.com/IgorGanapolsky/ThumbGate
-- Homepage: https://thumbgate-production.up.railway.app/?utm_source=cursor&utm_medium=marketplace&utm_campaign=cursor_plugin_listing&utm_content=homepage&campaign_variant=plugin_homepage&offer_code=CURSOR-PLUGIN_HOMEPAGE&cta_id=cursor_plugin_homepage&cta_placement=cursor_listing&surface=cursor_marketplace
+- Homepage: https://thumbgate-production.up.railway.app/guide?utm_source=cursor&utm_medium=marketplace&utm_campaign=cursor_plugin_guide&utm_content=guide&campaign_variant=plugin_homepage&offer_code=CURSOR-PLUGIN_HOMEPAGE&cta_id=cursor_plugin_homepage&cta_placement=cursor_listing&surface=cursor_marketplace
 - Proof: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 - Support: https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/cursor-marketplace/README.md
 - Tags: thumbgate, pre-action-checks, agent-reliability, guardrails, developer-tools, cursor
@@ -43,7 +43,7 @@ Proof links: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCI
 - Buyer: Researchers and buyers comparing Cursor plugins before install.
 - Submission path: https://cursor.directory/plugins/thumbgate
 - Repository: https://github.com/IgorGanapolsky/ThumbGate
-- Homepage: https://thumbgate-production.up.railway.app/?utm_source=cursor&utm_medium=directory&utm_campaign=cursor_directory_profile&utm_content=homepage&campaign_variant=directory_homepage&offer_code=CURSOR-DIRECTORY_HOMEPAGE&cta_id=cursor_directory_homepage&cta_placement=cursor_listing&surface=cursor_directory
+- Homepage: https://thumbgate-production.up.railway.app/guide?utm_source=cursor&utm_medium=directory&utm_campaign=cursor_directory_guide&utm_content=guide&campaign_variant=directory_homepage&offer_code=CURSOR-DIRECTORY_HOMEPAGE&cta_id=cursor_directory_homepage&cta_placement=cursor_listing&surface=cursor_directory
 - Proof: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 - Support: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/CURSOR_PLUGIN_OPERATIONS.md
 - Tags: cursor, pre-action-checks, agent-reliability, guardrails
@@ -103,7 +103,7 @@ Tracked metrics:
 - paid_pro_conversions
 
 Milestones:
-- days_0_30: Refresh the Marketplace listing, directory profile, and screenshot set with tracked homepage plus proof links. Decision rule: Do not rewrite the value prop until homepage clicks or installs show a clear mismatch.
+- days_0_30: Refresh the Marketplace listing, directory profile, and screenshot set with the tracked setup guide plus proof links. Decision rule: Do not rewrite the value prop until guide clicks or installs show a clear mismatch.
 - days_31_60: Promote whichever follow-on motion converts better: Pro self-serve or Workflow Hardening Sprint. Decision rule: If installs happen without paid intent, move proof and follow-on offers higher in post-install docs.
 - days_61_90: Decide whether Cursor should stay a plugin-only lane or become a team rollout channel. Decision rule: Only prioritize Team Marketplace motion when qualified conversations exist.
 

--- a/plugins/cursor-marketplace/README.md
+++ b/plugins/cursor-marketplace/README.md
@@ -98,6 +98,8 @@ Or copy the plugin MCP config into `.cursor/mcp.json`:
 }
 ```
 
+Full setup guide: https://thumbgate-production.up.railway.app/guide
+
 ## Update behavior
 
 - Runtime updates: the plugin asks npm for `thumbgate@latest`, so new npm releases can flow into the Cursor runtime without editing the plugin config.
@@ -122,3 +124,4 @@ ThumbGate gives Cursor agents a practical guardrail layer:
 
 Verification evidence for shipped behavior lives in `docs/VERIFICATION_EVIDENCE.md`.
 Release and promotion rules live in `docs/CURSOR_PLUGIN_OPERATIONS.md`.
+Proof-backed setup path: https://thumbgate-production.up.railway.app/guide

--- a/scripts/claude-workflow-hardening-pack.js
+++ b/scripts/claude-workflow-hardening-pack.js
@@ -166,6 +166,10 @@ function buildClaudeWorkflowHardeningPack(report = {}) {
       label: normalizeText(report.currentTruth?.publicSelfServeOffer) || 'Pro at $19/mo or $149/yr',
       cta: normalizeText(report.targets?.find((target) => normalizeText(target.motion) === 'pro')?.cta),
     },
+    selfServeGuide: {
+      label: 'Proof-backed setup guide',
+      cta: normalizeText(report.currentTruth?.guideLink),
+    },
     proofPolicy: 'Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms workflow pain.',
     signals,
     buyerLanes,
@@ -222,6 +226,7 @@ function renderClaudeWorkflowHardeningPackMarkdown(pack = {}) {
     '## Offer Stack',
     `- Primary: ${pack.primaryOffer?.label || 'n/a'}${pack.primaryOffer?.cta ? ` -> ${pack.primaryOffer.cta}` : ''}`,
     `- Secondary: ${pack.secondaryOffer?.label || 'n/a'}${pack.secondaryOffer?.cta ? ` -> ${pack.secondaryOffer.cta}` : ''}`,
+    `- Self-serve guide: ${pack.selfServeGuide?.label || 'n/a'}${pack.selfServeGuide?.cta ? ` -> ${pack.selfServeGuide.cta}` : ''}`,
     `- Proof policy: ${pack.proofPolicy}`,
     '',
     '## Evidence-Backed Signals',

--- a/scripts/cursor-marketplace-revenue-pack.js
+++ b/scripts/cursor-marketplace-revenue-pack.js
@@ -115,7 +115,11 @@ function buildScreenshotManifest() {
 
 function buildCursorSurface(config, links, about) {
   const tracking = buildCursorTrackingMetadata(config.trackingKey, config.tracking);
-  const homepageBaseUrl = config.homepageBase === 'sprint' ? links.sprintLink : links.appOrigin;
+  const homepageBaseUrl = config.homepageBase === 'sprint'
+    ? links.sprintLink
+    : config.homepageBase === 'guide'
+      ? links.guideLink
+      : links.appOrigin;
   const tags = typeof config.tags === 'function' ? config.tags(about) : config.tags;
 
   return {
@@ -152,11 +156,12 @@ function buildCursorMarketplaceSurfaces(links = buildRevenueLinks(), about = rea
       shortDescription: CANONICAL_SHORT_DESCRIPTION,
       longDescription: CANONICAL_LONG_DESCRIPTION,
       supportPath: 'plugins/cursor-marketplace/README.md',
+      homepageBase: 'guide',
       trackingKey: 'plugin_homepage',
       tracking: {
         utmMedium: MARKETPLACE_MEDIUM,
-        utmCampaign: 'cursor_plugin_listing',
-        utmContent: 'homepage',
+        utmCampaign: 'cursor_plugin_guide',
+        utmContent: 'guide',
         surface: 'cursor_marketplace',
       },
       tags: ({ topics }) => topics.filter((topic) => [
@@ -182,11 +187,12 @@ function buildCursorMarketplaceSurfaces(links = buildRevenueLinks(), about = rea
         'Lead with the outcome before architecture: stop costly AI agent mistakes, then mention pre-action checks, prevention rules, and proof.',
       ],
       supportPath: 'docs/CURSOR_PLUGIN_OPERATIONS.md',
+      homepageBase: 'guide',
       trackingKey: 'directory_homepage',
       tracking: {
         utmMedium: DIRECTORY_MEDIUM,
-        utmCampaign: 'cursor_directory_profile',
-        utmContent: 'homepage',
+        utmCampaign: 'cursor_directory_guide',
+        utmContent: 'guide',
         surface: 'cursor_directory',
       },
       tags: ['cursor', 'pre-action-checks', 'agent-reliability', 'guardrails'],
@@ -273,8 +279,8 @@ function buildMeasurementPlan() {
     milestones: [
       {
         window: 'days_0_30',
-        goal: 'Refresh the Marketplace listing, directory profile, and screenshot set with tracked homepage plus proof links.',
-        decision: 'Do not rewrite the value prop until homepage clicks or installs show a clear mismatch.',
+        goal: 'Refresh the Marketplace listing, directory profile, and screenshot set with the tracked setup guide plus proof links.',
+        decision: 'Do not rewrite the value prop until guide clicks or installs show a clear mismatch.',
       },
       {
         window: 'days_31_60',

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -259,6 +259,7 @@ function buildRevenueLinks(config = resolveHostedBillingConfig({
   const appOrigin = config.appOrigin;
   return {
     appOrigin,
+    guideLink: `${appOrigin}/guide`,
     proCheckoutLink: `${appOrigin}/checkout/pro`,
     sprintLink: `${appOrigin}/#workflow-sprint-intake`,
     commercialTruthLink: COMMERCIAL_TRUTH_LINK,
@@ -694,6 +695,7 @@ function buildRevenueLoopReport({ source, fallbackReason, summary, motionCatalog
   const currentTruth = {
     publicSelfServeOffer: motionCatalog.pro.label,
     teamPilotOffer: motionCatalog.sprint.label,
+    guideLink: buildRevenueLinks().guideLink,
     commercialTruthLink: motionCatalog.pro.truth,
     verificationEvidenceLink: motionCatalog.pro.proof,
   };
@@ -819,6 +821,11 @@ function buildMarketplaceCopy(report) {
     proofPolicy: 'Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms pain.',
     recommendedCtas: [
       {
+        motion: 'guide',
+        label: 'Proof-backed setup guide',
+        cta: normalizeText(report.currentTruth?.guideLink),
+      },
+      {
         motion: primaryMotion,
         label: resolveMotionLabel(report, primaryMotion),
         cta: resolveMotionCta(report, primaryMotion),
@@ -832,6 +839,7 @@ function buildMarketplaceCopy(report) {
     listingBullets: dedupeList([
       'Turn repeated AI-agent mistakes into enforceable pre-action gates.',
       topTheme ? topTheme.listingAngle : '',
+      'Route install-intent buyers through the proof-backed setup guide before direct checkout.',
       `Primary offer: ${resolveMotionLabel(report, primaryMotion)}.`,
       `Secondary offer: ${resolveMotionLabel(report, secondaryMotion)} after the buyer asks for the tool path.`,
       'Keep approval boundaries, rollback safety, and proof attached to the workflow before rollout.',

--- a/tests/claude-workflow-hardening-pack.test.js
+++ b/tests/claude-workflow-hardening-pack.test.js
@@ -22,6 +22,7 @@ function makeReportFixture() {
     currentTruth: {
       teamPilotOffer: 'Workflow Hardening Sprint',
       publicSelfServeOffer: 'Pro at $19/mo or $149/yr',
+      guideLink: 'https://thumbgate-production.up.railway.app/guide',
       commercialTruthLink: 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md',
       verificationEvidenceLink: 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md',
     },
@@ -125,6 +126,8 @@ test('rendered pack is operator-ready and anchored to proof links', () => {
   assert.match(markdown, /Make one Claude-first workflow safe enough to ship team-wide/);
   assert.match(markdown, /Workflow Hardening Sprint/);
   assert.match(markdown, /Pro at \$19\/mo or \$149\/yr/);
+  assert.match(markdown, /Proof-backed setup guide/);
+  assert.match(markdown, /thumbgate-production\.up\.railway\.app\/guide/);
   assert.match(markdown, /COMMERCIAL_TRUTH\.md/);
   assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
   assert.doesNotMatch(markdown, /official partner|booked revenue exists/i);

--- a/tests/cursor-marketplace-revenue-pack.test.js
+++ b/tests/cursor-marketplace-revenue-pack.test.js
@@ -26,6 +26,7 @@ const {
 
 const LINKS_FIXTURE = {
   appOrigin: 'https://thumbgate-production.up.railway.app',
+  guideLink: 'https://thumbgate-production.up.railway.app/guide',
   proCheckoutLink: 'https://thumbgate-production.up.railway.app/checkout/pro',
   sprintLink: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
   proPriceLabel: '$19/mo or $149/yr',
@@ -60,27 +61,29 @@ test('Cursor surfaces cover marketplace, directory, and team rollout lanes witho
 test('tracked Cursor links keep source, medium, and campaign machine-readable', () => {
   const marketplaceTracking = buildCursorTrackingMetadata('plugin_homepage', {
     utmMedium: MARKETPLACE_MEDIUM,
-    utmCampaign: 'cursor_plugin_listing',
-    utmContent: 'homepage',
+    utmCampaign: 'cursor_plugin_guide',
+    utmContent: 'guide',
   });
   const directoryTracking = buildCursorTrackingMetadata('directory_homepage', {
     utmMedium: DIRECTORY_MEDIUM,
-    utmCampaign: 'cursor_directory_profile',
-    utmContent: 'homepage',
+    utmCampaign: 'cursor_directory_guide',
+    utmContent: 'guide',
   });
   const teamTracking = buildCursorTrackingMetadata('team_marketplace_homepage', {
     utmMedium: TEAM_MARKETPLACE_MEDIUM,
     utmCampaign: 'cursor_team_marketplace',
     utmContent: 'homepage',
   });
-  const marketplaceUrl = new URL(buildTrackedCursorLink('https://thumbgate-production.up.railway.app', marketplaceTracking));
-  const directoryUrl = new URL(buildTrackedCursorLink('https://thumbgate-production.up.railway.app', directoryTracking));
+  const marketplaceUrl = new URL(buildTrackedCursorLink('https://thumbgate-production.up.railway.app/guide', marketplaceTracking));
+  const directoryUrl = new URL(buildTrackedCursorLink('https://thumbgate-production.up.railway.app/guide', directoryTracking));
   const teamUrl = new URL(buildTrackedCursorLink('https://thumbgate-production.up.railway.app/#workflow-sprint-intake', teamTracking));
 
   assert.equal(marketplaceUrl.searchParams.get('utm_source'), 'cursor');
   assert.equal(marketplaceUrl.searchParams.get('utm_medium'), MARKETPLACE_MEDIUM);
-  assert.equal(marketplaceUrl.searchParams.get('utm_campaign'), 'cursor_plugin_listing');
+  assert.equal(marketplaceUrl.pathname, '/guide');
+  assert.equal(marketplaceUrl.searchParams.get('utm_campaign'), 'cursor_plugin_guide');
   assert.equal(directoryUrl.searchParams.get('utm_medium'), DIRECTORY_MEDIUM);
+  assert.equal(directoryUrl.pathname, '/guide');
   assert.equal(teamUrl.searchParams.get('utm_medium'), TEAM_MARKETPLACE_MEDIUM);
   assert.equal(teamUrl.searchParams.get('surface'), 'team_marketplace_homepage');
 });
@@ -116,6 +119,7 @@ test('rendered pack is operator-ready and anchored to proof plus screenshots', (
   assert.match(rendered, /Cursor Marketplace/);
   assert.match(rendered, /Cursor Directory/);
   assert.match(rendered, /Cursor Team Marketplace/);
+  assert.match(rendered, /thumbgate-production\.up\.railway\.app\/guide/);
   assert.match(rendered, /VERIFICATION_EVIDENCE\.md/);
   assert.match(rendered, /docs\/marketing\/gallery\/05-hero\.png/);
   assert.doesNotMatch(rendered, /approved partner|guaranteed installs|guaranteed revenue/i);
@@ -128,7 +132,8 @@ test('CSV export keeps submission fields in one operator file', () => {
   assert.match(csv, /Cursor Marketplace/);
   assert.match(csv, /Cursor Directory/);
   assert.match(csv, /Cursor Team Marketplace/);
-  assert.match(csv, /cursor_plugin_listing/);
+  assert.match(csv, /cursor_plugin_guide/);
+  assert.match(csv, /thumbgate-production\.up\.railway\.app\/guide/);
 });
 
 test('CLI options and report writing produce markdown, JSON, and CSV artifacts', () => {

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -635,8 +635,10 @@ test('marketplace copy pack stays tied to current revenue-loop evidence', () => 
   const markdown = renderMarketplaceCopyMarkdown(pack);
 
   assert.match(pack.headline, /Harden one AI-agent workflow/i);
-  assert.equal(pack.recommendedCtas[0].label, catalog.sprint.label);
-  assert.equal(pack.recommendedCtas[1].label, catalog.pro.label);
+  assert.equal(pack.recommendedCtas[0].label, 'Proof-backed setup guide');
+  assert.match(pack.recommendedCtas[0].cta, /thumbgate-production\.up\.railway\.app\/guide/);
+  assert.equal(pack.recommendedCtas[1].label, catalog.sprint.label);
+  assert.equal(pack.recommendedCtas[2].label, catalog.pro.label);
   assert.ok(pack.topSignals.some((signal) => /Warm discovery workflows/.test(signal.label)));
   assert.ok(pack.topSignals.some((signal) => /Business-system workflow approvals/.test(signal.label)));
   assert.match(markdown, /Proof Policy/);
@@ -657,6 +659,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     currentTruth: {
       publicSelfServeOffer: catalog.pro.label,
       teamPilotOffer: catalog.sprint.label,
+      guideLink: links.guideLink,
       commercialTruthLink: catalog.pro.truth,
       verificationEvidenceLink: catalog.pro.proof,
     },
@@ -740,6 +743,8 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.match(csv, /Commercial truth: .*COMMERCIAL_TRUTH\.md/);
     assert.match(csv, /Do not claim revenue, installs, or marketplace approval without direct command evidence\./);
     assert.match(marketplaceCopy.headline, /workflow/i);
+    assert.equal(marketplaceCopy.recommendedCtas[0].label, 'Proof-backed setup guide');
+    assert.match(marketplaceCopy.recommendedCtas[0].cta, /thumbgate-production\.up\.railway\.app\/guide/);
     assert.ok(Array.isArray(marketplaceCopy.topSignals));
     assert.equal(JSON.parse(jsonl.trim()).repoName, 'production-mcp-server');
   } finally {
@@ -844,7 +849,9 @@ test('runRevenueLoop writes an evidence-backed target queue with discovery warni
     assert.equal(report.discoveryWarnings.length, 1);
     assert.match(report.discoveryWarnings[0], /temporarily unavailable/);
     assert.ok(report.marketplaceCopy);
+    assert.match(report.currentTruth.guideLink, /thumbgate-production\.up\.railway\.app\/guide/);
     assert.ok(Array.isArray(report.marketplaceCopy.topSignals));
+    assert.equal(report.marketplaceCopy.recommendedCtas[0].label, 'Proof-backed setup guide');
     assert.match(report.targets[0].proofPackTrigger, /buyer confirms pain/);
     assert.match(report.targets[0].painConfirmedFollowUpDraft, /VERIFICATION_EVIDENCE/);
     assert.equal(written.reportDir, reportDir);


### PR DESCRIPTION
## Summary
- route install-intent marketplace traffic through the proof-backed `/guide` path instead of the generic homepage
- expose the same guide path in Claude/Cursor operator assets and synced GTM docs
- refresh the tracked revenue-loop report and marketplace packs from the current cold-start evidence

## Verification
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`

## Revenue loop evidence
- landing page check: `landing up`
- sprint intake check: `sprint intake linked`
- local CFO snapshot: `0` paid orders, `0` checkout starts, `0` leads
- fresh ignored artifact bundle: `.artifacts/revenue-loop/2026-04-26-marketplace-proof-sync/`
