### PR TITLE
chore(release): publish thumbgate 1.16.5

### DIFF
--- a/.changeset/autonomous-sales-agent-codex-pack.md
+++ b/.changeset/autonomous-sales-agent-codex-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Restore the autonomous sales agent's Codex revenue-pack emission so GTM runs ship Codex listing copy, operator queue rows, and proof-linked follow-on assets alongside the Claude, Cursor, and Gemini packs.

--- a/.changeset/chatgpt-gpt-revenue-pack.md
+++ b/.changeset/chatgpt-gpt-revenue-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Emit a ChatGPT GPT revenue pack from the GTM automation so ThumbGate ships evidence-backed GPT discovery surfaces, builder-repair assets, tracked follow-on offers, and operator queue rows alongside the Claude, Cursor, Gemini, and Codex packs.

--- a/.changeset/claude-channel-acquisition-drafts.md
+++ b/.changeset/claude-channel-acquisition-drafts.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Extend the Claude workflow hardening pack with active-channel acquisition drafts so each revenue pass ships evidence-backed Reddit, LinkedIn, Threads, and Bluesky copy tied to live Claude install surfaces and proof-timing guardrails.

--- a/.changeset/claude-workflow-hardening-pack.md
+++ b/.changeset/claude-workflow-hardening-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a Claude workflow hardening pack to the GTM automation so each revenue-loop run emits operator-ready Claude-first outbound copy, buyer lanes, and proof-linked follow-up guidance.

--- a/.changeset/codex-operator-revenue-pack.md
+++ b/.changeset/codex-operator-revenue-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Emit a Codex operator revenue pack from the GTM automation so the repo ships evidence-backed listing copy, operator prospect queues, outreach drafts, and proof-first follow-on CTAs for the Codex install surface.

--- a/.changeset/codex-revenue-pack.md
+++ b/.changeset/codex-revenue-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a Codex plugin revenue pack with proof-backed install, guide, and bundle sales assets.

--- a/.changeset/cursor-marketplace-revenue-pack.md
+++ b/.changeset/cursor-marketplace-revenue-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Emit a Cursor marketplace revenue pack from the GTM automation so the repo ships operator-ready Marketplace, Directory, and Team Marketplace copy with tracked follow-on offers and proof links.

--- a/.changeset/evidence-backed-gtm-assets.md
+++ b/.changeset/evidence-backed-gtm-assets.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Keep GTM revenue-loop assets tied to explicit proof links and claim guardrails.

--- a/.changeset/gemini-cli-demand-pack.md
+++ b/.changeset/gemini-cli-demand-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Emit a Gemini CLI demand pack from the GTM automation so the repo ships evidence-backed Gemini guide surfaces, operator queue rows, outreach drafts, and corrected Gemini install copy.

--- a/.changeset/gtm-marketing-artifacts-path-fix.md
+++ b/.changeset/gtm-marketing-artifacts-path-fix.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Write GTM revenue loop docs into dedicated `docs/marketing` artifacts instead of overwriting the GitOps guide, and ship the generated marketplace copy and target-queue outputs with the repo.

--- a/.changeset/guide-proof-conversion-path.md
+++ b/.changeset/guide-proof-conversion-path.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a proof-backed conversion path to the public guide so operators can move from free install education into Pro or Workflow Hardening Sprint next steps with linked Commercial Truth and verification evidence.

--- a/.changeset/marketplace-proof-guide-sync.md
+++ b/.changeset/marketplace-proof-guide-sync.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Route install-intent marketplace and Claude operator surfaces through the proof-backed guide so listing traffic lands on the setup path that already carries Commercial Truth, verification evidence, and clear Pro versus Workflow Hardening Sprint next steps.

--- a/.changeset/strong-rivers-punch.md
+++ b/.changeset/strong-rivers-punch.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the Claude workflow hardening pack with verified install surfaces, tracked listing copy, and a live prospect queue.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -13,7 +13,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.16.4",
+      "version": "1.16.5",
       "author": {
         "name": "Igor Ganapolsky"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action checks, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.16.4"
+    "version": "1.16.5"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 1.16.5
+
+### Patch Changes
+
+- [#1322](https://github.com/IgorGanapolsky/ThumbGate/pull/1322) [`5e375d2`](https://github.com/IgorGanapolsky/ThumbGate/commit/5e375d20f69accfd11a04ff5dd573d0c5b904a1b) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Restore the autonomous sales agent's Codex revenue-pack emission so GTM runs ship Codex listing copy, operator queue rows, and proof-linked follow-on assets alongside the Claude, Cursor, and Gemini packs.
+
+- [#1325](https://github.com/IgorGanapolsky/ThumbGate/pull/1325) [`22dc6e0`](https://github.com/IgorGanapolsky/ThumbGate/commit/22dc6e09731ac3dfebcdbce865c8a39ec3b58930) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Emit a ChatGPT GPT revenue pack from the GTM automation so ThumbGate ships evidence-backed GPT discovery surfaces, builder-repair assets, tracked follow-on offers, and operator queue rows alongside the Claude, Cursor, Gemini, and Codex packs.
+
+- [#1311](https://github.com/IgorGanapolsky/ThumbGate/pull/1311) [`4e71af4`](https://github.com/IgorGanapolsky/ThumbGate/commit/4e71af451943eab31dfab79e56d498db490c8ce0) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a Claude workflow hardening pack to the GTM automation so each revenue-loop run emits operator-ready Claude-first outbound copy, buyer lanes, and proof-linked follow-up guidance.
+
+- [#1318](https://github.com/IgorGanapolsky/ThumbGate/pull/1318) [`910515f`](https://github.com/IgorGanapolsky/ThumbGate/commit/910515fe590f69239d9c2688d61adf35d5c5282e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Emit a Codex operator revenue pack from the GTM automation so the repo ships evidence-backed listing copy, operator prospect queues, outreach drafts, and proof-first follow-on CTAs for the Codex install surface.
+
+- [#1317](https://github.com/IgorGanapolsky/ThumbGate/pull/1317) [`39aaaf7`](https://github.com/IgorGanapolsky/ThumbGate/commit/39aaaf73f552e58f466fe546f43984841c605989) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a Codex plugin revenue pack with proof-backed install, guide, and bundle sales assets.
+
+- [#1307](https://github.com/IgorGanapolsky/ThumbGate/pull/1307) [`2af4acb`](https://github.com/IgorGanapolsky/ThumbGate/commit/2af4acbc65b7e7fd4b80473b9bc93e65fa64ee4f) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Emit a Cursor marketplace revenue pack from the GTM automation so the repo ships operator-ready Marketplace, Directory, and Team Marketplace copy with tracked follow-on offers and proof links.
+
+- [#1308](https://github.com/IgorGanapolsky/ThumbGate/pull/1308) [`69c2c71`](https://github.com/IgorGanapolsky/ThumbGate/commit/69c2c712dc1cb9fb72c022d797dd0ddd8ad8538a) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Keep GTM revenue-loop assets tied to explicit proof links and claim guardrails.
+
+- [#1320](https://github.com/IgorGanapolsky/ThumbGate/pull/1320) [`e58be96`](https://github.com/IgorGanapolsky/ThumbGate/commit/e58be9637e233f822797992ef8e7fd4ae8aa087e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Emit a Gemini CLI demand pack from the GTM automation so the repo ships evidence-backed Gemini guide surfaces, operator queue rows, outreach drafts, and corrected Gemini install copy.
+
+- [#1328](https://github.com/IgorGanapolsky/ThumbGate/pull/1328) [`8261d36`](https://github.com/IgorGanapolsky/ThumbGate/commit/8261d361f22955391bada3f61f593fb2ce3eb5e1) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Write GTM revenue loop docs into dedicated `docs/marketing` artifacts instead of overwriting the GitOps guide, and ship the generated marketplace copy and target-queue outputs with the repo.
+
+- [#1313](https://github.com/IgorGanapolsky/ThumbGate/pull/1313) [`688796c`](https://github.com/IgorGanapolsky/ThumbGate/commit/688796cc99dea39ac342b00faf06680645d3e127) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a proof-backed conversion path to the public guide so operators can move from free install education into Pro or Workflow Hardening Sprint next steps with linked Commercial Truth and verification evidence.
+
+- [#1315](https://github.com/IgorGanapolsky/ThumbGate/pull/1315) [`394253c`](https://github.com/IgorGanapolsky/ThumbGate/commit/394253cc364ea145070ef3dfe7b1ffc287b43056) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Route install-intent marketplace and Claude operator surfaces through the proof-backed guide so listing traffic lands on the setup path that already carries Commercial Truth, verification evidence, and clear Pro versus Workflow Hardening Sprint next steps.
+
+- [#1324](https://github.com/IgorGanapolsky/ThumbGate/pull/1324) [`4294a5a`](https://github.com/IgorGanapolsky/ThumbGate/commit/4294a5af68b96f0b39ec037be9fca3513e563b59) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the Claude workflow hardening pack with verified install surfaces, tracked listing copy, and a live prospect queue.
+
 ## 1.16.4
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 - [#1324](https://github.com/IgorGanapolsky/ThumbGate/pull/1324) [`4294a5a`](https://github.com/IgorGanapolsky/ThumbGate/commit/4294a5af68b96f0b39ec037be9fca3513e563b59) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the Claude workflow hardening pack with verified install surfaces, tracked listing copy, and a live prospect queue.
 
+- [#1332](https://github.com/IgorGanapolsky/ThumbGate/pull/1332) [`ae27b84`](https://github.com/IgorGanapolsky/ThumbGate/commit/ae27b84f55314e767e82bb4e8cea874697985b4b) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Extend the Claude workflow hardening pack with active-channel acquisition drafts so each revenue pass ships evidence-backed Reddit, LinkedIn, Threads, and Bluesky copy tied to live Claude install surfaces and proof-timing guardrails.
+
 ## 1.16.4
 
 ### Patch Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,7 +3,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.16.4 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.16.5 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.16.4", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.16.5", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.16.4", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.16.5", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -201,7 +201,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.16.4' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.16.5' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.16.4",
+        "thumbgate@1.16.5",
         "thumbgate",
         "serve"
       ],

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.16.4 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.16.5 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.16.4 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.16.5 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1517,7 +1517,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.16.4 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.16.5 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2734,7 +2734,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.16.4 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.16.5 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.16.4`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.16.5`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.16.4 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.16.5 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.16.4", "serve"],
+      "args": ["-y", "thumbgate@1.16.5", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.16.4", "serve"],
+      "args": ["-y", "thumbgate@1.16.5", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.16.4 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.16.5 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.16.4
+1.16.5
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.16.4"
+version: "1.16.5"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.16.4",
+      "version": "1.16.5",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "Self-improving agent governance: type thumbs-up or thumbs-down on any AI agent action. ThumbGate turns every mistake into a prevention rule and blocks the pattern from repeating. One thumbs-down, never again. 33 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.16.4",
+        "thumbgate@1.16.5",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.16.4", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.16.5", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -1082,7 +1082,7 @@ __GA_BOOTSTRAP__
 <!-- HOW IT WORKS -->
 <section class="how-it-works" id="how-it-works">
   <div class="container">
-    <div class="section-label">New in v1.16.4</div>
+    <div class="section-label">New in v1.16.5</div>
     <h2 class="section-title">Three steps to stop repeated AI failures</h2>
     <div class="steps">
       <div class="step">
@@ -1442,7 +1442,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.16.4</span>
+    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.16.5</span>
   </div>
 </footer>
 

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.16.4",
+  "version": "1.16.5",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.16.4",
+      "version": "1.16.5",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Version ThumbGate to 1.16.5 across all npm/package/plugin/MCP surfaces.
- Consume the merged GTM/acquisition changesets, including PR #1332, into CHANGELOG.md.
- Keep release package focused on ThumbGate-only public surfaces.

## Verification
- npm ci --onnxruntime-node-install-cuda=skip
- npm test: 4,780 tests, 4,776 pass, 0 fail, 4 skipped
- npm run test:coverage: 86.85% lines / 72.80% branches / 88.42% funcs
- THUMBGATE_PROOF_DIR=tmp npm run prove:adapters: 48/48 pass
- THUMBGATE_AUTOMATION_PROOF_DIR=tmp npm run prove:automation: 55/55 pass
- npm run self-heal:check: 6/6 healthy
- node scripts/sync-version.js --check: all 30 targets at v1.16.5
- npm audit --audit-level=moderate: 0 vulnerabilities
- npm pack --dry-run: thumbgate-1.16.5.tgz, 232 files, shasum 9ecdd8f1ee86abdab2d33fbd2999b4c9eb37edd6

## Release plan
After CI and security checks pass, merge through npm run pr:manage / Trunk, then verify npm latest and Railway health/dashboard on the exact main merge commit.