### PR TITLE
feat(gtm): add operator priority handoff

### DIFF
--- a/.changeset/operator-priority-handoff.md
+++ b/.changeset/operator-priority-handoff.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add a ranked revenue operator handoff artifact to the GTM revenue loop so warm outreach, cold GitHub targets, proof rules, and sales-ledger import steps stay synchronized.

--- a/docs/marketing/gtm-marketplace-copy.json
+++ b/docs/marketing/gtm-marketplace-copy.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-26T15:17:35.402Z",
+  "generatedAt": "2026-04-26T16:18:07.565Z",
   "state": "cold-start",
   "headline": "Harden one AI-agent workflow before you roll it out.",
   "shortDescription": "No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive.",

--- a/docs/marketing/gtm-revenue-loop.json
+++ b/docs/marketing/gtm-revenue-loop.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-26T15:17:35.402Z",
+  "generatedAt": "2026-04-26T16:18:07.565Z",
   "source": "local",
   "fallbackReason": "Hosted operational summary is not configured.",
   "objective": "First 10 paying customers",
@@ -598,7 +598,7 @@
     }
   ],
   "marketplaceCopy": {
-    "generatedAt": "2026-04-26T15:17:35.402Z",
+    "generatedAt": "2026-04-26T16:18:07.565Z",
     "state": "cold-start",
     "headline": "Harden one AI-agent workflow before you roll it out.",
     "shortDescription": "No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive.",

--- a/docs/marketing/gtm-revenue-loop.md
+++ b/docs/marketing/gtm-revenue-loop.md
@@ -1,7 +1,7 @@
 # GSD Revenue Loop
 
 Status: cold-start
-Updated: 2026-04-26T15:17:35.402Z
+Updated: 2026-04-26T16:18:07.565Z
 
 This report is an operator artifact for landing the first 10 paying customers. It is not proof of sent messages or booked revenue by itself.
 Outbound rule: do not treat posts as sales. A lead only moves when it is tracked as contacted, replied, call booked, checkout/sprint, or paid.

--- a/docs/marketing/operator-priority-handoff.md
+++ b/docs/marketing/operator-priority-handoff.md
@@ -1,0 +1,196 @@
+# Revenue Operator Priority Handoff
+
+Updated: 2026-04-26T16:18:07.565Z
+
+This is the ranked send order for the current zero-to-one revenue loop. Work warm discovery targets first, then expand into cold GitHub targets with the same proof discipline.
+
+This handoff sits on top of `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `team-outreach-messages.md` so an operator can decide who to contact next without re-ranking the queue manually.
+
+## Current Snapshot
+- Revenue state: cold-start
+- Headline: No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
+- Paid orders: 0
+- Checkout starts: 0
+- Warm targets ready now: 4
+- Cold GitHub targets ready next: 6
+
+## Operator Rules
+- Import the queue into the sales ledger before sending anything.
+- Lead with one concrete workflow-hardening offer, not generic Pro and not the proof pack.
+- Use [VERIFICATION_EVIDENCE.md](../VERIFICATION_EVIDENCE.md) and [COMMERCIAL_TRUTH.md](../COMMERCIAL_TRUTH.md) only after the buyer confirms pain.
+
+```bash
+npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json
+```
+
+## Send Now: Warm Discovery
+## 1. @Deep_Ad1959 — r/cursor
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Contact surface: https://www.reddit.com/user/Deep_Ad1959/
+- Evidence score: 10
+- Evidence: warm inbound engagement, workflow pain named: rollback risk, already in DMs
+- Motion: Workflow Hardening Sprint
+- Why now: Warm Reddit engager already named a repeated workflow risk, so the fastest path is a founder-led diagnostic.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Your question about rollback rates when context changes is exactly the right one. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have one workflow where context drift or rollback risk keeps showing up, I can harden that workflow for you. Worth a 15-minute diagnostic?
+
+Pain-confirmed follow-up:
+> If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 2. @game-of-kton — r/cursor
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Contact surface: https://www.reddit.com/user/game-of-kton/
+- Evidence score: 9
+- Evidence: warm inbound engagement, built serious memory systems, workflow pain named: stale context and conflicting facts
+- Motion: Workflow Hardening Sprint
+- Why now: Warm Reddit engager already works on advanced agent memory, so discovery should center on one repeated failure pattern.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Your ACT-R engram work is fascinating, especially the conflict resolution for opposing facts and the decay model. I am looking for one serious AI-agent workflow to harden end-to-end this week. If your memory system has one recurring failure mode such as stale context, opposing facts, bad handoffs, or unsafe tool calls, I can turn that into a prevention rule and proof run. Open to a 15-minute diagnostic?
+
+Pain-confirmed follow-up:
+> If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 3. @leogodin217 — r/ClaudeCode
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Contact surface: https://www.reddit.com/user/leogodin217/
+- Evidence score: 9
+- Evidence: warm inbound engagement, mature multi-step workflow described, workflow pain named: review boundaries and context risk
+- Motion: Workflow Hardening Sprint
+- Why now: Warm Reddit engager already described a mature workflow, so the next step is a targeted diagnostic on one failure mode.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Your arch-create to sprint workflow is one of the most mature agent processes I have seen anyone describe. I am looking for one AI-agent workflow to harden end-to-end this week. Your workflow already has phases, review boundaries, and context risk, so it is a strong fit: pick one repeating failure and I will help turn it into an enforceable Pre-Action Check plus proof run. Worth 15 minutes?
+
+Pain-confirmed follow-up:
+> If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 4. @Enthu-Cutlet-1337 — r/ClaudeCode
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Contact surface: https://www.reddit.com/user/Enthu-Cutlet-1337/
+- Evidence score: 8
+- Evidence: warm inbound engagement, responded to adaptive-gate positioning, workflow pain named: brittle guardrails
+- Motion: Workflow Hardening Sprint
+- Why now: Warm Reddit engager already understands the adaptive-gate thesis, so offer one concrete workflow hardening diagnostic.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Appreciate the kind words on the Thompson Sampling approach. You nailed the core insight: most guardrails are brittle prompt hacks that break when context shifts. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have a workflow where brittle guardrails keep failing, I can harden that workflow with you. Open to a 15-minute diagnostic?
+
+Pain-confirmed follow-up:
+> If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## Seed Next: Cold GitHub
+## 5. @manki-review — manki
+- Temperature: cold
+- Source: github / github
+- Contact surface: https://github.com/manki-review/manki
+- Evidence score: 13
+- Evidence: workflow control surface, business-system integration, agent infrastructure, 5 GitHub stars, updated in the last 7 days
+- Motion: Workflow Hardening Sprint
+- Why now: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Hey @manki-review, saw you're shipping `manki`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof. If `manki` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+Pain-confirmed follow-up:
+> If `manki` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 6. @freema — mcp-jira-stdio
+- Temperature: cold
+- Source: github / github
+- Contact surface: https://github.com/freema/mcp-jira-stdio
+- Evidence score: 13
+- Evidence: workflow control surface, business-system integration, agent infrastructure, 11 GitHub stars, updated in the last 7 days
+- Motion: Workflow Hardening Sprint
+- Why now: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Hey @freema, saw you're shipping `mcp-jira-stdio`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof. If `mcp-jira-stdio` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+Pain-confirmed follow-up:
+> If `mcp-jira-stdio` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 7. @salacoste — mcp-n8n-workflow-builder
+- Temperature: cold
+- Source: github / github
+- Contact surface: https://github.com/salacoste/mcp-n8n-workflow-builder
+- Evidence score: 12
+- Evidence: workflow control surface, agent infrastructure, 221 GitHub stars, updated in the last 7 days
+- Motion: Workflow Hardening Sprint
+- Why now: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Hey @salacoste, saw you're shipping `mcp-n8n-workflow-builder`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with context-drift hardening for one workflow before proposing any broader agent platform story. If `mcp-n8n-workflow-builder` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+Pain-confirmed follow-up:
+> If `mcp-n8n-workflow-builder` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 8. @bjeans — homelab-mcp
+- Temperature: cold
+- Source: github / github
+- Contact surface: https://github.com/bjeans/homelab-mcp
+- Evidence score: 11
+- Evidence: production or platform workflow, agent infrastructure, 25 GitHub stars, updated in the last 7 days
+- Motion: Workflow Hardening Sprint
+- Why now: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Hey @bjeans, saw you're shipping `homelab-mcp`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes. If `homelab-mcp` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+Pain-confirmed follow-up:
+> If `homelab-mcp` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 9. @WagnerAgent — awesome-mcp-servers-devops
+- Temperature: cold
+- Source: github / github
+- Contact surface: https://github.com/WagnerAgent/awesome-mcp-servers-devops
+- Evidence score: 11
+- Evidence: production or platform workflow, agent infrastructure, 93 GitHub stars, updated in the last 7 days
+- Motion: Pro at $19/mo or $149/yr
+- Why now: Target looks like a self-serve tooling surface, so Pro is the cleaner CTA unless a concrete workflow pain is confirmed.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/checkout/pro
+
+First-touch draft:
+> Hey @WagnerAgent, saw you're building around `awesome-mcp-servers-devops`. If you only want the self-serve path, ThumbGate Pro gives you compaction-safe memory and feedback-to-gate enforcement: https://thumbgate-production.up.railway.app/checkout/pro If you have a painful workflow instead, I can harden one concrete workflow first.
+
+Pain-confirmed follow-up:
+> If you want the self-serve path for `awesome-mcp-servers-devops`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## 10. @gensecaihq — MCP-Developer-SubAgent
+- Temperature: cold
+- Source: github / github
+- Contact surface: https://github.com/gensecaihq/MCP-Developer-SubAgent
+- Evidence score: 10
+- Evidence: production or platform workflow, agent infrastructure, 27 GitHub stars, updated in the last 30 days
+- Motion: Workflow Hardening Sprint
+- Why now: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Hey @gensecaihq, saw you're shipping `MCP-Developer-SubAgent`. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention gate, and a proof run. Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes. If `MCP-Developer-SubAgent` has one workflow that keeps breaking or losing context, I can harden that workflow for you: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+Pain-confirmed follow-up:
+> If `MCP-Developer-SubAgent` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md

--- a/docs/marketing/team-outreach-messages.md
+++ b/docs/marketing/team-outreach-messages.md
@@ -1,8 +1,9 @@
 # Workflow Hardening Sprint Outreach Messages
 
-Updated: 2026-04-26T15:17:35.402Z
+Updated: 2026-04-26T16:18:07.565Z
 
 These drafts are generated from the same evidence-backed revenue-loop report as `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `gtm-marketplace-copy.md`.
+Use `operator-priority-handoff.md` for the ranked send order; this file is the copy layer for warm outreach only.
 
 Track each lead in the sales ledger before sending anything:
 

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -967,6 +967,100 @@ function renderWarmTargetOutreachMarkdown(target, index) {
   ];
 }
 
+function rankOperatorTargets(targets = []) {
+  return [...targets].sort((left, right) => {
+    const leftWarm = normalizeText(left.temperature).toLowerCase() === 'warm' ? 1 : 0;
+    const rightWarm = normalizeText(right.temperature).toLowerCase() === 'warm' ? 1 : 0;
+    if (rightWarm !== leftWarm) {
+      return rightWarm - leftWarm;
+    }
+
+    const leftScore = Number(left.evidenceScore || 0);
+    const rightScore = Number(right.evidenceScore || 0);
+    if (rightScore !== leftScore) {
+      return rightScore - leftScore;
+    }
+
+    const leftSprint = normalizeText(left.motion).toLowerCase() === 'sprint' ? 1 : 0;
+    const rightSprint = normalizeText(right.motion).toLowerCase() === 'sprint' ? 1 : 0;
+    if (rightSprint !== leftSprint) {
+      return rightSprint - leftSprint;
+    }
+
+    return String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''));
+  });
+}
+
+function renderOperatorPriorityTargetMarkdown(target, index) {
+  const label = normalizeText(target.repoName)
+    ? `@${target.username} — ${target.repoName}`
+    : `@${target.username} — ${target.accountName || target.source || 'discovery lead'}`;
+  const contactSurface = target.contactUrl || target.repoUrl || 'n/a';
+  return [
+    `## ${index + 1}. ${label}`,
+    `- Temperature: ${target.temperature || 'cold'}`,
+    `- Source: ${target.source || 'github'} / ${target.channel || target.source || 'github'}`,
+    `- Contact surface: ${contactSurface}`,
+    `- Evidence score: ${target.evidenceScore}`,
+    `- Evidence: ${target.evidence.length ? target.evidence.join(', ') : 'n/a'}`,
+    `- Motion: ${target.motionLabel}`,
+    `- Why now: ${target.motionReason || target.outreachAngle || 'n/a'}`,
+    `- Proof rule: ${target.proofPackTrigger || 'Use proof pack only after the buyer confirms pain.'}`,
+    `- CTA: ${target.cta}`,
+    '',
+    'First-touch draft:',
+    ...renderQuotedText(target.firstTouchDraft || target.message),
+    '',
+    'Pain-confirmed follow-up:',
+    ...renderQuotedText(target.painConfirmedFollowUpDraft),
+    '',
+  ];
+}
+
+function renderOperatorHandoffMarkdown(report) {
+  const rankedTargets = rankOperatorTargets(Array.isArray(report?.targets) ? report.targets : []);
+  const warmTargets = rankedTargets.filter((target) => normalizeText(target.temperature).toLowerCase() === 'warm');
+  const coldTargets = rankedTargets.filter((target) => normalizeText(target.temperature).toLowerCase() !== 'warm');
+  const warmLines = warmTargets.length
+    ? warmTargets.flatMap(renderOperatorPriorityTargetMarkdown)
+    : ['- No warm discovery targets are available for this run.', ''];
+  const coldLines = coldTargets.length
+    ? coldTargets.flatMap((target, index) => renderOperatorPriorityTargetMarkdown(target, index + warmTargets.length))
+    : ['- No cold GitHub targets are available for this run.', ''];
+
+  return [
+    '# Revenue Operator Priority Handoff',
+    '',
+    `Updated: ${report.generatedAt}`,
+    '',
+    'This is the ranked send order for the current zero-to-one revenue loop. Work warm discovery targets first, then expand into cold GitHub targets with the same proof discipline.',
+    '',
+    'This handoff sits on top of `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `team-outreach-messages.md` so an operator can decide who to contact next without re-ranking the queue manually.',
+    '',
+    '## Current Snapshot',
+    `- Revenue state: ${report.directive?.state || 'cold-start'}`,
+    `- Headline: ${report.directive?.headline || 'No verified revenue and no active pipeline.'}`,
+    `- Paid orders: ${report.snapshot?.paidOrders || 0}`,
+    `- Checkout starts: ${report.snapshot?.checkoutStarts || 0}`,
+    `- Warm targets ready now: ${warmTargets.length}`,
+    `- Cold GitHub targets ready next: ${coldTargets.length}`,
+    '',
+    '## Operator Rules',
+    '- Import the queue into the sales ledger before sending anything.',
+    '- Lead with one concrete workflow-hardening offer, not generic Pro and not the proof pack.',
+    '- Use [VERIFICATION_EVIDENCE.md](../VERIFICATION_EVIDENCE.md) and [COMMERCIAL_TRUTH.md](../COMMERCIAL_TRUTH.md) only after the buyer confirms pain.',
+    '',
+    '```bash',
+    'npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json',
+    '```',
+    '',
+    '## Send Now: Warm Discovery',
+    ...warmLines,
+    '## Seed Next: Cold GitHub',
+    ...coldLines,
+  ].join('\n');
+}
+
 function renderTeamOutreachMessagesMarkdown(report) {
   const warmTargets = Array.isArray(report?.targets)
     ? report.targets.filter((target) => target.temperature === 'warm')
@@ -981,6 +1075,7 @@ function renderTeamOutreachMessagesMarkdown(report) {
     `Updated: ${report.generatedAt}`,
     '',
     'These drafts are generated from the same evidence-backed revenue-loop report as `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `gtm-marketplace-copy.md`.',
+    'Use `operator-priority-handoff.md` for the ranked send order; this file is the copy layer for warm outreach only.',
     '',
     'Track each lead in the sales ledger before sending anything:',
     '',
@@ -1136,12 +1231,14 @@ function writeRevenueLoopOutputs(report, options = {}) {
   const queueCsvDocsPath = path.join(docsDir, 'gtm-target-queue.csv');
   const queueJsonlDocsPath = path.join(docsDir, 'gtm-target-queue.jsonl');
   const teamOutreachDocsPath = path.join(docsDir, 'team-outreach-messages.md');
+  const operatorHandoffDocsPath = path.join(docsDir, 'operator-priority-handoff.md');
   const markdown = renderRevenueLoopMarkdown(report);
   const marketplaceCopy = report.marketplaceCopy || buildMarketplaceCopy(report);
   const marketplaceMarkdown = renderMarketplaceCopyMarkdown(marketplaceCopy);
   const csv = renderRevenueLoopCsv(report);
   const jsonl = renderRevenueLoopJsonl(report);
   const teamOutreachMarkdown = renderTeamOutreachMessagesMarkdown(report);
+  const operatorHandoffMarkdown = renderOperatorHandoffMarkdown(report);
   const reportDir = normalizeText(options.reportDir)
     ? path.resolve(repoRoot, options.reportDir)
     : '';
@@ -1156,6 +1253,7 @@ function writeRevenueLoopOutputs(report, options = {}) {
     fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.csv'), csv, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), jsonl, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'team-outreach-messages.md'), teamOutreachMarkdown, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'operator-priority-handoff.md'), operatorHandoffMarkdown, 'utf8');
   }
 
   if (shouldWriteDocs) {
@@ -1167,12 +1265,14 @@ function writeRevenueLoopOutputs(report, options = {}) {
     fs.writeFileSync(queueCsvDocsPath, csv, 'utf8');
     fs.writeFileSync(queueJsonlDocsPath, jsonl, 'utf8');
     fs.writeFileSync(teamOutreachDocsPath, teamOutreachMarkdown, 'utf8');
+    fs.writeFileSync(operatorHandoffDocsPath, operatorHandoffMarkdown, 'utf8');
   }
 
   return {
     markdown,
     marketplaceMarkdown,
     teamOutreachMarkdown,
+    operatorHandoffMarkdown,
     reportDir: reportDir || null,
     docsPath: shouldWriteDocs ? defaultDocsPath : null,
   };
@@ -1258,6 +1358,7 @@ module.exports = {
   prospectTargets,
   renderRevenueLoopMarkdown,
   renderMarketplaceCopyMarkdown,
+  renderOperatorHandoffMarkdown,
   renderTeamOutreachMessagesMarkdown,
   runRevenueLoop,
   selectOutreachMotion,

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -1022,7 +1022,7 @@ function renderOperatorHandoffMarkdown(report) {
   const warmTargets = rankedTargets.filter((target) => normalizeText(target.temperature).toLowerCase() === 'warm');
   const coldTargets = rankedTargets.filter((target) => normalizeText(target.temperature).toLowerCase() !== 'warm');
   const warmLines = warmTargets.length
-    ? warmTargets.flatMap(renderOperatorPriorityTargetMarkdown)
+    ? warmTargets.flatMap((target, index) => renderOperatorPriorityTargetMarkdown(target, index))
     : ['- No warm discovery targets are available for this run.', ''];
   const coldLines = coldTargets.length
     ? coldTargets.flatMap((target, index) => renderOperatorPriorityTargetMarkdown(target, index + warmTargets.length))

--- a/scripts/prove-adapters.js
+++ b/scripts/prove-adapters.js
@@ -12,6 +12,7 @@ const { ensureDir } = require('./fs-utils');
 
 const ROOT = path.join(__dirname, '..');
 const DEFAULT_PROOF_DIR = path.join(ROOT, 'proof', 'compatibility');
+const DEFAULT_STDIO_TIMEOUT_MS = 30_000;
 
 
 function check(condition, message) {
@@ -72,7 +73,7 @@ async function fetchWithRetry(url, options, { retries = 5, delayMs = 100 } = {})
 async function proveMcpStdioTransport({
   root,
   transport = 'ndjson',
-  timeoutMs = 10000,
+  timeoutMs = Number(process.env.THUMBGATE_PROOF_STDIO_TIMEOUT_MS || DEFAULT_STDIO_TIMEOUT_MS),
   cwd = root,
   env = process.env,
 }) {

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -20,6 +20,7 @@ const {
   parseArgs,
   prospectTargets,
   renderMarketplaceCopyMarkdown,
+  renderOperatorHandoffMarkdown,
   renderRevenueLoopMarkdown,
   renderTeamOutreachMessagesMarkdown,
   runRevenueLoop,
@@ -429,12 +430,72 @@ test('team outreach markdown stays discovery-first and evidence-backed', () => {
   });
 
   assert.match(markdown, /CUSTOMER_DISCOVERY_SPRINT\.md/);
+  assert.match(markdown, /operator-priority-handoff\.md/);
   assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
   assert.match(markdown, /COMMERCIAL_TRUTH\.md/);
   assert.match(markdown, /I will harden one AI-agent workflow for you/);
   assert.match(markdown, /Evidence sources:/);
   assert.match(markdown, /Pain-confirmed follow-up:/);
   assert.doesNotMatch(markdown, /checkout\/pro/);
+});
+
+test('operator handoff markdown ranks warm discovery ahead of cold GitHub targets', () => {
+  const links = buildRevenueLinks();
+  const catalog = buildMotionCatalog(links);
+  const markdown = renderOperatorHandoffMarkdown({
+    generatedAt: '2026-04-26T00:00:00.000Z',
+    directive: {
+      state: 'cold-start',
+      headline: 'No verified revenue and no active pipeline.',
+    },
+    snapshot: {
+      paidOrders: 0,
+      checkoutStarts: 0,
+    },
+    targets: [
+      {
+        temperature: 'cold',
+        source: 'github',
+        channel: 'github',
+        username: 'builder',
+        repoName: 'production-mcp-server',
+        repoUrl: 'https://github.com/builder/production-mcp-server',
+        evidenceScore: 11,
+        evidence: ['production or platform workflow', '42 GitHub stars'],
+        motion: 'sprint',
+        motionLabel: catalog.sprint.label,
+        motionReason: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+        proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+        cta: catalog.sprint.cta,
+        firstTouchDraft: 'I will harden one production workflow for you.',
+        painConfirmedFollowUpDraft: 'If the workflow pain is real, I can send the proof pack.',
+      },
+      {
+        temperature: 'warm',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        username: 'warm_builder',
+        accountName: 'r/ClaudeCode',
+        contactUrl: 'https://www.reddit.com/user/warm_builder/',
+        evidenceScore: 8,
+        evidence: ['warm inbound engagement', 'workflow pain named'],
+        motion: 'sprint',
+        motionLabel: catalog.sprint.label,
+        motionReason: 'Warm target already named a repeated workflow blocker.',
+        proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+        cta: catalog.sprint.cta,
+        firstTouchDraft: 'I will harden one AI-agent workflow for you.',
+        painConfirmedFollowUpDraft: 'If the workflow pain is real, I can send the proof pack.',
+      },
+    ],
+  });
+
+  assert.match(markdown, /sales:pipeline -- import --source docs\/marketing\/gtm-revenue-loop\.json/);
+  assert.match(markdown, /Warm targets ready now: 1/);
+  assert.match(markdown, /Cold GitHub targets ready next: 1/);
+  assert.ok(markdown.indexOf('@warm_builder') < markdown.indexOf('@builder'));
+  assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
+  assert.match(markdown, /COMMERCIAL_TRUTH\.md/);
 });
 
 test('first-touch outreach does not push proof before pain is confirmed', () => {
@@ -778,6 +839,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     const marketplaceCopy = JSON.parse(fs.readFileSync(path.join(reportDir, 'gtm-marketplace-copy.json'), 'utf8'));
     const jsonl = fs.readFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), 'utf8');
     const teamOutreach = fs.readFileSync(path.join(reportDir, 'team-outreach-messages.md'), 'utf8');
+    const operatorHandoff = fs.readFileSync(path.join(reportDir, 'operator-priority-handoff.md'), 'utf8');
 
     assert.equal(written.reportDir, reportDir);
     assert.equal(written.docsPath, null);
@@ -788,6 +850,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.ok(fs.existsSync(csvPath));
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.jsonl')));
     assert.ok(fs.existsSync(path.join(reportDir, 'team-outreach-messages.md')));
+    assert.ok(fs.existsSync(path.join(reportDir, 'operator-priority-handoff.md')));
     assert.match(csv, /^temperature,source,channel,username,accountName,contactUrl,repoName,repoUrl,updatedAt,offer,pipelineStage,evidenceScore,evidence,evidenceSource,evidenceLinks,claimGuardrails,outreachAngle,motionLabel,motionReason,proofPackTrigger,cta,firstTouchDraft,painConfirmedFollowUpDraft/m);
     assert.match(csv, /"I can harden one workflow, then prove it\."/);
     assert.match(csv, /"If the workflow pain is real, I can send the proof pack\."/);
@@ -799,8 +862,12 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.ok(Array.isArray(marketplaceCopy.topSignals));
     assert.equal(JSON.parse(jsonl.trim()).repoName, 'production-mcp-server');
     assert.match(teamOutreach, /CUSTOMER_DISCOVERY_SPRINT\.md/);
+    assert.match(teamOutreach, /operator-priority-handoff\.md/);
     assert.match(teamOutreach, /I will harden one AI-agent workflow for you/);
     assert.match(teamOutreach, /If the workflow pain is real, I can send the proof pack\./);
+    assert.match(operatorHandoff, /Revenue Operator Priority Handoff/);
+    assert.match(operatorHandoff, /sales:pipeline -- import --source docs\/marketing\/gtm-revenue-loop\.json/);
+    assert.match(operatorHandoff, /Send Now: Warm Discovery/);
   } finally {
     fs.rmSync(reportDir, { recursive: true, force: true });
   }
@@ -900,6 +967,7 @@ test('writeRevenueLoopOutputs mirrors dedicated GTM docs instead of overwriting 
     assert.ok(fs.existsSync(path.join(marketingDir, 'gtm-target-queue.csv')));
     assert.ok(fs.existsSync(path.join(marketingDir, 'gtm-target-queue.jsonl')));
     assert.ok(fs.existsSync(path.join(marketingDir, 'team-outreach-messages.md')));
+    assert.ok(fs.existsSync(path.join(marketingDir, 'operator-priority-handoff.md')));
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add a ranked operator-priority handoff artifact to the GTM revenue loop outputs
- link the warm outreach copy pack back to the ranked handoff so send order and copy stay aligned
- regenerate the evidence-backed marketing artifacts from the live queue

## Verification
- node --test tests/gtm-revenue-loop.test.js
- git diff --check