### PR TITLE
fix(gtm): sync codex marketplace release pack

### DIFF
--- a/docs/marketing/codex-marketplace-revenue-pack.md
+++ b/docs/marketing/codex-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Operator Revenue Pack
 
-Updated: 2026-04-26T17:15:59.278Z
+Updated: 2026-04-26T19:17:35.558Z
 
 This is a sales operator artifact. It is not proof of installs, revenue, or marketplace approval by itself.
 
@@ -26,7 +26,7 @@ Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and 
 
 ### Standalone bundle download
 - URL: https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip
-- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.6/thumbgate-codex-plugin-v1.16.6.zip
+- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.7/thumbgate-codex-plugin-v1.16.7.zip
 - Operator use: Portable plugin path for buyers who want a direct asset instead of a repo checkout.
 - Buyer signal: Warm buyers ready to install now if the runtime, update policy, and proof links are explicit.
 - Evidence source: plugins/codex-profile/README.md

--- a/tests/codex-marketplace-revenue-pack.test.js
+++ b/tests/codex-marketplace-revenue-pack.test.js
@@ -120,6 +120,21 @@ test('rendered markdown and CSV stay operator-ready', () => {
   assert.match(csv, /solo_repeat_mistake/);
 });
 
+test('checked-in Codex marketplace pack stays in sync with the generator output', () => {
+  const docsPath = path.join(__dirname, '..', 'docs', 'marketing', 'codex-marketplace-revenue-pack.md');
+  const committed = fs.readFileSync(docsPath, 'utf8');
+  const updatedMatch = committed.match(/^Updated: (.+)$/m);
+
+  assert.ok(updatedMatch, 'expected checked-in pack to include an Updated line');
+
+  const markdown = renderCodexMarketplaceRevenuePackMarkdown({
+    ...buildCodexMarketplaceRevenuePack(LINKS_FIXTURE, ABOUT_FIXTURE, path.join(__dirname, '..')),
+    generatedAt: updatedMatch[1],
+  });
+
+  assert.equal(markdown, committed);
+});
+
 test('CLI options and artifact writing emit markdown, JSON, and queue CSV', () => {
   const tempDir = makeTempDir();
   const options = parseArgs(['--write-docs', '--report-dir', tempDir]);


### PR DESCRIPTION
## Summary
- update the Codex marketplace revenue pack to use the current 1.16.7 versioned release asset
- add a regression test that keeps the checked-in pack synced with the generator output

## Verification
- node --test tests/codex-marketplace-revenue-pack.test.js
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check