### PR TITLE
fix(marketing): keep public proof surfaces honest

### DIFF
--- a/.changeset/public-proof-hygiene.md
+++ b/.changeset/public-proof-hygiene.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Keep public dashboard and numbers surfaces proof-safe by removing fabricated demo revenue copy, refreshing the generated numbers snapshot wording, and pinning both behaviors with regression tests.

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
   "scripts": {
     "postinstall": "node bin/postinstall.js || true",
     "start": "node src/api/server.js",
+    "numbers:generate": "node scripts/generate-numbers-page.js",
     "changeset": "changeset",
     "changeset:version": "changeset version && node scripts/sync-version.js",
     "changeset:status": "changeset status",

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1065,20 +1065,20 @@ function buildDemoGeneratedViewSpec(viewName) {
   }
   if (viewName === 'workflow-rollout') {
     base.components = [
-      { type: 'hero', title: 'Generated Workflow Rollout View', description: 'Turn funnel, attribution, and predictive data into a constrained operator dashboard for team rollout.' },
+      { type: 'hero', title: 'Generated Workflow Rollout View', description: 'Turn funnel, attribution, and predictive data into a constrained operator dashboard for team rollout. Demo mode shows sample structure only and waits for hosted evidence before showing paid signals.' },
       { type: 'stat_grid', title: 'Rollout pipeline', items: [
-        { label: 'Workflow sprint leads', value: '4', note: 'intake-first hosted funnel' },
-        { label: 'Qualified leads', value: '2', note: 'ready for proof-backed rollout' },
-        { label: 'Booked revenue', value: '$128.00', note: '1 paid order' },
-        { label: 'Team propensity', value: 'medium', note: 'score 0.54' }
+        { label: 'Workflow sprint leads', value: 'Sample', note: 'connect hosted funnel for live intake counts' },
+        { label: 'Qualified leads', value: 'Sample', note: 'proof-backed rollout data appears after intake review' },
+        { label: 'Booked revenue', value: 'Awaiting evidence', note: 'demo mode omits paid numbers until hosted analytics load' },
+        { label: 'Team propensity', value: 'Sample', note: 'score loads from hosted predictive analytics' }
       ] },
       { type: 'list', title: 'Top acquisition sources', emptyMessage: 'No sources.', items: [
-        { title: 'producthunt', subtitle: 'captured acquisition source', badge: '3 leads' },
-        { title: 'website', subtitle: 'captured acquisition source', badge: '1 lead' }
+        { title: 'producthunt', subtitle: 'example acquisition source', badge: 'sample only' },
+        { title: 'website', subtitle: 'example acquisition source', badge: 'sample only' }
       ] },
       { type: 'list', title: 'Next rollout moves', emptyMessage: 'No rollout moves.', items: [
-        { title: 'Double down on reach_vb', subtitle: 'Best creator opportunity from predictive revenue scoring.', badge: '+$31.00' },
-        { title: 'Qualify pending sprint leads', subtitle: 'More leads than qualified workflows today.', badge: '4 total' }
+        { title: 'Load hosted conversion signals', subtitle: 'Use authenticated funnel and revenue data before prioritizing paid rollout moves.', badge: 'evidence gate' },
+        { title: 'Qualify pending sprint leads', subtitle: 'Promote real workflow owners only after intake and proof review exist.', badge: 'proof-first' }
       ] }
     ];
     return base;
@@ -1086,20 +1086,20 @@ function buildDemoGeneratedViewSpec(viewName) {
   base.components = [
     { type: 'hero', title: 'Generated Team Reliability Review', description: 'A constrained hosted view assembled from approved dashboard components.' },
     { type: 'stat_grid', title: 'Team snapshot', items: [
-      { label: 'Active agents', value: '5', note: 'of 8 registered agents' },
-      { label: 'Org adherence', value: '92.4%', note: 'rolling 24h view' },
-      { label: 'Team propensity', value: 'medium', note: 'score 0.54' },
-      { label: 'Forecast revenue', value: '$128.00', note: 'opportunity $49.00' }
+      { label: 'Active agents', value: 'Sample', note: 'connect your workspace for live counts' },
+      { label: 'Org adherence', value: 'Sample', note: 'rolling view loads from your own telemetry' },
+      { label: 'Team propensity', value: 'Sample', note: 'score loads from hosted predictive analytics' },
+      { label: 'Forecast revenue', value: 'Awaiting evidence', note: 'demo mode never invents forecast dollars' }
     ] },
     { type: 'list', title: 'Highest-risk agents', emptyMessage: 'No risky agents.', items: [
-      { title: 'claude-reviewer', subtitle: 'checkout-flow · fix/stripe-timeout', badge: '67.5% adherence' },
-      { title: 'codex-second-pass', subtitle: 'dashboard · feat/team-rollout', badge: '74.2% adherence' }
+      { title: 'claude-reviewer', subtitle: 'example workflow · sample branch', badge: 'sample only' },
+      { title: 'codex-second-pass', subtitle: 'example workflow · sample branch', badge: 'sample only' }
     ] },
     { type: 'list', title: 'Predictive watchlist', emptyMessage: 'No anomalies.', items: [
       { title: 'pricing_resistance', subtitle: 'Price sensitivity dominates current loss reasons.', badge: 'warning' },
       { title: 'creator_underperformance', subtitle: 'Creator reach_vb is generating intent without revenue conversion.', badge: 'warning' }
     ] },
-    { type: 'callout', title: 'Commercial signal', body: 'Pro propensity is high and Team propensity is medium. Workflow sprint leads currently total 4.', tone: 'warning' }
+    { type: 'callout', title: 'Commercial signal', body: 'Demo mode keeps commercial numbers gated until hosted analytics and proof-backed workflow data are available.', tone: 'warning' }
   ];
   return base;
 }
@@ -1499,8 +1499,8 @@ function loadDemo() {
   var teaserHtml = demoData.map(renderResult).join('');
   var upgradeBanner = '<div style="margin-bottom:12px;padding:12px 16px;background:linear-gradient(90deg,rgba(184,92,45,0.14),rgba(184,92,45,0.06));border:1px solid rgba(184,92,45,0.35);border-radius:10px;display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;">' +
     '<div style="color:#ddd;font-size:14px;">' +
-    '<span style="color:#ffb98a;font-weight:700;">Live demo data below.</span> ' +
-    'Point ThumbGate at your own feedback to see <em>your</em> gates, lessons, and team signals — no signup required.' +
+    '<span style="color:#ffb98a;font-weight:700;">Sample demo data below.</span> ' +
+    'Point ThumbGate at your own feedback to see <em>your</em> gates, lessons, and team signals. Paid and revenue fields stay hidden until hosted evidence loads.' +
     '</div>' +
     '<a href="/go/pro?utm_source=dashboard_live" rel="noopener" ' +
     'style="flex:none;background:#b85c2d;color:#fff;padding:8px 18px;border-radius:8px;text-decoration:none;font-weight:700;font-size:13px;white-space:nowrap;">Go Pro — $19/mo</a>' +

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -5,10 +5,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="ThumbGate">
 <meta name="author" content="Igor Ganapolsky">
-<title>ThumbGate — The Numbers | Live First-Party Data</title>
-<meta name="description" content="ThumbGate's live operational numbers: active pre-action checks, AI agent actions blocked, estimated LLM tokens and dollars saved, and the Bayes error rate of our intervention scorer. First-party data, regenerated on every release.">
+<title>ThumbGate — The Numbers | First-Party Data Snapshot</title>
+<meta name="description" content="ThumbGate's generated first-party operational snapshot: active pre-action checks, AI agent actions blocked, estimated LLM tokens and dollars saved, and the Bayes error rate of the intervention scorer.">
 <meta property="og:title" content="ThumbGate — The Numbers">
-<meta property="og:description" content="Live first-party operational metrics: checks, blocks, token savings, and scorer calibration. Regenerated on every release.">
+<meta property="og:description" content="Generated first-party operational metrics: gates, blocks, token savings, and scorer calibration.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://thumbgate-production.up.railway.app/numbers">
 <meta name="twitter:card" content="summary_large_image">
@@ -25,9 +25,9 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.12.2",
+  "softwareVersion": "1.16.8",
   "url": "https://thumbgate-production.up.railway.app/numbers",
-  "dateModified": "2026-04-20",
+  "dateModified": "2026-04-27",
   "creator": {
     "@type": "Person",
     "name": "Igor Ganapolsky",
@@ -57,10 +57,10 @@
       "https://www.linkedin.com/in/igorganapolsky"
     ]
   },
-  "dateModified": "2026-04-20",
-  "datePublished": "2026-04-20",
+  "dateModified": "2026-04-27",
+  "datePublished": "2026-04-27",
   "keywords": [
-    "AI agent checks",
+    "AI agent gates",
     "LLM token savings",
     "prevention rules",
     "Bayes error rate",
@@ -70,7 +70,7 @@
     {
       "@type": "PropertyValue",
       "name": "active_gates",
-      "value": 52
+      "value": 36
     },
     {
       "@type": "PropertyValue",
@@ -80,12 +80,12 @@
     {
       "@type": "PropertyValue",
       "name": "actions_warned",
-      "value": 455
+      "value": 0
     },
     {
       "@type": "PropertyValue",
       "name": "estimated_hours_saved",
-      "value": "113.8"
+      "value": "0.0"
     },
     {
       "@type": "PropertyValue",
@@ -101,7 +101,7 @@
     {
       "@type": "PropertyValue",
       "name": "bayes_error_rate",
-      "value": 0.015
+      "value": null
     }
   ]
 }
@@ -189,34 +189,34 @@
 
 <main class="container">
   <h1>The Numbers</h1>
-  <p class="subtitle">Live first-party operational data from the ThumbGate runtime. No surveys, no projections — counts pulled from the same local scripts that power the CLI and dashboard.</p>
-  <div class="freshness">Updated: 2026-04-20 · Version 1.12.2</div>
+  <p class="subtitle">Generated first-party operational data from the ThumbGate runtime. No surveys or projections — this page is a release-time snapshot produced by the same local scripts that power the CLI and dashboard.</p>
+  <div class="freshness">Updated: 2026-04-27 · Version 1.16.8</div>
 
-  <h2>Check enforcement</h2>
+  <h2>Gate enforcement</h2>
   <div class="stats-grid">
     <div class="stat-card">
-      <div class="stat-label">Active checks</div>
-      <div class="stat-value">52</div>
-      <div class="stat-sub">33 manual · 19 auto-promoted</div>
-      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/check-stats.js">source: check-stats.js</a>
+      <div class="stat-label">Active gates</div>
+      <div class="stat-value">36</div>
+      <div class="stat-sub">36 manual · 0 auto-promoted</div>
+      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Actions blocked</div>
       <div class="stat-value">0</div>
-      <div class="stat-sub">repeat AI mistakes prevented at the check</div>
-      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/check-stats.js">source: check-stats.js</a>
+      <div class="stat-sub">repeat AI mistakes prevented at the gate</div>
+      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Actions warned</div>
-      <div class="stat-value">455</div>
+      <div class="stat-value">0</div>
       <div class="stat-sub">soft interventions; not blocks</div>
-      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/check-stats.js">source: check-stats.js</a>
+      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
-      <div class="stat-label">Top blocked check</div>
+      <div class="stat-label">Top blocked gate</div>
       <div class="stat-value" style="font-size:1.1rem;">local-only-git-writes (0 blocks)</div>
       <div class="stat-sub">highest-occurrence prevention rule</div>
-      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/check-stats.js">source: check-stats.js</a>
+      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
   </div>
 
@@ -224,9 +224,9 @@
   <div class="stats-grid">
     <div class="stat-card">
       <div class="stat-label">Estimated hours saved</div>
-      <div class="stat-value">113.8</div>
+      <div class="stat-value">0.0</div>
       <div class="stat-sub">~15 min per blocked mistake × blocks+warns</div>
-      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/check-stats.js">source: check-stats.js</a>
+      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Estimated LLM dollars saved</div>
@@ -242,9 +242,9 @@
     </div>
     <div class="stat-card">
       <div class="stat-label">Scorer Bayes error</div>
-      <div class="stat-value">1.5%</div>
+      <div class="stat-value">n/a (no feedback sequences recorded yet)</div>
       <div class="stat-sub">irreducible error given current feature set</div>
-      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/bayes-optimal-check.js">source: bayes-optimal-check.js</a>
+      <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/bayes-optimal-gate.js">source: bayes-optimal-gate.js</a>
     </div>
   </div>
 
@@ -253,18 +253,18 @@
     <p><strong>Where the numbers come from.</strong> This page is regenerated from local scripts — no survey data, no hand-edited figures, no third-party attribution. Every number on this page is produced by code in the public <a href="https://github.com/IgorGanapolsky/ThumbGate">ThumbGate repo</a>.</p>
     <ul>
       <li><strong>Active checks</strong> — union of shipped default rules and the auto-promotion ledger (auto).</li>
-      <li><strong>Actions blocked/warned</strong> — sum of <code>occurrences</code> across checks with the corresponding action.</li>
+      <li><strong>Actions blocked/warned</strong> — sum of <code>occurrences</code> across gates with the corresponding action.</li>
       <li><strong>Hours saved</strong> — conservative 15-minute/incident estimate for debugging a repeated AI mistake × (blocks + warns).</li>
       <li><strong>Dollars saved</strong> — blended per-call token estimate (2k input + 600 output) × blocks × 2026-04-15 Anthropic + OpenAI list prices. See <code>scripts/token-savings.js</code> for the full price snapshot.</li>
       <li><strong>Bayes error rate</strong> — irreducible classifier error of the current risk scorer given its feature set. High values mean "add features, don't tune thresholds."</li>
     </ul>
-    <p style="margin-top:12px;">Last auto-promotion: auto-entity-funnel-metric-roi on 2026-04-17. Regenerated on every release via <code>npm run numbers:generate</code> and on a weekly cadence.</p>
+    <p style="margin-top:12px;">Last auto-promotion: none. Regenerated on every release via <code>npm run numbers:generate</code> and on a weekly cadence.</p>
   </div>
 
   <div class="cta">
     <a href="https://www.npmjs.com/package/thumbgate">Install ThumbGate — npx thumbgate init</a>
-    <div class="footer-note">Prefer the raw feed? See <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a> or run <code>npm run check:stats</code> locally.</div>
-    <div class="footer-note">Generated at 2026-04-20T21:45:34.500Z UTC.</div>
+    <div class="footer-note">Prefer the raw feed? See <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a> or run <code>npm run gate:stats</code> locally.</div>
+    <div class="footer-note">Generated at 2026-04-27T08:42:59.023Z UTC.</div>
   </div>
 </main>
 </body>

--- a/scripts/generate-numbers-page.js
+++ b/scripts/generate-numbers-page.js
@@ -176,10 +176,10 @@ function renderNumbersPage(input) {
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="ThumbGate">
 <meta name="author" content="Igor Ganapolsky">
-<title>ThumbGate — The Numbers | Live First-Party Data</title>
-<meta name="description" content="ThumbGate's live operational numbers: active pre-action checks, AI agent actions blocked, estimated LLM tokens and dollars saved, and the Bayes error rate of our intervention scorer. First-party data, regenerated on every release.">
+<title>ThumbGate — The Numbers | First-Party Data Snapshot</title>
+<meta name="description" content="ThumbGate's generated first-party operational snapshot: active pre-action checks, AI agent actions blocked, estimated LLM tokens and dollars saved, and the Bayes error rate of the intervention scorer.">
 <meta property="og:title" content="ThumbGate — The Numbers">
-<meta property="og:description" content="Live first-party operational metrics: gates, blocks, token savings, and scorer calibration. Regenerated on every release.">
+<meta property="og:description" content="Generated first-party operational metrics: gates, blocks, token savings, and scorer calibration.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://thumbgate-production.up.railway.app/numbers">
 <meta name="twitter:card" content="summary_large_image">
@@ -278,7 +278,7 @@ ${JSON.stringify(datasetLd, null, 2)}
 
 <main class="container">
   <h1>The Numbers</h1>
-  <p class="subtitle">Live first-party operational data from the ThumbGate runtime. No surveys, no projections — counts pulled from the same local scripts that power the CLI and dashboard.</p>
+  <p class="subtitle">Generated first-party operational data from the ThumbGate runtime. No surveys or projections — this page is a release-time snapshot produced by the same local scripts that power the CLI and dashboard.</p>
   <div class="freshness">Updated: ${escapeHtml(nowDate)} · Version ${escapeHtml(version)}</div>
 
   <h2>Gate enforcement</h2>

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -124,3 +124,16 @@ test('dashboard has noindex and meta description for SEO safety', () => {
 test('dashboard inline script parses after generated-view additions', () => {
   assert.doesNotThrow(() => new vm.Script(readDashboardScript()));
 });
+
+test('dashboard demo keeps paid and revenue placeholders evidence-safe', () => {
+  const dashboard = readDashboard();
+
+  assert.match(dashboard, /Sample demo data below\./);
+  assert.match(dashboard, /Paid and revenue fields stay hidden until hosted evidence loads\./);
+  assert.match(dashboard, /Awaiting evidence/);
+  assert.match(dashboard, /demo mode never invents forecast dollars/);
+  assert.doesNotMatch(dashboard, /\$128\.00/);
+  assert.doesNotMatch(dashboard, /1 paid order/);
+  assert.doesNotMatch(dashboard, /opportunity \$49\.00/);
+  assert.doesNotMatch(dashboard, /Live demo data below\./);
+});

--- a/tests/numbers-page.test.js
+++ b/tests/numbers-page.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const pkg = require('../package.json');
 
 const {
   generate,
@@ -208,6 +209,18 @@ describe('public/numbers.html generated artifact', () => {
       /"dateModified":\s*"\d{4}-\d{2}-\d{2}"/,
       'expected JSON-LD dateModified ISO date',
     );
+  });
+
+  it('stays synced to the current package version and snapshot wording', () => {
+    const contents = fs.readFileSync(numbersPath, 'utf8');
+
+    assert.match(
+      contents,
+      new RegExp(`"softwareVersion": "${pkg.version.replaceAll('.', '\\.')}"`),
+      'expected public/numbers.html to match package.json version',
+    );
+    assert.match(contents, /First-Party Data Snapshot/);
+    assert.doesNotMatch(contents, /Live First-Party Data/);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove fabricated paid and revenue copy from dashboard demo states
- regenerate the public numbers page as a first-party snapshot with current version/date wording
- add regression tests and a named numbers:generate script to keep those public trust surfaces synced

## Verification
- npm ci
- npm test
- npm run test:coverage
- THUMBGATE_PROOF_DIR="$(mktemp -d)/proof" npm run prove:adapters
- THUMBGATE_AUTOMATION_PROOF_DIR="$(mktemp -d)/proof-automation" npm run prove:automation
- npm run self-heal:check

## Context
This change is acquisition/conversion trust hygiene: public demo and proof surfaces should not imply paid results without evidence-backed data.
