### PR TITLE
fix(gtm): preserve secondary marketplace cta

### DIFF
--- a/.changeset/gtm-secondary-cta-fallback.md
+++ b/.changeset/gtm-secondary-cta-fallback.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Preserve the canonical Pro checkout CTA in generated GTM marketplace assets when the current target set is sprint-only.

--- a/docs/marketing/aiventyx-marketplace-revenue-pack.md
+++ b/docs/marketing/aiventyx-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Aiventyx Marketplace Revenue Pack
 
-Updated: 2026-04-27T04:33:51.586Z
+Updated: 2026-04-27T10:43:39.473Z
 Dashboard: https://aiventyx.com/dashboard
 
 This is a sales operator artifact. It is not proof of revenue, sent messages, or marketplace approval.

--- a/docs/marketing/chatgpt-gpt-revenue-pack.md
+++ b/docs/marketing/chatgpt-gpt-revenue-pack.md
@@ -1,6 +1,6 @@
 # ChatGPT GPT Revenue Pack
 
-Updated: 2026-04-27T04:33:51.571Z
+Updated: 2026-04-27T10:43:39.459Z
 
 This is a sales operator artifact. It is not proof of GPT traffic, sent outreach, saved feedback, paid revenue, or GPT Store ranking by itself.
 
@@ -8,10 +8,10 @@ This is a sales operator artifact. It is not proof of GPT traffic, sent outreach
 Turn ChatGPT GPT discovery and trust-boundary demand into tracked proof clicks, Pro checkout starts, and qualified workflow-hardening conversations.
 
 ## Positioning
-- State: cold-start
+- State: post-first-dollar
 - Headline: Use ChatGPT for discovery, then force risky actions through real checks.
 - Short description: ThumbGate turns the published ChatGPT GPT into a proof-backed front door for action checks, typed feedback capture, and local enforcement handoff.
-- Summary: ChatGPT demand in ThumbGate should start with one useful action check or typed lesson, then hand the buyer into proof and local enforcement. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
+- Summary: ChatGPT demand in ThumbGate should start with one useful action check or typed lesson, then hand the buyer into proof and local enforcement. Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
 
 ## Canonical Identity
 - Display name: ThumbGate GPT

--- a/docs/marketing/claude-workflow-hardening-pack.md
+++ b/docs/marketing/claude-workflow-hardening-pack.md
@@ -1,6 +1,6 @@
 # Claude Workflow Hardening Pack
 
-Updated: 2026-04-27T04:33:51.571Z
+Updated: 2026-04-27T10:43:39.459Z
 
 This is a sales operator artifact. It is not proof of sent outreach, directory approval, paid revenue, or deployment success by itself.
 
@@ -8,10 +8,10 @@ This is a sales operator artifact. It is not proof of sent outreach, directory a
 Turn Claude install demand and workflow-hardening pain into tracked sprint intakes, proof clicks, and Pro checkout starts without making approval or revenue claims the repo cannot verify.
 
 ## Positioning
-- State: cold-start
+- State: post-first-dollar
 - Headline: Turn Claude install demand into workflow-hardening revenue.
 - Short description: ThumbGate gives Claude Desktop and Claude Code a proof-backed install path, thumbs-up/down feedback capture, and Pre-Action Checks that block repeated workflow mistakes before the next risky action runs.
-- Summary: Claude demand in ThumbGate should stay install-first for evaluators and workflow-hardening-first for teams that already feel the pain. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
+- Summary: Claude demand in ThumbGate should stay install-first for evaluators and workflow-hardening-first for teams that already feel the pain. Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
 
 ## Canonical Identity
 - Display name: ThumbGate for Claude

--- a/docs/marketing/codex-marketplace-revenue-pack.md
+++ b/docs/marketing/codex-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Operator Revenue Pack
 
-Updated: 2026-04-27T04:33:51.592Z
+Updated: 2026-04-27T10:43:39.478Z
 
 This is a sales operator artifact. It is not proof of installs, revenue, or marketplace approval by itself.
 

--- a/docs/marketing/codex-plugin-revenue-pack.md
+++ b/docs/marketing/codex-plugin-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Plugin Revenue Pack
 
-Updated: 2026-04-27T04:33:51.571Z
+Updated: 2026-04-27T10:43:39.459Z
 
 This is a sales operator artifact. It is not proof of bundle downloads, installs, paid revenue, or marketplace publication by itself.
 

--- a/docs/marketing/cursor-marketplace-revenue-pack.md
+++ b/docs/marketing/cursor-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Cursor Marketplace Revenue Pack
 
-Updated: 2026-04-27T04:33:51.584Z
+Updated: 2026-04-27T10:43:39.471Z
 
 This is a sales operator artifact. It is not proof of installs, paid revenue, directory approval, or marketplace publication by itself.
 

--- a/docs/marketing/gemini-cli-demand-pack.md
+++ b/docs/marketing/gemini-cli-demand-pack.md
@@ -1,6 +1,6 @@
 # Gemini CLI Demand Pack
 
-Updated: 2026-04-27T04:33:51.571Z
+Updated: 2026-04-27T10:43:39.459Z
 
 This is a sales operator artifact. It is not proof of rankings, sent outreach, installs, paid revenue, or marketplace approval by itself.
 
@@ -8,10 +8,10 @@ This is a sales operator artifact. It is not proof of rankings, sent outreach, i
 Turn Gemini CLI memory demand and Google Cloud MCP guardrail demand into tracked proof clicks, Pro checkout starts, and qualified workflow-hardening conversations.
 
 ## Positioning
-- State: cold-start
+- State: post-first-dollar
 - Headline: Turn Gemini CLI memory demand into enforced workflow safety.
 - Short description: ThumbGate gives Gemini CLI local-first memory that can become prevention rules and Pre-Action Checks before the next risky MCP call runs.
-- Summary: Gemini CLI demand in ThumbGate is guide-led: memory query first, then enforcement proof, then paid intent. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
+- Summary: Gemini CLI demand in ThumbGate is guide-led: memory query first, then enforcement proof, then paid intent. Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
 
 ## Canonical Identity
 - Display name: ThumbGate

--- a/docs/marketing/gtm-marketplace-copy.json
+++ b/docs/marketing/gtm-marketplace-copy.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-27T09:46:33.392Z",
+  "generatedAt": "2026-04-27T10:43:39.459Z",
   "state": "post-first-dollar",
   "headline": "Harden one AI-agent workflow before you roll it out.",
   "shortDescription": "Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain.",
@@ -19,7 +19,7 @@
     {
       "motion": "pro",
       "label": "Pro at $19/mo or $149/yr",
-      "cta": ""
+      "cta": "https://thumbgate-production.up.railway.app/checkout/pro"
     }
   ],
   "listingBullets": [

--- a/docs/marketing/gtm-marketplace-copy.md
+++ b/docs/marketing/gtm-marketplace-copy.md
@@ -22,7 +22,7 @@ ThumbGate is a reliability gateway for AI coding workflows. It captures repeated
 ## Recommended CTAs
 - Proof-backed setup guide: https://thumbgate-production.up.railway.app/guide
 - Workflow Hardening Sprint: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
-- Pro at $19/mo or $149/yr: cta unavailable in this run
+- Pro at $19/mo or $149/yr: https://thumbgate-production.up.railway.app/checkout/pro
 
 ## Evidence-Backed Buyer Signals
 - Workflow control surfaces (6): The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Examples: Adqui9608/ai-code-review-agent, DGouron/review-flow, nihannihu/Omni-SRE

--- a/docs/marketing/gtm-revenue-loop.json
+++ b/docs/marketing/gtm-revenue-loop.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-27T09:46:33.392Z",
+  "generatedAt": "2026-04-27T10:43:39.459Z",
   "source": "hosted-via-railway-env",
   "fallbackReason": null,
   "objective": "First 10 paying customers",
@@ -18,7 +18,9 @@
   },
   "currentTruth": {
     "publicSelfServeOffer": "Pro at $19/mo or $149/yr",
+    "publicSelfServeCta": "https://thumbgate-production.up.railway.app/checkout/pro",
     "teamPilotOffer": "Workflow Hardening Sprint",
+    "teamPilotCta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
     "guideLink": "https://thumbgate-production.up.railway.app/guide",
     "commercialTruthLink": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
     "verificationEvidenceLink": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md"
@@ -41,7 +43,7 @@
     "bookedRevenueCents": 2000,
     "checkoutStarts": 1,
     "ctaClicks": 3,
-    "visitors": 72,
+    "visitors": 108,
     "uniqueLeads": 1,
     "sprintLeads": 0,
     "qualifiedSprintLeads": 0,
@@ -701,7 +703,7 @@
     }
   ],
   "marketplaceCopy": {
-    "generatedAt": "2026-04-27T09:46:33.392Z",
+    "generatedAt": "2026-04-27T10:43:39.459Z",
     "state": "post-first-dollar",
     "headline": "Harden one AI-agent workflow before you roll it out.",
     "shortDescription": "Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain.",
@@ -721,7 +723,7 @@
       {
         "motion": "pro",
         "label": "Pro at $19/mo or $149/yr",
-        "cta": ""
+        "cta": "https://thumbgate-production.up.railway.app/checkout/pro"
       }
     ],
     "listingBullets": [

--- a/docs/marketing/gtm-revenue-loop.md
+++ b/docs/marketing/gtm-revenue-loop.md
@@ -1,7 +1,7 @@
 # GSD Revenue Loop
 
 Status: post-first-dollar
-Updated: 2026-04-27T09:46:33.392Z
+Updated: 2026-04-27T10:43:39.459Z
 
 This report is an operator artifact for landing the first 10 paying customers. It is not proof of sent messages or booked revenue by itself.
 Outbound rule: do not treat posts as sales. A lead only moves when it is tracked as contacted, replied, call booked, checkout/sprint, or paid.

--- a/docs/marketing/operator-priority-handoff.md
+++ b/docs/marketing/operator-priority-handoff.md
@@ -1,6 +1,6 @@
 # Revenue Operator Priority Handoff
 
-Updated: 2026-04-27T09:46:33.392Z
+Updated: 2026-04-27T10:43:39.459Z
 
 This is the ranked send order for the current zero-to-one revenue loop. Work warm discovery targets first, then expand into cold GitHub targets with the same proof discipline.
 

--- a/docs/marketing/team-outreach-messages.md
+++ b/docs/marketing/team-outreach-messages.md
@@ -1,6 +1,6 @@
 # Workflow Hardening Sprint Outreach Messages
 
-Updated: 2026-04-27T09:46:33.392Z
+Updated: 2026-04-27T10:43:39.459Z
 
 These drafts are generated from the same evidence-backed revenue-loop report as `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `gtm-marketplace-copy.md`.
 Use `operator-priority-handoff.md` for the ranked send order; this file is the copy layer for warm outreach only.

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -952,7 +952,9 @@ function buildRevenueLoopReport({ source, fallbackReason, summary, motionCatalog
   const snapshot = summarizeCommercialSnapshot(summary);
   const currentTruth = {
     publicSelfServeOffer: motionCatalog.pro.label,
+    publicSelfServeCta: motionCatalog.pro.cta,
     teamPilotOffer: motionCatalog.sprint.label,
+    teamPilotCta: motionCatalog.sprint.cta,
     guideLink: buildRevenueLinks().guideLink,
     commercialTruthLink: motionCatalog.pro.truth,
     verificationEvidenceLink: motionCatalog.pro.proof,
@@ -1026,7 +1028,16 @@ function resolveMotionCta(report, motionKey) {
   const matchingTarget = Array.isArray(report.targets)
     ? report.targets.find((target) => normalizeText(target.motion) === normalizeText(motionKey) && normalizeText(target.cta))
     : null;
-  return matchingTarget ? matchingTarget.cta : '';
+  if (matchingTarget) {
+    return matchingTarget.cta;
+  }
+  if (motionKey === 'pro') {
+    return normalizeText(report.currentTruth?.publicSelfServeCta);
+  }
+  if (motionKey === 'sprint') {
+    return normalizeText(report.currentTruth?.teamPilotCta);
+  }
+  return '';
 }
 
 function buildMarketplaceCopy(report) {

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -1140,6 +1140,62 @@ test('marketplace copy pack stays tied to current revenue-loop evidence', () => 
   assert.doesNotMatch(markdown, /paid customers already exist/i);
 });
 
+test('marketplace copy keeps the Pro CTA when no target currently uses the Pro motion', () => {
+  const links = buildRevenueLinks();
+  const catalog = buildMotionCatalog(links);
+  const report = buildRevenueLoopReport({
+    source: 'local',
+    fallbackReason: 'Hosted operational summary is not configured.',
+    summary: {
+      revenue: { paidOrders: 0, bookedRevenueCents: 0 },
+      trafficMetrics: {},
+      signups: {},
+      pipeline: {},
+    },
+    motionCatalog: catalog,
+    directive: {
+      state: 'cold-start',
+      objective: 'First 10 paying customers',
+      headline: 'No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.',
+      primaryMotion: 'sprint',
+      secondaryMotion: 'pro',
+      actions: ['Lead with one workflow.'],
+    },
+    targets: [
+      {
+        temperature: 'warm',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        username: 'builder',
+        accountName: 'r/ClaudeCode',
+        contactUrl: 'https://www.reddit.com/user/builder/',
+        repoName: '',
+        repoUrl: '',
+        evidence: {
+          score: 8,
+          evidence: ['warm inbound engagement'],
+          outreachAngle: 'Lead with one repeated workflow failure.',
+        },
+        selectedMotion: {
+          key: 'sprint',
+          label: catalog.sprint.label,
+          reason: 'Warm workflow pain already exists.',
+        },
+        pipelineStage: 'targeted',
+        message: 'I can harden one workflow for you this week.',
+      },
+    ],
+  });
+
+  const pack = buildMarketplaceCopy(report);
+  const markdown = renderMarketplaceCopyMarkdown(pack);
+
+  assert.equal(pack.recommendedCtas[2].label, catalog.pro.label);
+  assert.equal(pack.recommendedCtas[2].cta, catalog.pro.cta);
+  assert.match(markdown, /Pro at \$19\/mo or \$149\/yr: https:\/\/thumbgate-production\.up\.railway\.app\/checkout\/pro/);
+  assert.doesNotMatch(markdown, /cta unavailable in this run/);
+});
+
 test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for operator import', () => {
   const links = buildRevenueLinks();
   const catalog = buildMotionCatalog(links);


### PR DESCRIPTION
## Summary
- preserve canonical sprint and Pro CTAs in the GTM revenue-loop report so marketplace copy never degrades to an empty fallback
- add a regression for the all-sprint-targets case that previously emitted `cta unavailable in this run`
- regenerate the checked-in GTM operator assets from current hosted revenue evidence

## Verification
- node --test tests/gtm-revenue-loop.test.js
- node --test tests/customer-discovery-sprint.test.js tests/positioning-contract.test.js tests/autonomous-sales-agent.test.js
- clean worktree verification in progress: npm ci, npm test, npm run test:coverage, npm run prove:adapters, npm run prove:automation, npm run self-heal:check