### PR TITLE
feat(gtm): add machine-readable operator handoff

### DIFF
--- a/.changeset/operator-handoff-json.md
+++ b/.changeset/operator-handoff-json.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add a machine-readable `operator-priority-handoff.json` revenue-loop artifact so operators and automations can consume the ranked outreach queue, CTA, proof rules, and sales pipeline commands without scraping markdown.

--- a/docs/CUSTOMER_DISCOVERY_SPRINT.md
+++ b/docs/CUSTOMER_DISCOVERY_SPRINT.md
@@ -59,6 +59,7 @@ The revenue loop emits these operator artifacts in that folder:
 - `gtm-target-queue.jsonl` for line-by-line operator handoff with first-touch and pain-confirmed follow-up drafts
 - `team-outreach-messages.md` for the warm-outbound copy layer tied to the same ranked queue
 - `operator-priority-handoff.md` for the ranked send order across warm discovery and cold GitHub targets
+- `operator-priority-handoff.json` for the same ranked send order, CTA, proof rule, and sales commands in machine-readable form
 - `claude-workflow-hardening-pack.md` for Claude-first positioning, buyer lanes, and evidence-backed outbound copy
 - `claude-workflow-hardening-pack.json` for the same Claude-first outbound pack in machine-readable form
 - `cursor-marketplace-revenue-pack.md` for Cursor Marketplace, Cursor Directory, and Team Marketplace submission copy

--- a/docs/marketing/operator-priority-handoff.json
+++ b/docs/marketing/operator-priority-handoff.json
@@ -1,0 +1,653 @@
+{
+  "generatedAt": "2026-04-27T17:22:01.540Z",
+  "summary": {
+    "revenueState": "post-first-dollar",
+    "headline": "Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.",
+    "paidOrders": 2,
+    "checkoutStarts": 1,
+    "activeFollowUps": 0,
+    "warmTargetsReadyNow": 4,
+    "coldGitHubTargetsReadyNext": 6
+  },
+  "operatorRules": [
+    "Import the queue into the sales ledger before sending anything.",
+    "Lead with one concrete workflow-hardening offer, not generic Pro and not the proof pack.",
+    "Use VERIFICATION_EVIDENCE.md and COMMERCIAL_TRUTH.md only after the buyer confirms pain."
+  ],
+  "importCommand": "npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json",
+  "sections": [
+    {
+      "key": "follow_up_now",
+      "label": "Follow Up Now",
+      "targets": []
+    },
+    {
+      "key": "send_now_warm_discovery",
+      "label": "Send Now: Warm Discovery",
+      "targets": [
+        {
+          "rank": 1,
+          "label": "@Deep_Ad1959 - r/cursor",
+          "username": "Deep_Ad1959",
+          "accountName": "r/cursor",
+          "repoName": "",
+          "repoUrl": "",
+          "temperature": "warm",
+          "source": "reddit",
+          "channel": "reddit_dm",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "reddit_deep_ad1959_r_cursor",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://www.reddit.com/user/Deep_Ad1959/",
+          "contactSurfaces": [],
+          "company": "",
+          "evidenceScore": 10,
+          "evidence": [
+            "warm inbound engagement",
+            "workflow pain named: rollback risk",
+            "already in DMs"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://www.reddit.com/user/Deep_Ad1959/",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Warm Reddit engager already named a repeated workflow risk, so the fastest path is a founder-led diagnostic.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Your question about rollback rates when context changes is exactly the right one. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have one workflow where context drift or rollback risk keeps showing up, I can harden that workflow for you. Worth a 15-minute diagnostic?",
+          "painConfirmedFollowUpDraft": "If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'reddit_deep_ad1959_r_cursor' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on rollback risk.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'reddit_deep_ad1959_r_cursor' --channel 'reddit_dm' --stage 'replied' --note 'Buyer confirmed pain around rollback risk.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'reddit_deep_ad1959_r_cursor' --channel 'reddit_dm' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for rollback risk.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'reddit_deep_ad1959_r_cursor' --channel 'reddit_dm' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing rollback risk.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'reddit_deep_ad1959_r_cursor' --channel 'reddit_dm' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for rollback risk.'"
+          }
+        },
+        {
+          "rank": 2,
+          "label": "@game-of-kton - r/cursor",
+          "username": "game-of-kton",
+          "accountName": "r/cursor",
+          "repoName": "",
+          "repoUrl": "",
+          "temperature": "warm",
+          "source": "reddit",
+          "channel": "reddit_dm",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "reddit_game_of_kton_r_cursor",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://www.reddit.com/user/game-of-kton/",
+          "contactSurfaces": [],
+          "company": "",
+          "evidenceScore": 9,
+          "evidence": [
+            "warm inbound engagement",
+            "built serious memory systems",
+            "workflow pain named: stale context and conflicting facts"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://www.reddit.com/user/game-of-kton/",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Warm Reddit engager already works on advanced agent memory, so discovery should center on one repeated failure pattern.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Your ACT-R engram work is fascinating, especially the conflict resolution for opposing facts and the decay model. I am looking for one serious AI-agent workflow to harden end-to-end this week. If your memory system has one recurring failure mode such as stale context, opposing facts, bad handoffs, or unsafe tool calls, I can turn that into a prevention rule and proof run. Open to a 15-minute diagnostic?",
+          "painConfirmedFollowUpDraft": "If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'reddit_game_of_kton_r_cursor' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on stale context and conflicting facts.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'reddit_game_of_kton_r_cursor' --channel 'reddit_dm' --stage 'replied' --note 'Buyer confirmed pain around stale context and conflicting facts.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'reddit_game_of_kton_r_cursor' --channel 'reddit_dm' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for stale context and conflicting facts.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'reddit_game_of_kton_r_cursor' --channel 'reddit_dm' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing stale context and conflicting facts.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'reddit_game_of_kton_r_cursor' --channel 'reddit_dm' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for stale context and conflicting facts.'"
+          }
+        },
+        {
+          "rank": 3,
+          "label": "@leogodin217 - r/ClaudeCode",
+          "username": "leogodin217",
+          "accountName": "r/ClaudeCode",
+          "repoName": "",
+          "repoUrl": "",
+          "temperature": "warm",
+          "source": "reddit",
+          "channel": "reddit_dm",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "reddit_leogodin217_r_claudecode",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://www.reddit.com/user/leogodin217/",
+          "contactSurfaces": [],
+          "company": "",
+          "evidenceScore": 9,
+          "evidence": [
+            "warm inbound engagement",
+            "mature multi-step workflow described",
+            "workflow pain named: review boundaries and context risk"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://www.reddit.com/user/leogodin217/",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Warm Reddit engager already described a mature workflow, so the next step is a targeted diagnostic on one failure mode.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Your arch-create to sprint workflow is one of the most mature agent processes I have seen anyone describe. I am looking for one AI-agent workflow to harden end-to-end this week. Your workflow already has phases, review boundaries, and context risk, so it is a strong fit: pick one repeating failure and I will help turn it into an enforceable Pre-Action Check plus proof run. Worth 15 minutes?",
+          "painConfirmedFollowUpDraft": "If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'reddit_leogodin217_r_claudecode' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on review boundaries and context risk.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'reddit_leogodin217_r_claudecode' --channel 'reddit_dm' --stage 'replied' --note 'Buyer confirmed pain around review boundaries and context risk.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'reddit_leogodin217_r_claudecode' --channel 'reddit_dm' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for review boundaries and context risk.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'reddit_leogodin217_r_claudecode' --channel 'reddit_dm' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing review boundaries and context risk.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'reddit_leogodin217_r_claudecode' --channel 'reddit_dm' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for review boundaries and context risk.'"
+          }
+        },
+        {
+          "rank": 4,
+          "label": "@Enthu-Cutlet-1337 - r/ClaudeCode",
+          "username": "Enthu-Cutlet-1337",
+          "accountName": "r/ClaudeCode",
+          "repoName": "",
+          "repoUrl": "",
+          "temperature": "warm",
+          "source": "reddit",
+          "channel": "reddit_dm",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "reddit_enthu_cutlet_1337_r_claudecode",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://www.reddit.com/user/Enthu-Cutlet-1337/",
+          "contactSurfaces": [],
+          "company": "",
+          "evidenceScore": 8,
+          "evidence": [
+            "warm inbound engagement",
+            "responded to adaptive-gate positioning",
+            "workflow pain named: brittle guardrails"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://www.reddit.com/user/Enthu-Cutlet-1337/",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Warm Reddit engager already understands the adaptive-gate thesis, so offer one concrete workflow hardening diagnostic.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Appreciate the kind words on the Thompson Sampling approach. You nailed the core insight: most guardrails are brittle prompt hacks that break when context shifts. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have a workflow where brittle guardrails keep failing, I can harden that workflow with you. Open to a 15-minute diagnostic?",
+          "painConfirmedFollowUpDraft": "If your workflow really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on brittle guardrails.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'replied' --note 'Buyer confirmed pain around brittle guardrails.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for brittle guardrails.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing brittle guardrails.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for brittle guardrails.'"
+          }
+        }
+      ]
+    },
+    {
+      "key": "seed_next_cold_github",
+      "label": "Seed Next: Cold GitHub",
+      "targets": [
+        {
+          "rank": 1,
+          "label": "@Adqui9608 - ai-code-review-agent",
+          "username": "Adqui9608",
+          "accountName": "Adqui9608",
+          "repoName": "ai-code-review-agent",
+          "repoUrl": "https://github.com/Adqui9608/ai-code-review-agent",
+          "temperature": "cold",
+          "source": "github",
+          "channel": "github",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "github_adqui9608_ai_code_review_agent",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://github.com/Adqui9608",
+          "contactSurfaces": [
+            {
+              "label": "GitHub profile",
+              "url": "https://github.com/Adqui9608"
+            },
+            {
+              "label": "Repository",
+              "url": "https://github.com/Adqui9608/ai-code-review-agent"
+            }
+          ],
+          "company": "",
+          "evidenceScore": 15,
+          "evidence": [
+            "workflow control surface",
+            "production or platform workflow",
+            "business-system integration",
+            "agent infrastructure",
+            "updated in the last 7 days"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://github.com/Adqui9608/ai-code-review-agent",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Hey @Adqui9608, saw you're shipping `ai-code-review-agent`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "painConfirmedFollowUpDraft": "If `ai-code-review-agent` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'github_adqui9608_ai_code_review_agent' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'github_adqui9608_ai_code_review_agent' --channel 'manual' --stage 'replied' --note 'Buyer confirmed pain around one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'github_adqui9608_ai_code_review_agent' --channel 'manual' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'github_adqui9608_ai_code_review_agent' --channel 'manual' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'github_adqui9608_ai_code_review_agent' --channel 'manual' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for one business-system workflow that needs approval boundaries, rollback safety, and proof.'"
+          }
+        },
+        {
+          "rank": 2,
+          "label": "@DGouron - review-flow",
+          "username": "DGouron",
+          "accountName": "DGouron",
+          "repoName": "review-flow",
+          "repoUrl": "https://github.com/DGouron/review-flow",
+          "temperature": "cold",
+          "source": "github",
+          "channel": "github",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "github_dgouron_review_flow",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://dgouron.fr/",
+          "contactSurfaces": [
+            {
+              "label": "Website",
+              "url": "https://dgouron.fr/"
+            },
+            {
+              "label": "GitHub profile",
+              "url": "https://github.com/DGouron"
+            },
+            {
+              "label": "Repository",
+              "url": "https://github.com/DGouron/review-flow"
+            }
+          ],
+          "company": "Mentor Goal",
+          "evidenceScore": 14,
+          "evidence": [
+            "workflow control surface",
+            "business-system integration",
+            "agent infrastructure",
+            "36 GitHub stars",
+            "updated in the last 7 days"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://github.com/DGouron/review-flow",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Hey @DGouron, saw you're shipping `review-flow`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "painConfirmedFollowUpDraft": "If `review-flow` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'github_dgouron_review_flow' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'github_dgouron_review_flow' --channel 'manual' --stage 'replied' --note 'Buyer confirmed pain around one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'github_dgouron_review_flow' --channel 'manual' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'github_dgouron_review_flow' --channel 'manual' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'github_dgouron_review_flow' --channel 'manual' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for one business-system workflow that needs approval boundaries, rollback safety, and proof.'"
+          }
+        },
+        {
+          "rank": 3,
+          "label": "@nihannihu - Omni-SRE",
+          "username": "nihannihu",
+          "accountName": "nihannihu",
+          "repoName": "Omni-SRE",
+          "repoUrl": "https://github.com/nihannihu/Omni-SRE",
+          "temperature": "cold",
+          "source": "github",
+          "channel": "github",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "github_nihannihu_omni_sre",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://github.com/nihannihu",
+          "contactSurfaces": [
+            {
+              "label": "GitHub profile",
+              "url": "https://github.com/nihannihu"
+            },
+            {
+              "label": "Repository",
+              "url": "https://github.com/nihannihu/Omni-SRE"
+            }
+          ],
+          "company": "@Omni-IDE",
+          "evidenceScore": 14,
+          "evidence": [
+            "workflow control surface",
+            "production or platform workflow",
+            "business-system integration",
+            "agent infrastructure",
+            "updated in the last 30 days"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://github.com/nihannihu/Omni-SRE",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Hey @nihannihu, saw you're shipping `Omni-SRE`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "painConfirmedFollowUpDraft": "If `Omni-SRE` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'github_nihannihu_omni_sre' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'github_nihannihu_omni_sre' --channel 'manual' --stage 'replied' --note 'Buyer confirmed pain around one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'github_nihannihu_omni_sre' --channel 'manual' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'github_nihannihu_omni_sre' --channel 'manual' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'github_nihannihu_omni_sre' --channel 'manual' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for one business-system workflow that needs approval boundaries, rollback safety, and proof.'"
+          }
+        },
+        {
+          "rank": 4,
+          "label": "@manki-review - manki",
+          "username": "manki-review",
+          "accountName": "manki-review",
+          "repoName": "manki",
+          "repoUrl": "https://github.com/manki-review/manki",
+          "temperature": "cold",
+          "source": "github",
+          "channel": "github",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "github_manki_review_manki",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://manki.dustinface.me/",
+          "contactSurfaces": [
+            {
+              "label": "Website",
+              "url": "https://manki.dustinface.me/"
+            },
+            {
+              "label": "GitHub profile",
+              "url": "https://github.com/manki-review"
+            },
+            {
+              "label": "Repository",
+              "url": "https://github.com/manki-review/manki"
+            }
+          ],
+          "company": "",
+          "evidenceScore": 13,
+          "evidence": [
+            "workflow control surface",
+            "business-system integration",
+            "agent infrastructure",
+            "5 GitHub stars",
+            "updated in the last 7 days"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://github.com/manki-review/manki",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Hey @manki-review, saw you're shipping `manki`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "painConfirmedFollowUpDraft": "If `manki` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'github_manki_review_manki' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'github_manki_review_manki' --channel 'manual' --stage 'replied' --note 'Buyer confirmed pain around one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'github_manki_review_manki' --channel 'manual' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'github_manki_review_manki' --channel 'manual' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'github_manki_review_manki' --channel 'manual' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for one business-system workflow that needs approval boundaries, rollback safety, and proof.'"
+          }
+        },
+        {
+          "rank": 5,
+          "label": "@yungookim - oh-my-pr",
+          "username": "yungookim",
+          "accountName": "yungookim",
+          "repoName": "oh-my-pr",
+          "repoUrl": "https://github.com/yungookim/oh-my-pr",
+          "temperature": "cold",
+          "source": "github",
+          "channel": "github",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "github_yungookim_oh_my_pr",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://github.com/yungookim",
+          "contactSurfaces": [
+            {
+              "label": "GitHub profile",
+              "url": "https://github.com/yungookim"
+            },
+            {
+              "label": "Repository",
+              "url": "https://github.com/yungookim/oh-my-pr"
+            }
+          ],
+          "company": "",
+          "evidenceScore": 12,
+          "evidence": [
+            "workflow control surface",
+            "business-system integration",
+            "39 GitHub stars",
+            "updated in the last 7 days"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://github.com/yungookim/oh-my-pr",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Hey @yungookim, saw you're shipping `oh-my-pr`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "painConfirmedFollowUpDraft": "If `oh-my-pr` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'github_yungookim_oh_my_pr' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'github_yungookim_oh_my_pr' --channel 'manual' --stage 'replied' --note 'Buyer confirmed pain around one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'github_yungookim_oh_my_pr' --channel 'manual' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'github_yungookim_oh_my_pr' --channel 'manual' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'github_yungookim_oh_my_pr' --channel 'manual' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for one business-system workflow that needs approval boundaries, rollback safety, and proof.'"
+          }
+        },
+        {
+          "rank": 6,
+          "label": "@tarinagarwal - lgtm-feedback",
+          "username": "tarinagarwal",
+          "accountName": "tarinagarwal",
+          "repoName": "lgtm-feedback",
+          "repoUrl": "https://github.com/tarinagarwal/lgtm-feedback",
+          "temperature": "cold",
+          "source": "github",
+          "channel": "github",
+          "pipelineStage": "targeted",
+          "pipelineLeadId": "github_tarinagarwal_lgtm_feedback",
+          "nextOperatorStep": "Send the first-touch draft and log the outreach in the sales pipeline.",
+          "pipelineUpdatedAt": "",
+          "contactSurface": "https://tarinagarwal.in/",
+          "contactSurfaces": [
+            {
+              "label": "Website",
+              "url": "https://tarinagarwal.in/"
+            },
+            {
+              "label": "GitHub profile",
+              "url": "https://github.com/tarinagarwal"
+            },
+            {
+              "label": "Repository",
+              "url": "https://github.com/tarinagarwal/lgtm-feedback"
+            }
+          ],
+          "company": "",
+          "evidenceScore": 12,
+          "evidence": [
+            "workflow control surface",
+            "production or platform workflow",
+            "business-system integration",
+            "updated in the last 30 days"
+          ],
+          "evidenceSources": [
+            {
+              "label": "Target signal",
+              "url": "https://github.com/tarinagarwal/lgtm-feedback",
+              "reason": "Source of the workflow or buyer signal behind this outreach row."
+            },
+            {
+              "label": "Commercial truth",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md",
+              "reason": "Current pricing, traction, and offer guardrail."
+            },
+            {
+              "label": "Verification evidence",
+              "url": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+              "reason": "Current engineering proof pack and verification artifact."
+            }
+          ],
+          "motionLabel": "Workflow Hardening Sprint",
+          "whyNow": "Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.",
+          "proofRule": "Use proof pack only after the buyer confirms pain.",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "firstTouchDraft": "Hey @tarinagarwal, saw you're shipping `lgtm-feedback`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+          "painConfirmedFollowUpDraft": "If `lgtm-feedback` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+          "salesCommands": {
+            "markContacted": "npm run sales:pipeline -- advance --lead 'github_tarinagarwal_lgtm_feedback' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markReplied": "npm run sales:pipeline -- advance --lead 'github_tarinagarwal_lgtm_feedback' --channel 'manual' --stage 'replied' --note 'Buyer confirmed pain around one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCallBooked": "npm run sales:pipeline -- advance --lead 'github_tarinagarwal_lgtm_feedback' --channel 'manual' --stage 'call_booked' --note 'Booked a 15-minute workflow hardening diagnostic for one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markCheckoutStarted": "npm run sales:pipeline -- advance --lead 'github_tarinagarwal_lgtm_feedback' --channel 'manual' --stage 'checkout_started' --note 'Buyer started the self-serve checkout after discussing one business-system workflow that needs approval boundaries, rollback safety, and proof.'",
+            "markSprintIntake": "npm run sales:pipeline -- advance --lead 'github_tarinagarwal_lgtm_feedback' --channel 'manual' --stage 'sprint_intake' --note 'Buyer moved into Workflow Hardening Sprint intake for one business-system workflow that needs approval boundaries, rollback safety, and proof.'"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -1481,12 +1481,95 @@ function renderOperatorPriorityTargetMarkdown(target, index) {
   ];
 }
 
-function renderOperatorHandoffMarkdown(report) {
+function buildOperatorPriorityTargetSummary(target, index) {
+  const enrichedTarget = enrichRenderableTarget(target);
+  const label = normalizeText(enrichedTarget.repoName)
+    ? `@${enrichedTarget.username} - ${enrichedTarget.repoName}`
+    : `@${enrichedTarget.username} - ${enrichedTarget.accountName || enrichedTarget.source || 'discovery lead'}`;
+  return {
+    rank: index + 1,
+    label,
+    username: normalizeText(enrichedTarget.username),
+    accountName: normalizeText(enrichedTarget.accountName),
+    repoName: normalizeText(enrichedTarget.repoName),
+    repoUrl: normalizeText(enrichedTarget.repoUrl),
+    temperature: normalizeText(enrichedTarget.temperature) || 'cold',
+    source: normalizeText(enrichedTarget.source) || 'github',
+    channel: normalizeText(enrichedTarget.channel) || normalizeText(enrichedTarget.source) || 'github',
+    pipelineStage: normalizeText(enrichedTarget.pipelineStage) || 'targeted',
+    pipelineLeadId: normalizeText(enrichedTarget.pipelineLeadId) || 'n/a',
+    nextOperatorStep: normalizeText(enrichedTarget.nextOperatorAction) || buildNextOperatorAction(enrichedTarget.pipelineStage),
+    pipelineUpdatedAt: normalizeText(enrichedTarget.pipelineUpdatedAt),
+    contactSurface: normalizeText(enrichedTarget.contactUrl) || normalizeText(enrichedTarget.repoUrl) || 'n/a',
+    contactSurfaces: dedupeContactSurfaces(enrichedTarget.contactSurfaces),
+    company: normalizeText(enrichedTarget.company),
+    evidenceScore: Number(enrichedTarget.evidenceScore || 0),
+    evidence: Array.isArray(enrichedTarget.evidence) ? enrichedTarget.evidence : [],
+    evidenceSources: Array.isArray(enrichedTarget.evidenceSources) ? enrichedTarget.evidenceSources : [],
+    motionLabel: normalizeText(enrichedTarget.motionLabel),
+    whyNow: normalizeText(enrichedTarget.motionReason) || normalizeText(enrichedTarget.outreachAngle),
+    proofRule: normalizeText(enrichedTarget.proofPackTrigger) || 'Use proof pack only after the buyer confirms pain.',
+    cta: normalizeText(enrichedTarget.cta),
+    firstTouchDraft: normalizeText(enrichedTarget.firstTouchDraft || enrichedTarget.message),
+    painConfirmedFollowUpDraft: normalizeText(enrichedTarget.painConfirmedFollowUpDraft),
+    salesCommands: enrichedTarget.salesCommands || {},
+  };
+}
+
+function buildOperatorHandoffPayload(report) {
   const rankedTargets = rankOperatorTargets(Array.isArray(report?.targets) ? report.targets.map(enrichRenderableTarget) : []);
   const followUpTargets = rankedTargets.filter((target) => normalizePipelineStage(target.pipelineStage) !== 'targeted');
   const freshTargets = rankedTargets.filter((target) => normalizePipelineStage(target.pipelineStage) === 'targeted');
   const warmTargets = freshTargets.filter((target) => normalizeText(target.temperature).toLowerCase() === 'warm');
   const coldTargets = freshTargets.filter((target) => normalizeText(target.temperature).toLowerCase() !== 'warm');
+  const sections = [
+    {
+      key: 'follow_up_now',
+      label: 'Follow Up Now',
+      targets: followUpTargets,
+    },
+    {
+      key: 'send_now_warm_discovery',
+      label: 'Send Now: Warm Discovery',
+      targets: warmTargets,
+    },
+    {
+      key: 'seed_next_cold_github',
+      label: 'Seed Next: Cold GitHub',
+      targets: coldTargets,
+    },
+  ];
+
+  return {
+    generatedAt: report?.generatedAt || new Date().toISOString(),
+    summary: {
+      revenueState: normalizeText(report?.directive?.state) || 'cold-start',
+      headline: normalizeText(report?.directive?.headline) || 'No verified revenue and no active pipeline.',
+      paidOrders: Number(report?.snapshot?.paidOrders || 0),
+      checkoutStarts: Number(report?.snapshot?.checkoutStarts || 0),
+      activeFollowUps: followUpTargets.length,
+      warmTargetsReadyNow: warmTargets.length,
+      coldGitHubTargetsReadyNext: coldTargets.length,
+    },
+    operatorRules: [
+      'Import the queue into the sales ledger before sending anything.',
+      'Lead with one concrete workflow-hardening offer, not generic Pro and not the proof pack.',
+      'Use VERIFICATION_EVIDENCE.md and COMMERCIAL_TRUTH.md only after the buyer confirms pain.',
+    ],
+    importCommand: 'npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json',
+    sections: sections.map((section) => ({
+      key: section.key,
+      label: section.label,
+      targets: section.targets.map((target, index) => buildOperatorPriorityTargetSummary(target, index)),
+    })),
+  };
+}
+
+function renderOperatorHandoffMarkdown(report) {
+  const handoff = buildOperatorHandoffPayload(report);
+  const followUpTargets = handoff.sections.find((section) => section.key === 'follow_up_now')?.targets || [];
+  const warmTargets = handoff.sections.find((section) => section.key === 'send_now_warm_discovery')?.targets || [];
+  const coldTargets = handoff.sections.find((section) => section.key === 'seed_next_cold_github')?.targets || [];
   const followUpLines = followUpTargets.length
     ? followUpTargets.flatMap((target, index) => renderOperatorPriorityTargetMarkdown(target, index))
     : ['- No in-flight follow-ups are currently tracked.', ''];
@@ -1500,28 +1583,31 @@ function renderOperatorHandoffMarkdown(report) {
   return [
     '# Revenue Operator Priority Handoff',
     '',
-    `Updated: ${report.generatedAt}`,
+    `Updated: ${handoff.generatedAt}`,
     '',
     'This is the ranked send order for the current zero-to-one revenue loop. Work warm discovery targets first, then expand into cold GitHub targets with the same proof discipline.',
     '',
     'This handoff sits on top of `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `team-outreach-messages.md` so an operator can decide who to contact next without re-ranking the queue manually.',
     '',
     '## Current Snapshot',
-    `- Revenue state: ${report.directive?.state || 'cold-start'}`,
-    `- Headline: ${report.directive?.headline || 'No verified revenue and no active pipeline.'}`,
-    `- Paid orders: ${report.snapshot?.paidOrders || 0}`,
-    `- Checkout starts: ${report.snapshot?.checkoutStarts || 0}`,
-    `- Active follow-ups: ${followUpTargets.length}`,
-    `- Warm targets ready now: ${warmTargets.length}`,
-    `- Cold GitHub targets ready next: ${coldTargets.length}`,
+    `- Revenue state: ${handoff.summary.revenueState}`,
+    `- Headline: ${handoff.summary.headline}`,
+    `- Paid orders: ${handoff.summary.paidOrders}`,
+    `- Checkout starts: ${handoff.summary.checkoutStarts}`,
+    `- Active follow-ups: ${handoff.summary.activeFollowUps}`,
+    `- Warm targets ready now: ${handoff.summary.warmTargetsReadyNow}`,
+    `- Cold GitHub targets ready next: ${handoff.summary.coldGitHubTargetsReadyNext}`,
     '',
     '## Operator Rules',
-    '- Import the queue into the sales ledger before sending anything.',
-    '- Lead with one concrete workflow-hardening offer, not generic Pro and not the proof pack.',
-    '- Use [VERIFICATION_EVIDENCE.md](../VERIFICATION_EVIDENCE.md) and [COMMERCIAL_TRUTH.md](../COMMERCIAL_TRUTH.md) only after the buyer confirms pain.',
+    ...handoff.operatorRules.map((rule) => {
+      if (/VERIFICATION_EVIDENCE\.md/.test(rule) && /COMMERCIAL_TRUTH\.md/.test(rule)) {
+        return '- Use [VERIFICATION_EVIDENCE.md](../VERIFICATION_EVIDENCE.md) and [COMMERCIAL_TRUTH.md](../COMMERCIAL_TRUTH.md) only after the buyer confirms pain.';
+      }
+      return `- ${rule}`;
+    }),
     '',
     '```bash',
-    'npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json',
+    handoff.importCommand,
     '```',
     '',
     '## Follow Up Now',
@@ -1710,12 +1796,14 @@ function writeRevenueLoopOutputs(report, options = {}) {
   const queueJsonlDocsPath = path.join(docsDir, 'gtm-target-queue.jsonl');
   const teamOutreachDocsPath = path.join(docsDir, 'team-outreach-messages.md');
   const operatorHandoffDocsPath = path.join(docsDir, 'operator-priority-handoff.md');
+  const operatorHandoffJsonDocsPath = path.join(docsDir, 'operator-priority-handoff.json');
   const markdown = renderRevenueLoopMarkdown(report);
   const marketplaceCopy = report.marketplaceCopy || buildMarketplaceCopy(report);
   const marketplaceMarkdown = renderMarketplaceCopyMarkdown(marketplaceCopy);
   const csv = renderRevenueLoopCsv(report);
   const jsonl = renderRevenueLoopJsonl(report);
   const teamOutreachMarkdown = renderTeamOutreachMessagesMarkdown(report);
+  const operatorHandoff = buildOperatorHandoffPayload(report);
   const operatorHandoffMarkdown = renderOperatorHandoffMarkdown(report);
   const reportDir = normalizeText(options.reportDir)
     ? path.resolve(repoRoot, options.reportDir)
@@ -1732,6 +1820,7 @@ function writeRevenueLoopOutputs(report, options = {}) {
     fs.writeFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), jsonl, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'team-outreach-messages.md'), teamOutreachMarkdown, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'operator-priority-handoff.md'), operatorHandoffMarkdown, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'operator-priority-handoff.json'), `${JSON.stringify(operatorHandoff, null, 2)}\n`, 'utf8');
   }
 
   if (shouldWriteDocs) {
@@ -1744,6 +1833,7 @@ function writeRevenueLoopOutputs(report, options = {}) {
     fs.writeFileSync(queueJsonlDocsPath, jsonl, 'utf8');
     fs.writeFileSync(teamOutreachDocsPath, teamOutreachMarkdown, 'utf8');
     fs.writeFileSync(operatorHandoffDocsPath, operatorHandoffMarkdown, 'utf8');
+    fs.writeFileSync(operatorHandoffJsonDocsPath, `${JSON.stringify(operatorHandoff, null, 2)}\n`, 'utf8');
   }
 
   return {
@@ -1845,6 +1935,7 @@ module.exports = {
   applyPipelineStateToTargets,
   renderRevenueLoopMarkdown,
   renderMarketplaceCopyMarkdown,
+  buildOperatorHandoffPayload,
   renderOperatorHandoffMarkdown,
   renderTeamOutreachMessagesMarkdown,
   resolveRevenueLoopSummary,

--- a/tests/customer-discovery-sprint.test.js
+++ b/tests/customer-discovery-sprint.test.js
@@ -16,6 +16,7 @@ const EXPECTED_ARTIFACTS = [
   'gtm-target-queue.jsonl',
   'team-outreach-messages.md',
   'operator-priority-handoff.md',
+  'operator-priority-handoff.json',
   'claude-workflow-hardening-pack.md',
   'claude-workflow-hardening-pack.json',
   'cursor-marketplace-revenue-pack.md',

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -8,6 +8,7 @@ const {
   analyzeTargetEvidence,
   applyPipelineStateToTargets,
   buildFallbackMessage,
+  buildOperatorHandoffPayload,
   buildMarketplaceCopy,
   buildMotionCatalog,
   buildPainConfirmedFollowUp,
@@ -994,6 +995,116 @@ test('operator handoff markdown prioritizes follow-ups, then warm discovery, the
   assert.match(markdown, /Log after sprint intake: `npm run sales:pipeline -- advance --lead 'reddit_follow_builder_/);
 });
 
+test('operator handoff payload mirrors the ranked queue and sales commands in machine-readable form', () => {
+  const links = buildRevenueLinks();
+  const catalog = buildMotionCatalog(links);
+  const payload = buildOperatorHandoffPayload({
+    generatedAt: '2026-04-26T00:00:00.000Z',
+    directive: {
+      state: 'post-first-dollar',
+      headline: 'Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.',
+    },
+    snapshot: {
+      paidOrders: 2,
+      checkoutStarts: 1,
+    },
+    targets: [
+      {
+        temperature: 'warm',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        username: 'follow_builder',
+        accountName: 'r/ClaudeCode',
+        contactUrl: 'https://www.reddit.com/user/follow_builder/',
+        contactSurfaces: [
+          {
+            label: 'Reddit DM',
+            url: 'https://www.reddit.com/user/follow_builder/',
+          },
+        ],
+        evidenceScore: 10,
+        evidence: ['warm inbound engagement', 'buyer replied'],
+        motion: 'sprint',
+        motionLabel: catalog.sprint.label,
+        motionReason: 'Warm target already replied and should be converted now.',
+        pipelineStage: 'replied',
+        nextOperatorAction: 'Convert the reply into a 15-minute diagnostic or sprint intake.',
+        pipelineUpdatedAt: '2026-04-26T01:00:00.000Z',
+        proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+        cta: catalog.sprint.cta,
+        firstTouchDraft: 'I will harden one AI-agent workflow for you.',
+        painConfirmedFollowUpDraft: 'If the workflow pain is real, I can send the proof pack.',
+      },
+      {
+        temperature: 'warm',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        username: 'warm_builder',
+        accountName: 'r/ClaudeCode',
+        contactUrl: 'https://www.reddit.com/user/warm_builder/',
+        contactSurfaces: [
+          {
+            label: 'Reddit DM',
+            url: 'https://www.reddit.com/user/warm_builder/',
+          },
+        ],
+        evidenceScore: 8,
+        evidence: ['warm inbound engagement', 'workflow pain named'],
+        motion: 'sprint',
+        motionLabel: catalog.sprint.label,
+        motionReason: 'Warm target already named a repeated workflow blocker.',
+        pipelineStage: 'targeted',
+        proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+        cta: catalog.sprint.cta,
+        firstTouchDraft: 'I will harden one AI-agent workflow for you.',
+        painConfirmedFollowUpDraft: 'If the workflow pain is real, I can send the proof pack.',
+      },
+      {
+        temperature: 'cold',
+        source: 'github',
+        channel: 'github',
+        username: 'builder',
+        company: 'Builder Labs',
+        contactUrl: 'https://builder.dev/',
+        contactSurfaces: [
+          {
+            label: 'Website',
+            url: 'https://builder.dev/',
+          },
+          {
+            label: 'GitHub profile',
+            url: 'https://github.com/builder',
+          },
+        ],
+        repoName: 'production-mcp-server',
+        repoUrl: 'https://github.com/builder/production-mcp-server',
+        evidenceScore: 11,
+        evidence: ['production or platform workflow', '42 GitHub stars'],
+        motion: 'sprint',
+        motionLabel: catalog.sprint.label,
+        motionReason: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+        pipelineStage: 'targeted',
+        proofPackTrigger: 'Use proof pack only after the buyer confirms pain.',
+        cta: catalog.sprint.cta,
+        firstTouchDraft: 'I will harden one production workflow for you.',
+        painConfirmedFollowUpDraft: 'If the workflow pain is real, I can send the proof pack.',
+      },
+    ],
+  });
+
+  assert.equal(payload.summary.revenueState, 'post-first-dollar');
+  assert.equal(payload.summary.activeFollowUps, 1);
+  assert.equal(payload.summary.warmTargetsReadyNow, 1);
+  assert.equal(payload.summary.coldGitHubTargetsReadyNext, 1);
+  assert.equal(payload.importCommand, 'npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json');
+  assert.equal(payload.sections[0].key, 'follow_up_now');
+  assert.equal(payload.sections[0].targets[0].label, '@follow_builder - r/ClaudeCode');
+  assert.equal(payload.sections[0].targets[0].salesCommands.markSprintIntake.includes('reddit_follow_builder_'), true);
+  assert.equal(payload.sections[1].targets[0].contactSurfaces[0].label, 'Reddit DM');
+  assert.equal(payload.sections[2].targets[0].label, '@builder - production-mcp-server');
+  assert.equal(payload.sections[2].targets[0].contactSurfaces[1].url, 'https://github.com/builder');
+});
+
 test('first-touch outreach does not push proof before pain is confirmed', () => {
   const catalog = buildMotionCatalog(buildRevenueLinks());
   const selectedMotion = selectOutreachMotion({
@@ -1507,6 +1618,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     const jsonl = fs.readFileSync(path.join(reportDir, 'gtm-target-queue.jsonl'), 'utf8');
     const teamOutreach = fs.readFileSync(path.join(reportDir, 'team-outreach-messages.md'), 'utf8');
     const operatorHandoff = fs.readFileSync(path.join(reportDir, 'operator-priority-handoff.md'), 'utf8');
+    const operatorHandoffJson = JSON.parse(fs.readFileSync(path.join(reportDir, 'operator-priority-handoff.json'), 'utf8'));
 
     assert.equal(written.reportDir, reportDir);
     assert.equal(written.docsPath, null);
@@ -1518,6 +1630,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.ok(fs.existsSync(path.join(reportDir, 'gtm-target-queue.jsonl')));
     assert.ok(fs.existsSync(path.join(reportDir, 'team-outreach-messages.md')));
     assert.ok(fs.existsSync(path.join(reportDir, 'operator-priority-handoff.md')));
+    assert.ok(fs.existsSync(path.join(reportDir, 'operator-priority-handoff.json')));
     assert.match(csv, /^temperature,source,channel,username,accountName,company,contactUrl,contactSurfaces,repoName,repoUrl,updatedAt,offer,pipelineStage,evidenceScore,evidence,evidenceSource,evidenceLinks,claimGuardrails,outreachAngle,motionLabel,motionReason,proofPackTrigger,cta,firstTouchDraft,painConfirmedFollowUpDraft/m);
     assert.match(csv, /"I can harden one workflow, then prove it\."/);
     assert.match(csv, /"If the workflow pain is real, I can send the proof pack\."/);
@@ -1544,6 +1657,8 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.match(operatorHandoff, /Send Now: Warm Discovery/);
     assert.match(operatorHandoff, /Pipeline lead id: reddit_builder_production_mcp_server/);
     assert.match(operatorHandoff, /Log after pain-confirmed reply: `npm run sales:pipeline -- advance --lead 'reddit_builder_production_mcp_server'/);
+    assert.equal(operatorHandoffJson.sections[1].label, 'Send Now: Warm Discovery');
+    assert.equal(operatorHandoffJson.sections[1].targets[0].pipelineLeadId, 'reddit_builder_production_mcp_server');
   } finally {
     fs.rmSync(reportDir, { recursive: true, force: true });
   }
@@ -1644,6 +1759,7 @@ test('writeRevenueLoopOutputs mirrors dedicated GTM docs instead of overwriting 
     assert.ok(fs.existsSync(path.join(marketingDir, 'gtm-target-queue.jsonl')));
     assert.ok(fs.existsSync(path.join(marketingDir, 'team-outreach-messages.md')));
     assert.ok(fs.existsSync(path.join(marketingDir, 'operator-priority-handoff.md')));
+    assert.ok(fs.existsSync(path.join(marketingDir, 'operator-priority-handoff.json')));
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add `operator-priority-handoff.json` as a machine-readable GTM artifact for the ranked revenue queue
- derive the markdown handoff from the same payload so operator copy and automation stay in sync
- cover the JSON handoff in GTM and customer-discovery tests and document the new artifact

## Why
ThumbGate still needs acquisition and conversion leverage. The ranked outreach queue already existed in markdown, but operators and automations had to parse prose to recover CTA, proof rules, contact surfaces, and `sales:pipeline` commands. This change makes the evidence-backed handoff consumable without re-ranking or markdown scraping.

## Verification
- `node --test tests/gtm-revenue-loop.test.js`
- `node --test tests/customer-discovery-sprint.test.js`
- `npm test`
- `npm run test:coverage`
- `THUMBGATE_PROOF_DIR=$(mktemp -d)/proof npm run prove:adapters`
- `THUMBGATE_AUTOMATION_PROOF_DIR=$(mktemp -d)/proof-automation npm run prove:automation`
- `npm run self-heal:check`
