### PR TITLE
feat(gtm): refresh github outreach assets

### DIFF
--- a/.changeset/github-outreach-automation-refresh.md
+++ b/.changeset/github-outreach-automation-refresh.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Refresh the autonomous GTM runner so it regenerates the GitHub outreach asset from the current revenue-loop queue and keeps the checked-in outreach targets aligned with the latest evidence-backed pipeline state.

--- a/docs/OUTREACH_TARGETS.md
+++ b/docs/OUTREACH_TARGETS.md
@@ -1,14 +1,14 @@
 # Revenue Pipeline Outreach Targets
 
 Status: current
-Updated: 2026-04-27T12:59:31.009Z
+Updated: 2026-04-28T10:16:20.911Z
 
 This file mirrors the evidence-backed GTM queue in `docs/marketing/gtm-target-queue.jsonl`.
 It is the qualification screen and send surface for the current Workflow Hardening Sprint revenue loop, not a raw GitHub scrape.
 
 ## Current Queue
-- Revenue state: cold-start
-- Headline: No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
+- Revenue state: post-first-dollar
+- Headline: Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
 - Follow-ups now: 0
 - Warm discovery ready: 4
 - Cold GitHub ready: 6
@@ -144,7 +144,24 @@ Pain-confirmed follow-up:
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_nihannihu_omni_sre' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
 
-### 4. freema — mcp-jira-stdio
+### 4. oliver-kriska — claude-elixir-phoenix
+- Temperature: cold
+- Current stage: targeted
+- Contact surface: https://github.com/oliver-kriska
+- Evidence score: 14
+- Evidence: workflow control surface, agent infrastructure, self-serve agent tooling, 290 GitHub stars, updated in the last 7 days
+- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
+- CTA: https://thumbgate-production.up.railway.app/guide
+
+First-touch draft:
+> Hey @oliver-kriska, saw you're building around `claude-elixir-phoenix`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
+
+Pain-confirmed follow-up:
+> If you want the self-serve path for `claude-elixir-phoenix`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+Track next step: `npm run sales:pipeline -- advance --lead 'github_oliver_kriska_claude_elixir_phoenix' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
+
+### 5. freema — mcp-jira-stdio
 - Temperature: cold
 - Current stage: targeted
 - Contact surface: http://www.tomasgrasl.cz/
@@ -161,39 +178,22 @@ Pain-confirmed follow-up:
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_freema_mcp_jira_stdio' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
 
-### 5. manki-review — manki
+### 6. gmickel — flow-next
 - Temperature: cold
 - Current stage: targeted
-- Contact surface: https://manki.dustinface.me/
-- Evidence score: 13
-- Evidence: workflow control surface, business-system integration, agent infrastructure, 5 GitHub stars, updated in the last 7 days
-- Why now: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
-- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
-
-First-touch draft:
-> Hey @manki-review, saw you're shipping `manki`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
-
-Pain-confirmed follow-up:
-> If `manki` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
-
-Track next step: `npm run sales:pipeline -- advance --lead 'github_manki_review_manki' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
-
-### 6. oliver-kriska — claude-elixir-phoenix
-- Temperature: cold
-- Current stage: targeted
-- Contact surface: https://github.com/oliver-kriska
+- Contact surface: https://mickel.tech/
 - Evidence score: 12
-- Evidence: workflow control surface, agent infrastructure, 290 GitHub stars, updated in the last 7 days
-- Why now: Lead with context-drift hardening for one workflow before proposing any broader agent platform story.
-- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Evidence: workflow control surface, self-serve agent tooling, 576 GitHub stars, updated in the last 7 days
+- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
+- CTA: https://thumbgate-production.up.railway.app/guide
 
 First-touch draft:
-> Hey @oliver-kriska, saw you're shipping `claude-elixir-phoenix`. If one context, memory, or tool-use failure keeps repeating, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+> Hey @gmickel, saw you're building around `flow-next`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
 
 Pain-confirmed follow-up:
-> If `claude-elixir-phoenix` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+> If you want the self-serve path for `flow-next`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
-Track next step: `npm run sales:pipeline -- advance --lead 'github_oliver_kriska_claude_elixir_phoenix' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on context-drift hardening for one workflow before proposing any broader agent platform story.'`
+Track next step: `npm run sales:pipeline -- advance --lead 'github_gmickel_flow_next' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
 
 ## Core Links
 - Sprint intake: https://thumbgate-production.up.railway.app/#workflow-sprint-intake

--- a/scripts/autonomous-sales-agent.js
+++ b/scripts/autonomous-sales-agent.js
@@ -14,6 +14,12 @@
 const path = require('node:path');
 const { parseArgs, runRevenueLoop } = require('./gtm-revenue-loop');
 const {
+  main: runGitHubOutreach,
+  DEFAULT_DOCS_PATH: DEFAULT_GITHUB_OUTREACH_DOCS_PATH,
+  DEFAULT_QUEUE_PATH: DEFAULT_GITHUB_OUTREACH_QUEUE_PATH,
+  DEFAULT_REPORT_PATH: DEFAULT_GITHUB_OUTREACH_REPORT_PATH,
+} = require('./github-outreach');
+const {
   buildClaudeWorkflowHardeningPack,
   writeClaudeWorkflowHardeningPack,
 } = require('./claude-workflow-hardening-pack');
@@ -50,6 +56,7 @@ function buildDependencies(overrides = {}) {
   return {
     parseArgs,
     runRevenueLoop,
+    runGitHubOutreach,
     buildClaudeWorkflowHardeningPack,
     writeClaudeWorkflowHardeningPack,
     buildCursorMarketplaceRevenuePack,
@@ -78,6 +85,29 @@ function isCliInvocation(argv = process.argv) {
   return path.resolve(scriptPath) === path.resolve(__filename);
 }
 
+function buildGitHubOutreachJobs(written = {}, repoRoot = path.resolve(__dirname, '..')) {
+  const jobs = [];
+
+  if (written.reportDir) {
+    const reportDir = path.resolve(written.reportDir);
+    jobs.push({
+      queuePath: path.join(reportDir, 'gtm-target-queue.jsonl'),
+      reportPath: path.join(reportDir, 'gtm-revenue-loop.json'),
+      outPath: path.join(reportDir, 'OUTREACH_TARGETS.md'),
+    });
+  }
+
+  if (written.docsPath) {
+    jobs.push({
+      queuePath: path.resolve(repoRoot, DEFAULT_GITHUB_OUTREACH_QUEUE_PATH),
+      reportPath: path.resolve(repoRoot, DEFAULT_GITHUB_OUTREACH_REPORT_PATH),
+      outPath: path.resolve(repoRoot, DEFAULT_GITHUB_OUTREACH_DOCS_PATH),
+    });
+  }
+
+  return jobs;
+}
+
 async function main(argv = process.argv.slice(2), overrides = {}) {
   const deps = buildDependencies(overrides);
   const options = deps.parseArgs(argv);
@@ -98,6 +128,8 @@ async function main(argv = process.argv.slice(2), overrides = {}) {
   const codexMarketplaceWritten = deps.writeCodexMarketplaceRevenuePack(codexMarketplacePack, options);
   const codexPluginPack = deps.buildCodexPluginRevenuePack(report);
   const codexPluginWritten = deps.writeCodexPluginRevenuePack(codexPluginPack, options);
+  const githubOutreachJobs = buildGitHubOutreachJobs(written);
+  const githubOutreachWritten = githubOutreachJobs.map((job) => deps.runGitHubOutreach(job));
 
   console.log('\n✅ GTM automation complete.');
   if (written.docsPath) {
@@ -130,6 +162,11 @@ async function main(argv = process.argv.slice(2), overrides = {}) {
   if (codexPluginWritten.docsPath) {
     console.log(`Codex plugin pack updated: ${codexPluginWritten.docsPath}`);
   }
+  for (const asset of githubOutreachWritten) {
+    if (asset?.docsPath) {
+      console.log(`GitHub outreach asset updated: ${asset.docsPath}`);
+    }
+  }
   console.log(`State: ${report.directive.state} | Targets: ${report.targets.length}`);
 }
 
@@ -141,6 +178,7 @@ if (isCliInvocation(process.argv)) {
 }
 
 module.exports = {
+  buildGitHubOutreachJobs,
   buildDependencies,
   isCliInvocation,
   main,

--- a/tests/autonomous-sales-agent.test.js
+++ b/tests/autonomous-sales-agent.test.js
@@ -2,10 +2,15 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const path = require('node:path');
 
-const { isCliInvocation, main } = require('../scripts/autonomous-sales-agent');
+const {
+  buildGitHubOutreachJobs,
+  isCliInvocation,
+  main,
+} = require('../scripts/autonomous-sales-agent');
 
-test('automation emits LinkedIn, Aiventyx, ChatGPT, and Codex alongside Claude, Cursor, and Gemini packs', async () => {
+test('automation emits LinkedIn, Aiventyx, ChatGPT, Codex, and GitHub outreach assets from the revenue loop outputs', async () => {
   const calls = [];
   const logs = [];
   const originalLog = console.log;
@@ -98,11 +103,16 @@ test('automation emits LinkedIn, Aiventyx, ChatGPT, and Codex alongside Claude, 
         calls.push(['writeCodexPluginRevenuePack', pack.channel, options.writeDocs]);
         return { docsPath: '/tmp/codex-plugin.md' };
       },
+      runGitHubOutreach(options) {
+        calls.push(['runGitHubOutreach', options]);
+        return { docsPath: options.outPath };
+      },
     });
   } finally {
     console.log = originalLog;
   }
 
+  const repoRoot = path.resolve(__dirname, '..');
   assert.deepEqual(calls, [
     ['parseArgs', ['--write-docs']],
     ['runRevenueLoop', { writeDocs: true, reportDir: 'reports/gtm/test' }],
@@ -122,13 +132,46 @@ test('automation emits LinkedIn, Aiventyx, ChatGPT, and Codex alongside Claude, 
     ['writeCodexMarketplaceRevenuePack', 'codex', true],
     ['buildCodexPluginRevenuePack', 2],
     ['writeCodexPluginRevenuePack', 'codex-plugin', true],
+    ['runGitHubOutreach', {
+      queuePath: path.resolve('/tmp/reports/gtm', 'gtm-target-queue.jsonl'),
+      reportPath: path.resolve('/tmp/reports/gtm', 'gtm-revenue-loop.json'),
+      outPath: path.resolve('/tmp/reports/gtm', 'OUTREACH_TARGETS.md'),
+    }],
+    ['runGitHubOutreach', {
+      queuePath: path.resolve(repoRoot, 'docs/marketing/gtm-target-queue.jsonl'),
+      reportPath: path.resolve(repoRoot, 'docs/marketing/gtm-revenue-loop.json'),
+      outPath: path.resolve(repoRoot, 'docs/OUTREACH_TARGETS.md'),
+    }],
   ]);
   assert.ok(logs.some((line) => line.includes('Aiventyx pack updated: /tmp/aiventyx.md')));
   assert.ok(logs.some((line) => line.includes('LinkedIn pack updated: /tmp/linkedin.md')));
   assert.ok(logs.some((line) => line.includes('ChatGPT pack updated: /tmp/chatgpt.md')));
   assert.ok(logs.some((line) => line.includes('Codex marketplace pack updated: /tmp/codex-marketplace.md')));
   assert.ok(logs.some((line) => line.includes('Codex plugin pack updated: /tmp/codex-plugin.md')));
+  assert.ok(logs.some((line) => line.includes('GitHub outreach asset updated: /tmp/reports/gtm/OUTREACH_TARGETS.md')));
+  assert.ok(logs.some((line) => line.includes(`GitHub outreach asset updated: ${path.resolve(repoRoot, 'docs/OUTREACH_TARGETS.md')}`)));
   assert.ok(logs.some((line) => line.includes('State: cold-start | Targets: 2')));
+});
+
+test('buildGitHubOutreachJobs writes report-dir and repo docs assets from the current revenue loop outputs', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+  const jobs = buildGitHubOutreachJobs({
+    reportDir: '/tmp/reports/gtm',
+    docsPath: path.join(repoRoot, 'docs', 'marketing', 'gtm-revenue-loop.md'),
+  }, repoRoot);
+
+  assert.deepEqual(jobs, [
+    {
+      queuePath: path.resolve('/tmp/reports/gtm', 'gtm-target-queue.jsonl'),
+      reportPath: path.resolve('/tmp/reports/gtm', 'gtm-revenue-loop.json'),
+      outPath: path.resolve('/tmp/reports/gtm', 'OUTREACH_TARGETS.md'),
+    },
+    {
+      queuePath: path.resolve(repoRoot, 'docs/marketing/gtm-target-queue.jsonl'),
+      reportPath: path.resolve(repoRoot, 'docs/marketing/gtm-revenue-loop.json'),
+      outPath: path.resolve(repoRoot, 'docs/OUTREACH_TARGETS.md'),
+    },
+  ]);
 });
 
 test('CLI entrypoint detection is path based', () => {


### PR DESCRIPTION
## Summary
- wire GitHub outreach generation into the autonomous sales agent so the revenue loop refreshes both report-local and repo docs assets
- add coverage for the new GitHub outreach job builder and generated asset logging
- regenerate `docs/OUTREACH_TARGETS.md` from the current evidence-backed GTM queue so the queue matches post-first-dollar state

## Verification
- `node --test tests/autonomous-sales-agent.test.js tests/github-outreach.test.js`
- `npm ci --onnxruntime-node-install-cuda=skip`
- `npm test`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`