### PR TITLE
feat(gtm): split self-serve outreach handoff

### DIFF
--- a/.changeset/outreach-self-serve-handoff-refresh.md
+++ b/.changeset/outreach-self-serve-handoff-refresh.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Refresh the outreach handoff generator so self-serve Pro prospects render in their own operator lane instead of being mixed into the generic cold GitHub queue.

--- a/docs/OUTREACH_TARGETS.md
+++ b/docs/OUTREACH_TARGETS.md
@@ -1,17 +1,18 @@
 # Revenue Pipeline Outreach Targets
 
 Status: current
-Updated: 2026-04-28T10:16:20.911Z
+Updated: 2026-04-28T18:24:06.772Z
 
 This file mirrors the evidence-backed GTM queue in `docs/marketing/gtm-target-queue.jsonl`.
 It is the qualification screen and send surface for the current Workflow Hardening Sprint revenue loop, not a raw GitHub scrape.
 
 ## Current Queue
-- Revenue state: post-first-dollar
-- Headline: Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
+- Revenue state: cold-start
+- Headline: No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
 - Follow-ups now: 0
 - Warm discovery ready: 4
-- Cold GitHub ready: 6
+- Self-serve closes ready: 2
+- Cold GitHub ready: 4
 - Sales ledger tracked leads: 0 (pipeline file not created yet)
 - Proof rule: Use proof links only after the buyer confirms the workflow pain.
 
@@ -92,6 +93,41 @@ Pain-confirmed follow-up:
 
 Track next step: `npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on brittle guardrails.'`
 
+## Self-Serve Closes
+### 1. zaxbysauce — opencode-swarm
+- Temperature: cold
+- Current stage: targeted
+- Contact surface: https://github.com/zaxbysauce
+- Evidence score: 12
+- Evidence: workflow control surface, self-serve agent tooling, 241 GitHub stars, updated in the last 7 days
+- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
+- CTA: https://thumbgate-production.up.railway.app/guide
+
+First-touch draft:
+> Hey @zaxbysauce, saw you're building around `opencode-swarm`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
+
+Pain-confirmed follow-up:
+> If you want the self-serve path for `opencode-swarm`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+Track next step: `npm run sales:pipeline -- advance --lead 'github_zaxbysauce_opencode_swarm' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
+
+### 2. yvgude — lean-ctx
+- Temperature: cold
+- Current stage: targeted
+- Contact surface: https://yvesgugger.ch/
+- Evidence score: 10
+- Evidence: agent infrastructure, self-serve agent tooling, 907 GitHub stars, updated in the last 7 days
+- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
+- CTA: https://thumbgate-production.up.railway.app/guide
+
+First-touch draft:
+> Hey @yvgude, saw you're building around `lean-ctx`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
+
+Pain-confirmed follow-up:
+> If you want the self-serve path for `lean-ctx`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+Track next step: `npm run sales:pipeline -- advance --lead 'github_yvgude_lean_ctx' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
+
 ## Cold GitHub
 ### 1. Adqui9608 — ai-code-review-agent
 - Temperature: cold
@@ -110,7 +146,24 @@ Pain-confirmed follow-up:
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_adqui9608_ai_code_review_agent' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
 
-### 2. DGouron — review-flow
+### 2. arcasilesgroup — ai-engineering
+- Temperature: cold
+- Current stage: targeted
+- Contact surface: https://arcasiles.com/
+- Evidence score: 14
+- Evidence: production or platform workflow, business-system integration, self-serve agent tooling, 25 GitHub stars, updated in the last 7 days
+- Why now: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+First-touch draft:
+> Hey @arcasilesgroup, saw you're shipping `ai-engineering`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+
+Pain-confirmed follow-up:
+> If `ai-engineering` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+Track next step: `npm run sales:pipeline -- advance --lead 'github_arcasilesgroup_ai_engineering' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
+
+### 3. DGouron — review-flow
 - Temperature: cold
 - Current stage: targeted
 - Contact surface: https://dgouron.fr/
@@ -127,7 +180,7 @@ Pain-confirmed follow-up:
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_dgouron_review_flow' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
 
-### 3. nihannihu — Omni-SRE
+### 4. nihannihu — Omni-SRE
 - Temperature: cold
 - Current stage: targeted
 - Contact surface: https://github.com/nihannihu
@@ -143,57 +196,6 @@ Pain-confirmed follow-up:
 > If `Omni-SRE` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_nihannihu_omni_sre' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
-
-### 4. oliver-kriska — claude-elixir-phoenix
-- Temperature: cold
-- Current stage: targeted
-- Contact surface: https://github.com/oliver-kriska
-- Evidence score: 14
-- Evidence: workflow control surface, agent infrastructure, self-serve agent tooling, 290 GitHub stars, updated in the last 7 days
-- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
-- CTA: https://thumbgate-production.up.railway.app/guide
-
-First-touch draft:
-> Hey @oliver-kriska, saw you're building around `claude-elixir-phoenix`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
-
-Pain-confirmed follow-up:
-> If you want the self-serve path for `claude-elixir-phoenix`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
-
-Track next step: `npm run sales:pipeline -- advance --lead 'github_oliver_kriska_claude_elixir_phoenix' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
-
-### 5. freema — mcp-jira-stdio
-- Temperature: cold
-- Current stage: targeted
-- Contact surface: http://www.tomasgrasl.cz/
-- Evidence score: 13
-- Evidence: workflow control surface, business-system integration, agent infrastructure, 11 GitHub stars, updated in the last 7 days
-- Why now: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
-- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
-
-First-touch draft:
-> Hey @freema, saw you're shipping `mcp-jira-stdio`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
-
-Pain-confirmed follow-up:
-> If `mcp-jira-stdio` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
-
-Track next step: `npm run sales:pipeline -- advance --lead 'github_freema_mcp_jira_stdio' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
-
-### 6. gmickel — flow-next
-- Temperature: cold
-- Current stage: targeted
-- Contact surface: https://mickel.tech/
-- Evidence score: 12
-- Evidence: workflow control surface, self-serve agent tooling, 576 GitHub stars, updated in the last 7 days
-- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
-- CTA: https://thumbgate-production.up.railway.app/guide
-
-First-touch draft:
-> Hey @gmickel, saw you're building around `flow-next`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
-
-Pain-confirmed follow-up:
-> If you want the self-serve path for `flow-next`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
-
-Track next step: `npm run sales:pipeline -- advance --lead 'github_gmickel_flow_next' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
 
 ## Core Links
 - Sprint intake: https://thumbgate-production.up.railway.app/#workflow-sprint-intake

--- a/scripts/github-outreach.js
+++ b/scripts/github-outreach.js
@@ -32,6 +32,8 @@ const FOLLOW_UP_PRIORITY = {
   contacted: 1,
 };
 const TARGETED_STAGE = 'targeted';
+const SELF_SERVE_MOTIONS = new Set(['pro']);
+const SELF_SERVE_OFFERS = new Set(['pro_self_serve']);
 
 function normalizeText(value, maxLength = 4000) {
   if (value === undefined || value === null) return '';
@@ -59,6 +61,12 @@ function buildPipelineIndex(options = {}) {
 
 function toStagePriority(stage) {
   return FOLLOW_UP_PRIORITY[normalizeText(stage)] || 0;
+}
+
+function isSelfServeTarget(target = {}) {
+  const motion = normalizeText(target.motion).toLowerCase();
+  const offer = normalizeText(target.offer).toLowerCase();
+  return SELF_SERVE_MOTIONS.has(motion) || SELF_SERVE_OFFERS.has(offer);
 }
 
 function compareTargetPriority(left, right) {
@@ -147,10 +155,17 @@ function buildOutreachTargetsReport({
     .sort(compareTargetPriority);
   const followUpTargets = targets.filter((target) => FOLLOW_UP_STAGES.has(target.stage));
   const warmTargets = targets.filter((target) => target.stage === TARGETED_STAGE && normalizeText(target.temperature) === 'warm');
+  const selfServeTargets = targets.filter((target) => {
+    return target.stage === TARGETED_STAGE
+      && normalizeText(target.temperature) !== 'warm'
+      && normalizeText(target.source) === 'github'
+      && isSelfServeTarget(target);
+  });
   const coldTargets = targets.filter((target) => {
     return target.stage === TARGETED_STAGE
       && normalizeText(target.temperature) !== 'warm'
-      && normalizeText(target.source) === 'github';
+      && normalizeText(target.source) === 'github'
+      && !isSelfServeTarget(target);
   });
 
   return {
@@ -176,6 +191,7 @@ function buildOutreachTargetsReport({
     },
     followUpTargets,
     warmTargets,
+    selfServeTargets,
     coldTargets,
     totalTargets: targets.length,
   };
@@ -215,6 +231,9 @@ function renderOutreachTargetsMarkdown(report = {}) {
   const warmLines = report.warmTargets.length
     ? report.warmTargets.flatMap((target, index) => renderTargetMarkdown(target, index))
     : ['- No warm discovery targets are currently ready.', ''];
+  const selfServeLines = report.selfServeTargets.length
+    ? report.selfServeTargets.flatMap((target, index) => renderTargetMarkdown(target, index))
+    : ['- No self-serve close targets are currently ready.', ''];
   const coldLines = report.coldTargets.length
     ? report.coldTargets.flatMap((target, index) => renderTargetMarkdown(target, index))
     : ['- No cold GitHub targets are currently ready.', ''];
@@ -233,6 +252,7 @@ function renderOutreachTargetsMarkdown(report = {}) {
     `- Headline: ${report.headline || 'No verified revenue and no active pipeline.'}`,
     `- Follow-ups now: ${report.followUpTargets.length}`,
     `- Warm discovery ready: ${report.warmTargets.length}`,
+    `- Self-serve closes ready: ${report.selfServeTargets.length}`,
     `- Cold GitHub ready: ${report.coldTargets.length}`,
     `- Sales ledger tracked leads: ${report.pipelineTrackedLeadCount || 0}${report.pipelineExists ? '' : ' (pipeline file not created yet)'}`,
     `- Proof rule: ${report.proofRule}`,
@@ -244,6 +264,8 @@ function renderOutreachTargetsMarkdown(report = {}) {
     ...followUpLines,
     '## Warm Discovery',
     ...warmLines,
+    '## Self-Serve Closes',
+    ...selfServeLines,
     '## Cold GitHub',
     ...coldLines,
     '## Core Links',
@@ -272,7 +294,9 @@ function main(options = {}) {
   const markdown = renderOutreachTargetsMarkdown(report);
   const docsPath = writeOutreachTargetsDoc(markdown, options.outPath || DEFAULT_DOCS_PATH);
   console.log(`Updated ${docsPath} from the current evidence-backed queue.`);
-  console.log(`Warm: ${report.warmTargets.length} | Cold: ${report.coldTargets.length} | Follow-up: ${report.followUpTargets.length}`);
+  console.log(
+    `Warm: ${report.warmTargets.length} | Self-serve: ${report.selfServeTargets.length} | Cold: ${report.coldTargets.length} | Follow-up: ${report.followUpTargets.length}`
+  );
   return {
     docsPath,
     report,

--- a/tests/github-outreach.test.js
+++ b/tests/github-outreach.test.js
@@ -66,13 +66,39 @@ function makeColdTarget() {
   };
 }
 
-test('queue-backed outreach report keeps warm and cold targets tied to current evidence', () => {
+function makeSelfServeTarget() {
+  return {
+    temperature: 'cold',
+    source: 'github',
+    channel: 'github',
+    username: 'gmickel',
+    accountName: 'gmickel',
+    repoName: 'flow-next',
+    repoUrl: 'https://github.com/gmickel/flow-next',
+    contactUrl: 'https://mickel.tech/',
+    evidenceScore: 12,
+    evidence: ['workflow control surface', 'self-serve agent tooling', '576 GitHub stars'],
+    motion: 'pro',
+    offer: 'pro_self_serve',
+    motionReason: 'Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.',
+    cta: 'https://thumbgate-production.up.railway.app/guide',
+    firstTouchDraft: 'Hey @gmickel, start with the proof-backed setup guide and move to Pro if the local path fits.',
+    painConfirmedFollowUpDraft: 'If the self-serve path looks right, I can send the Pro checkout plus proof links.',
+    salesCommands: {
+      markContacted: 'npm run sales:pipeline -- advance --lead \'github_gmickel_flow_next\' --stage \'contacted\'',
+      markReplied: 'npm run sales:pipeline -- advance --lead \'github_gmickel_flow_next\' --stage \'replied\'',
+      markCallBooked: 'npm run sales:pipeline -- advance --lead \'github_gmickel_flow_next\' --stage \'call_booked\'',
+    },
+  };
+}
+
+test('queue-backed outreach report separates warm, self-serve, and cold sprint lanes', () => {
   const tempDir = makeTempDir();
   const queuePath = path.join(tempDir, 'gtm-target-queue.jsonl');
   const reportPath = path.join(tempDir, 'gtm-revenue-loop.json');
   const statePath = path.join(tempDir, 'sales-pipeline.jsonl');
 
-  writeJsonl(queuePath, [makeWarmTarget(), makeColdTarget()]);
+  writeJsonl(queuePath, [makeWarmTarget(), makeSelfServeTarget(), makeColdTarget()]);
   fs.writeFileSync(reportPath, JSON.stringify({
     generatedAt: '2026-04-27T17:00:00.000Z',
     directive: {
@@ -87,12 +113,16 @@ test('queue-backed outreach report keeps warm and cold targets tied to current e
 
   assert.equal(report.followUpTargets.length, 0);
   assert.equal(report.warmTargets.length, 1);
+  assert.equal(report.selfServeTargets.length, 1);
   assert.equal(report.coldTargets.length, 1);
   assert.equal(report.pipelineTrackedLeadCount, 0);
   assert.equal(report.pipelineExists, false);
   assert.match(markdown, /mirrors the evidence-backed GTM queue/i);
   assert.match(markdown, /Warm discovery ready: 1/);
+  assert.match(markdown, /Self-serve closes ready: 1/);
   assert.match(markdown, /Cold GitHub ready: 1/);
+  assert.match(markdown, /## Self-Serve Closes/);
+  assert.match(markdown, /flow-next/);
   assert.match(markdown, /review-flow/);
   assert.match(markdown, /stage 'contacted'/);
   assert.equal(fs.existsSync(outPath), true);
@@ -104,10 +134,11 @@ test('active follow-ups are promoted ahead of fresh sends using sales ledger sta
   const reportPath = path.join(tempDir, 'gtm-revenue-loop.json');
   const statePath = path.join(tempDir, 'sales-pipeline.jsonl');
   const warmTarget = makeWarmTarget();
+  const selfServeTarget = makeSelfServeTarget();
   const coldTarget = makeColdTarget();
   const lead = buildLeadFromRevenueTarget(coldTarget, { sourcePath: queuePath });
 
-  writeJsonl(queuePath, [warmTarget, coldTarget]);
+  writeJsonl(queuePath, [warmTarget, selfServeTarget, coldTarget]);
   fs.writeFileSync(reportPath, JSON.stringify({
     generatedAt: '2026-04-27T17:00:00.000Z',
     directive: {
@@ -127,10 +158,12 @@ test('active follow-ups are promoted ahead of fresh sends using sales ledger sta
   assert.equal(report.followUpTargets.length, 1);
   assert.equal(report.followUpTargets[0].stage, 'replied');
   assert.equal(report.warmTargets.length, 1);
+  assert.equal(report.selfServeTargets.length, 1);
   assert.equal(report.coldTargets.length, 0);
   assert.equal(report.pipelineTrackedLeadCount, 1);
   assert.equal(report.pipelineExists, true);
   assert.match(markdown, /## Follow Up Now/);
+  assert.match(markdown, /## Self-Serve Closes/);
   assert.match(markdown, /Current stage: replied/);
   assert.match(markdown, /stage 'call_booked'/);
 });


### PR DESCRIPTION
## Summary
- split self-serve Pro prospects into their own outreach lane in the GitHub handoff generator
- expose the extra lane in counts, markdown sections, and CLI summaries
- refresh `docs/OUTREACH_TARGETS.md` from the current evidence-backed GTM queue

## Verification
- node --test tests/github-outreach.test.js
- npm ci
- node --test tests/billing.test.js tests/stripe-sync-product-images.test.js
- npm run test:coverage
- npm run self-heal:check