### PR TITLE
feat(gtm): add codex-ready target queue

### DIFF
--- a/.changeset/codex-ready-target-queue.md
+++ b/.changeset/codex-ready-target-queue.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add a Codex-ready target queue export to the revenue pack and refresh the operator-facing Codex sales asset.

--- a/docs/marketing/codex-plugin-revenue-pack.md
+++ b/docs/marketing/codex-plugin-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Plugin Revenue Pack
 
-Updated: 2026-04-27T10:43:39.459Z
+Updated: 2026-04-28T18:24:06.772Z
 
 This is a sales operator artifact. It is not proof of bundle downloads, installs, paid revenue, or marketplace publication by itself.
 
@@ -24,14 +24,14 @@ ThumbGate gives Codex a proof-backed install path, pre-action gate enforcement, 
 - Examples: @Deep_Ad1959, @game-of-kton, @leogodin217
 
 ### Workflow control surfaces remain the strongest buyer signal
-- Count: 6
-- Summary: 6 current targets expose review, approval, governance, or workflow control surfaces where a Codex install story can convert into a workflow-hardening offer.
+- Count: 4
+- Summary: 4 current targets expose review, approval, governance, or workflow control surfaces where a Codex install story can convert into a workflow-hardening offer.
 - Examples: Adqui9608/ai-code-review-agent, DGouron/review-flow, nihannihu/Omni-SRE
 
 ### Production rollout proof matters
-- Count: 2
-- Summary: 2 targets touch production-sensitive workflows where proof and rollback safety should appear before the buyer expands usage.
-- Examples: Adqui9608/ai-code-review-agent, nihannihu/Omni-SRE
+- Count: 3
+- Summary: 3 targets touch production-sensitive workflows where proof and rollback safety should appear before the buyer expands usage.
+- Examples: Adqui9608/ai-code-review-agent, arcasilesgroup/ai-engineering, nihannihu/Omni-SRE
 
 ## Submission Surfaces
 ### Codex plugin install page
@@ -130,6 +130,105 @@ Draft:
 > If one approval, handoff, or rollout failure keeps repeating around Codex or a neighboring review lane, route it to the Workflow Hardening Sprint instead of a generic plugin pitch: https://thumbgate-production.up.railway.app/?utm_source=codex&utm_medium=setup_guide&utm_campaign=codex_sprint_follow_on&utm_content=workflow_sprint&campaign_variant=sprint_follow_on&offer_code=CODEX-SPRINT_FOLLOW_ON&cta_id=codex_sprint_follow_on&cta_placement=codex_follow_on&surface=codex_follow_on#workflow-sprint-intake . That keeps the conversation anchored on one workflow, one owner, and one proof review.
 
 Use Commercial Truth and Verification Evidence only after the buyer confirms the workflow pain or asks for proof.
+
+## Ready-Now Target Queue
+### Send Now: Codex-Adjacent Workflow Hardening
+- Motion: Workflow Hardening Sprint
+- Summary: Use these when the buyer already named one repeated failure, mature review boundary, or rollout risk.
+
+#### 1. @Deep_Ad1959
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Evidence score: 10
+- Why now: Warm Reddit engager already named a repeated workflow risk, so the fastest path is a founder-led diagnostic.
+- Evidence: warm inbound engagement; workflow pain named: rollback risk; already in DMs
+- Contact: https://www.reddit.com/user/Deep_Ad1959/
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- Pipeline lead id: reddit_deep_ad1959_r_cursor
+- Log after send: `npm run sales:pipeline -- advance --lead 'reddit_deep_ad1959_r_cursor' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on rollback risk.'`
+
+First-touch draft:
+> Your question about rollback rates when context changes is exactly the right one. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have one workflow where context drift or rollback risk keeps showing up, I can harden that workflow for you. Worth a 15-minute diagnostic?
+
+#### 2. @game-of-kton
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Evidence score: 9
+- Why now: Warm Reddit engager already works on advanced agent memory, so discovery should center on one repeated failure pattern.
+- Evidence: warm inbound engagement; built serious memory systems; workflow pain named: stale context and conflicting facts
+- Contact: https://www.reddit.com/user/game-of-kton/
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- Pipeline lead id: reddit_game_of_kton_r_cursor
+- Log after send: `npm run sales:pipeline -- advance --lead 'reddit_game_of_kton_r_cursor' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on stale context and conflicting facts.'`
+
+First-touch draft:
+> Your ACT-R engram work is fascinating, especially the conflict resolution for opposing facts and the decay model. I am looking for one serious AI-agent workflow to harden end-to-end this week. If your memory system has one recurring failure mode such as stale context, opposing facts, bad handoffs, or unsafe tool calls, I can turn that into a prevention rule and proof run. Open to a 15-minute diagnostic?
+
+#### 3. @leogodin217
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Evidence score: 9
+- Why now: Warm Reddit engager already described a mature workflow, so the next step is a targeted diagnostic on one failure mode.
+- Evidence: warm inbound engagement; mature multi-step workflow described; workflow pain named: review boundaries and context risk
+- Contact: https://www.reddit.com/user/leogodin217/
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- Pipeline lead id: reddit_leogodin217_r_claudecode
+- Log after send: `npm run sales:pipeline -- advance --lead 'reddit_leogodin217_r_claudecode' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on review boundaries and context risk.'`
+
+First-touch draft:
+> Your arch-create to sprint workflow is one of the most mature agent processes I have seen anyone describe. I am looking for one AI-agent workflow to harden end-to-end this week. Your workflow already has phases, review boundaries, and context risk, so it is a strong fit: pick one repeating failure and I will help turn it into an enforceable Pre-Action Check plus proof run. Worth 15 minutes?
+
+#### 4. @Enthu-Cutlet-1337
+- Temperature: warm
+- Source: reddit / reddit_dm
+- Evidence score: 8
+- Why now: Warm Reddit engager already understands the adaptive-gate thesis, so offer one concrete workflow hardening diagnostic.
+- Evidence: warm inbound engagement; responded to adaptive-gate positioning; workflow pain named: brittle guardrails
+- Contact: https://www.reddit.com/user/Enthu-Cutlet-1337/
+- CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- Pipeline lead id: reddit_enthu_cutlet_1337_r_claudecode
+- Log after send: `npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on brittle guardrails.'`
+
+First-touch draft:
+> Appreciate the kind words on the Thompson Sampling approach. You nailed the core insight: most guardrails are brittle prompt hacks that break when context shifts. I am looking for one AI-agent workflow to harden end-to-end this week: repeated failure, prevention rule, and proof run. If you have a workflow where brittle guardrails keep failing, I can harden that workflow with you. Open to a 15-minute diagnostic?
+
+### Send Next: Codex Self-Serve Install + Pro
+- Motion: Pro at $19/mo or $149/yr
+- Summary: Use these when the buyer already exposes a plugin, local-hook, or repo-backed tooling surface and should start with the guide path.
+
+#### 1. zaxbysauce/opencode-swarm
+- Temperature: cold
+- Source: github / github
+- Evidence score: 12
+- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
+- Evidence: workflow control surface; self-serve agent tooling; 241 GitHub stars; updated in the last 7 days
+- Contact: https://github.com/zaxbysauce
+- CTA: https://thumbgate-production.up.railway.app/guide
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- Pipeline lead id: github_zaxbysauce_opencode_swarm
+- Log after send: `npm run sales:pipeline -- advance --lead 'github_zaxbysauce_opencode_swarm' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
+
+First-touch draft:
+> Hey @zaxbysauce, saw you're building around `opencode-swarm`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
+
+#### 2. yvgude/lean-ctx
+- Temperature: cold
+- Source: github / github
+- Evidence score: 10
+- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
+- Evidence: agent infrastructure; self-serve agent tooling; 907 GitHub stars; updated in the last 7 days
+- Contact: https://yvesgugger.ch/
+- CTA: https://thumbgate-production.up.railway.app/guide
+- Proof rule: Use proof pack only after the buyer confirms pain.
+- Pipeline lead id: github_yvgude_lean_ctx
+- Log after send: `npm run sales:pipeline -- advance --lead 'github_yvgude_lean_ctx' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
+
+First-touch draft:
+> Hey @yvgude, saw you're building around `lean-ctx`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
 
 ## Sample Targets Behind This Pack
 - @Deep_Ad1959 (warm): Warm Reddit engager already named a repeated workflow risk, so the fastest path is a founder-led diagnostic.

--- a/scripts/codex-plugin-revenue-pack.js
+++ b/scripts/codex-plugin-revenue-pack.js
@@ -99,6 +99,96 @@ function summarizeExamples(targets = [], limit = 3) {
   ));
 }
 
+function formatTargetAccount(target = {}) {
+  const username = normalizeText(target.username);
+  const repoName = normalizeText(target.repoName);
+
+  if (username && repoName) {
+    return `${username}/${repoName}`;
+  }
+
+  if (username) {
+    return `@${username}`;
+  }
+
+  return 'unknown-target';
+}
+
+function summarizeEvidence(target = {}) {
+  const evidence = Array.isArray(target.evidence) ? target.evidence : [];
+  return evidence
+    .map((entry) => normalizeText(entry))
+    .filter(Boolean)
+    .join('; ');
+}
+
+function pickPrimaryContact(target = {}) {
+  const directContact = normalizeText(target.contactUrl);
+  if (directContact) {
+    return directContact;
+  }
+
+  const contactSurfaces = Array.isArray(target.contactSurfaces) ? target.contactSurfaces : [];
+  for (const surface of contactSurfaces) {
+    const url = normalizeText(surface?.url);
+    if (url) {
+      return url;
+    }
+  }
+
+  return 'n/a';
+}
+
+function targetTemperatureRank(target = {}) {
+  const temperature = normalizeText(target.temperature).toLowerCase();
+  if (temperature === 'warm') {
+    return 0;
+  }
+  if (temperature === 'cold') {
+    return 1;
+  }
+  return 2;
+}
+
+function compareReadyTargets(a = {}, b = {}) {
+  const temperatureDelta = targetTemperatureRank(a) - targetTemperatureRank(b);
+  if (temperatureDelta !== 0) {
+    return temperatureDelta;
+  }
+
+  const scoreDelta = Number(b.evidenceScore || 0) - Number(a.evidenceScore || 0);
+  if (scoreDelta !== 0) {
+    return scoreDelta;
+  }
+
+  return formatTargetAccount(a).localeCompare(formatTargetAccount(b));
+}
+
+function buildReadyTarget(target = {}) {
+  const source = [normalizeText(target.source), normalizeText(target.channel)]
+    .filter(Boolean)
+    .join(' / ');
+  const firstTouchDraft = normalizeText(target.firstTouchDraft) || normalizeText(target.message);
+  const markContactedCommand = normalizeText(target.salesCommands?.markContacted)
+    || normalizeText(target.markContactedCommand);
+
+  return {
+    account: formatTargetAccount(target),
+    temperature: normalizeText(target.temperature) || 'cold',
+    source: source || 'n/a',
+    evidenceScore: Number.isFinite(Number(target.evidenceScore)) ? Number(target.evidenceScore) : null,
+    whyNow: normalizeText(target.motionReason) || normalizeText(target.outreachAngle) || 'n/a',
+    evidence: summarizeEvidence(target) || 'n/a',
+    contact: pickPrimaryContact(target),
+    cta: normalizeText(target.cta) || 'n/a',
+    proofTrigger: normalizeText(target.proofPackTrigger)
+      || 'Use Commercial Truth and Verification Evidence only after the buyer confirms pain.',
+    firstTouchDraft: firstTouchDraft || 'n/a',
+    markContactedCommand: markContactedCommand || '',
+    pipelineLeadId: normalizeText(target.pipelineLeadId) || '',
+  };
+}
+
 function buildSignalSummary(report = {}) {
   const targets = Array.isArray(report.targets) ? report.targets : [];
   const warmTargets = targets.filter((target) => normalizeText(target.temperature).toLowerCase() === 'warm');
@@ -140,6 +230,37 @@ function buildPackTargets(report = {}) {
     why: normalizeText(target.motionReason) || normalizeText(target.outreachAngle),
     motion: normalizeText(target.motionLabel),
   }));
+}
+
+function buildReadyTargetLanes(report = {}) {
+  const targets = Array.isArray(report.targets) ? report.targets : [];
+  const workflowTargets = targets
+    .filter((target) => /workflow hardening sprint/i.test(normalizeText(target.motionLabel)))
+    .sort(compareReadyTargets)
+    .slice(0, 4)
+    .map(buildReadyTarget);
+  const selfServeTargets = targets
+    .filter((target) => /pro at/i.test(normalizeText(target.motionLabel)))
+    .sort(compareReadyTargets)
+    .slice(0, 3)
+    .map(buildReadyTarget);
+
+  return [
+    {
+      key: 'workflow_hardening',
+      label: 'Send Now: Codex-Adjacent Workflow Hardening',
+      motion: 'Workflow Hardening Sprint',
+      summary: 'Use these when the buyer already named one repeated failure, mature review boundary, or rollout risk.',
+      targets: workflowTargets,
+    },
+    {
+      key: 'self_serve',
+      label: 'Send Next: Codex Self-Serve Install + Pro',
+      motion: 'Pro at $19/mo or $149/yr',
+      summary: 'Use these when the buyer already exposes a plugin, local-hook, or repo-backed tooling surface and should start with the guide path.',
+      targets: selfServeTargets,
+    },
+  ].filter((lane) => lane.targets.length > 0);
 }
 
 function buildCodexSurface(config, links, about) {
@@ -402,6 +523,7 @@ function buildCodexPluginRevenuePack(report = {}, links = buildRevenueLinks(), a
     surfaces: buildCodexPluginSurfaces(links, about),
     followOnOffers: buildFollowOnOffers(links),
     operatorSequences: buildOperatorSequences(links),
+    readyTargetLanes: buildReadyTargetLanes(report),
     sampleTargets: buildPackTargets(report),
     measurementPlan: buildMeasurementPlan(),
   };
@@ -454,6 +576,31 @@ function renderCodexPluginRevenuePackMarkdown(pack) {
       '',
     ]))
     : ['- No Codex operator sequences were generated in this run.', ''];
+  const readyTargetLines = Array.isArray(pack.readyTargetLanes) && pack.readyTargetLanes.length
+    ? pack.readyTargetLanes.flatMap((lane) => ([
+      `### ${lane.label}`,
+      `- Motion: ${lane.motion}`,
+      `- Summary: ${lane.summary}`,
+      '',
+      ...lane.targets.flatMap((target, index) => ([
+        `#### ${index + 1}. ${target.account}`,
+        `- Temperature: ${target.temperature}`,
+        `- Source: ${target.source}`,
+        `- Evidence score: ${target.evidenceScore ?? 'n/a'}`,
+        `- Why now: ${target.whyNow}`,
+        `- Evidence: ${target.evidence}`,
+        `- Contact: ${target.contact}`,
+        `- CTA: ${target.cta}`,
+        `- Proof rule: ${target.proofTrigger}`,
+        `- Pipeline lead id: ${target.pipelineLeadId || 'n/a'}`,
+        `- Log after send: ${target.markContactedCommand ? `\`${target.markContactedCommand}\`` : 'n/a'}`,
+        '',
+        'First-touch draft:',
+        `> ${target.firstTouchDraft}`,
+        '',
+      ])),
+    ]))
+    : ['- No Codex-ready targets were generated in this run.', ''];
   const sampleTargetLines = Array.isArray(pack.sampleTargets) && pack.sampleTargets.length
     ? pack.sampleTargets.map((target) => `- ${target.account} (${target.temperature}): ${target.why}`)
     : ['- No sample targets available in this run.'];
@@ -489,6 +636,8 @@ function renderCodexPluginRevenuePackMarkdown(pack) {
     ...operatorSequenceLines,
     'Use Commercial Truth and Verification Evidence only after the buyer confirms the workflow pain or asks for proof.',
     '',
+    '## Ready-Now Target Queue',
+    ...readyTargetLines,
     '## Sample Targets Behind This Pack',
     ...sampleTargetLines,
     '',
@@ -545,6 +694,48 @@ function renderCodexPluginRevenuePackCsv(pack) {
   return `${rows.map((row) => row.map(csvCell).join(',')).join('\n')}\n`;
 }
 
+function renderCodexReadyTargetsCsv(pack) {
+  const readyTargetLanes = Array.isArray(pack.readyTargetLanes) ? pack.readyTargetLanes : [];
+  const rows = [
+    [
+      'laneKey',
+      'laneLabel',
+      'motion',
+      'account',
+      'temperature',
+      'source',
+      'evidenceScore',
+      'whyNow',
+      'evidence',
+      'contact',
+      'cta',
+      'proofTrigger',
+      'pipelineLeadId',
+      'markContactedCommand',
+      'firstTouchDraft',
+    ],
+    ...readyTargetLanes.flatMap((lane) => lane.targets.map((target) => ([
+      lane.key,
+      lane.label,
+      lane.motion,
+      target.account,
+      target.temperature,
+      target.source,
+      target.evidenceScore ?? '',
+      target.whyNow,
+      target.evidence,
+      target.contact,
+      target.cta,
+      target.proofTrigger,
+      target.pipelineLeadId,
+      target.markContactedCommand,
+      target.firstTouchDraft,
+    ]))),
+  ];
+
+  return `${rows.map((row) => row.map(csvCell).join(',')).join('\n')}\n`;
+}
+
 function parseArgs(argv = []) {
   const options = {
     reportDir: '',
@@ -573,6 +764,7 @@ function writeCodexPluginRevenuePack(pack, options = {}) {
   const repoRoot = path.resolve(__dirname, '..');
   const markdown = renderCodexPluginRevenuePackMarkdown(pack);
   const csv = renderCodexPluginRevenuePackCsv(pack);
+  const readyTargetsCsv = renderCodexReadyTargetsCsv(pack);
   const reportDir = normalizeText(options.reportDir)
     ? path.resolve(repoRoot, options.reportDir)
     : '';
@@ -583,6 +775,7 @@ function writeCodexPluginRevenuePack(pack, options = {}) {
     fs.writeFileSync(path.join(reportDir, 'codex-plugin-revenue-pack.md'), markdown, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'codex-plugin-revenue-pack.json'), `${JSON.stringify(pack, null, 2)}\n`, 'utf8');
     fs.writeFileSync(path.join(reportDir, 'codex-plugin-surfaces.csv'), csv, 'utf8');
+    fs.writeFileSync(path.join(reportDir, 'codex-ready-targets.csv'), readyTargetsCsv, 'utf8');
   }
 
   if (options.writeDocs) {
@@ -640,10 +833,12 @@ module.exports = {
   buildFollowOnOffers,
   buildMeasurementPlan,
   buildOperatorSequences,
+  buildReadyTargetLanes,
   buildTrackedCodexLink,
   isCliInvocation,
   parseArgs,
   renderCodexPluginRevenuePackCsv,
+  renderCodexReadyTargetsCsv,
   renderCodexPluginRevenuePackMarkdown,
   writeCodexPluginRevenuePack,
 };

--- a/tests/codex-plugin-revenue-pack.test.js
+++ b/tests/codex-plugin-revenue-pack.test.js
@@ -18,9 +18,11 @@ const {
   buildFollowOnOffers,
   buildMeasurementPlan,
   buildOperatorSequences,
+  buildReadyTargetLanes,
   buildTrackedCodexLink,
   isCliInvocation,
   parseArgs,
+  renderCodexReadyTargetsCsv,
   renderCodexPluginRevenuePackCsv,
   renderCodexPluginRevenuePackMarkdown,
   writeCodexPluginRevenuePack,
@@ -48,26 +50,59 @@ function makeReportFixture() {
       {
         temperature: 'warm',
         username: 'workflow_owner',
+        source: 'reddit',
+        channel: 'reddit_dm',
+        contactUrl: 'https://reddit.com/u/workflow_owner',
         repoName: '',
+        evidenceScore: 11,
         evidence: ['warm inbound engagement'],
         motionLabel: 'Workflow Hardening Sprint',
         motionReason: 'Warm workflow pain is already explicit.',
+        cta: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+        proofPackTrigger: 'Use proof only after pain is confirmed.',
+        firstTouchDraft: 'Warm workflow draft.',
+        pipelineLeadId: 'reddit_workflow_owner',
+        salesCommands: {
+          markContacted: 'npm run sales:pipeline -- advance --lead reddit_workflow_owner',
+        },
       },
       {
         temperature: 'cold',
         username: 'freema',
+        source: 'github',
+        channel: 'manual',
+        contactUrl: 'https://github.com/freema',
         repoName: 'mcp-jira-stdio',
+        evidenceScore: 14,
         evidence: ['workflow control surface', 'production or platform workflow'],
         motionLabel: 'Workflow Hardening Sprint',
         motionReason: 'Production workflow approvals need proof.',
+        cta: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+        proofPackTrigger: 'Use proof only after pain is confirmed.',
+        firstTouchDraft: 'Production workflow draft.',
+        pipelineLeadId: 'github_freema_mcp_jira_stdio',
+        salesCommands: {
+          markContacted: 'npm run sales:pipeline -- advance --lead github_freema_mcp_jira_stdio',
+        },
       },
       {
         temperature: 'cold',
         username: 'builder',
+        source: 'github',
+        channel: 'manual',
+        contactUrl: 'https://github.com/builder',
         repoName: 'agent-handoff',
+        evidenceScore: 10,
         evidence: ['workflow control surface'],
         motionLabel: 'Pro at $19/mo or $149/yr',
         motionReason: 'Self-serve tooling path is explicit.',
+        cta: 'https://thumbgate-production.up.railway.app/guide',
+        proofPackTrigger: 'Use proof only after pain is confirmed.',
+        firstTouchDraft: 'Self-serve draft.',
+        pipelineLeadId: 'github_builder_agent_handoff',
+        salesCommands: {
+          markContacted: 'npm run sales:pipeline -- advance --lead github_builder_agent_handoff',
+        },
       },
     ],
   };
@@ -157,6 +192,16 @@ test('operator sequences stay evidence-backed and route to real Codex follow-up 
   assert.ok(sequences.every((sequence) => !/guaranteed installs|guaranteed revenue|approved marketplace/i.test(sequence.draft)));
 });
 
+test('ready target lanes split workflow-hardening and self-serve targets for operator send order', () => {
+  const lanes = buildReadyTargetLanes(makeReportFixture());
+
+  assert.deepEqual(lanes.map((lane) => lane.key), ['workflow_hardening', 'self_serve']);
+  assert.equal(lanes[0].targets[0].account, '@workflow_owner');
+  assert.equal(lanes[0].targets[1].account, 'freema/mcp-jira-stdio');
+  assert.equal(lanes[1].targets[0].account, 'builder/agent-handoff');
+  assert.match(lanes[0].targets[0].markContactedCommand, /sales:pipeline/);
+});
+
 test('rendered pack is operator-ready and anchored to proof, guide, and bundle surfaces', () => {
   const rendered = renderCodexPluginRevenuePackMarkdown({
     ...buildPack(),
@@ -170,6 +215,9 @@ test('rendered pack is operator-ready and anchored to proof, guide, and bundle s
   assert.match(rendered, /Proof-backed setup guide/);
   assert.match(rendered, /GitHub release bundle/);
   assert.match(rendered, /Operator Follow-Up Sequences/);
+  assert.match(rendered, /Ready-Now Target Queue/);
+  assert.match(rendered, /Send Now: Codex-Adjacent Workflow Hardening/);
+  assert.match(rendered, /Send Next: Codex Self-Serve Install \+ Pro/);
   assert.match(rendered, /proof-backed Codex setup guide/i);
   assert.match(rendered, /VERIFICATION_EVIDENCE\.md/);
   assert.match(rendered, /workflow control surfaces/i);
@@ -178,12 +226,16 @@ test('rendered pack is operator-ready and anchored to proof, guide, and bundle s
 
 test('CSV export keeps Codex submission fields in one operator file', () => {
   const csv = renderCodexPluginRevenuePackCsv(buildPack());
+  const readyTargetsCsv = renderCodexReadyTargetsCsv(buildPack());
 
   assert.match(csv, /^key,name,role,operatorStatus,conversionGoal,/);
   assert.match(csv, /Codex plugin install page/);
   assert.match(csv, /Proof-backed setup guide/);
   assert.match(csv, /GitHub release bundle/);
   assert.match(csv, /codex_plugin_install_page/);
+  assert.match(readyTargetsCsv, /^laneKey,laneLabel,motion,account,/);
+  assert.match(readyTargetsCsv, /workflow_hardening/);
+  assert.match(readyTargetsCsv, /builder\/agent-handoff/);
 });
 
 test('CLI options and report writing produce markdown, JSON, and CSV artifacts', () => {
@@ -201,11 +253,13 @@ test('CLI options and report writing produce markdown, JSON, and CSV artifacts',
   assert.equal(fs.existsSync(path.join(tempDir, 'codex-plugin-revenue-pack.md')), true);
   assert.equal(fs.existsSync(path.join(tempDir, 'codex-plugin-revenue-pack.json')), true);
   assert.equal(fs.existsSync(path.join(tempDir, 'codex-plugin-surfaces.csv')), true);
+  assert.equal(fs.existsSync(path.join(tempDir, 'codex-ready-targets.csv')), true);
 
   const json = JSON.parse(fs.readFileSync(path.join(tempDir, 'codex-plugin-revenue-pack.json'), 'utf8'));
   assert.equal(json.surfaces.length, 3);
   assert.equal(json.measurementPlan.northStar, 'codex_install_intent_to_paid_intent');
   assert.match(fs.readFileSync(path.join(tempDir, 'codex-plugin-surfaces.csv'), 'utf8'), /utm_source/);
+  assert.match(fs.readFileSync(path.join(tempDir, 'codex-ready-targets.csv'), 'utf8'), /workflow_hardening/);
 });
 
 test('CLI entrypoint detection is path based for importer safety', () => {


### PR DESCRIPTION
## Summary
- add a ready-now Codex target queue to the Codex plugin revenue pack generator
- export the queue as structured CSV alongside the existing Codex surfaces artifacts
- refresh the checked-in Codex operator pack from the current GTM report

## Verification
- `npm run changeset:check -- --since=origin/main`
- `node --test tests/codex-plugin-revenue-pack.test.js tests/customer-discovery-sprint.test.js`
