### PR TITLE
fix(gtm): align active pack truth with live revenue loop

### DIFF
--- a/.changeset/truthful-pack-refresh.md
+++ b/.changeset/truthful-pack-refresh.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Keep the Claude, Gemini CLI, LinkedIn, and ChatGPT sales packs aligned with the live GTM revenue loop so operator copy stays cold-start truthful and the generated docs stop implying verified revenue before it exists.

--- a/docs/marketing/chatgpt-gpt-revenue-pack.md
+++ b/docs/marketing/chatgpt-gpt-revenue-pack.md
@@ -1,6 +1,6 @@
 # ChatGPT GPT Revenue Pack
 
-Updated: 2026-04-27T10:43:39.459Z
+Updated: 2026-04-28T18:24:06.772Z
 
 This is a sales operator artifact. It is not proof of GPT traffic, sent outreach, saved feedback, paid revenue, or GPT Store ranking by itself.
 
@@ -8,10 +8,10 @@ This is a sales operator artifact. It is not proof of GPT traffic, sent outreach
 Turn ChatGPT GPT discovery and trust-boundary demand into tracked proof clicks, Pro checkout starts, and qualified workflow-hardening conversations.
 
 ## Positioning
-- State: post-first-dollar
+- State: cold-start
 - Headline: Use ChatGPT for discovery, then force risky actions through real checks.
 - Short description: ThumbGate turns the published ChatGPT GPT into a proof-backed front door for action checks, typed feedback capture, and local enforcement handoff.
-- Summary: ChatGPT demand in ThumbGate should start with one useful action check or typed lesson, then hand the buyer into proof and local enforcement. Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
+- Summary: ChatGPT demand in ThumbGate should start with one useful action check or typed lesson, then hand the buyer into proof and local enforcement. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
 
 ## Canonical Identity
 - Display name: ThumbGate GPT

--- a/docs/marketing/claude-workflow-hardening-pack.md
+++ b/docs/marketing/claude-workflow-hardening-pack.md
@@ -1,6 +1,6 @@
 # Claude Workflow Hardening Pack
 
-Updated: 2026-04-27T10:43:39.459Z
+Updated: 2026-04-28T18:24:06.772Z
 
 This is a sales operator artifact. It is not proof of sent outreach, directory approval, paid revenue, or deployment success by itself.
 
@@ -8,10 +8,10 @@ This is a sales operator artifact. It is not proof of sent outreach, directory a
 Turn Claude install demand and workflow-hardening pain into tracked sprint intakes, proof clicks, and Pro checkout starts without making approval or revenue claims the repo cannot verify.
 
 ## Positioning
-- State: post-first-dollar
-- Headline: Turn Claude install demand into workflow-hardening revenue.
+- State: cold-start
+- Headline: Turn Claude install demand into workflow-hardening paid intent.
 - Short description: ThumbGate gives Claude Desktop and Claude Code a proof-backed install path, thumbs-up/down feedback capture, and Pre-Action Checks that block repeated workflow mistakes before the next risky action runs.
-- Summary: Claude demand in ThumbGate should stay install-first for evaluators and workflow-hardening-first for teams that already feel the pain. Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
+- Summary: Claude demand in ThumbGate should stay install-first for evaluators and workflow-hardening-first for teams that already feel the pain. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
 
 ## Canonical Identity
 - Display name: ThumbGate for Claude
@@ -101,7 +101,7 @@ You already called out the risky part of Claude workflows: the same failure keep
 
 ### LinkedIn — Founder post
 - Audience: Platform lead, consultancy owner, or AI delivery lead evaluating Claude rollout risk
-- Evidence: 2 production/platform targets and 5 business-system targets in the current report point to approval boundaries, rollback safety, and review-ready rollout proof as the strongest B2B angle.
+- Evidence: 3 production/platform targets and 4 business-system targets in the current report point to approval boundaries, rollback safety, and review-ready rollout proof as the strongest B2B angle.
 - CTA: https://thumbgate-production.up.railway.app/?utm_source=claude&utm_medium=linkedin_post&utm_campaign=claude_channel_linkedin&utm_content=landing_section&campaign_variant=review_ready&offer_code=CLAUDE-CHANNEL-LINKEDIN&cta_id=claude_channel_linkedin&cta_placement=channel_draft&surface=claude_linkedin#claude-desktop
 - Proof timing: Public post can mention proof-ready rollout, but keep the proof links for the reply or DM after pain is confirmed.
 Teams already shipping with Claude usually do not need another agent platform. They need one workflow that stops repeating the same mistake before it touches a repo, approval step, or customer system. ThumbGate is the lane I use for that: local-first install, repeated-mistake capture, and Pre-Action Checks before the next risky action runs. If you are evaluating Claude rollout risk, start with the review-ready install lane here: https://thumbgate-production.up.railway.app/?utm_source=claude&utm_medium=linkedin_post&utm_campaign=claude_channel_linkedin&utm_content=landing_section&campaign_variant=review_ready&offer_code=CLAUDE-CHANNEL-LINKEDIN&cta_id=claude_channel_linkedin&cta_placement=channel_draft&surface=claude_linkedin#claude-desktop .
@@ -150,8 +150,8 @@ Do not count as success:
 
 ## Evidence Backstop
 - Warm Claude targets in current report: 2
-- Production or platform targets in current report: 2
-- Business-system targets in current report: 5
+- Production or platform targets in current report: 3
+- Business-system targets in current report: 4
 - Landing source: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/landing-page.html
 - Review packet: https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip
 

--- a/docs/marketing/gemini-cli-demand-pack.md
+++ b/docs/marketing/gemini-cli-demand-pack.md
@@ -1,6 +1,6 @@
 # Gemini CLI Demand Pack
 
-Updated: 2026-04-27T10:43:39.459Z
+Updated: 2026-04-28T18:24:06.772Z
 
 This is a sales operator artifact. It is not proof of rankings, sent outreach, installs, paid revenue, or marketplace approval by itself.
 
@@ -8,10 +8,10 @@ This is a sales operator artifact. It is not proof of rankings, sent outreach, i
 Turn Gemini CLI memory demand and Google Cloud MCP guardrail demand into tracked proof clicks, Pro checkout starts, and qualified workflow-hardening conversations.
 
 ## Positioning
-- State: post-first-dollar
+- State: cold-start
 - Headline: Turn Gemini CLI memory demand into enforced workflow safety.
 - Short description: ThumbGate gives Gemini CLI local-first memory that can become prevention rules and Pre-Action Checks before the next risky MCP call runs.
-- Summary: Gemini CLI demand in ThumbGate is guide-led: memory query first, then enforcement proof, then paid intent. Revenue is proven. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
+- Summary: Gemini CLI demand in ThumbGate is guide-led: memory query first, then enforcement proof, then paid intent. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
 
 ## Canonical Identity
 - Display name: ThumbGate
@@ -66,14 +66,14 @@ Turn Gemini CLI memory demand and Google Cloud MCP guardrail demand into tracked
 - Recommended motion: Guide -> proof -> Pro once one blocked repeat is real.
 
 ### Google Cloud workflow owner running Gemini CLI near data or production systems
-- Evidence: The GCP guardrails guide documents BigQuery, Spanner, AlloyDB, Cloud SQL, and IAM escalation patterns. Current report production-style targets: 2.
+- Evidence: The GCP guardrails guide documents BigQuery, Spanner, AlloyDB, Cloud SQL, and IAM escalation patterns. Current report production-style targets: 3.
 - Proof trigger: They already described one risky BigQuery, Spanner, or MCP-backed workflow that cannot afford another destructive repeat.
 - Proof asset: https://github.com/IgorGanapolsky/ThumbGate/blob/main/public/guides/gcp-mcp-guardrails.html
 - Next ask: https://thumbgate-production.up.railway.app/?utm_source=gemini&utm_medium=operator_outreach&utm_campaign=gemini_queue_gcp_sprint&utm_content=workflow_sprint&campaign_variant=gcp_workflow_owner&offer_code=GEMINI-QUEUE_GCP_SPRINT&cta_id=gemini_queue_gcp_sprint&cta_placement=operator_queue&surface=gemini_workflow_queue#workflow-sprint-intake
 - Recommended motion: Qualify one high-risk workflow for the Workflow Hardening Sprint.
 
 ### Security-sensitive evaluator comparing hosted memory versus local-first enforcement
-- Evidence: The Gemini guide keeps local-first posture explicit, and the compare surface supports buyers who object to hosted memory first. Current business-system targets: 5.
+- Evidence: The Gemini guide keeps local-first posture explicit, and the compare surface supports buyers who object to hosted memory first. Current business-system targets: 4.
 - Proof trigger: They care about keeping workflow history local and need proof that enforcement happens without a hosted memory dependency.
 - Proof asset: https://github.com/IgorGanapolsky/ThumbGate/blob/main/public/compare/mem0.html
 - Next ask: https://thumbgate-production.up.railway.app/guide?utm_source=gemini&utm_medium=seo_guide&utm_campaign=gemini_queue_local_first&utm_content=setup&campaign_variant=local_first_evaluator&offer_code=GEMINI-QUEUE_LOCAL_FIRST&cta_id=gemini_queue_local_first&cta_placement=operator_queue&surface=gemini_cli
@@ -99,7 +99,7 @@ If Gemini CLI keeps repeating the same mistake, the missing piece is not more me
 
 ### LinkedIn — Founder post
 - Audience: Platform, cloud, or data team lead evaluating Gemini CLI near production systems
-- Evidence: 2 current production-style target(s) point to BigQuery, Spanner, AlloyDB, Cloud SQL, and approval-boundary risk as the strongest B2B Gemini angle.
+- Evidence: 3 current production-style target(s) point to BigQuery, Spanner, AlloyDB, Cloud SQL, and approval-boundary risk as the strongest B2B Gemini angle.
 - CTA: https://thumbgate-production.up.railway.app/guides/gcp-mcp-guardrails?utm_source=gemini&utm_medium=linkedin_post&utm_campaign=gemini_channel_linkedin&utm_content=guide&campaign_variant=gcp_guardrails&offer_code=GEMINI-CHANNEL-LINKEDIN&cta_id=gemini_channel_linkedin&cta_placement=channel_draft&surface=gemini_linkedin
 - Proof timing: Public post can mention blast radius and guardrails, but hold proof links for the DM or reply after the workflow risk is named.
 Gemini CLI gets interesting when it moves from drafts into BigQuery, Spanner, AlloyDB, Cloud SQL, or approval-boundary workflows. At that point the question is not “does memory exist,” it is “what stops the same risky MCP call from running again?” ThumbGate is the lane I use for that boundary. If you are evaluating Gemini near production systems, start with the guardrails guide: https://thumbgate-production.up.railway.app/guides/gcp-mcp-guardrails?utm_source=gemini&utm_medium=linkedin_post&utm_campaign=gemini_channel_linkedin&utm_content=guide&campaign_variant=gcp_guardrails&offer_code=GEMINI-CHANNEL-LINKEDIN&cta_id=gemini_channel_linkedin&cta_placement=channel_draft&surface=gemini_linkedin .
@@ -113,7 +113,7 @@ Gemini CLI memory is not enough if the same mistake still runs again tomorrow. T
 
 ### Bluesky — Short post
 - Audience: Security-sensitive evaluator comparing hosted memory to local-first enforcement
-- Evidence: 5 current business-system target(s) reinforce the local-first posture: keep workflow memory local, then prove enforcement before the next risky call.
+- Evidence: 4 current business-system target(s) reinforce the local-first posture: keep workflow memory local, then prove enforcement before the next risky call.
 - CTA: https://thumbgate-production.up.railway.app/compare/mem0?utm_source=gemini&utm_medium=bluesky_post&utm_campaign=gemini_channel_bluesky&utm_content=comparison&campaign_variant=local_first&offer_code=GEMINI-CHANNEL-BLUESKY&cta_id=gemini_channel_bluesky&cta_placement=channel_draft&surface=gemini_bluesky
 - Proof timing: Lead with the comparison surface first. Send Commercial Truth and Verification Evidence only after the buyer replies with a concrete privacy or workflow objection.
 Hosted memory is not the only option for Gemini CLI. If you want the workflow history to stay local and still become enforceable checks before the next MCP call runs, start with the local-first comparison: https://thumbgate-production.up.railway.app/compare/mem0?utm_source=gemini&utm_medium=bluesky_post&utm_campaign=gemini_channel_bluesky&utm_content=comparison&campaign_variant=local_first&offer_code=GEMINI-CHANNEL-BLUESKY&cta_id=gemini_channel_bluesky&cta_placement=channel_draft&surface=gemini_bluesky .

--- a/docs/marketing/linkedin-workflow-hardening-pack.md
+++ b/docs/marketing/linkedin-workflow-hardening-pack.md
@@ -1,6 +1,6 @@
 # LinkedIn Workflow Hardening Pack
 
-Updated: 2026-04-27T17:22:01.540Z
+Updated: 2026-04-28T18:24:06.772Z
 
 This is a sales operator artifact. It is not proof of sent outreach, paid revenue, installs, or marketplace approval by itself.
 
@@ -8,10 +8,10 @@ This is a sales operator artifact. It is not proof of sent outreach, paid revenu
 Turn LinkedIn workflow-risk conversations into tracked guide clicks, qualified workflow-hardening conversations, sprint-intake movement, and self-serve follow-on only after pain is qualified.
 
 ## Positioning
-- State: post-first-dollar
-- Headline: Turn LinkedIn workflow-risk conversations into sprint-qualified revenue.
+- State: cold-start
+- Headline: Turn LinkedIn workflow-risk conversations into sprint-qualified paid intent.
 - Short description: ThumbGate gives founder-led LinkedIn outreach one honest offer: harden one AI-agent workflow with approval boundaries, rollback safety, and proof before wider rollout.
-- Summary: LinkedIn should carry one offer: workflow hardening for teams that already feel rollout risk. Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
+- Summary: LinkedIn should carry one offer: workflow hardening for teams that already feel rollout risk. No verified revenue and no active pipeline. Stop treating posts as sales; directly sell one Workflow Hardening Sprint.
 
 ## Canonical Identity
 - Display name: ThumbGate
@@ -66,14 +66,14 @@ Turn LinkedIn workflow-risk conversations into tracked guide clicks, qualified w
 - Recommended motion: Workflow Hardening Sprint first. Use proof only after pain is confirmed.
 
 ### Platform or ops lead wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM workflows
-- Evidence: 3 production-style target(s), 6 business-system target(s), and 6 workflow-control target(s) point to approval boundaries and rollback safety as the strongest LinkedIn angle.
+- Evidence: 3 production-style target(s), 4 business-system target(s), and 4 workflow-control target(s) point to approval boundaries and rollback safety as the strongest LinkedIn angle.
 - Proof trigger: They can name one approval boundary, rollback risk, or bad handoff that blocks broader rollout.
 - Proof asset: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
 - Next ask: https://thumbgate-production.up.railway.app/?utm_source=linkedin&utm_medium=linkedin_dm&utm_campaign=linkedin_queue_sprint&utm_content=workflow_sprint&campaign_variant=pain_confirmed&offer_code=LINKEDIN-QUEUE_SPRINT&cta_id=linkedin_queue_sprint&cta_placement=operator_queue&surface=linkedin_outreach#workflow-sprint-intake
 - Recommended motion: Discovery DM -> sprint intake -> proof pack once the workflow risk is explicit.
 
 ### Individual builder who asks for the tool path after the workflow pain is qualified
-- Evidence: 0 current target(s) skew self-serve after qualification, but the guide should still carry the proof and pricing guardrails first.
+- Evidence: 2 current target(s) skew self-serve after qualification, but the guide should still carry the proof and pricing guardrails first.
 - Proof trigger: The buyer explicitly asks for install, pricing, or self-serve instead of founder-led workflow help.
 - Proof asset: https://github.com/IgorGanapolsky/ThumbGate/blob/main/public/guide.html
 - Next ask: https://thumbgate-production.up.railway.app/guide?utm_source=linkedin&utm_medium=linkedin_dm&utm_campaign=linkedin_queue_guide&utm_content=guide&campaign_variant=self_serve_interest&offer_code=LINKEDIN-QUEUE_GUIDE&cta_id=linkedin_queue_guide&cta_placement=operator_queue&surface=linkedin_outreach then https://thumbgate-production.up.railway.app/checkout/pro?utm_source=linkedin&utm_medium=linkedin_dm&utm_campaign=linkedin_queue_pro&utm_content=pro&campaign_variant=self_serve_follow_on&offer_code=LINKEDIN-QUEUE_PRO&cta_id=linkedin_queue_pro&cta_placement=operator_queue&plan_id=pro&surface=linkedin_outreach
@@ -106,7 +106,7 @@ If you already have one workflow where approval boundaries, rollback safety, or 
 
 ### LinkedIn — Reply or DM follow-up
 - Audience: Commenter who named repeated workflow risk
-- Evidence: 6 workflow-control target(s) and 6 business-system target(s) make workflow-risk follow-up more credible than a generic product pitch.
+- Evidence: 4 workflow-control target(s) and 4 business-system target(s) make workflow-risk follow-up more credible than a generic product pitch.
 - CTA: https://thumbgate-production.up.railway.app/guides/claude-code-prevent-repeated-mistakes?utm_source=linkedin&utm_medium=linkedin_comment&utm_campaign=linkedin_channel_repeat_guide&utm_content=guide&campaign_variant=workflow_risk&offer_code=LINKEDIN-CHANNEL_REPEAT&cta_id=linkedin_channel_repeat_guide&cta_placement=channel_draft&surface=linkedin_comment
 - Proof timing: Use the repeated-mistakes guide in the reply first. Send proof links only if they ask for evidence after naming the workflow.
 That is exactly the kind of workflow risk I am talking about. The useful next step is not a bigger AI pitch. It is isolating the repeated mistake and deciding what check should fire before the next risky action runs. This guide is the shortest explanation of that loop: https://thumbgate-production.up.railway.app/guides/claude-code-prevent-repeated-mistakes?utm_source=linkedin&utm_medium=linkedin_comment&utm_campaign=linkedin_channel_repeat_guide&utm_content=guide&campaign_variant=workflow_risk&offer_code=LINKEDIN-CHANNEL_REPEAT&cta_id=linkedin_channel_repeat_guide&cta_placement=channel_draft&surface=linkedin_comment .
@@ -114,10 +114,10 @@ That is exactly the kind of workflow risk I am talking about. The useful next st
 ## Evidence Backstop
 - Warm targets: 4
 - Production-style targets: 3
-- Business-system targets: 6
-- Workflow-control targets: 6
-- Sprint-motion targets: 10
-- Pro-motion targets: 0
+- Business-system targets: 4
+- Workflow-control targets: 4
+- Sprint-motion targets: 8
+- Pro-motion targets: 2
 - Named pain signals: rollback risk, stale context and conflicting facts, review boundaries and context risk, brittle guardrails
 
 ## 90-Day Measurement Plan

--- a/scripts/chatgpt-gpt-revenue-pack.js
+++ b/scripts/chatgpt-gpt-revenue-pack.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('node:fs');
 const path = require('node:path');
 const {
   COMMERCIAL_TRUTH_LINK,
@@ -19,6 +20,7 @@ const {
 } = require('./revenue-pack-utils');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
+const REVENUE_LOOP_REPORT_PATH = path.join(REPO_ROOT, 'docs', 'marketing', 'gtm-revenue-loop.json');
 const CHATGPT_SOURCE = 'chatgpt';
 const GPT_MEDIUM = 'gpt_store';
 const OUTREACH_MEDIUM = 'operator_outreach';
@@ -61,6 +63,14 @@ const SURFACE_FIELDS = [
   { label: 'Evidence source', key: 'evidenceSource' },
   { label: 'Proof', key: 'proofUrl' },
 ];
+
+function readRevenueLoopReport(reportPath = REVENUE_LOOP_REPORT_PATH) {
+  try {
+    return JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  } catch {
+    return {};
+  }
+}
 
 function buildTrackedChatgptLink(baseUrl, tracking = {}) {
   return buildTrackedPackLink(baseUrl, tracking, TRACKING_DEFAULTS);
@@ -387,7 +397,7 @@ function writeChatgptGptRevenuePack(pack, options = {}) {
 
 function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
-  const pack = buildChatgptGptRevenuePack();
+  const pack = buildChatgptGptRevenuePack(readRevenueLoopReport());
   const written = writeChatgptGptRevenuePack(pack, options);
 
   console.log('ChatGPT GPT revenue pack ready.');
@@ -428,6 +438,7 @@ module.exports = {
   GPT_SUBMISSION_PACKET_URL,
   GPT_TRUST_GUIDE_URL,
   PUBLISHED_GPT_URL,
+  REVENUE_LOOP_REPORT_PATH,
   buildChatgptGptRevenuePack,
   buildEvidenceSurfaces,
   buildFollowOnOffers,
@@ -437,6 +448,7 @@ module.exports = {
   buildTrackedChatgptLink,
   isCliInvocation,
   parseArgs,
+  readRevenueLoopReport,
   renderChatgptGptRevenuePackMarkdown,
   renderChatgptOperatorQueueCsv,
   writeChatgptGptRevenuePack,

--- a/scripts/claude-workflow-hardening-pack.js
+++ b/scripts/claude-workflow-hardening-pack.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('node:fs');
 const path = require('node:path');
 const { buildUTMLink } = require('./social-analytics/utm');
 const {
@@ -18,6 +19,7 @@ const {
 } = require('./revenue-pack-utils');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
+const REVENUE_LOOP_REPORT_PATH = path.join(REPO_ROOT, 'docs', 'marketing', 'gtm-revenue-loop.json');
 const CLAUDE_SOURCE = 'claude';
 const GUIDE_MEDIUM = 'guide_surface';
 const OUTREACH_MEDIUM = 'operator_outreach';
@@ -34,8 +36,16 @@ const CLAUDE_PLUGIN_README_URL = 'https://github.com/IgorGanapolsky/ThumbGate/bl
 const CLAUDE_EXTENSION_PLAN_URL = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/CLAUDE_DESKTOP_EXTENSION.md';
 const CLAUDE_LANDING_SOURCE_URL = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/landing-page.html';
 const PROOF_LINKS = [COMMERCIAL_TRUTH_LINK, VERIFICATION_EVIDENCE_LINK];
-const CANONICAL_HEADLINE = 'Turn Claude install demand into workflow-hardening revenue.';
+const CANONICAL_HEADLINE = 'Turn Claude install demand into workflow-hardening paid intent.';
 const CANONICAL_SHORT_DESCRIPTION = 'ThumbGate gives Claude Desktop and Claude Code a proof-backed install path, thumbs-up/down feedback capture, and Pre-Action Checks that block repeated workflow mistakes before the next risky action runs.';
+
+function readRevenueLoopReport(reportPath = REVENUE_LOOP_REPORT_PATH) {
+  try {
+    return JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  } catch {
+    return {};
+  }
+}
 
 function buildTrackedClaudeLink(baseUrl, tracking = {}) {
   const url = new URL(buildUTMLink(baseUrl, {
@@ -698,7 +708,7 @@ function writeClaudeWorkflowHardeningPack(pack, options = {}) {
 
 async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
-  const pack = buildClaudeWorkflowHardeningPack();
+  const pack = buildClaudeWorkflowHardeningPack(readRevenueLoopReport());
   const written = writeClaudeWorkflowHardeningPack(pack, options);
 
   console.log('Claude workflow hardening pack ready.');
@@ -737,6 +747,7 @@ module.exports = {
   CLAUDE_CODE_GUIDE_URL,
   CLAUDE_DESKTOP_GUIDE_URL,
   CLAUDE_REVIEW_PACKET_URL,
+  REVENUE_LOOP_REPORT_PATH,
   buildClaudeWorkflowHardeningPack,
   buildEvidenceSurfaces,
   buildFollowOnOffers,
@@ -748,6 +759,7 @@ module.exports = {
   buildTrackedClaudeLink,
   isCliInvocation,
   parseArgs,
+  readRevenueLoopReport,
   renderClaudeProspectQueueCsv,
   renderClaudeWorkflowHardeningPackMarkdown,
   writeClaudeWorkflowHardeningPack,

--- a/scripts/linkedin-workflow-hardening-pack.js
+++ b/scripts/linkedin-workflow-hardening-pack.js
@@ -32,7 +32,7 @@ const DM_MEDIUM = 'linkedin_dm';
 const COMMENT_MEDIUM = 'linkedin_comment';
 const LINKEDIN_SURFACE = 'linkedin_workflow_hardening';
 const PROOF_LINKS = [COMMERCIAL_TRUTH_LINK, VERIFICATION_EVIDENCE_LINK];
-const CANONICAL_HEADLINE = 'Turn LinkedIn workflow-risk conversations into sprint-qualified revenue.';
+const CANONICAL_HEADLINE = 'Turn LinkedIn workflow-risk conversations into sprint-qualified paid intent.';
 const CANONICAL_SHORT_DESCRIPTION = 'ThumbGate gives founder-led LinkedIn outreach one honest offer: harden one AI-agent workflow with approval boundaries, rollback safety, and proof before wider rollout.';
 const CANONICAL_FIELDS = [
   { label: 'Display name', key: 'displayName', fallback: 'ThumbGate' },

--- a/tests/chatgpt-gpt-revenue-pack.test.js
+++ b/tests/chatgpt-gpt-revenue-pack.test.js
@@ -14,6 +14,7 @@ const {
   GPT_SUBMISSION_PACKET_URL,
   GPT_TRUST_GUIDE_URL,
   PUBLISHED_GPT_URL,
+  REVENUE_LOOP_REPORT_PATH,
   buildChatgptGptRevenuePack,
   buildEvidenceSurfaces,
   buildFollowOnOffers,
@@ -23,6 +24,7 @@ const {
   buildTrackedChatgptLink,
   isCliInvocation,
   parseArgs,
+  readRevenueLoopReport,
   renderChatgptGptRevenuePackMarkdown,
   renderChatgptOperatorQueueCsv,
   writeChatgptGptRevenuePack,
@@ -143,6 +145,24 @@ test('rendered pack is operator-ready and anchored to GPT plus proof surfaces', 
   assert.match(markdown, /chatgpt-live-audit-2026-04-24\.md/);
   assert.match(markdown, /COMMERCIAL_TRUTH\.md/);
   assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
+});
+
+test('pack summary stays tied to the live revenue-loop directive instead of invented wins', () => {
+  const pack = buildChatgptGptRevenuePack(REPORT_FIXTURE, LINKS_FIXTURE, ABOUT_FIXTURE);
+
+  assert.equal(pack.state, 'cold-start');
+  assert.match(pack.summary, /No verified revenue and no active pipeline/);
+  assert.doesNotMatch(pack.summary, /Revenue is proven/i);
+});
+
+test('revenue-loop report reader falls back safely and parses live JSON when present', () => {
+  const tempDir = makeTempDir();
+  const reportPath = path.join(tempDir, 'gtm-revenue-loop.json');
+  fs.writeFileSync(reportPath, JSON.stringify({ directive: { state: 'cold-start' } }), 'utf8');
+
+  assert.equal(REVENUE_LOOP_REPORT_PATH.endsWith('docs/marketing/gtm-revenue-loop.json'), true);
+  assert.deepEqual(readRevenueLoopReport(path.join(tempDir, 'missing.json')), {});
+  assert.deepEqual(readRevenueLoopReport(reportPath), { directive: { state: 'cold-start' } });
 });
 
 test('CSV export keeps one operator queue file for ChatGPT lane', () => {

--- a/tests/claude-workflow-hardening-pack.test.js
+++ b/tests/claude-workflow-hardening-pack.test.js
@@ -10,6 +10,7 @@ const {
   CLAUDE_CODE_GUIDE_URL,
   CLAUDE_DESKTOP_GUIDE_URL,
   CLAUDE_REVIEW_PACKET_URL,
+  REVENUE_LOOP_REPORT_PATH,
   buildClaudeWorkflowHardeningPack,
   buildChannelDrafts,
   buildEvidenceSurfaces,
@@ -18,6 +19,7 @@ const {
   buildProspectQueue,
   buildTrackedClaudeLink,
   isCliInvocation,
+  readRevenueLoopReport,
   renderClaudeProspectQueueCsv,
   renderClaudeWorkflowHardeningPackMarkdown,
   writeClaudeWorkflowHardeningPack,
@@ -157,7 +159,10 @@ test('active channel drafts stay tied to live Claude surfaces and first-touch gu
 test('pack includes verified surfaces, listing copy, measurement plan, and evidence backstop', () => {
   const pack = buildClaudeWorkflowHardeningPack(makeReportFixture());
 
+  assert.equal(pack.state, 'cold-start');
   assert.equal(pack.headline, CANONICAL_HEADLINE);
+  assert.match(pack.summary, /No verified revenue and no active pipeline/);
+  assert.doesNotMatch(pack.summary, /Revenue is proven/i);
   assert.equal(pack.surfaces.length, 4);
   assert.equal(pack.listingCopy.followOnOffers.length, 2);
   assert.equal(pack.outreachDrafts.length, 3);
@@ -175,6 +180,18 @@ test('measurement plan keeps approval and revenue guardrails explicit', () => {
   assert.equal(measurementPlan.metrics.includes('claude_bundle_downloads'), true);
   assert.equal(measurementPlan.guardrails.some((entry) => /directory approval/.test(entry)), true);
   assert.equal(measurementPlan.doNotCountAsSuccess.includes('unverified directory approval or revenue claims'), true);
+});
+
+test('revenue-loop report reader falls back safely and parses live JSON when present', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-claude-report-'));
+  const reportPath = path.join(tempDir, 'gtm-revenue-loop.json');
+  fs.writeFileSync(reportPath, JSON.stringify({ directive: { state: 'cold-start' } }), 'utf8');
+
+  assert.equal(REVENUE_LOOP_REPORT_PATH.endsWith('docs/marketing/gtm-revenue-loop.json'), true);
+  assert.deepEqual(readRevenueLoopReport(path.join(tempDir, 'missing.json')), {});
+  assert.deepEqual(readRevenueLoopReport(reportPath), { directive: { state: 'cold-start' } });
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
 test('rendered markdown exposes listing copy, prospect queue, and proof backstop', () => {

--- a/tests/linkedin-workflow-hardening-pack.test.js
+++ b/tests/linkedin-workflow-hardening-pack.test.js
@@ -26,8 +26,8 @@ function makeReportFixture() {
   return {
     generatedAt: '2026-04-27T17:22:01.540Z',
     directive: {
-      state: 'post-first-dollar',
-      headline: 'Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.',
+      state: 'cold-start',
+      headline: 'No verified revenue and no active pipeline. Keep one Workflow Hardening Sprint offer live, then route self-serve buyers to Pro only after the buyer asks for the tool path.',
     },
     targets: [
       {
@@ -171,7 +171,10 @@ test('LinkedIn channel drafts stay workflow-first and keep proof out of the publ
 test('pack includes evidence backstop, LinkedIn drafts, and proof-linked follow-on offers', () => {
   const pack = buildLinkedinWorkflowHardeningPack(makeReportFixture());
 
+  assert.equal(pack.state, 'cold-start');
   assert.equal(pack.headline, CANONICAL_HEADLINE);
+  assert.match(pack.summary, /No verified revenue and no active pipeline/);
+  assert.doesNotMatch(pack.summary, /Revenue is proven/i);
   assert.equal(pack.surfaces.length, 4);
   assert.equal(pack.followOnOffers.length, 2);
   assert.equal(pack.operatorQueue.length, 3);


### PR DESCRIPTION
## Summary
- make the Claude and ChatGPT pack CLIs read the live GTM revenue-loop report before regenerating docs
- remove active pack headline language that implied closed revenue and regenerate the Claude, Gemini CLI, LinkedIn, and ChatGPT demand packs from current cold-start truth
- add tests covering honest cold-start summaries and revenue-loop report loading for the active pack generators

## Verification
- node --test tests/claude-workflow-hardening-pack.test.js tests/gemini-cli-demand-pack.test.js tests/linkedin-workflow-hardening-pack.test.js tests/chatgpt-gpt-revenue-pack.test.js