### PR TITLE
fix(gtm): retire x from active launch playbooks

### DIFF
--- a/FIRST_CUSTOMER_BATTLE_PLAN.md
+++ b/FIRST_CUSTOMER_BATTLE_PLAN.md
@@ -107,76 +107,45 @@ GitHub: https://github.com/IgorGanapolsky/ThumbGate
 
 ---
 
-### 1D. Twitter/X Thread (7 tweets)
+### 1D. LinkedIn Founder Post
 
-**Tweet 1:**
-I watched Claude Code repeat the same mistakes for 3 weeks before I realized the problem: there's no system-level enforcement for "don't do that again."
+Most AI coding agents do not fail because they forgot your prompt. They fail because nothing sits between the model and the next risky tool call.
 
-You can give feedback, but the agent doesn't *learn*. So I built ThumbGate. A PreToolUse gate that actually works. 🧵
+ThumbGate turns structured thumbs-down feedback into PreToolUse enforcement:
 
-**Tweet 2:**
-Here's the workflow:
+1. The agent repeats a known bad pattern.
+2. You capture what went wrong and what should change.
+3. ThumbGate turns that into a prevention rule.
+4. The next matching tool call gets blocked before execution.
 
-1. Claude (or Cursor, or Codex) tries something broken
-2. You give it a thumbs down
-3. ThumbGate captures the feedback and generates a prevention rule
-4. Next session, that rule blocks the same mistake at the tool-use level
+That is the difference between memory and enforcement.
 
-No weight training. Just enforced prevention in Markdown files.
+The free path stays local-first. Pro is for the personal dashboard, exports, and proof when a workflow owner asks what changed.
 
-**Tweet 3:**
-Why this matters:
+If you already have one repeated workflow failure in Claude Code, Cursor, Codex, Gemini, or Amp, start here:
+https://thumbgate-production.up.railway.app/?utm_source=linkedin&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=founder_post&creator=IgorGanapolsky&campaign_variant=workflow_hardening
 
-Vibe coding with agents is powerful but risky. One bad pattern repeated across 10 sessions costs you hours. You can't write enough context to override training. But you *can* enforce a rule.
-
-ThumbGate: local-first free tier. $19/mo Pro with dashboard + DPO export.
-
-**Tweet 4:**
-The tech stack is lean:
-
-- SQLite + FTS5 for lesson storage
-- Thompson Sampling for rule ranking
-- PreToolUse hooks for enforcement
-- ContextFS for rule assembly
-
-Local-first. Free runs on your machine and stores feedback state in `.thumbgate/` while agent hooks stay in your editor or CLI config.
-
-**Tweet 5:**
-Install it in 30 seconds:
-
-```
-npx thumbgate init --agent claude-code
-```
-
-Then give Claude a thumbs down next time it breaks something. Watch it never make that mistake again.
-
-Free to use. Pro trial is 7 days.
-
-**Tweet 6:**
-I've tested it on my own workflows for 2 weeks. Zero repeated mistakes.
-
-https://thumbgate-production.up.railway.app/?utm_source=x&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=launch_thread&creator=IgorGanapolsky&campaign_variant=founder_story
-
-**Tweet 7:**
 Repo: https://github.com/IgorGanapolsky/ThumbGate
-Tracked landing: https://thumbgate-production.up.railway.app/?utm_source=x&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=launch_thread_cta&creator=IgorGanapolsky&campaign_variant=founder_story
 
-Built by @IgorGanapolsky. If you're tired of your AI agent making the same mistakes over and over — this is for you.
+Optional first comment:
+- Proof: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
 
 ---
 
 ## STEP 2: Reply to These Live Threads (Do This Second — 20 min)
 
-People are actively complaining about this exact problem RIGHT NOW. Reply helpfully (not spammy) to these:
+People are actively complaining about this exact problem RIGHT NOW. Reply helpfully (not spammy) to these. Do not use X/Twitter for this step; that channel was retired from active distribution on April 20, 2026.
 
 | Platform | Thread | Pain Point |
 |----------|--------|------------|
 | DEV.to | [Claude Code Memory Fix](https://dev.to/gonewx/i-tried-3-different-ways-to-fix-claude-codes-memory-problem-heres-what-actually-worked-30fk) | Every new session is a blank slate |
 | DEV.to | [Claude Keeps Forgetting](https://dev.to/kiwibreaksme/claude-code-keeps-forgetting-your-project-heres-the-fix-2026-3flm) | Claude forgets project architecture |
 | DEV.to | [Why Claude's Memory Fails](https://dev.to/nikita_benkovich_eb86e54d/we-investigated-why-claudes-memory-fails-heres-what-we-learned-3pl6) | Context compaction causes amnesia |
-| Twitter/X | [@Dan_Jeffries1](https://x.com/Dan_Jeffries1/status/1953170619471937584) | "Claude Code getting amnesia after every auto-compact" |
-| Twitter/X | [@about_hiroppy](https://x.com/about_hiroppy/status/1950153718248222991) | Context amnesia causing silent code deletion |
-| Twitter/X | [@tomcrawshaw01](https://x.com/tomcrawshaw01/status/2029919688713719809) | Need for persistent memory across sessions |
+| Reddit DM | [Deep_Ad1959](https://www.reddit.com/user/Deep_Ad1959/) | Warm inbound, rollback risk, already in DMs |
+| Reddit DM | [game-of-kton](https://www.reddit.com/user/game-of-kton/) | Warm inbound, stale context, conflicting facts |
+| Reddit DM | [leogodin217](https://www.reddit.com/user/leogodin217/) | Warm inbound, mature workflow, review boundaries |
+| Reddit DM | [Enthu-Cutlet-1337](https://www.reddit.com/user/Enthu-Cutlet-1337/) | Warm inbound, brittle guardrails, adaptive gates |
 | HN | [Context Loss Solutions](https://news.ycombinator.com/item?id=46471286) | Context loss forces workarounds |
 | HN | [AI Agent Context Rot](https://news.ycombinator.com/item?id=47461861) | Context rot is #1 problem |
 | HN | [Context Bottleneck](https://news.ycombinator.com/item?id=45387374) | Large context windows don't help |
@@ -199,5 +168,5 @@ Find 5-10 developers who have starred similar repos (Mem0, SpecLock, context-eng
 1. **Post the r/ClaudeAI thread first** — highest concentration of people with this exact pain
 2. **Post the HN Show HN** — longest tail, biggest potential reach
 3. **Reply to the 10 existing threads** — these people are already hurting
-4. **Post the Twitter thread** — builds social proof
-5. **Post the r/cursor thread** — secondary audience
+4. **Post the LinkedIn founder post** — current public channel with the best fit for workflow-owner language
+5. **Work the warm Reddit DMs** — highest-probability conversations already surfaced in the operator queue

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -15,6 +15,8 @@ ThumbGate is a **human-in-the-loop enforcement layer** for AI coding agents — 
 
 ## 2. Distribution Channels
 
+Active outbound channels as of April 20, 2026: Reddit, LinkedIn, Threads, Bluesky, Instagram, and YouTube. X/Twitter is retired from active distribution and should stay archival only.
+
 | Channel | URL |
 |---------|-----|
 | npm | https://www.npmjs.com/package/thumbgate |
@@ -25,17 +27,16 @@ ThumbGate is a **human-in-the-loop enforcement layer** for AI coding agents — 
 
 ## 3. Acquisition: Social Post Templates
 
-### Twitter/X
+### Bluesky / Threads
 
-> "Your AI agent just mass-deleted prod data. Again.
+> "Most AI agent memory tools help the model remember. ThumbGate also enforces.
 >
-> We built **Pre-Action Gates** for MCP agents — configurable checkpoints that block dangerous tool calls before they execute.
+> One thumbs-down on a repeated failure becomes a Pre-Action Check that blocks the same tool-call pattern before execution.
 >
-> Free: 5 built-in gates + feedback capture + prevention rules
-> Pro ($19/mo): auto-gate promotion, unlimited custom gates, multi-repo sync
+> That is the difference between context and enforcement.
 >
-> OSS core: https://github.com/IgorGanapolsky/thumbgate
-> Pro: https://thumbgate-production.up.railway.app/checkout/pro"
+> Start with one repeated workflow failure, not a generic AI-agent pitch:
+> https://thumbgate-production.up.railway.app/?utm_source=bluesky&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=workflow_enforcement_post&campaign_variant=workflow_hardening"
 
 ### LinkedIn
 

--- a/LAUNCH_POSTS.md
+++ b/LAUNCH_POSTS.md
@@ -144,69 +144,33 @@ GitHub: https://github.com/IgorGanapolsky/ThumbGate
 
 ---
 
-## Post 4: Twitter/X Thread
+## Post 4: LinkedIn Founder Post
 
 ---
 
-**Tweet 1:**
-I watched Claude Code repeat the same mistakes for 3 weeks before I realized the problem: there's no system-level enforcement for "don't do that again."
+Most AI coding agents do not fail because they forgot your prompt. They fail because nothing sits between the model and the next risky tool call.
 
-You can give feedback, but the agent doesn't *learn*. You can write more context, but the agent doesn't *enforce* anything.
+ThumbGate turns structured thumbs-down feedback into PreToolUse enforcement:
 
-So I built ThumbGate. A PreToolUse gate that actually works.
+1. The agent repeats a known bad pattern.
+2. You capture what went wrong and what should change.
+3. ThumbGate turns that into a prevention rule.
+4. The next matching tool call gets blocked before execution.
 
-**Tweet 2:**
-Here's the workflow:
+That is the difference between memory and enforcement.
 
-1. Claude (or Cursor, or Codex) tries something broken
-2. You give it a thumbs down
-3. ThumbGate captures the feedback and generates a prevention rule
-4. Next session, that rule blocks the same mistake at the tool-use level
+The free path stays local-first. Pro is for the personal dashboard, exports, and proof when a workflow owner asks what changed.
 
-No weight training. No fine-tuning required. Just enforced prevention backed by local lessons and gates in `.thumbgate/`.
+If you already have one repeated workflow failure in Claude Code, Cursor, Codex, Gemini, or Amp, start here:
+https://thumbgate-production.up.railway.app/?utm_source=linkedin&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=founder_post&creator=IgorGanapolsky&campaign_variant=workflow_hardening
 
-**Tweet 3:**
-Why this matters:
+Repo:
+https://github.com/IgorGanapolsky/ThumbGate
 
-Vibe coding with agents is *powerful* but risky. One bad pattern repeated across 10 sessions costs you hours. You can't write enough context to override training. But you *can* enforce a rule.
-
-ThumbGate: local-first free tier. $19/mo Pro with a dashboard + DPO export.
-
-**Tweet 4:**
-The tech stack is small and lean:
-
-- SQLite + FTS5 for lesson storage
-- Thompson Sampling for rule ranking
-- PreToolUse hooks for enforcement
-- ContextFS for rule assembly
-
-Local-first. Free runs on your machine, and feedback state lives in `.thumbgate/` while hooks run inside your agent config.
-
-**Tweet 5:**
-Install it in 30 seconds:
-
-```
-npx thumbgate init --agent claude-code
-```
-
-Then give Claude a thumbs down next time it breaks something. Watch it never make that mistake again.
-
-Free to use. Pro trial is 7 days.
-
-**Tweet 6:**
-Dashboard demo + local walkthrough:
-
-Give Claude Code a thumbs down, watch the prevention rule appear, and see the same pattern get blocked in the next session.
-
-On the workflows I had explicitly marked down, it stopped the repeats that kept wasting my time.
-
-https://thumbgate-production.up.railway.app/?utm_source=x&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=launch_thread&creator=IgorGanapolsky&campaign_variant=founder_story
-
-**Tweet 7:**
-Repo: https://github.com/IgorGanapolsky/ThumbGate
-Tracked landing: https://thumbgate-production.up.railway.app/?utm_source=x&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=launch_thread_cta&creator=IgorGanapolsky&campaign_variant=founder_story
-
-Built by @IgorGanapolsky. If you're tired of your AI agent making the same mistakes over and over—this is for you.
+Optional first comment:
+Proof and commercial truth stay public:
+- https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
 
 ---
 
@@ -218,7 +182,7 @@ npx thumbgate init --agent claude-code
 ```
 
 **Checkout/Pricing Link:**
-https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&billing_cycle=monthly&utm_source=x&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=thread_direct_checkout&creator=IgorGanapolsky
+https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&billing_cycle=monthly&utm_source=linkedin&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=founder_post_checkout&creator=IgorGanapolsky
 
 **Landing Page:**
 https://thumbgate-production.up.railway.app/?utm_source=direct&utm_medium=manual_link&utm_campaign=first_customer_push&utm_content=launch_assets
@@ -226,8 +190,8 @@ https://thumbgate-production.up.railway.app/?utm_source=direct&utm_medium=manual
 **GitHub:**
 https://github.com/IgorGanapolsky/ThumbGate
 
-**Hashtags (for Twitter/X):**
-#ClaudeAI #Cursor #AI #CodingAgents #MCP #DevTools
+**LinkedIn Topic Tags:**
+#ClaudeCode #AICoding #CodingAgents #MCP #DevTools #WorkflowHardening
 
 ---
 
@@ -239,6 +203,6 @@ https://github.com/IgorGanapolsky/ThumbGate
 
 3. **HN post** — Lead with architecture. Use proper terminology (PreToolUse hooks, Thompson Sampling, FTS5). No marketing speak. Just clear technical description.
 
-4. **Twitter thread** — Hook hard with the problem. Build momentum. End with the install link and honest proof from your own repeated-failure workflows.
+4. **LinkedIn founder post** — Lead with one repeated workflow failure, explain the enforcement loop, and keep proof links ready in the first comment if the buyer asks.
 
 **Timing:** Post these ~30 minutes apart to avoid clustering. Monitor comments and respond authentically to questions.

--- a/docs/marketing/launch-content.md
+++ b/docs/marketing/launch-content.md
@@ -114,61 +114,29 @@ GitHub: https://github.com/IgorGanapolsky/ThumbGate
 
 ---
 
-## 4. X/Twitter Thread
+## 4. LinkedIn Founder Post
 
-**Tweet 1:**
-What if your AI coding agent had a 👎 button that actually worked?
+Most AI coding agents do not fail because they forgot your prompt. They fail because nothing sits between the model and the next risky tool call.
 
-Not "noted." Not "I'll try to remember."
+ThumbGate turns structured thumbs-down feedback into Pre-Action Checks:
 
-👎 = the agent physically cannot repeat that mistake. Ever.
+👎 repeated failure -> prevention rule -> tool-call block before execution
 
-Thread:
+That is the difference between memory and enforcement.
 
-**Tweet 2:**
-How it works:
+The free path stays local-first. Pro ($19/mo or $149/yr) is for the searchable personal dashboard, exports, and proof when a workflow owner asks what changed.
 
-👎 Thumbs down → captures what went wrong → becomes a prevention rule → rule fires before the tool call executes → blocked.
-
-👍 Thumbs up → reinforces what worked → pattern gets stronger.
-
-Your feedback builds an immune system for your agent.
-
-**Tweet 3:**
-Example: my agent kept force-pushing to main.
-
-I gave it a 👎 once. That thumbs-down became a gate.
-
-Now it literally cannot run `git push --force` — the gate blocks it before execution. Not a suggestion. A physical block.
-
-**Tweet 4:**
-The difference from memory tools:
-
-Mem0/Zep: "Here's context about past mistakes" (agent can still ignore it)
-
-ThumbGate: "You cannot execute this action" (gate fires before the tool call)
-
-Memory is advisory. 👎 is enforcement.
-
-**Tweet 5:**
-Works with Claude Code, Codex, Gemini, Amp, Cursor.
+Works with Claude Code, Codex, Gemini, Amp, and Cursor.
 
 One command:
 ```
 npx thumbgate init
 ```
 
-Local-first free path. MIT licensed.
+Landing: https://thumbgate-production.up.railway.app/?utm_source=linkedin&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=founder_post&creator=IgorGanapolsky&campaign_variant=workflow_hardening
+GitHub: https://github.com/IgorGanapolsky/ThumbGate
 
-**Tweet 6:**
-Pro ($19/mo or $149/yr) adds a searchable personal local dashboard to query and export your 👍/👎 entries.
-
-But captures, recalls, Pre-Action Checks, and blocking all work on the free local path. No cloud account required.
-
-Landing: https://thumbgate-production.up.railway.app/?utm_source=x&utm_medium=organic_social&utm_campaign=first_customer_push&utm_content=launch_thread_cta&creator=IgorGanapolsky&campaign_variant=founder_story
-GitHub: github.com/IgorGanapolsky/ThumbGate
-
-#MCP #AIcoding #vibecoding
+#MCP #AICoding #DevTools #WorkflowHardening
 
 ---
 

--- a/tests/check-congruence.test.js
+++ b/tests/check-congruence.test.js
@@ -76,7 +76,8 @@ test('launch content uses tracked landing links for community distribution', () 
 
   assert.match(launchContent, /thumbgate-production\.up\.railway\.app\/\?utm_source=reddit/i);
   assert.match(launchContent, /thumbgate-production\.up\.railway\.app\/\?utm_source=hackernews/i);
-  assert.match(launchContent, /thumbgate-production\.up\.railway\.app\/\?utm_source=x/i);
+  assert.match(launchContent, /thumbgate-production\.up\.railway\.app\/\?utm_source=linkedin/i);
+  assert.doesNotMatch(launchContent, /utm_source=x/i);
   assert.doesNotMatch(launchContent, /buy\.stripe\.com/i);
 });
 

--- a/tests/social-marketing-assets.test.js
+++ b/tests/social-marketing-assets.test.js
@@ -78,6 +78,21 @@ test('product hunt launch kit links the live listing and the Claude plugin bundl
   assert.match(productHuntKit, /Claude plugin guide/i);
 });
 
+test('active launch playbooks retire X and route the operator to current channels', () => {
+  const launchPlan = read('LAUNCH.md');
+  const launchPosts = read('LAUNCH_POSTS.md');
+  const battlePlan = read('FIRST_CUSTOMER_BATTLE_PLAN.md');
+
+  assert.match(launchPlan, /X\/Twitter is retired from active distribution/i);
+  assert.match(launchPlan, /utm_source=bluesky/i);
+  assert.doesNotMatch(launchPosts, /utm_source=x/i);
+  assert.match(launchPosts, /LinkedIn Founder Post/i);
+  assert.match(launchPosts, /utm_source=linkedin/i);
+  assert.match(battlePlan, /Do not use X\/Twitter/i);
+  assert.match(battlePlan, /LinkedIn Founder Post/i);
+  assert.match(battlePlan, /Deep_Ad1959/i);
+});
+
 test('private local SVG assets exist for LinkedIn carousel and X card', () => {
   const assetDir = path.join(repoRoot, 'docs/marketing/assets');
   const assetFiles = [


### PR DESCRIPTION
## Summary
- retire stale X/Twitter guidance from the active ThumbGate launch playbooks
- route the operator to current evidence-backed channels: LinkedIn founder post, Bluesky/Threads copy, and warm Reddit DM follow-up
- add regression coverage so launch assets no longer drift back to `utm_source=x`

## Verification
- `node --test tests/social-marketing-assets.test.js tests/check-congruence.test.js`
- `npm ci`
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`