### PR TITLE
feat(gtm): align offer split across landing and assets

### DIFF
--- a/.changeset/offer-split-surface-alignment.md
+++ b/.changeset/offer-split-surface-alignment.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Align the public FAQ and GTM revenue-loop assets around the current Pro versus Workflow Hardening Sprint offer split so operator copy stays consistent across discovery and conversion surfaces.

--- a/docs/marketing/gtm-marketplace-copy.json
+++ b/docs/marketing/gtm-marketplace-copy.json
@@ -27,6 +27,7 @@
     "Lead with one repeated workflow failure, then show how ThumbGate turns it into an enforceable pre-action gate.",
     "Route install-intent buyers through the proof-backed setup guide before direct checkout.",
     "Lead with the proof-backed setup guide first, then convert proven local usage into Pro.",
+    "Use Pro after one blocked repeat or explicit self-serve install intent. Use the Workflow Hardening Sprint when one workflow owner needs approval boundaries, rollback safety, and proof before wider rollout.",
     "Primary offer: Workflow Hardening Sprint.",
     "Secondary offer: Pro at $19/mo or $149/yr after the buyer asks for the tool path.",
     "Keep approval boundaries, rollback safety, and proof attached to the workflow before rollout."

--- a/docs/marketing/gtm-marketplace-copy.md
+++ b/docs/marketing/gtm-marketplace-copy.md
@@ -16,6 +16,7 @@ ThumbGate is a reliability gateway for AI coding workflows. It captures repeated
 - Lead with one repeated workflow failure, then show how ThumbGate turns it into an enforceable pre-action gate.
 - Route install-intent buyers through the proof-backed setup guide before direct checkout.
 - Lead with the proof-backed setup guide first, then convert proven local usage into Pro.
+- Use Pro after one blocked repeat or explicit self-serve install intent. Use the Workflow Hardening Sprint when one workflow owner needs approval boundaries, rollback safety, and proof before wider rollout.
 - Primary offer: Workflow Hardening Sprint.
 - Secondary offer: Pro at $19/mo or $149/yr after the buyer asks for the tool path.
 - Keep approval boundaries, rollback safety, and proof attached to the workflow before rollout.

--- a/docs/marketing/operator-priority-handoff.json
+++ b/docs/marketing/operator-priority-handoff.json
@@ -14,6 +14,7 @@
   "operatorRules": [
     "Import the queue into the sales ledger before sending anything.",
     "Follow the row motion: sprint rows get one workflow-hardening offer; self-serve rows get the guide-to-Pro lane unless pain is confirmed.",
+    "Qualify the offer split: Use Pro after one blocked repeat or explicit self-serve install intent. Use the Workflow Hardening Sprint when one workflow owner needs approval boundaries, rollback safety, and proof before wider rollout.",
     "Use VERIFICATION_EVIDENCE.md and COMMERCIAL_TRUTH.md only after the buyer confirms pain."
   ],
   "importCommand": "npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json",

--- a/docs/marketing/operator-priority-handoff.md
+++ b/docs/marketing/operator-priority-handoff.md
@@ -20,6 +20,7 @@ This handoff sits on top of `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `
 ## Operator Rules
 - Import the queue into the sales ledger before sending anything.
 - Follow the row motion: sprint rows get one workflow-hardening offer; self-serve rows get the guide-to-Pro lane unless pain is confirmed.
+- Qualify the offer split: Use Pro after one blocked repeat or explicit self-serve install intent. Use the Workflow Hardening Sprint when one workflow owner needs approval boundaries, rollback safety, and proof before wider rollout.
 - Use [VERIFICATION_EVIDENCE.md](../VERIFICATION_EVIDENCE.md) and [COMMERCIAL_TRUTH.md](../COMMERCIAL_TRUTH.md) only after the buyer confirms pain.
 
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -211,10 +211,10 @@ __GA_BOOTSTRAP__
     },
     {
       "@type": "Question",
-      "name": "Why does the ChatGPT ads rollout matter to ThumbGate?",
+      "name": "When should I use Pro versus the Workflow Hardening Sprint?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "OpenAI began testing ads in ChatGPT in the US on February 9, 2026, and Digiday reported CPC bidding on April 21, 2026. As conversational AI becomes a monetized discovery surface, teams need a cleaner boundary between AI advice and risky execution. ThumbGate is that pre-action check layer."
+        "text": "Start with the setup guide if you only need the local path. Choose Pro after one real blocked repeat when you want your own dashboard, DPO export, and proof-ready exports. Choose the Workflow Hardening Sprint when one workflow owner needs approval boundaries, rollback safety, and rollout proof before wider rollout."
       }
     },
     {
@@ -1365,8 +1365,8 @@ __GA_BOOTSTRAP__
         <div class="faq-a">No. The ThumbGate GPT is the ChatGPT entrypoint for checking proposed actions, capturing thumbs-up/down lessons, and getting setup help. Use it for advice and checkpointing; hard enforcement still runs locally where the agent executes after <code>npx thumbgate init</code>.</div>
       </div>
       <div class="faq-item">
-        <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">Why does the ChatGPT ads rollout matter to ThumbGate?</div>
-        <div class="faq-a">OpenAI began testing ads in ChatGPT in the US on February 9, 2026, and Digiday reported CPC bidding on April 21, 2026. That makes trust and measurement more important around AI-assisted decisions. ThumbGate gives teams a hard boundary between conversational discovery and risky local execution, so a suggested action still has to pass a real check before it runs. <a href="/guides/chatgpt-ads-trust" style="color:var(--cyan);text-decoration:underline;">Read the full positioning guide</a>.</div>
+        <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">When should I use Pro versus the Workflow Hardening Sprint?</div>
+        <div class="faq-a">Start with the <a href="/guide" style="color:var(--cyan);text-decoration:underline;">setup guide</a> if you only need the local path. Choose Pro after one real blocked repeat when you want your own dashboard, DPO export, and proof-ready exports. Choose the <a href="#workflow-sprint-intake" style="color:var(--cyan);text-decoration:underline;">Workflow Hardening Sprint</a> when one workflow owner needs approval boundaries, rollback safety, and rollout proof before wider rollout.</div>
       </div>
       <div class="faq-item">
         <button class="faq-q" type="button" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How do we keep high-risk autonomous runs off the host?</button>

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -110,6 +110,7 @@ const CLAIM_GUARDRAILS = [
   'Keep public pricing and traction claims aligned with COMMERCIAL_TRUTH.md.',
   'Keep proof and quality claims aligned with VERIFICATION_EVIDENCE.md.',
 ];
+const OFFER_SPLIT_RULE = 'Use Pro after one blocked repeat or explicit self-serve install intent. Use the Workflow Hardening Sprint when one workflow owner needs approval boundaries, rollback safety, and proof before wider rollout.';
 const TERMINAL_PIPELINE_STAGES = new Set(['paid', 'lost']);
 const PIPELINE_STAGE_PRIORITY = {
   sprint_intake: 6,
@@ -1589,6 +1590,7 @@ function buildMarketplaceCopy(report) {
       topTheme ? topTheme.listingAngle : '',
       'Route install-intent buyers through the proof-backed setup guide before direct checkout.',
       selfServeSignal ? selfServeSignal.listingAngle : '',
+      OFFER_SPLIT_RULE,
       `Primary offer: ${resolveMotionLabel(report, primaryMotion)}.`,
       `Secondary offer: ${resolveMotionLabel(report, secondaryMotion)} after the buyer asks for the tool path.`,
       'Keep approval boundaries, rollback safety, and proof attached to the workflow before rollout.',
@@ -1911,6 +1913,7 @@ function buildOperatorHandoffPayload(report) {
     operatorRules: [
       'Import the queue into the sales ledger before sending anything.',
       'Follow the row motion: sprint rows get one workflow-hardening offer; self-serve rows get the guide-to-Pro lane unless pain is confirmed.',
+      `Qualify the offer split: ${OFFER_SPLIT_RULE}`,
       'Use VERIFICATION_EVIDENCE.md and COMMERCIAL_TRUTH.md only after the buyer confirms pain.',
     ],
     importCommand: 'npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json',

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -1308,6 +1308,7 @@ test('operator handoff payload mirrors the ranked queue and sales commands in ma
   assert.equal(payload.summary.warmTargetsReadyNow, 1);
   assert.equal(payload.summary.selfServeTargetsReadyNow, 1);
   assert.equal(payload.summary.coldGitHubTargetsReadyNext, 1);
+  assert.ok(payload.operatorRules.some((rule) => /Use Pro after one blocked repeat/i.test(rule)));
   assert.equal(payload.importCommand, 'npm run sales:pipeline -- import --source docs/marketing/gtm-revenue-loop.json');
   const followUpSection = payload.sections.find((section) => section.key === 'follow_up_now');
   const warmSection = payload.sections.find((section) => section.key === 'send_now_warm_discovery');
@@ -1797,8 +1798,10 @@ test('marketplace copy pack stays tied to current revenue-loop evidence', () => 
   assert.ok(pack.topSignals.some((signal) => /Business-system workflow approvals/.test(signal.label)));
   assert.ok(pack.topSignals.some((signal) => /Self-serve agent tooling/.test(signal.label)));
   assert.ok(pack.sampleTargets.some((target) => target.account === 'buildertools/codex-hook-pack'));
+  assert.ok(pack.listingBullets.some((bullet) => /Use Pro after one blocked repeat/i.test(bullet)));
   assert.match(markdown, /Proof Policy/);
   assert.match(markdown, /Evidence Backstop/);
+  assert.match(markdown, /Use Pro after one blocked repeat or explicit self-serve install intent/i);
   assert.match(markdown, /Self-serve agent tooling/);
   assert.match(markdown, /COMMERCIAL_TRUTH\.md/);
   assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -28,11 +28,14 @@ test('public landing page keeps FAQPage JSON-LD parity for SEO and GEO', () => {
   assert.match(landingPage, /What is the ThumbGate tech stack\?/);
   assert.match(landingPage, /What AI agents does ThumbGate work with\?/);
   assert.match(landingPage, /Do I have to chat inside the ThumbGate GPT for enforcement\?/);
+  assert.match(landingPage, /When should I use Pro versus the Workflow Hardening Sprint\?/);
   assert.match(landingPage, /How are pre-action checks different from prompt rules\?/);
   assert.match(landingPage, /behavioral immune system/i);
   assert.match(landingPage, /PreToolUse hook enforcement/i);
   assert.match(landingPage, /Thompson Sampling/i);
   assert.match(landingPage, /prompt evaluation/i);
+  assert.match(landingPage, /one real blocked repeat/i);
+  assert.match(landingPage, /workflow owner needs approval boundaries/i);
 });
 
 test('public landing page routes Pro buyers through the hosted checkout surface', () => {


### PR DESCRIPTION
## Summary
- align the public FAQ with the current Pro vs Workflow Hardening Sprint buyer split
- carry the same offer-split rule into marketplace copy and operator handoff assets
- add regression tests for the landing FAQ and GTM generator outputs

## Verification
- node --test tests/public-landing.test.js tests/gtm-revenue-loop.test.js
- npm test
- npm run test:coverage
- tmp=$(mktemp -d) && THUMBGATE_PROOF_DIR="$tmp/proof" npm run prove:adapters
- tmp=$(mktemp -d) && THUMBGATE_AUTOMATION_PROOF_DIR="$tmp/proof-automation" npm run prove:automation
- npm run self-heal:check