### PR TITLE
feat(gtm): add marketplace listing variants

### DIFF
--- a/.changeset/marketplace-variant-assets.md
+++ b/.changeset/marketplace-variant-assets.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add evidence-backed marketplace listing variants to the GTM revenue loop, regenerate the operator queue artifacts, and keep the marketplace copy pack aligned to proof-backed sprint versus guide-to-Pro motions.

--- a/docs/marketing/gtm-marketplace-copy.json
+++ b/docs/marketing/gtm-marketplace-copy.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-29T21:20:24.731Z",
+  "generatedAt": "2026-04-29T22:23:06.232Z",
   "state": "post-first-dollar",
   "headline": "Harden one AI-agent workflow before you roll it out.",
   "shortDescription": "Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.",
@@ -76,6 +76,104 @@
       "listingAngle": "Lead with the proof-backed setup guide first, then convert proven local usage into Pro.",
       "count": 3,
       "examples": [
+        "Abhi268170/Stagix",
+        "zaxbysauce/opencode-swarm",
+        "iliaal/compound-engineering-plugin"
+      ]
+    }
+  ],
+  "listingVariants": [
+    {
+      "key": "workflow_control",
+      "label": "Workflow control surfaces",
+      "audience": "Operators with visible workflow-control surfaces and repeated handoff failures.",
+      "headline": "Harden one workflow control surface before the next agent rollout.",
+      "shortDescription": "Lead with one repeated approval, review, or handoff failure and show how ThumbGate turns it into an enforceable pre-action gate.",
+      "evidenceSummary": "The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive.",
+      "listingAngle": "Lead with one repeated workflow failure, then show how ThumbGate turns it into an enforceable pre-action gate.",
+      "primaryCta": {
+        "motion": "sprint",
+        "label": "Workflow Hardening Sprint",
+        "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+      },
+      "secondaryCta": {
+        "motion": "guide",
+        "label": "Proof-backed setup guide",
+        "cta": "https://thumbgate-production.up.railway.app/guide"
+      },
+      "sampleTargets": [
+        "dolutech/engine_context",
+        "Adqui9608/ai-code-review-agent",
+        "Abhi268170/Stagix"
+      ]
+    },
+    {
+      "key": "warm_discovery",
+      "label": "Warm discovery workflows",
+      "audience": "Warm buyers who already named a repeated workflow failure.",
+      "headline": "Turn one repeated AI-agent workflow failure into a proof-backed sprint.",
+      "shortDescription": "Lead with one concrete workflow failure, then offer a founder-led hardening diagnostic before any generic tool pitch.",
+      "evidenceSummary": "Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain.",
+      "listingAngle": "Lead with one repeated workflow failure and a founder-led diagnostic before any generic tool pitch.",
+      "primaryCta": {
+        "motion": "sprint",
+        "label": "Workflow Hardening Sprint",
+        "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+      },
+      "secondaryCta": {
+        "motion": "guide",
+        "label": "Proof-backed setup guide",
+        "cta": "https://thumbgate-production.up.railway.app/guide"
+      },
+      "sampleTargets": [
+        "@Deep_Ad1959",
+        "@game-of-kton",
+        "@leogodin217"
+      ]
+    },
+    {
+      "key": "business_system_workflows",
+      "label": "Business-system workflow approvals",
+      "audience": "Teams wiring agents into approval-heavy business systems.",
+      "headline": "Add approval boundaries and rollback safety to one agent workflow.",
+      "shortDescription": "Lead with one workflow in Jira, GitHub, ServiceNow, Slack, or CRM systems that needs proof before wider rollout.",
+      "evidenceSummary": "Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof.",
+      "listingAngle": "Lead with approval boundaries, rollback safety, and proof for one workflow.",
+      "primaryCta": {
+        "motion": "sprint",
+        "label": "Workflow Hardening Sprint",
+        "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+      },
+      "secondaryCta": {
+        "motion": "guide",
+        "label": "Proof-backed setup guide",
+        "cta": "https://thumbgate-production.up.railway.app/guide"
+      },
+      "sampleTargets": [
+        "dolutech/engine_context",
+        "Adqui9608/ai-code-review-agent",
+        "Abhi268170/Stagix"
+      ]
+    },
+    {
+      "key": "self_serve_tooling",
+      "label": "Self-serve agent tooling",
+      "audience": "Plugin, hook, and local-rule buyers who want the fastest self-serve proof path first.",
+      "headline": "Block repeated agent mistakes before the next install or config rollout.",
+      "shortDescription": "Lead with the proof-backed setup guide first, then route install-intent buyers to Pro after one blocked repeat or explicit self-serve intent.",
+      "evidenceSummary": "Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.",
+      "listingAngle": "Lead with the proof-backed setup guide first, then convert proven local usage into Pro.",
+      "primaryCta": {
+        "motion": "guide",
+        "label": "Proof-backed setup guide",
+        "cta": "https://thumbgate-production.up.railway.app/guide"
+      },
+      "secondaryCta": {
+        "motion": "pro",
+        "label": "Pro at $19/mo or $149/yr",
+        "cta": "https://thumbgate-production.up.railway.app/checkout/pro"
+      },
+      "sampleTargets": [
         "Abhi268170/Stagix",
         "zaxbysauce/opencode-swarm",
         "iliaal/compound-engineering-plugin"

--- a/docs/marketing/gtm-marketplace-copy.md
+++ b/docs/marketing/gtm-marketplace-copy.md
@@ -32,6 +32,47 @@ ThumbGate is a reliability gateway for AI coding workflows. It captures repeated
 - Business-system workflow approvals (4): Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Examples: dolutech/engine_context, Adqui9608/ai-code-review-agent, Abhi268170/Stagix
 - Self-serve agent tooling (3): Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible. Examples: Abhi268170/Stagix, zaxbysauce/opencode-swarm, iliaal/compound-engineering-plugin
 
+## Listing Variants
+### Workflow control surfaces
+- Audience: Operators with visible workflow-control surfaces and repeated handoff failures.
+- Headline: Harden one workflow control surface before the next agent rollout.
+- Short description: Lead with one repeated approval, review, or handoff failure and show how ThumbGate turns it into an enforceable pre-action gate.
+- Evidence: The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive.
+- Listing angle: Lead with one repeated workflow failure, then show how ThumbGate turns it into an enforceable pre-action gate.
+- Primary CTA: Workflow Hardening Sprint: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Secondary CTA: Proof-backed setup guide: https://thumbgate-production.up.railway.app/guide
+- Sample targets: dolutech/engine_context, Adqui9608/ai-code-review-agent, Abhi268170/Stagix
+
+### Warm discovery workflows
+- Audience: Warm buyers who already named a repeated workflow failure.
+- Headline: Turn one repeated AI-agent workflow failure into a proof-backed sprint.
+- Short description: Lead with one concrete workflow failure, then offer a founder-led hardening diagnostic before any generic tool pitch.
+- Evidence: Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain.
+- Listing angle: Lead with one repeated workflow failure and a founder-led diagnostic before any generic tool pitch.
+- Primary CTA: Workflow Hardening Sprint: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Secondary CTA: Proof-backed setup guide: https://thumbgate-production.up.railway.app/guide
+- Sample targets: @Deep_Ad1959, @game-of-kton, @leogodin217
+
+### Business-system workflow approvals
+- Audience: Teams wiring agents into approval-heavy business systems.
+- Headline: Add approval boundaries and rollback safety to one agent workflow.
+- Short description: Lead with one workflow in Jira, GitHub, ServiceNow, Slack, or CRM systems that needs proof before wider rollout.
+- Evidence: Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof.
+- Listing angle: Lead with approval boundaries, rollback safety, and proof for one workflow.
+- Primary CTA: Workflow Hardening Sprint: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Secondary CTA: Proof-backed setup guide: https://thumbgate-production.up.railway.app/guide
+- Sample targets: dolutech/engine_context, Adqui9608/ai-code-review-agent, Abhi268170/Stagix
+
+### Self-serve agent tooling
+- Audience: Plugin, hook, and local-rule buyers who want the fastest self-serve proof path first.
+- Headline: Block repeated agent mistakes before the next install or config rollout.
+- Short description: Lead with the proof-backed setup guide first, then route install-intent buyers to Pro after one blocked repeat or explicit self-serve intent.
+- Evidence: Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.
+- Listing angle: Lead with the proof-backed setup guide first, then convert proven local usage into Pro.
+- Primary CTA: Proof-backed setup guide: https://thumbgate-production.up.railway.app/guide
+- Secondary CTA: Pro at $19/mo or $149/yr: https://thumbgate-production.up.railway.app/checkout/pro
+- Sample targets: Abhi268170/Stagix, zaxbysauce/opencode-swarm, iliaal/compound-engineering-plugin
+
 ## Proof Policy
 - Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms pain.
 

--- a/docs/marketing/gtm-revenue-loop.json
+++ b/docs/marketing/gtm-revenue-loop.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-29T21:20:24.731Z",
+  "generatedAt": "2026-04-29T22:23:06.232Z",
   "source": "hosted-via-railway-env",
   "fallbackReason": null,
   "verification": {
@@ -47,10 +47,10 @@
   "snapshot": {
     "paidOrders": 2,
     "bookedRevenueCents": 2000,
-    "checkoutStarts": 5,
-    "ctaClicks": 20,
-    "visitors": 774,
-    "uniqueLeads": 5,
+    "checkoutStarts": 6,
+    "ctaClicks": 22,
+    "visitors": 835,
+    "uniqueLeads": 6,
     "sprintLeads": 0,
     "qualifiedSprintLeads": 0,
     "latestPaidAt": "2025-11-18T12:36:00.000Z"
@@ -836,7 +836,7 @@
   ],
   "snapshotWindow": "today",
   "marketplaceCopy": {
-    "generatedAt": "2026-04-29T21:20:24.731Z",
+    "generatedAt": "2026-04-29T22:23:06.232Z",
     "state": "post-first-dollar",
     "headline": "Harden one AI-agent workflow before you roll it out.",
     "shortDescription": "Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.",
@@ -913,6 +913,104 @@
         "listingAngle": "Lead with the proof-backed setup guide first, then convert proven local usage into Pro.",
         "count": 3,
         "examples": [
+          "Abhi268170/Stagix",
+          "zaxbysauce/opencode-swarm",
+          "iliaal/compound-engineering-plugin"
+        ]
+      }
+    ],
+    "listingVariants": [
+      {
+        "key": "workflow_control",
+        "label": "Workflow control surfaces",
+        "audience": "Operators with visible workflow-control surfaces and repeated handoff failures.",
+        "headline": "Harden one workflow control surface before the next agent rollout.",
+        "shortDescription": "Lead with one repeated approval, review, or handoff failure and show how ThumbGate turns it into an enforceable pre-action gate.",
+        "evidenceSummary": "The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive.",
+        "listingAngle": "Lead with one repeated workflow failure, then show how ThumbGate turns it into an enforceable pre-action gate.",
+        "primaryCta": {
+          "motion": "sprint",
+          "label": "Workflow Hardening Sprint",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+        },
+        "secondaryCta": {
+          "motion": "guide",
+          "label": "Proof-backed setup guide",
+          "cta": "https://thumbgate-production.up.railway.app/guide"
+        },
+        "sampleTargets": [
+          "dolutech/engine_context",
+          "Adqui9608/ai-code-review-agent",
+          "Abhi268170/Stagix"
+        ]
+      },
+      {
+        "key": "warm_discovery",
+        "label": "Warm discovery workflows",
+        "audience": "Warm buyers who already named a repeated workflow failure.",
+        "headline": "Turn one repeated AI-agent workflow failure into a proof-backed sprint.",
+        "shortDescription": "Lead with one concrete workflow failure, then offer a founder-led hardening diagnostic before any generic tool pitch.",
+        "evidenceSummary": "Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain.",
+        "listingAngle": "Lead with one repeated workflow failure and a founder-led diagnostic before any generic tool pitch.",
+        "primaryCta": {
+          "motion": "sprint",
+          "label": "Workflow Hardening Sprint",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+        },
+        "secondaryCta": {
+          "motion": "guide",
+          "label": "Proof-backed setup guide",
+          "cta": "https://thumbgate-production.up.railway.app/guide"
+        },
+        "sampleTargets": [
+          "@Deep_Ad1959",
+          "@game-of-kton",
+          "@leogodin217"
+        ]
+      },
+      {
+        "key": "business_system_workflows",
+        "label": "Business-system workflow approvals",
+        "audience": "Teams wiring agents into approval-heavy business systems.",
+        "headline": "Add approval boundaries and rollback safety to one agent workflow.",
+        "shortDescription": "Lead with one workflow in Jira, GitHub, ServiceNow, Slack, or CRM systems that needs proof before wider rollout.",
+        "evidenceSummary": "Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof.",
+        "listingAngle": "Lead with approval boundaries, rollback safety, and proof for one workflow.",
+        "primaryCta": {
+          "motion": "sprint",
+          "label": "Workflow Hardening Sprint",
+          "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+        },
+        "secondaryCta": {
+          "motion": "guide",
+          "label": "Proof-backed setup guide",
+          "cta": "https://thumbgate-production.up.railway.app/guide"
+        },
+        "sampleTargets": [
+          "dolutech/engine_context",
+          "Adqui9608/ai-code-review-agent",
+          "Abhi268170/Stagix"
+        ]
+      },
+      {
+        "key": "self_serve_tooling",
+        "label": "Self-serve agent tooling",
+        "audience": "Plugin, hook, and local-rule buyers who want the fastest self-serve proof path first.",
+        "headline": "Block repeated agent mistakes before the next install or config rollout.",
+        "shortDescription": "Lead with the proof-backed setup guide first, then route install-intent buyers to Pro after one blocked repeat or explicit self-serve intent.",
+        "evidenceSummary": "Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.",
+        "listingAngle": "Lead with the proof-backed setup guide first, then convert proven local usage into Pro.",
+        "primaryCta": {
+          "motion": "guide",
+          "label": "Proof-backed setup guide",
+          "cta": "https://thumbgate-production.up.railway.app/guide"
+        },
+        "secondaryCta": {
+          "motion": "pro",
+          "label": "Pro at $19/mo or $149/yr",
+          "cta": "https://thumbgate-production.up.railway.app/checkout/pro"
+        },
+        "sampleTargets": [
           "Abhi268170/Stagix",
           "zaxbysauce/opencode-swarm",
           "iliaal/compound-engineering-plugin"

--- a/docs/marketing/gtm-revenue-loop.md
+++ b/docs/marketing/gtm-revenue-loop.md
@@ -1,7 +1,7 @@
 # GSD Revenue Loop
 
 Status: post-first-dollar
-Updated: 2026-04-29T21:20:24.731Z
+Updated: 2026-04-29T22:23:06.232Z
 
 This report is an operator artifact for landing the first 10 paying customers. It is not proof of sent messages or booked revenue by itself.
 Outbound rule: do not treat posts as sales. A lead only moves when it is tracked as contacted, replied, call booked, checkout/sprint, or paid.
@@ -25,8 +25,8 @@ Outbound rule: do not treat posts as sales. A lead only moves when it is tracked
 - Revenue window: today
 - Paid orders: 2
 - Booked revenue: $20.00
-- Checkout starts: 5
-- Unique leads: 5
+- Checkout starts: 6
+- Unique leads: 6
 - Workflow sprint leads: 0
 - Qualified sprint leads: 0
 - Billing source: hosted-via-railway-env

--- a/docs/marketing/operator-priority-handoff.json
+++ b/docs/marketing/operator-priority-handoff.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-04-29T21:20:24.731Z",
+  "generatedAt": "2026-04-29T22:23:06.232Z",
   "summary": {
     "revenueState": "post-first-dollar",
     "headline": "Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.",
     "billingVerification": "Live hosted billing summary verified for this run.",
     "paidOrders": 2,
-    "checkoutStarts": 5,
+    "checkoutStarts": 6,
     "activeFollowUps": 0,
     "warmTargetsReadyNow": 4,
     "selfServeTargetsReadyNow": 2,

--- a/docs/marketing/operator-priority-handoff.md
+++ b/docs/marketing/operator-priority-handoff.md
@@ -1,6 +1,6 @@
 # Revenue Operator Priority Handoff
 
-Updated: 2026-04-29T21:20:24.731Z
+Updated: 2026-04-29T22:23:06.232Z
 
 This is the ranked send order for the current zero-to-one revenue loop. Work follow-ups first, then warm discovery, then self-serve closes, then expand into cold GitHub targets with the same proof discipline.
 
@@ -11,7 +11,7 @@ This handoff sits on top of `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `
 - Headline: Verified booked revenue exists. Keep selling one concrete Workflow Hardening Sprint first, then route self-serve buyers to Pro.
 - Billing verification: Live hosted billing summary verified for this run.
 - Paid orders: 2
-- Checkout starts: 5
+- Checkout starts: 6
 - Active follow-ups: 0
 - Warm targets ready now: 4
 - Self-serve closes ready now: 2

--- a/docs/marketing/team-outreach-messages.md
+++ b/docs/marketing/team-outreach-messages.md
@@ -1,6 +1,6 @@
 # Workflow Hardening Sprint Outreach Messages
 
-Updated: 2026-04-29T21:20:24.731Z
+Updated: 2026-04-29T22:23:06.232Z
 
 These drafts are generated from the same evidence-backed revenue-loop report as `gtm-revenue-loop.md`, `gtm-target-queue.csv`, and `gtm-marketplace-copy.md`.
 Use `operator-priority-handoff.md` for the ranked send order; this file is the copy layer for warm outreach only.

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -105,6 +105,43 @@ const MARKETPLACE_SIGNAL_THEMES = [
     match: (target) => hasEvidenceLabel(target, 'self-serve agent tooling'),
   },
 ];
+const MARKETPLACE_VARIANT_TEMPLATES = {
+  warm_discovery: {
+    audience: 'Warm buyers who already named a repeated workflow failure.',
+    headline: 'Turn one repeated AI-agent workflow failure into a proof-backed sprint.',
+    shortDescription: 'Lead with one concrete workflow failure, then offer a founder-led hardening diagnostic before any generic tool pitch.',
+    primaryMotion: 'sprint',
+    secondaryMotion: 'guide',
+  },
+  business_system_workflows: {
+    audience: 'Teams wiring agents into approval-heavy business systems.',
+    headline: 'Add approval boundaries and rollback safety to one agent workflow.',
+    shortDescription: 'Lead with one workflow in Jira, GitHub, ServiceNow, Slack, or CRM systems that needs proof before wider rollout.',
+    primaryMotion: 'sprint',
+    secondaryMotion: 'guide',
+  },
+  production_rollout: {
+    audience: 'Platform teams protecting production, release, incident, or compliance workflows.',
+    headline: 'Prove one production agent workflow is safe before the next rollout.',
+    shortDescription: 'Lead with one production workflow where repeated mistakes, rollback risk, or audit pressure already make the pain expensive.',
+    primaryMotion: 'sprint',
+    secondaryMotion: 'guide',
+  },
+  workflow_control: {
+    audience: 'Operators with visible workflow-control surfaces and repeated handoff failures.',
+    headline: 'Harden one workflow control surface before the next agent rollout.',
+    shortDescription: 'Lead with one repeated approval, review, or handoff failure and show how ThumbGate turns it into an enforceable pre-action gate.',
+    primaryMotion: 'sprint',
+    secondaryMotion: 'guide',
+  },
+  self_serve_tooling: {
+    audience: 'Plugin, hook, and local-rule buyers who want the fastest self-serve proof path first.',
+    headline: 'Block repeated agent mistakes before the next install or config rollout.',
+    shortDescription: 'Lead with the proof-backed setup guide first, then route install-intent buyers to Pro after one blocked repeat or explicit self-serve intent.',
+    primaryMotion: 'guide',
+    secondaryMotion: 'pro',
+  },
+};
 const CLAIM_GUARDRAILS = [
   'Do not claim revenue, installs, or marketplace approval without direct command evidence.',
   'Do not lead with proof links before the buyer confirms pain.',
@@ -1474,6 +1511,9 @@ function resolveMotionLabel(report, motionKey) {
 
 function resolveMotionCta(report, motionKey) {
   const links = buildRevenueLinks();
+  if (motionKey === 'guide') {
+    return normalizeText(report.currentTruth?.guideLink) || links.guideLink;
+  }
   if (motionKey === 'pro') {
     return normalizeText(report.currentTruth?.publicSelfServeCta) || links.proCheckoutLink;
   }
@@ -1487,6 +1527,42 @@ function resolveMotionCta(report, motionKey) {
     return matchingTarget.cta;
   }
   return '';
+}
+
+function resolveMarketplaceVariantLabel(report, motionKey) {
+  if (motionKey === 'guide') {
+    return 'Proof-backed setup guide';
+  }
+  return resolveMotionLabel(report, motionKey);
+}
+
+function buildMarketplaceListingVariants(report, signalThemes = []) {
+  return signalThemes.map((theme) => {
+    const template = MARKETPLACE_VARIANT_TEMPLATES[theme.key] || {};
+    const primaryMotion = normalizeText(template.primaryMotion) || 'sprint';
+    const secondaryMotion = normalizeText(template.secondaryMotion) || 'guide';
+
+    return {
+      key: theme.key,
+      label: theme.label,
+      audience: template.audience || 'Buyers already showing evidence for this workflow theme.',
+      headline: template.headline || 'Harden one AI-agent workflow before you roll it out.',
+      shortDescription: template.shortDescription || theme.summary,
+      evidenceSummary: theme.summary,
+      listingAngle: theme.listingAngle,
+      primaryCta: {
+        motion: primaryMotion,
+        label: resolveMarketplaceVariantLabel(report, primaryMotion),
+        cta: resolveMotionCta(report, primaryMotion),
+      },
+      secondaryCta: {
+        motion: secondaryMotion,
+        label: resolveMarketplaceVariantLabel(report, secondaryMotion),
+        cta: resolveMotionCta(report, secondaryMotion),
+      },
+      sampleTargets: Array.isArray(theme.examples) ? theme.examples : [],
+    };
+  });
 }
 
 function buildMarketplaceCopy(report) {
@@ -1568,6 +1644,7 @@ function buildMarketplaceCopy(report) {
       motion: target.motionLabel || resolveMotionLabel(report, target.motion),
       why: target.motionReason || target.outreachAngle || '',
     }));
+  const listingVariants = buildMarketplaceListingVariants(report, signalThemes);
 
   return {
     generatedAt: report.generatedAt,
@@ -1604,6 +1681,7 @@ function buildMarketplaceCopy(report) {
       'Keep approval boundaries, rollback safety, and proof attached to the workflow before rollout.',
     ]),
     topSignals: signalThemes,
+    listingVariants,
     sampleTargets,
     evidenceBackstop: buildEvidenceBackstop(report.currentTruth || {}),
     proofLinks: [
@@ -2033,6 +2111,20 @@ function renderMarketplaceCopyMarkdown(pack) {
   const signalLines = pack.topSignals.length
     ? pack.topSignals.map((signal) => `- ${signal.label} (${signal.count}): ${signal.summary}${signal.examples.length ? ` Examples: ${signal.examples.join(', ')}` : ''}`)
     : ['- No target evidence was available for this run.'];
+  const variantLines = Array.isArray(pack.listingVariants) && pack.listingVariants.length
+    ? pack.listingVariants.flatMap((variant) => [
+      `### ${variant.label}`,
+      `- Audience: ${variant.audience}`,
+      `- Headline: ${variant.headline}`,
+      `- Short description: ${variant.shortDescription}`,
+      `- Evidence: ${variant.evidenceSummary}`,
+      `- Listing angle: ${variant.listingAngle}`,
+      `- Primary CTA: ${variant.primaryCta?.label || 'cta unavailable in this run'}${variant.primaryCta?.cta ? `: ${variant.primaryCta.cta}` : ''}`,
+      `- Secondary CTA: ${variant.secondaryCta?.label || 'cta unavailable in this run'}${variant.secondaryCta?.cta ? `: ${variant.secondaryCta.cta}` : ''}`,
+      `- Sample targets: ${(variant.sampleTargets || []).join(', ') || 'n/a'}`,
+      '',
+    ])
+    : ['- No listing variants available in this run.'];
   const ctaLines = pack.recommendedCtas
     .filter((entry) => entry.label || entry.cta)
     .map((entry) => `- ${entry.label}: ${entry.cta || 'cta unavailable in this run'}`);
@@ -2070,6 +2162,8 @@ function renderMarketplaceCopyMarkdown(pack) {
     '## Evidence-Backed Buyer Signals',
     ...signalLines,
     '',
+    '## Listing Variants',
+    ...variantLines,
     '## Proof Policy',
     `- ${pack.proofPolicy}`,
     '',

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -1910,8 +1910,16 @@ test('marketplace copy pack stays tied to current revenue-loop evidence', () => 
   assert.ok(pack.topSignals.some((signal) => /Warm discovery workflows/.test(signal.label)));
   assert.ok(pack.topSignals.some((signal) => /Business-system workflow approvals/.test(signal.label)));
   assert.ok(pack.topSignals.some((signal) => /Self-serve agent tooling/.test(signal.label)));
+  assert.ok(Array.isArray(pack.listingVariants));
+  assert.ok(pack.listingVariants.some((variant) => /Warm discovery workflows/.test(variant.label)));
+  assert.ok(pack.listingVariants.some((variant) => variant.primaryCta.label === 'Proof-backed setup guide'));
+  assert.ok(pack.listingVariants.some((variant) => variant.secondaryCta.label === catalog.pro.label));
   assert.ok(pack.sampleTargets.some((target) => target.account === 'buildertools/codex-hook-pack'));
   assert.ok(pack.listingBullets.some((bullet) => /Use Pro after one blocked repeat/i.test(bullet)));
+  assert.match(markdown, /Listing Variants/);
+  assert.match(markdown, /Audience: Warm buyers who already named a repeated workflow failure\./);
+  assert.match(markdown, /Headline: Turn one repeated AI-agent workflow failure into a proof-backed sprint\./);
+  assert.match(markdown, /Primary CTA: Proof-backed setup guide: https:\/\/thumbgate-production\.up\.railway\.app\/guide/);
   assert.match(markdown, /Proof Policy/);
   assert.match(markdown, /Evidence Backstop/);
   assert.match(markdown, /Use Pro after one blocked repeat or explicit self-serve install intent/i);
@@ -2130,6 +2138,8 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.match(marketplaceCopy.recommendedCtas[1].cta, /#workflow-sprint-intake$/);
     assert.match(marketplaceCopy.recommendedCtas[2].cta, /\/checkout\/pro$/);
     assert.ok(Array.isArray(marketplaceCopy.topSignals));
+    assert.ok(Array.isArray(marketplaceCopy.listingVariants));
+    assert.ok(marketplaceCopy.listingVariants.some((variant) => /Warm discovery workflows|Workflow control surfaces/.test(variant.label)));
     assert.equal(JSON.parse(jsonl.trim()).repoName, 'production-mcp-server');
     assert.match(jsonl, /"pipelineLeadId":"reddit_builder_production_mcp_server"/);
     assert.match(jsonl, /"salesCommands":\{"markContacted":"npm run sales:pipeline -- advance --lead 'reddit_builder_production_mcp_server'/);


### PR DESCRIPTION
## Summary
- add evidence-backed marketplace listing variants to the GTM revenue loop output
- regenerate marketplace copy, target queue, and operator handoff docs from the updated asset contract
- cover the new variant layer in revenue-loop tests and add a release changeset

## Verification
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check