### PR TITLE
feat(gtm): clarify landing-page buying paths

### DIFF
--- a/.changeset/landing-path-clarity.md
+++ b/.changeset/landing-path-clarity.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Clarify the public landing-page buying paths so Sprint, Solo Pro, and free OSS routing match the repo's current commercial truth.

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -96,6 +96,14 @@
       },
       {
         "@type": "Question",
+        "name": "When should I choose the Workflow Hardening Sprint instead of Solo Pro?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Choose the Workflow Hardening Sprint when one workflow already matters, one owner can carry rollout, and a repeated blocker needs proof before a wider team launch. Choose Solo Pro only after a real blocked repeat when one operator wants the personal dashboard, export-ready evidence, and more capture depth without the team rollout motion."
+        }
+      },
+      {
+        "@type": "Question",
         "name": "Can I install ThumbGate as a Claude Desktop extension?",
         "acceptedAnswer": {
           "@type": "Answer",
@@ -726,6 +734,49 @@
           </div>
         </div>
         <p class='note'>Qualification aid only. It does not claim measured savings, buyer validation, or conversion evidence.</p>
+      </div>
+    </section>
+
+    <section id='buying-paths'>
+      <div class='section-inner'>
+        <div class='section-head'>
+          <span class='eyebrow'>Next step</span>
+          <h2>Choose the buying path that matches the workflow you already have.</h2>
+          <p>ThumbGate does not ask buyers to guess. The path depends on whether there is a repeated blocker, one workflow owner, and a need for proof before wider rollout.</p>
+        </div>
+        <div class='grid-3'>
+          <div class='card'>
+            <h3>Workflow Hardening Sprint</h3>
+            <p>Use this path when one workflow already matters, one owner can carry it, and one repeated blocker needs proof before the team rolls it out wider.</p>
+            <ul>
+              <li>Best for approvals, rollback risk, review churn, or fragile handoffs.</li>
+              <li>Start with one workflow, one owner, and one proof review.</li>
+              <li>Use commercial truth and verification evidence after the buyer confirms pain.</li>
+            </ul>
+            <p><a href='https://thumbgate-production.up.railway.app/#workflow-sprint-intake' target='_blank' rel='noreferrer'>Start Workflow Hardening Sprint intake</a></p>
+          </div>
+          <div class='card'>
+            <h3>Solo Pro</h3>
+            <p>Use this path only after one operator hits a real blocked repeat and wants the personal dashboard, export-ready evidence, and deeper capture without the team rollout motion.</p>
+            <ul>
+              <li>Best for one operator evaluating the self-serve lane first.</li>
+              <li>Install the guide, validate the local path, then move to checkout.</li>
+              <li>Keep Sprint as the escalation path when the blocker is bigger than one seat.</li>
+            </ul>
+            <p><a href='https://thumbgate-production.up.railway.app/checkout/pro?utm_source=landing_page&utm_medium=path_card&utm_campaign=pro_pack&utm_content=solo_pro_path' target='_blank' rel='noreferrer'>See Solo Pro checkout</a></p>
+          </div>
+          <div class='card'>
+            <h3>Free OSS</h3>
+            <p>Use this path when the workflow is still exploratory, educational, or too early for a paid motion. Install the local CLI, capture one lesson, and prove the workflow deserves more.</p>
+            <ul>
+              <li>Best for first install, early experiments, and solo evaluation.</li>
+              <li>Use the hosted fit checker once a real blocker appears.</li>
+              <li>Move to Solo Pro or Sprint only when the workflow earns it.</li>
+            </ul>
+            <p><a href='https://thumbgate-production.up.railway.app/guide' target='_blank' rel='noreferrer'>Install the free CLI</a></p>
+          </div>
+        </div>
+        <p class='note'>Routing language is aligned with COMMERCIAL_TRUTH.md, FIRST_DOLLAR_PLAYBOOK.md, and the hosted fit checker. It is offer guidance, not proof of buyer conversion.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add a landing-page buying-path section that routes buyers into Sprint, Solo Pro, or free OSS using current commercial-truth rules
- add FAQPage JSON-LD for choosing Workflow Hardening Sprint versus Solo Pro so search and page copy stay aligned
- attach the required changeset for this public-surface update

## Verification
- node --test tests/pro-landing.test.js
- npm ci
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check