### PR TITLE
feat(gtm): add machine-readable buyer paths

### DIFF
--- a/.changeset/machine-readable-buyer-paths.md
+++ b/.changeset/machine-readable-buyer-paths.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add machine-readable landing-page buyer paths for the install guide, Pro checkout, and Workflow Hardening Sprint so search parsers and operators can route buyers to the right conversion path.

--- a/docs/CUSTOMER_DISCOVERY_SPRINT.md
+++ b/docs/CUSTOMER_DISCOVERY_SPRINT.md
@@ -60,6 +60,8 @@ The revenue loop emits these operator artifacts in that folder:
 - `team-outreach-messages.md` for the warm-outbound copy layer tied to the same ranked queue
 - `operator-priority-handoff.md` for the ranked send order across warm discovery and cold GitHub targets
 - `operator-priority-handoff.json` for the same ranked send order, CTA, proof rule, and sales commands in machine-readable form
+- `operator-send-now.csv` for one flat batch-send sheet with the ready-now rows, drafts, and log commands
+- `operator-send-now.json` for the same ready-now batch-send payload in machine-readable form
 - `claude-workflow-hardening-pack.md` for Claude-first positioning, buyer lanes, and evidence-backed outbound copy
 - `claude-workflow-hardening-pack.json` for the same Claude-first outbound pack in machine-readable form
 - `cursor-marketplace-revenue-pack.md` for Cursor Marketplace, Cursor Directory, and Team Marketplace submission copy

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -44,6 +44,51 @@ curl -H "Authorization: Bearer YOUR_KEY" \
 
 # Verification log
 
+## April 30, 2026: machine-readable buyer-path schema for acquisition and conversion surfaces
+
+Scope:
+
+- Added explicit machine-readable buyer actions to the public landing page and the generated docs landing page so AI parsers and buyers can distinguish the install path, Pro checkout path, and Workflow Hardening Sprint intake path.
+- Added a dedicated `Service` JSON-LD entity for the Workflow Hardening Sprint offer.
+- Tightened regression coverage around landing-page structured data and customer-discovery artifact documentation.
+- Kept operator-only runtime state out of tracked outputs.
+
+Commands run in the dedicated clean verification worktree at `/Users/ganapolsky_i/.codex/worktrees/verify-revenue-loop-offer-schema-20260429/ThumbGate`:
+
+```bash
+npm ci
+npm test
+npm run test:coverage
+THUMBGATE_PROOF_DIR="$(mktemp -d)/proof" npm run prove:adapters
+THUMBGATE_AUTOMATION_PROOF_DIR="$(mktemp -d)/proof-automation" npm run prove:automation
+npm run self-heal:check
+git diff --check
+```
+
+Observed result:
+
+- `npm ci` exited `0`.
+- `npm test` exited `0`.
+- `npm run test:coverage` exited `0` with all-files coverage at:
+  - `87.16` lines
+  - `72.57` branches
+  - `88.76` functions
+- `THUMBGATE_PROOF_DIR=... npm run prove:adapters` exited `0`: `48` passed, `0` failed.
+- `THUMBGATE_AUTOMATION_PROOF_DIR=... npm run prove:automation` exited `0`: `55` passed, `0` failed.
+- `npm run self-heal:check` exited `0`: `Overall: HEALTHY` with `6/6 healthy` checks.
+- `git diff --check` exited `0`.
+- Targeted regression probes for the changed surfaces also passed before the clean-lane run:
+  - `node --test tests/public-landing.test.js`
+  - `node --test tests/api-server.test.js`
+  - `node --test tests/customer-discovery-sprint.test.js`
+- No tracked `.thumbgate/*` or `.claude/*` runtime artifacts were added or modified by this change.
+
+Requirements verified:
+
+- Public and generated landing surfaces now advertise the three buyer paths in machine-readable form.
+- The Workflow Hardening Sprint offer is represented as a distinct service entity for search/indexing and buyer parsing.
+- Regression coverage now protects both the schema additions and the operator handoff artifact documentation that supports outreach execution.
+
 ## April 9, 2026: technical debt audit follow-through for stale-claim cleanup, docs hygiene regression coverage, and protected-system revalidation
 
 Scope:

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -38,7 +38,80 @@
       "Auto-prevention rules from failures",
       "KTO/DPO export for fine-tuning",
       "Local-first, offline capable"
+    ],
+    "potentialAction": [
+      {
+        "@type": "InstallAction",
+        "name": "Install ThumbGate Free",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "__APP_ORIGIN__/guide",
+          "actionPlatform": [
+            "https://schema.org/DesktopWebPlatform"
+          ]
+        }
+      },
+      {
+        "@type": "BuyAction",
+        "name": "Start ThumbGate Pro",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "__APP_ORIGIN__/checkout/pro",
+          "actionPlatform": [
+            "https://schema.org/DesktopWebPlatform"
+          ]
+        },
+        "expectsAcceptanceOf": {
+          "@type": "Offer",
+          "name": "ThumbGate Pro",
+          "price": "19",
+          "priceCurrency": "USD",
+          "url": "__APP_ORIGIN__/checkout/pro"
+        }
+      },
+      {
+        "@type": "CommunicateAction",
+        "name": "Start Workflow Hardening Sprint intake",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "__APP_ORIGIN__/#workflow-sprint-intake",
+          "actionPlatform": [
+            "https://schema.org/DesktopWebPlatform"
+          ]
+        }
+      }
     ]
+  }
+  </script>
+  <script type='application/ld+json'>
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "name": "ThumbGate Workflow Hardening Sprint",
+    "serviceType": "AI-agent workflow hardening sprint",
+    "provider": {
+      "@type": "Organization",
+      "name": "ThumbGate",
+      "url": "__APP_ORIGIN__"
+    },
+    "url": "__APP_ORIGIN__/#workflow-sprint-intake",
+    "description": "Founder-led workflow hardening for one AI-agent workflow that needs approval boundaries, rollback safety, and rollout proof before wider team rollout.",
+    "offers": {
+      "@type": "Offer",
+      "name": "Workflow Hardening Sprint intake",
+      "url": "__APP_ORIGIN__/#workflow-sprint-intake"
+    },
+    "potentialAction": {
+      "@type": "CommunicateAction",
+      "name": "Book a workflow hardening intake",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "__APP_ORIGIN__/#workflow-sprint-intake",
+        "actionPlatform": [
+          "https://schema.org/DesktopWebPlatform"
+        ]
+      }
+    }
   }
   </script>
   <script type='application/ld+json'>

--- a/public/index.html
+++ b/public/index.html
@@ -123,7 +123,81 @@ __GA_BOOTSTRAP__
       "description": "Annual Pro for individual operators who want personal enforcement proof, the local dashboard, and proof-ready exports",
       "url": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&billing_cycle=annual&landing_path=%2F"
     }
+  ],
+  "potentialAction": [
+    {
+      "@type": "InstallAction",
+      "name": "Install ThumbGate Free",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://thumbgate-production.up.railway.app/guide",
+        "actionPlatform": [
+          "https://schema.org/DesktopWebPlatform"
+        ]
+      }
+    },
+    {
+      "@type": "BuyAction",
+      "name": "Start ThumbGate Pro",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&landing_path=%2F",
+        "actionPlatform": [
+          "https://schema.org/DesktopWebPlatform"
+        ]
+      },
+      "expectsAcceptanceOf": {
+        "@type": "Offer",
+        "name": "Pro Monthly",
+        "price": "19",
+        "priceCurrency": "USD",
+        "url": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&landing_path=%2F"
+      }
+    },
+    {
+      "@type": "CommunicateAction",
+      "name": "Start Workflow Hardening Sprint intake",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+        "actionPlatform": [
+          "https://schema.org/DesktopWebPlatform"
+        ]
+      }
+    }
   ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "name": "ThumbGate Workflow Hardening Sprint",
+  "serviceType": "AI-agent workflow hardening sprint",
+  "provider": {
+    "@type": "Organization",
+    "name": "ThumbGate",
+    "url": "https://thumbgate-production.up.railway.app"
+  },
+  "url": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+  "description": "Founder-led workflow hardening for one AI-agent workflow that needs approval boundaries, rollback safety, and rollout proof before wider team rollout.",
+  "offers": {
+    "@type": "Offer",
+    "name": "Workflow Hardening Sprint intake",
+    "url": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+  },
+  "potentialAction": {
+    "@type": "CommunicateAction",
+    "name": "Book a workflow hardening intake",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+      "actionPlatform": [
+        "https://schema.org/DesktopWebPlatform"
+      ]
+    }
+  }
 }
 </script>
 

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -482,6 +482,10 @@ test('root serves the landing page by default', async () => {
   assert.match(body, /Thompson Sampling/i);
   assert.match(body, /FAQPage/);
   assert.match(body, /SoftwareApplication/);
+  assert.match(body, /InstallAction/);
+  assert.match(body, /BuyAction/);
+  assert.match(body, /CommunicateAction/);
+  assert.match(body, /ThumbGate Workflow Hardening Sprint/);
   assert.match(body, /\$19/);
   assert.match(body, /\$149/);
   assert.match(body, /plausible\.io\/js\/script\.js/);

--- a/tests/customer-discovery-sprint.test.js
+++ b/tests/customer-discovery-sprint.test.js
@@ -18,6 +18,8 @@ const EXPECTED_ARTIFACTS = [
   'team-outreach-messages.md',
   'operator-priority-handoff.md',
   'operator-priority-handoff.json',
+  'operator-send-now.csv',
+  'operator-send-now.json',
   'claude-workflow-hardening-pack.md',
   'claude-workflow-hardening-pack.json',
   'cursor-marketplace-revenue-pack.md',

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -23,7 +23,11 @@ test('public landing page keeps FAQPage JSON-LD parity for SEO and GEO', () => {
   const landingPage = readLandingPage();
 
   assert.match(landingPage, /"@type": "SoftwareApplication"/);
+  assert.match(landingPage, /"@type": "Service"/);
   assert.match(landingPage, /"@type": "FAQPage"/);
+  assert.match(landingPage, /"@type": "InstallAction"/);
+  assert.match(landingPage, /"@type": "BuyAction"/);
+  assert.match(landingPage, /"@type": "CommunicateAction"/);
   assert.match(landingPage, /How is ThumbGate different from model-training feedback loops\?/);
   assert.match(landingPage, /What is the ThumbGate tech stack\?/);
   assert.match(landingPage, /What AI agents does ThumbGate work with\?/);


### PR DESCRIPTION
## Summary
- add explicit machine-readable buyer actions for install, Pro checkout, and Workflow Hardening Sprint intake on the public landing surfaces
- expose the Workflow Hardening Sprint as a distinct structured `Service` entity for search/indexing parsers
- document the operator send-now artifacts and extend regression coverage for landing schema + discovery asset docs

## Verification
- node --test tests/public-landing.test.js
- node --test tests/api-server.test.js
- node --test tests/customer-discovery-sprint.test.js
- npm ci
- npm test
- npm run test:coverage
- THUMBGATE_PROOF_DIR="$(mktemp -d)/proof" npm run prove:adapters
- THUMBGATE_AUTOMATION_PROOF_DIR="$(mktemp -d)/proof-automation" npm run prove:automation
- npm run self-heal:check
- git diff --check