### PR TITLE
feat(gtm): track MCP directory follow-on CTAs

### DIFF
--- a/.changeset/mcp-directory-tracked-ctas.md
+++ b/.changeset/mcp-directory-tracked-ctas.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Track MCP directory follow-on offers with machine-readable UTM attribution and add a dedicated ThumbGate Pro CTA so self-serve paid intent is measurable alongside the guide and workflow sprint motions.

--- a/docs/marketing/mcp-directory-revenue-pack.json
+++ b/docs/marketing/mcp-directory-revenue-pack.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-30T04:26:21.983Z",
+  "generatedAt": "2026-04-30T06:27:55.921Z",
   "objective": "Repair MCP directory drift so ThumbGate discovery points to one canonical identity and one proof-backed install path.",
   "state": "directory-repair",
   "headline": "Fix legacy-name MCP directory drift before scaling discovery.",
@@ -91,13 +91,19 @@
       "label": "Proof-backed setup guide",
       "pricing": "Discovery CTA",
       "buyer": "Directory visitors who want a current install and proof surface before anything sales-led.",
-      "cta": "https://thumbgate-production.up.railway.app/guide"
+      "cta": "https://thumbgate-production.up.railway.app/guide?utm_source=mcp_directories&utm_medium=directory&utm_campaign=mcp_directory_guide&utm_content=guide&campaign_variant=directory_repair&offer_code=MCP-DIRECTORY_GUIDE&cta_id=mcp_directory_guide&cta_placement=follow_on_offer&surface=mcp_directory_guide"
+    },
+    {
+      "label": "ThumbGate Pro",
+      "pricing": "$19/mo or $149/yr",
+      "buyer": "Directory visitors who already want the self-serve path and need a tracked paid-intent lane after the guide.",
+      "cta": "https://thumbgate-production.up.railway.app/checkout/pro?utm_source=mcp_directories&utm_medium=directory&utm_campaign=mcp_directory_pro&utm_content=pro&campaign_variant=self_serve_paid_intent&offer_code=MCP-DIRECTORY_PRO&cta_id=mcp_directory_pro&cta_placement=follow_on_offer&plan_id=pro&surface=mcp_directory_pro"
     },
     {
       "label": "Workflow Hardening Sprint",
       "pricing": "Primary revenue motion",
       "buyer": "Teams that already named one repeated workflow failure and want rollout proof, not just a directory listing.",
-      "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+      "cta": "https://thumbgate-production.up.railway.app/?utm_source=mcp_directories&utm_medium=directory&utm_campaign=mcp_directory_sprint&utm_content=workflow_sprint&campaign_variant=repair_to_team_motion&offer_code=MCP-DIRECTORY_SPRINT&cta_id=mcp_directory_sprint&cta_placement=follow_on_offer&surface=mcp_directory_sprint#workflow-sprint-intake"
     }
   ],
   "operatorQueue": [

--- a/docs/marketing/mcp-directory-revenue-pack.md
+++ b/docs/marketing/mcp-directory-revenue-pack.md
@@ -1,6 +1,6 @@
 # MCP Directory Repair Pack
 
-Updated: 2026-04-30T04:26:21.983Z
+Updated: 2026-04-30T06:27:55.921Z
 
 This is a sales operator artifact. It is not proof of directory approval, ranking, installs, or revenue by itself.
 
@@ -86,10 +86,13 @@ Repair MCP directory drift so ThumbGate discovery points to one canonical identi
 ## Follow-On Offers
 - Proof-backed setup guide: Discovery CTA
   Buyer: Directory visitors who want a current install and proof surface before anything sales-led.
-  CTA: https://thumbgate-production.up.railway.app/guide
+  CTA: https://thumbgate-production.up.railway.app/guide?utm_source=mcp_directories&utm_medium=directory&utm_campaign=mcp_directory_guide&utm_content=guide&campaign_variant=directory_repair&offer_code=MCP-DIRECTORY_GUIDE&cta_id=mcp_directory_guide&cta_placement=follow_on_offer&surface=mcp_directory_guide
+- ThumbGate Pro: $19/mo or $149/yr
+  Buyer: Directory visitors who already want the self-serve path and need a tracked paid-intent lane after the guide.
+  CTA: https://thumbgate-production.up.railway.app/checkout/pro?utm_source=mcp_directories&utm_medium=directory&utm_campaign=mcp_directory_pro&utm_content=pro&campaign_variant=self_serve_paid_intent&offer_code=MCP-DIRECTORY_PRO&cta_id=mcp_directory_pro&cta_placement=follow_on_offer&plan_id=pro&surface=mcp_directory_pro
 - Workflow Hardening Sprint: Primary revenue motion
   Buyer: Teams that already named one repeated workflow failure and want rollout proof, not just a directory listing.
-  CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+  CTA: https://thumbgate-production.up.railway.app/?utm_source=mcp_directories&utm_medium=directory&utm_campaign=mcp_directory_sprint&utm_content=workflow_sprint&campaign_variant=repair_to_team_motion&offer_code=MCP-DIRECTORY_SPRINT&cta_id=mcp_directory_sprint&cta_placement=follow_on_offer&surface=mcp_directory_sprint#workflow-sprint-intake
 
 ## Operator Queue
 ### Glama listing owner or claimant

--- a/scripts/mcp-directory-revenue-pack.js
+++ b/scripts/mcp-directory-revenue-pack.js
@@ -8,6 +8,7 @@ const {
   buildRevenueLinks,
 } = require('./gtm-revenue-loop');
 const {
+  buildTrackedPackLink,
   isCliInvocation: isCliCall,
   parseReportArgs,
   renderRevenuePackMarkdown,
@@ -26,6 +27,17 @@ const APPCYPHER_LIST_URL = 'https://github.com/appcypher/awesome-mcp-servers';
 const MCP_DIRECTORIES_GUIDE_URL = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/marketing/mcp-directories.md';
 const MCP_HUB_SUBMISSION_URL = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/mcp-hub-submission.md';
 const CHECKED_AT = '2026-04-29';
+const DIRECTORY_SOURCE = 'mcp_directories';
+const DIRECTORY_MEDIUM = 'directory';
+const DIRECTORY_SURFACE = 'mcp_directory';
+
+function buildTrackedDirectoryLink(baseUrl, tracking = {}) {
+  return buildTrackedPackLink(baseUrl, tracking, {
+    utmSource: DIRECTORY_SOURCE,
+    utmMedium: DIRECTORY_MEDIUM,
+    surface: tracking.surface || DIRECTORY_SURFACE,
+  });
+}
 
 function buildSurfaces() {
   return [
@@ -108,13 +120,44 @@ function buildFollowOnOffers(links = buildRevenueLinks()) {
       label: 'Proof-backed setup guide',
       pricing: 'Discovery CTA',
       buyer: 'Directory visitors who want a current install and proof surface before anything sales-led.',
-      cta: links.guideLink,
+      cta: buildTrackedDirectoryLink(links.guideLink, {
+        utmCampaign: 'mcp_directory_guide',
+        utmContent: 'guide',
+        campaignVariant: 'directory_repair',
+        offerCode: 'MCP-DIRECTORY_GUIDE',
+        ctaId: 'mcp_directory_guide',
+        ctaPlacement: 'follow_on_offer',
+        surface: 'mcp_directory_guide',
+      }),
+    },
+    {
+      label: 'ThumbGate Pro',
+      pricing: links.proPriceLabel,
+      buyer: 'Directory visitors who already want the self-serve path and need a tracked paid-intent lane after the guide.',
+      cta: buildTrackedDirectoryLink(links.proCheckoutLink, {
+        utmCampaign: 'mcp_directory_pro',
+        utmContent: 'pro',
+        campaignVariant: 'self_serve_paid_intent',
+        offerCode: 'MCP-DIRECTORY_PRO',
+        ctaId: 'mcp_directory_pro',
+        ctaPlacement: 'follow_on_offer',
+        planId: 'pro',
+        surface: 'mcp_directory_pro',
+      }),
     },
     {
       label: 'Workflow Hardening Sprint',
       pricing: 'Primary revenue motion',
       buyer: 'Teams that already named one repeated workflow failure and want rollout proof, not just a directory listing.',
-      cta: links.sprintLink,
+      cta: buildTrackedDirectoryLink(links.sprintLink, {
+        utmCampaign: 'mcp_directory_sprint',
+        utmContent: 'workflow_sprint',
+        campaignVariant: 'repair_to_team_motion',
+        offerCode: 'MCP-DIRECTORY_SPRINT',
+        ctaId: 'mcp_directory_sprint',
+        ctaPlacement: 'follow_on_offer',
+        surface: 'mcp_directory_sprint',
+      }),
     },
   ];
 }
@@ -338,6 +381,9 @@ if (isCliInvocation(process.argv)) {
 module.exports = {
   APPCYPHER_LIST_URL,
   CHECKED_AT,
+  DIRECTORY_MEDIUM,
+  DIRECTORY_SOURCE,
+  DIRECTORY_SURFACE,
   DOCS_PATH,
   GLAMA_LEGACY_URL,
   GLAMA_SEARCH_URL,
@@ -346,6 +392,7 @@ module.exports = {
   SMITHERY_DETAILS_URL,
   SMITHERY_SEARCH_URL,
   buildMcpDirectoryRevenuePack,
+  buildTrackedDirectoryLink,
   isCliInvocation,
   parseArgs,
   renderMcpDirectoryRevenuePackMarkdown,

--- a/tests/mcp-directory-revenue-pack.test.js
+++ b/tests/mcp-directory-revenue-pack.test.js
@@ -9,6 +9,9 @@ const path = require('node:path');
 const {
   APPCYPHER_LIST_URL,
   CHECKED_AT,
+  DIRECTORY_MEDIUM,
+  DIRECTORY_SOURCE,
+  DIRECTORY_SURFACE,
   DOCS_PATH,
   GLAMA_LEGACY_URL,
   GLAMA_SEARCH_URL,
@@ -17,6 +20,7 @@ const {
   SMITHERY_DETAILS_URL,
   SMITHERY_SEARCH_URL,
   buildMcpDirectoryRevenuePack,
+  buildTrackedDirectoryLink,
   isCliInvocation,
   parseArgs,
   renderMcpDirectoryRevenuePackMarkdown,
@@ -73,6 +77,46 @@ test('operator queue focuses on repair before expansion', () => {
   assert.ok(pack.operatorQueue.every((entry) => !/guaranteed ranking|guaranteed revenue/i.test(entry.recommendedMotion)));
 });
 
+test('follow-on offers use tracked directory CTAs for guide, Pro, and sprint lanes', () => {
+  const pack = buildMcpDirectoryRevenuePack(LINKS_FIXTURE);
+
+  assert.equal(pack.followOnOffers.length, 3);
+  assert.equal(pack.followOnOffers[1].label, 'ThumbGate Pro');
+
+  for (const offer of pack.followOnOffers) {
+    const url = new URL(offer.cta);
+    assert.equal(url.searchParams.get('utm_source'), DIRECTORY_SOURCE);
+    assert.equal(url.searchParams.get('utm_medium'), DIRECTORY_MEDIUM);
+    assert.ok(url.searchParams.get('utm_campaign'));
+    assert.ok(url.searchParams.get('cta_id'));
+    assert.ok(url.searchParams.get('offer_code'));
+  }
+
+  const guideUrl = new URL(pack.followOnOffers[0].cta);
+  const proUrl = new URL(pack.followOnOffers[1].cta);
+  const sprintUrl = new URL(pack.followOnOffers[2].cta);
+
+  assert.equal(guideUrl.searchParams.get('surface'), 'mcp_directory_guide');
+  assert.equal(proUrl.searchParams.get('plan_id'), 'pro');
+  assert.equal(proUrl.searchParams.get('surface'), 'mcp_directory_pro');
+  assert.equal(sprintUrl.searchParams.get('surface'), 'mcp_directory_sprint');
+});
+
+test('tracked directory link helper keeps attribution machine-readable', () => {
+  const url = new URL(buildTrackedDirectoryLink('https://thumbgate-production.up.railway.app/guide', {
+    utmCampaign: 'mcp_directory_guide',
+    utmContent: 'guide',
+    campaignVariant: 'directory_repair',
+    offerCode: 'MCP-DIRECTORY_GUIDE',
+    ctaId: 'mcp_directory_guide',
+    ctaPlacement: 'follow_on_offer',
+  }));
+
+  assert.equal(url.searchParams.get('utm_source'), DIRECTORY_SOURCE);
+  assert.equal(url.searchParams.get('utm_medium'), DIRECTORY_MEDIUM);
+  assert.equal(url.searchParams.get('surface'), DIRECTORY_SURFACE);
+});
+
 test('rendered markdown stays operator-ready and names the legacy leaks explicitly', () => {
   const markdown = renderMcpDirectoryRevenuePackMarkdown({
     ...buildMcpDirectoryRevenuePack(LINKS_FIXTURE),
@@ -84,6 +128,8 @@ test('rendered markdown stays operator-ready and names the legacy leaks explicit
   assert.match(markdown, /`rlhf-loop\/thumbgate`/);
   assert.match(markdown, /punkpeye awesome-mcp-servers/);
   assert.match(markdown, /Proof-backed setup guide/);
+  assert.match(markdown, /utm_source=mcp_directories/);
+  assert.match(markdown, /ThumbGate Pro/);
   assert.match(markdown, /VERIFICATION_EVIDENCE\.md/);
   assert.doesNotMatch(markdown, /official registry approved|guaranteed installs|guaranteed revenue/i);
 });


### PR DESCRIPTION
**Summary**
- add tracked MCP directory follow-on CTA helpers so directory traffic keeps machine-readable attribution
- add an explicit ThumbGate Pro follow-on offer for paid-intent self-serve visitors
- regenerate the checked-in MCP directory revenue pack and cover the new attribution behavior with tests

**Verification**
- npm ci
- node --test tests/mcp-directory-revenue-pack.test.js
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check