### PR TITLE
feat(gtm): split production rollout outreach lane

### DIFF
--- a/.changeset/production-rollout-outreach-lane.md
+++ b/.changeset/production-rollout-outreach-lane.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Split the GitHub outreach operator asset into a dedicated production-rollout lane so proof-sensitive workflow buyers are prioritized ahead of generic cold outreach.

--- a/docs/OUTREACH_TARGETS.md
+++ b/docs/OUTREACH_TARGETS.md
@@ -1,7 +1,7 @@
 # Revenue Pipeline Outreach Targets
 
 Status: current
-Updated: 2026-04-30T03:12:06.400Z
+Updated: 2026-04-30T04:14:20.304Z
 
 This file mirrors the evidence-backed GTM queue in `docs/marketing/gtm-target-queue.jsonl`.
 It is the qualification screen and send surface for the current Workflow Hardening Sprint revenue loop, not a raw GitHub scrape.
@@ -12,7 +12,8 @@ It is the qualification screen and send surface for the current Workflow Hardeni
 - Follow-ups now: 0
 - Warm discovery ready: 4
 - Self-serve closes ready: 3
-- Cold GitHub ready: 3
+- Production-rollout buyers ready: 3
+- Cold GitHub ready: 0
 - Sales ledger tracked leads: 0 (pipeline file not created yet)
 - Proof rule: Use proof links only after the buyer confirms the workflow pain.
 
@@ -94,7 +95,24 @@ Pain-confirmed follow-up:
 Track next step: `npm run sales:pipeline -- advance --lead 'reddit_enthu_cutlet_1337_r_claudecode' --channel 'reddit_dm' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on brittle guardrails.'`
 
 ## Self-Serve Closes
-### 1. BaseInfinity — claude-sdlc-wizard
+### 1. opensesh — KARIMO
+- Temperature: cold
+- Current stage: targeted
+- Contact surface: https://link.opensession.co/github
+- Evidence score: 17
+- Evidence: workflow control surface, production or platform workflow, agent infrastructure, self-serve agent tooling, 34 GitHub stars, updated in the last 7 days
+- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
+- CTA: https://thumbgate-production.up.railway.app/guide
+
+First-touch draft:
+> Hey @opensesh, saw you're building around `KARIMO`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
+
+Pain-confirmed follow-up:
+> If you want the self-serve path for `KARIMO`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+Track next step: `npm run sales:pipeline -- advance --lead 'github_opensesh_karimo' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
+
+### 2. BaseInfinity — claude-sdlc-wizard
 - Temperature: cold
 - Current stage: targeted
 - Contact surface: https://www.youtube.com/@Basecase_/featured
@@ -111,29 +129,12 @@ Pain-confirmed follow-up:
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_baseinfinity_claude_sdlc_wizard' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
 
-### 2. iliaal — compound-engineering-plugin
-- Temperature: cold
-- Current stage: targeted
-- Contact surface: http://ilia.ws/
-- Evidence score: 12
-- Evidence: workflow control surface, agent infrastructure, self-serve agent tooling, 11 GitHub stars, updated in the last 7 days
-- Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
-- CTA: https://thumbgate-production.up.railway.app/guide
-
-First-touch draft:
-> Hey @iliaal, saw you're building around `compound-engineering-plugin`. If you want the clean self-serve tool path first, start with the proof-backed setup guide: https://thumbgate-production.up.railway.app/guide. If one repeated agent mistake is still slowing the workflow down after that, Pro is the clean next step.
-
-Pain-confirmed follow-up:
-> If you want the self-serve path for `compound-engineering-plugin`, here is the live Pro checkout: https://thumbgate-production.up.railway.app/checkout/pro Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
-
-Track next step: `npm run sales:pipeline -- advance --lead 'github_iliaal_compound_engineering_plugin' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
-
 ### 3. zaxbysauce — opencode-swarm
 - Temperature: cold
 - Current stage: targeted
 - Contact surface: https://github.com/zaxbysauce
 - Evidence score: 12
-- Evidence: workflow control surface, self-serve agent tooling, 247 GitHub stars, updated in the last 7 days
+- Evidence: workflow control surface, self-serve agent tooling, 248 GitHub stars, updated in the last 7 days
 - Why now: Target looks like a local hook, plugin, or config surface, so start with the setup guide and Pro follow-on before pitching a sprint.
 - CTA: https://thumbgate-production.up.railway.app/guide
 
@@ -145,23 +146,23 @@ Pain-confirmed follow-up:
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_zaxbysauce_opencode_swarm' --channel 'manual' --stage 'contacted' --note 'Sent Pro at $19/mo or $149/yr self-serve first touch focused on the proof-backed setup guide and local-first enforcement before any team-motion pitch.'`
 
-## Cold GitHub
-### 1. jmanhype — claude-code-plugin-marketplace
+## Production Rollout Buyers
+### 1. Abhi268170 — Stagix
 - Temperature: cold
 - Current stage: targeted
-- Contact surface: https://vaos.sh/
-- Evidence score: 16
-- Evidence: production or platform workflow, business-system integration, agent infrastructure, self-serve agent tooling, 27 GitHub stars, updated in the last 7 days
+- Contact surface: https://github.com/Abhi268170
+- Evidence score: 15
+- Evidence: workflow control surface, production or platform workflow, business-system integration, agent infrastructure, self-serve agent tooling
 - Why now: Lead with one business-system workflow that needs approval boundaries, rollback safety, and proof.
 - CTA: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
 
 First-touch draft:
-> Hey @jmanhype, saw you're shipping `claude-code-plugin-marketplace`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+> Hey @Abhi268170, saw you're shipping `Stagix`. If one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you with a prevention gate and proof run: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
 
 Pain-confirmed follow-up:
-> If `claude-code-plugin-marketplace` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+> If `Stagix` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
-Track next step: `npm run sales:pipeline -- advance --lead 'github_jmanhype_claude_code_plugin_marketplace' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
+Track next step: `npm run sales:pipeline -- advance --lead 'github_abhi268170_stagix' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
 
 ### 2. Adqui9608 — ai-code-review-agent
 - Temperature: cold
@@ -196,6 +197,9 @@ Pain-confirmed follow-up:
 > If `engine_context` really has one repeated workflow failure blocking rollout, I can send the Workflow Hardening Sprint brief plus the commercial truth and verification evidence: https://thumbgate-production.up.railway.app/#workflow-sprint-intake Commercial truth: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
 
 Track next step: `npm run sales:pipeline -- advance --lead 'github_dolutech_engine_context' --channel 'manual' --stage 'contacted' --note 'Sent Workflow Hardening Sprint first touch focused on one business-system workflow that needs approval boundaries, rollback safety, and proof.'`
+
+## Cold GitHub
+- No cold GitHub targets are currently ready.
 
 ## Core Links
 - Sprint intake: https://thumbgate-production.up.railway.app/#workflow-sprint-intake

--- a/scripts/github-outreach.js
+++ b/scripts/github-outreach.js
@@ -34,6 +34,7 @@ const FOLLOW_UP_PRIORITY = {
 const TARGETED_STAGE = 'targeted';
 const SELF_SERVE_MOTIONS = new Set(['pro']);
 const SELF_SERVE_OFFERS = new Set(['pro_self_serve']);
+const PRODUCTION_ROLLOUT_EVIDENCE = 'production or platform workflow';
 
 function normalizeText(value, maxLength = 4000) {
   if (value === undefined || value === null) return '';
@@ -67,6 +68,11 @@ function isSelfServeTarget(target = {}) {
   const motion = normalizeText(target.motion).toLowerCase();
   const offer = normalizeText(target.offer).toLowerCase();
   return SELF_SERVE_MOTIONS.has(motion) || SELF_SERVE_OFFERS.has(offer);
+}
+
+function isProductionRolloutTarget(target = {}) {
+  const evidence = Array.isArray(target.evidence) ? target.evidence : [];
+  return evidence.some((entry) => normalizeText(entry).toLowerCase() === PRODUCTION_ROLLOUT_EVIDENCE);
 }
 
 function compareTargetPriority(left, right) {
@@ -161,11 +167,19 @@ function buildOutreachTargetsReport({
       && normalizeText(target.source) === 'github'
       && isSelfServeTarget(target);
   });
+  const productionRolloutTargets = targets.filter((target) => {
+    return target.stage === TARGETED_STAGE
+      && normalizeText(target.temperature) !== 'warm'
+      && normalizeText(target.source) === 'github'
+      && !isSelfServeTarget(target)
+      && isProductionRolloutTarget(target);
+  });
   const coldTargets = targets.filter((target) => {
     return target.stage === TARGETED_STAGE
       && normalizeText(target.temperature) !== 'warm'
       && normalizeText(target.source) === 'github'
-      && !isSelfServeTarget(target);
+      && !isSelfServeTarget(target)
+      && !isProductionRolloutTarget(target);
   });
 
   return {
@@ -192,6 +206,7 @@ function buildOutreachTargetsReport({
     followUpTargets,
     warmTargets,
     selfServeTargets,
+    productionRolloutTargets,
     coldTargets,
     totalTargets: targets.length,
   };
@@ -234,6 +249,9 @@ function renderOutreachTargetsMarkdown(report = {}) {
   const selfServeLines = report.selfServeTargets.length
     ? report.selfServeTargets.flatMap((target, index) => renderTargetMarkdown(target, index))
     : ['- No self-serve close targets are currently ready.', ''];
+  const productionRolloutLines = report.productionRolloutTargets.length
+    ? report.productionRolloutTargets.flatMap((target, index) => renderTargetMarkdown(target, index))
+    : ['- No production-rollout buyers are currently ready.', ''];
   const coldLines = report.coldTargets.length
     ? report.coldTargets.flatMap((target, index) => renderTargetMarkdown(target, index))
     : ['- No cold GitHub targets are currently ready.', ''];
@@ -253,6 +271,7 @@ function renderOutreachTargetsMarkdown(report = {}) {
     `- Follow-ups now: ${report.followUpTargets.length}`,
     `- Warm discovery ready: ${report.warmTargets.length}`,
     `- Self-serve closes ready: ${report.selfServeTargets.length}`,
+    `- Production-rollout buyers ready: ${report.productionRolloutTargets.length}`,
     `- Cold GitHub ready: ${report.coldTargets.length}`,
     `- Sales ledger tracked leads: ${report.pipelineTrackedLeadCount || 0}${report.pipelineExists ? '' : ' (pipeline file not created yet)'}`,
     `- Proof rule: ${report.proofRule}`,
@@ -266,6 +285,8 @@ function renderOutreachTargetsMarkdown(report = {}) {
     ...warmLines,
     '## Self-Serve Closes',
     ...selfServeLines,
+    '## Production Rollout Buyers',
+    ...productionRolloutLines,
     '## Cold GitHub',
     ...coldLines,
     '## Core Links',
@@ -295,7 +316,7 @@ function main(options = {}) {
   const docsPath = writeOutreachTargetsDoc(markdown, options.outPath || DEFAULT_DOCS_PATH);
   console.log(`Updated ${docsPath} from the current evidence-backed queue.`);
   console.log(
-    `Warm: ${report.warmTargets.length} | Self-serve: ${report.selfServeTargets.length} | Cold: ${report.coldTargets.length} | Follow-up: ${report.followUpTargets.length}`
+    `Warm: ${report.warmTargets.length} | Self-serve: ${report.selfServeTargets.length} | Production rollout: ${report.productionRolloutTargets.length} | Cold: ${report.coldTargets.length} | Follow-up: ${report.followUpTargets.length}`
   );
   return {
     docsPath,
@@ -317,6 +338,7 @@ module.exports = {
   DEFAULT_QUEUE_PATH,
   DEFAULT_REPORT_PATH,
   buildOutreachTargetsReport,
+  isProductionRolloutTarget,
   isCliInvocation,
   main,
   renderOutreachTargetsMarkdown,

--- a/tests/github-outreach.test.js
+++ b/tests/github-outreach.test.js
@@ -66,6 +66,30 @@ function makeColdTarget() {
   };
 }
 
+function makeProductionTarget() {
+  return {
+    temperature: 'cold',
+    source: 'github',
+    channel: 'github',
+    username: 'Adqui9608',
+    accountName: 'Adqui9608',
+    repoName: 'ai-code-review-agent',
+    repoUrl: 'https://github.com/Adqui9608/ai-code-review-agent',
+    contactUrl: 'https://github.com/Adqui9608',
+    evidenceScore: 15,
+    evidence: ['workflow control surface', 'production or platform workflow', 'agent infrastructure'],
+    motionReason: 'Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.',
+    cta: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+    firstTouchDraft: 'Hey @Adqui9608, if one approval, handoff, or rollback step keeps creating trouble, I can harden that workflow for you.',
+    painConfirmedFollowUpDraft: 'If the workflow pain is real, I can send the proof pack.',
+    salesCommands: {
+      markContacted: 'npm run sales:pipeline -- advance --lead \'github_adqui9608_ai_code_review_agent\' --stage \'contacted\'',
+      markReplied: 'npm run sales:pipeline -- advance --lead \'github_adqui9608_ai_code_review_agent\' --stage \'replied\'',
+      markCallBooked: 'npm run sales:pipeline -- advance --lead \'github_adqui9608_ai_code_review_agent\' --stage \'call_booked\'',
+    },
+  };
+}
+
 function makeSelfServeTarget() {
   return {
     temperature: 'cold',
@@ -92,13 +116,13 @@ function makeSelfServeTarget() {
   };
 }
 
-test('queue-backed outreach report separates warm, self-serve, and cold sprint lanes', () => {
+test('queue-backed outreach report separates warm, self-serve, production-rollout, and cold sprint lanes', () => {
   const tempDir = makeTempDir();
   const queuePath = path.join(tempDir, 'gtm-target-queue.jsonl');
   const reportPath = path.join(tempDir, 'gtm-revenue-loop.json');
   const statePath = path.join(tempDir, 'sales-pipeline.jsonl');
 
-  writeJsonl(queuePath, [makeWarmTarget(), makeSelfServeTarget(), makeColdTarget()]);
+  writeJsonl(queuePath, [makeWarmTarget(), makeSelfServeTarget(), makeProductionTarget(), makeColdTarget()]);
   fs.writeFileSync(reportPath, JSON.stringify({
     generatedAt: '2026-04-27T17:00:00.000Z',
     directive: {
@@ -114,14 +138,18 @@ test('queue-backed outreach report separates warm, self-serve, and cold sprint l
   assert.equal(report.followUpTargets.length, 0);
   assert.equal(report.warmTargets.length, 1);
   assert.equal(report.selfServeTargets.length, 1);
+  assert.equal(report.productionRolloutTargets.length, 1);
   assert.equal(report.coldTargets.length, 1);
   assert.equal(report.pipelineTrackedLeadCount, 0);
   assert.equal(report.pipelineExists, false);
   assert.match(markdown, /mirrors the evidence-backed GTM queue/i);
   assert.match(markdown, /Warm discovery ready: 1/);
   assert.match(markdown, /Self-serve closes ready: 1/);
+  assert.match(markdown, /Production-rollout buyers ready: 1/);
   assert.match(markdown, /Cold GitHub ready: 1/);
   assert.match(markdown, /## Self-Serve Closes/);
+  assert.match(markdown, /## Production Rollout Buyers/);
+  assert.match(markdown, /ai-code-review-agent/);
   assert.match(markdown, /flow-next/);
   assert.match(markdown, /review-flow/);
   assert.match(markdown, /stage 'contacted'/);
@@ -138,7 +166,7 @@ test('active follow-ups are promoted ahead of fresh sends using sales ledger sta
   const coldTarget = makeColdTarget();
   const lead = buildLeadFromRevenueTarget(coldTarget, { sourcePath: queuePath });
 
-  writeJsonl(queuePath, [warmTarget, selfServeTarget, coldTarget]);
+  writeJsonl(queuePath, [warmTarget, selfServeTarget, makeProductionTarget(), coldTarget]);
   fs.writeFileSync(reportPath, JSON.stringify({
     generatedAt: '2026-04-27T17:00:00.000Z',
     directive: {
@@ -159,11 +187,13 @@ test('active follow-ups are promoted ahead of fresh sends using sales ledger sta
   assert.equal(report.followUpTargets[0].stage, 'replied');
   assert.equal(report.warmTargets.length, 1);
   assert.equal(report.selfServeTargets.length, 1);
+  assert.equal(report.productionRolloutTargets.length, 1);
   assert.equal(report.coldTargets.length, 0);
   assert.equal(report.pipelineTrackedLeadCount, 1);
   assert.equal(report.pipelineExists, true);
   assert.match(markdown, /## Follow Up Now/);
   assert.match(markdown, /## Self-Serve Closes/);
+  assert.match(markdown, /## Production Rollout Buyers/);
   assert.match(markdown, /Current stage: replied/);
   assert.match(markdown, /stage 'call_booked'/);
 });


### PR DESCRIPTION
## Summary
- split the GitHub outreach generator into warm, self-serve, production-rollout, and residual cold lanes
- regenerate `docs/OUTREACH_TARGETS.md` so operator send order matches the higher-intent production workflow evidence
- add workflow tests that pin the new production-rollout bucket and keep follow-up ordering intact

## Verification
- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm run self-heal:check`
