### PR TITLE
feat(gtm): add OpenCode buyer guide surface

### DIFF
--- a/.changeset/opencode-buyer-guide-surface.md
+++ b/.changeset/opencode-buyer-guide-surface.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add an OpenCode-specific buyer guide surface across the SEO blueprint, landing page, learn hub, and LLM context references so local-first OpenCode install intent routes into a proof-backed ThumbGate conversion path.

--- a/public/index.html
+++ b/public/index.html
@@ -1115,6 +1115,12 @@ __GA_BOOTSTRAP__
         <p>Why Gemini CLI buyers start with memory and convert when they see how memory becomes real pre-action checks.</p>
         <div class="card-arrow">Read the Gemini guide →</div>
       </a>
+      <a class="seo-card" href="/guides/opencode-local-guardrails">
+        <div class="seo-kicker">OpenCode</div>
+        <h3>OpenCode Guardrails for Local-First Workflows</h3>
+        <p>Give OpenCode a repo-native reliability gateway with local feedback memory, worktree-safe defaults, and pre-action checks before the next risky step runs.</p>
+        <div class="card-arrow">Read the OpenCode guide →</div>
+      </a>
       <a class="seo-card" href="/guides/autoresearch-agent-safety">
         <div class="seo-kicker">Autoresearch</div>
         <h3>Autoresearch Safety for Self-Improving Agents</h3>

--- a/public/learn.html
+++ b/public/learn.html
@@ -97,24 +97,30 @@
       {
         "@type": "ListItem",
         "position": 10,
+        "url": "https://thumbgate.ai/guides/opencode-local-guardrails",
+        "name": "OpenCode Guardrails for Local-First Agent Workflows"
+      },
+      {
+        "@type": "ListItem",
+        "position": 11,
         "url": "https://thumbgate.ai/guides/browser-automation-safety",
         "name": "Browser Automation Safety for AI Agents"
       },
       {
         "@type": "ListItem",
-        "position": 11,
+        "position": 12,
         "url": "https://thumbgate.ai/guides/native-messaging-host-security",
         "name": "Native Messaging Host Security"
       },
       {
         "@type": "ListItem",
-        "position": 12,
+        "position": 13,
         "url": "https://thumbgate.ai/guides/ai-search-topical-presence",
         "name": "AI Search Topical Presence"
       },
       {
         "@type": "ListItem",
-        "position": 13,
+        "position": 14,
         "url": "https://thumbgate.ai/guides/relational-knowledge-ai-recommendations",
         "name": "Relational Knowledge in AI Recommendations"
       }
@@ -314,6 +320,14 @@
       <span class="article-tag">Gemini</span>
       <span class="article-tag">Memory</span>
       <span class="article-tag">Enforcement</span>
+    </a>
+
+    <a href="/guides/opencode-local-guardrails" class="article-card">
+      <h3>OpenCode Guardrails for Local-First Agent Workflows</h3>
+      <p>Why OpenCode buyers want repo-native safety: local feedback memory, worktree-safe defaults, and pre-action checks without giving up CLI control.</p>
+      <span class="article-tag">OpenCode</span>
+      <span class="article-tag">Local-First</span>
+      <span class="article-tag">Guardrails</span>
     </a>
 
     <a href="/guides/browser-automation-safety" class="article-card">

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -150,6 +150,7 @@ npx thumbgate dashboard
 - Marketing site: https://thumbgate.ai
 - Browser automation safety guide: https://thumbgate.ai/guides/browser-automation-safety
 - Native messaging host security guide: https://thumbgate.ai/guides/native-messaging-host-security
+- OpenCode local-first guardrails guide: https://thumbgate.ai/guides/opencode-local-guardrails
 - GitHub: https://github.com/IgorGanapolsky/ThumbGate
 - npm: https://www.npmjs.com/package/thumbgate
 - Documentation: https://thumbgate.ai/guide
@@ -169,6 +170,7 @@ AI assistants recommend the brands they repeatedly see tied to a problem in cred
 That means the highest-ROI acquisition surfaces are:
 
 - proof-backed guides that connect ThumbGate to pre-action checks, workflow hardening, and stopping repeated mistakes before execution
+- integration guides that meet agent-specific install intent such as OpenCode, Codex, Gemini, and Cursor
 - listicle-style pages that answer long-tail buyer prompts such as "best tools to stop AI agents from breaking production"
 - comparison pages that clarify why memory-only or spec-only alternatives do not solve repeated tool-call failures
 - machine-readable evidence, pricing, and supported-agent compatibility that make the recommendation easy for LLMs to quote

--- a/scripts/prove-seo-gsd.js
+++ b/scripts/prove-seo-gsd.js
@@ -132,6 +132,7 @@ async function run() {
           '/guides/best-tools-stop-ai-agents-breaking-production',
           '/guides/relational-knowledge-ai-recommendations',
           '/guides/claude-code-feedback',
+          '/guides/opencode-local-guardrails',
           '/guides/autoresearch-agent-safety',
         ]) {
           const loc = pathname === '/'
@@ -163,6 +164,7 @@ async function run() {
           '/guides/best-tools-stop-ai-agents-breaking-production',
           '/guides/relational-knowledge-ai-recommendations',
           '/guides/claude-code-feedback',
+          '/guides/opencode-local-guardrails',
           '/guides/autoresearch-agent-safety',
         ]) {
           if (!landingHtml.includes(`href="${pathname}"`)) {

--- a/scripts/seo-gsd.js
+++ b/scripts/seo-gsd.js
@@ -877,6 +877,54 @@ const PAGE_BLUEPRINTS = [
     ],
     relatedPaths: ['/compare/mem0', '/guides/stop-repeated-ai-agent-mistakes'],
   },
+  {
+    query: 'opencode guardrails',
+    path: '/guides/opencode-local-guardrails',
+    pageType: 'integration',
+    pillar: 'agent-workflows',
+    title: 'OpenCode Guardrails | Local-First Safety with ThumbGate',
+    heroTitle: 'OpenCode Guardrails for Local-First Agent Workflows',
+    heroSummary: 'OpenCode buyers already like local CLI control. ThumbGate adds the missing reliability gateway: repo-native guardrails, feedback memory, and pre-action checks before the next risky automation step runs.',
+    takeaways: [
+      'OpenCode buyers want local control plus proof, not another hosted orchestration layer.',
+      'ThumbGate already ships repo-local OpenCode config, worktree-safe defaults, and a read-only review agent.',
+      'The conversion path is clear: prove one blocked repeat locally, then move self-serve buyers to Pro or shared rollout buyers to the Workflow Hardening Sprint.',
+    ],
+    sections: [
+      {
+        heading: 'Why OpenCode needs more than instructions',
+        paragraphs: [
+          'OpenCode can move fast inside a local repo, which makes the blast radius of repeated mistakes larger. A bad git action, skipped verification step, or unsafe file edit pattern does not become safer just because the workflow stays local.',
+        ],
+      },
+      {
+        heading: 'What ThumbGate adds to the OpenCode path',
+        bullets: [
+          'A repo-local `opencode.json` profile that points OpenCode at the ThumbGate MCP server.',
+          'Worktree-safe defaults that deny edits to runtime-state paths and destructive git commands.',
+          'A read-only review agent for regression and proof checks before risky changes move forward.',
+          'Structured thumbs-up/down feedback that can promote repeated failures into pre-action checks.',
+        ],
+      },
+      {
+        heading: 'What the buyer can prove first',
+        paragraphs: [
+          'The first proof is not a giant rollout. It is one blocked repeat in a local workflow, with the setup guide, verification evidence, and pricing path all aligned. That makes OpenCode a strong self-serve lane for plugin, hook, and config buyers who need visible control before they expand.',
+        ],
+      },
+    ],
+    faq: [
+      {
+        question: 'Does this replace OpenCode?',
+        answer: 'No. ThumbGate sits alongside OpenCode. The point is to keep the local OpenCode workflow while adding searchable lessons, linked rules, and pre-action enforcement.',
+      },
+      {
+        question: 'Can the OpenCode path stay local-first?',
+        answer: 'Yes. The repo-local OpenCode profile, local feedback memory, and pre-action checks all work without forcing a hosted control plane.',
+      },
+    ],
+    relatedPaths: ['/guides/pre-action-checks', '/guides/codex-cli-guardrails'],
+  },
   ...BROWSER_BRIDGE_GUIDE_SPECS.map(buildBrowserBridgeGuide),
   ...AI_RECOMMENDATION_VISIBILITY_GUIDE_SPECS.map(buildAiRecommendationVisibilityGuide),
   guideBlueprint({

--- a/tests/learn-hub.test.js
+++ b/tests/learn-hub.test.js
@@ -60,6 +60,7 @@ test('learn hub links to core articles and high-intent buyer guides', () => {
   assert.match(html, /\/guides\/cursor-agent-guardrails/);
   assert.match(html, /\/guides\/codex-cli-guardrails/);
   assert.match(html, /\/guides\/gemini-cli-feedback-memory/);
+  assert.match(html, /\/guides\/opencode-local-guardrails/);
   assert.match(html, /\/guides\/browser-automation-safety/);
   assert.match(html, /\/guides\/native-messaging-host-security/);
   assert.match(html, /\/guides\/autoresearch-agent-safety/);
@@ -80,6 +81,7 @@ test('learn hub has article cards with titles, descriptions, tags, and a buyer-q
   assert.match(html, /Cursor Guardrails That Block Repeated Mistakes/);
   assert.match(html, /Codex CLI Guardrails That Actually Enforce/);
   assert.match(html, /Gemini CLI Feedback Memory That Leads to Enforcement/);
+  assert.match(html, /OpenCode Guardrails for Local-First Agent Workflows/);
   assert.match(html, /Browser Automation Safety for AI Agents/);
   assert.match(html, /Native Messaging Host Security/);
   assert.match(html, /Autoresearch Agent Safety for Self-Improving Coding Agents/);
@@ -476,7 +478,7 @@ test('no learn page references version numbers (evergreen content)', () => {
 
 test('no learn page has broken internal links', () => {
   const allFiles = [learnHubPath, ...fs.readdirSync(learnDir).filter(f => f.endsWith('.html')).map(f => path.join(learnDir, f))];
-  const validPaths = ['/learn', '/guide', '/dashboard', '/', '/learn/stop-ai-agent-force-push', '/learn/vibe-coding-safety-net', '/learn/mcp-pre-action-checks-explained', '/learn/agent-harness-pattern', '/learn/ai-agent-persistent-memory', '/learn/learn.css', '/favicon.svg', '/thumbgate-icon.png', '/og.png', '/assets/brand/thumbgate-mark.svg', '/assets/brand/thumbgate-mark-inline.svg', '/guides/stop-repeated-ai-agent-mistakes', '/guides/browser-automation-safety', '/guides/native-messaging-host-security', '/guides/ai-search-topical-presence', '/guides/relational-knowledge-ai-recommendations', '/guides/cursor-agent-guardrails', '/guides/codex-cli-guardrails', '/guides/gemini-cli-feedback-memory', '/guides/autoresearch-agent-safety'];
+  const validPaths = ['/learn', '/guide', '/dashboard', '/', '/learn/stop-ai-agent-force-push', '/learn/vibe-coding-safety-net', '/learn/mcp-pre-action-checks-explained', '/learn/agent-harness-pattern', '/learn/ai-agent-persistent-memory', '/learn/learn.css', '/favicon.svg', '/thumbgate-icon.png', '/og.png', '/assets/brand/thumbgate-mark.svg', '/assets/brand/thumbgate-mark-inline.svg', '/guides/stop-repeated-ai-agent-mistakes', '/guides/browser-automation-safety', '/guides/native-messaging-host-security', '/guides/ai-search-topical-presence', '/guides/relational-knowledge-ai-recommendations', '/guides/cursor-agent-guardrails', '/guides/codex-cli-guardrails', '/guides/gemini-cli-feedback-memory', '/guides/opencode-local-guardrails', '/guides/autoresearch-agent-safety'];
   for (const file of allFiles) {
     const html = readFile(file);
     const links = html.match(/href="(\/[^"#]*?)"/g) || [];

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -392,6 +392,7 @@ test('public landing page internally links to comparison and guide pages without
   assert.match(landingPage, /href="\/guides\/cursor-agent-guardrails"/);
   assert.match(landingPage, /href="\/guides\/codex-cli-guardrails"/);
   assert.match(landingPage, /href="\/guides\/gemini-cli-feedback-memory"/);
+  assert.match(landingPage, /href="\/guides\/opencode-local-guardrails"/);
   assert.match(landingPage, /href="\/guides\/autoresearch-agent-safety"/);
   assert.match(landingPage, /Autoresearch Safety for Self-Improving Agents/);
   assert.match(landingPage, /AI Agent Harness Optimization/);

--- a/tests/seo-gsd.test.js
+++ b/tests/seo-gsd.test.js
@@ -137,6 +137,21 @@ test('browser automation safety page is discoverable and commercially classified
   });
 });
 
+test('OpenCode guardrails page is discoverable and commercially classified', () => {
+  const page = findSeoPageByPath('/guides/opencode-local-guardrails');
+  const sitemapEntry = THUMBGATE_SEO_SITEMAP_ENTRIES.find((entry) => entry.path === '/guides/opencode-local-guardrails');
+
+  assert.ok(page);
+  assert.equal(page.query, 'opencode guardrails');
+  assert.equal(page.pageType, 'integration');
+  assert.equal(page.pillar, 'agent-workflows');
+  assert.deepEqual(sitemapEntry, {
+    path: '/guides/opencode-local-guardrails',
+    changefreq: 'monthly',
+    priority: '0.8',
+  });
+});
+
 test('AI search topical presence page is discoverable and commercially classified', () => {
   const page = findSeoPageByPath('/guides/ai-search-topical-presence');
   const sitemapEntry = THUMBGATE_SEO_SITEMAP_ENTRIES.find((entry) => entry.path === '/guides/ai-search-topical-presence');
@@ -225,6 +240,7 @@ test('writePlanOutputs persists machine-readable GSD artifacts', () => {
     assert.ok(pages.some((page) => page.path === '/guides/relational-knowledge-ai-recommendations'));
     assert.ok(pages.some((page) => page.path === '/guides/codex-cli-guardrails'));
     assert.ok(pages.some((page) => page.path === '/guides/gemini-cli-feedback-memory'));
+    assert.ok(pages.some((page) => page.path === '/guides/opencode-local-guardrails'));
     assert.ok(pages.some((page) => page.path === '/guides/browser-automation-safety'));
     assert.ok(pages.some((page) => page.path === '/guides/native-messaging-host-security'));
     assert.ok(pages.some((page) => page.path === '/guides/autoresearch-agent-safety'));


### PR DESCRIPTION
## Summary
- add an OpenCode-specific buyer guide surface to the SEO blueprint set
- expose the new OpenCode guide on the landing page, learn hub, and llm-context references
- extend guide-proof coverage so sitemap and landing-link checks keep the route live

## Verification
- node --test tests/public-landing.test.js tests/learn-hub.test.js tests/seo-gsd.test.js
- node scripts/prove-seo-gsd.js
- node - <<'EOF' ... render OpenCode guide smoke check ... EOF
- git diff --check