### PR TITLE
fix(automation): handle detached PR manager worktrees

### DIFF
--- a/.changeset/detached-pr-manager-fallback.md
+++ b/.changeset/detached-pr-manager-fallback.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Allow `npm run pr:manage` to inspect and queue open revenue PRs from detached worktrees by falling back to the open PR list when GitHub CLI cannot resolve the current branch.

--- a/scripts/pr-manager.js
+++ b/scripts/pr-manager.js
@@ -110,12 +110,14 @@ function formatGhError(result) {
   return (result.stderr || result.stdout || 'Unknown GH CLI failure').trim();
 }
 
-function isMissingCurrentBranchPr(result, prNumber) {
+function canFallbackToOpenPrList(result, prNumber) {
   if (prNumber) {
     return false;
   }
 
-  return /no pull requests found for branch/i.test(formatGhError(result));
+  const error = formatGhError(result);
+  return /no pull requests found for branch/i.test(error)
+    || /could not determine current branch/i.test(error);
 }
 
 /**
@@ -129,7 +131,7 @@ function getPrStatus(prNumber = '', runner = runGh) {
 
   const result = runner(args);
   if (result.status !== 0) {
-    if (isMissingCurrentBranchPr(result, normalizedPrNumber)) {
+    if (canFallbackToOpenPrList(result, normalizedPrNumber)) {
       return null;
     }
 

--- a/tests/pr-manager.test.js
+++ b/tests/pr-manager.test.js
@@ -261,6 +261,31 @@ test('PR Manager - loadManagedPrs falls back to open PR list when branch has no 
   assert.deepEqual(loadManagedPrs('', runner), [mockPr]);
 });
 
+test('PR Manager - loadManagedPrs falls back to open PR list when HEAD is detached', () => {
+  const mockPr = {
+    number: 312,
+    title: 'Repo open PR from detached worktree',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    isDraft: false,
+    statusCheckRollup: []
+  };
+  const runner = createRunner([
+    {
+      status: 1,
+      stdout: '',
+      stderr: 'could not determine current branch: failed to run git: not on any branch\n'
+    },
+    {
+      status: 0,
+      stdout: JSON.stringify([mockPr]),
+      stderr: ''
+    }
+  ]);
+
+  assert.deepEqual(loadManagedPrs('', runner), [mockPr]);
+});
+
 test('PR Manager - isOpenPr returns false for merged PR state', () => {
   assert.equal(isOpenPr({ state: 'MERGED' }), false);
   assert.equal(isOpenPr({ state: 'OPEN' }), true);


### PR DESCRIPTION
## Summary
- let `scripts/pr-manager.js` fall back to the open PR list when `gh pr view` cannot resolve the current branch from a detached worktree
- add a regression test for the detached-head path
- add a patch changeset for the automation fix

## Why
The ThumbGate revenue loop starts from dedicated worktrees, and this run landed on a detached HEAD. Before this fix, `npm run pr:manage` aborted instead of inspecting open PRs, which blocked autonomous PR hygiene for the active GTM queue.

## Verification
- `node --test tests/pr-manager.test.js`
- `npm run prove:adapters`
- `npm run prove:automation`
- `npm ci`
- `git push` pre-push guards passed (`npm pack` dry-run, public HTML link validation, regression-guard tests)

## Runtime evidence
- After the fix, `npm run pr:manage` successfully inspected open PRs from this worktree and submitted `/trunk merge` for PR #1504.
- PR #1504 later failed its separate `Trunk Merge Queue (main)` check at `2026-05-01T04:05:11Z`; that blocker is outside this patch.
