### PR TITLE
fix(automation): handle detached-head pr scans

### DIFF
--- a/.changeset/pr-manager-detached-head.md
+++ b/.changeset/pr-manager-detached-head.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Keep the PR manager usable from detached verification worktrees by falling back to repository-wide PR discovery when GitHub CLI cannot resolve the current branch.

--- a/scripts/pr-manager.js
+++ b/scripts/pr-manager.js
@@ -115,7 +115,11 @@ function isMissingCurrentBranchPr(result, prNumber) {
     return false;
   }
 
-  return /no pull requests found for branch/i.test(formatGhError(result));
+  const error = formatGhError(result);
+  return (
+    /no pull requests found for branch/i.test(error) ||
+    /could not determine current branch: failed to run git: not on any branch/i.test(error)
+  );
 }
 
 /**

--- a/tests/pr-manager.test.js
+++ b/tests/pr-manager.test.js
@@ -195,6 +195,18 @@ test('PR Manager - getPrStatus returns null when current branch has no PR', () =
   assert.equal(getPrStatus('', runner), null);
 });
 
+test('PR Manager - getPrStatus returns null when checkout is detached', () => {
+  const runner = createRunner([
+    {
+      status: 1,
+      stdout: '',
+      stderr: 'could not determine current branch: failed to run git: not on any branch\n'
+    }
+  ]);
+
+  assert.equal(getPrStatus('', runner), null);
+});
+
 test('PR Manager - normalizePrNumber rejects unsafe values', () => {
   assert.equal(normalizePrNumber('123'), '123');
   assert.throws(() => normalizePrNumber('../665', { allowEmpty: false }), /Unsafe PR number/);
@@ -250,6 +262,31 @@ test('PR Manager - loadManagedPrs falls back to open PR list when branch has no 
       status: 1,
       stdout: '',
       stderr: 'no pull requests found for branch "codex/tech-debt-audit-20260320"\n'
+    },
+    {
+      status: 0,
+      stdout: JSON.stringify([mockPr]),
+      stderr: ''
+    }
+  ]);
+
+  assert.deepEqual(loadManagedPrs('', runner), [mockPr]);
+});
+
+test('PR Manager - loadManagedPrs falls back to open PR list when checkout is detached', () => {
+  const mockPr = {
+    number: 286,
+    title: 'Repo PR from detached worktree',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    isDraft: false,
+    statusCheckRollup: []
+  };
+  const runner = createRunner([
+    {
+      status: 1,
+      stdout: '',
+      stderr: 'could not determine current branch: failed to run git: not on any branch\n'
     },
     {
       status: 0,


### PR DESCRIPTION
## What Changed

- Taught `scripts/pr-manager.js` to treat detached-head `gh pr view` failures as a repo-scan fallback instead of aborting the whole manager run.
- Added regression tests for both `getPrStatus()` and `loadManagedPrs()` so detached verification worktrees still enumerate open PRs.

## Why

- The revenue-loop automation starts from detached worktrees often enough that `npm run pr:manage` was failing before it could inspect open PRs or advance merge-ready work.
- Non-goals: no product, GTM copy, or marketplace listing changes in this PR.

## Verification

```bash
node --test tests/pr-manager.test.js
npm ci
npm test
npm run test:coverage
THUMBGATE_PROOF_DIR="$(mktemp -d)/proof" npm run prove:adapters
THUMBGATE_AUTOMATION_PROOF_DIR="$(mktemp -d)/proof-automation" npm run prove:automation
npm run self-heal:check
```

- `npm run self-heal:check` initially failed due host-level `ENOSPC` during the packaged runtime install lane; after clearing disposable caches and rerunning on the same branch head it passed `6/6 healthy`.

## Evidence

- Detached-head failure reproduced locally before the patch: `Failed to fetch PR status: could not determine current branch: failed to run git: not on any branch`.
- Live validation after the patch: `npm run pr:manage` completed repo-wide scanning from the detached checkout and queued ready PR `#1525` for `/trunk merge` instead of aborting.
- No `docs/VERIFICATION_EVIDENCE.md` update in this PR because behavior stayed internal to the PR manager and verification remained command-backed in the PR itself.

## Risks

- `npm test` still emits timestamp-only GTM artifacts in the working tree; I restored those before commit, but the side effect remains outside this fix.
