### PR TITLE
fix(automation): harden detached PR scans and send-now evidence

### DIFF
--- a/.changeset/detached-pr-send-now-evidence.md
+++ b/.changeset/detached-pr-send-now-evidence.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Harden detached `pr:manage` scans and carry billing verification metadata into operator send-now exports.

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -2108,6 +2108,10 @@ function buildOperatorSendNowPayload(report) {
   const rows = handoff.sections.flatMap((section) => (
     section.targets.map((target) => ({
       rank: Number(target.rank || 0),
+      revenueState: normalizeText(handoff.summary?.revenueState) || 'cold-start',
+      billingVerification: normalizeText(handoff.summary?.billingVerification) || 'n/a',
+      billingSource: normalizeText(report?.source) || 'local',
+      revenueWindow: normalizeText(report?.snapshotWindow) || 'today',
       sectionKey: section.key,
       sectionLabel: section.label,
       temperature: normalizeText(target.temperature) || 'cold',
@@ -2155,6 +2159,10 @@ function renderOperatorSendNowCsv(report) {
   const rows = [
     [
       'rank',
+      'revenueState',
+      'billingVerification',
+      'billingSource',
+      'revenueWindow',
       'sectionKey',
       'sectionLabel',
       'temperature',
@@ -2190,6 +2198,10 @@ function renderOperatorSendNowCsv(report) {
     ],
     ...payload.rows.map((row) => [
       String(row.rank || 0),
+      row.revenueState,
+      row.billingVerification,
+      row.billingSource,
+      row.revenueWindow,
       row.sectionKey,
       row.sectionLabel,
       row.temperature,

--- a/scripts/pr-manager.js
+++ b/scripts/pr-manager.js
@@ -118,6 +118,14 @@ function isMissingCurrentBranchPr(result, prNumber) {
   return /no pull requests found for branch/i.test(formatGhError(result));
 }
 
+function isDetachedCurrentBranchLookup(result, prNumber) {
+  if (prNumber) {
+    return false;
+  }
+
+  return /could not determine current branch|not on any branch/i.test(formatGhError(result));
+}
+
 /**
  * Fetch granular PR status using GH CLI
  */
@@ -129,7 +137,10 @@ function getPrStatus(prNumber = '', runner = runGh) {
 
   const result = runner(args);
   if (result.status !== 0) {
-    if (isMissingCurrentBranchPr(result, normalizedPrNumber)) {
+    if (
+      isMissingCurrentBranchPr(result, normalizedPrNumber)
+      || isDetachedCurrentBranchLookup(result, normalizedPrNumber)
+    ) {
       return null;
     }
 

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -2255,8 +2255,9 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.match(operatorHandoff, /Log after pain-confirmed reply: `npm run sales:pipeline -- advance --lead 'reddit_builder_production_mcp_server'/);
     assert.equal(operatorHandoffJson.sections.find((section) => section.key === 'send_now_warm_discovery').label, 'Send Now: Warm Discovery');
     assert.equal(operatorHandoffJson.sections.find((section) => section.key === 'send_now_warm_discovery').targets[0].pipelineLeadId, 'reddit_builder_production_mcp_server');
-    assert.match(operatorSendNowCsv, /^rank,sectionKey,sectionLabel,temperature,source,channel,pipelineStage,pipelineLeadId,username,accountName,company,repoName,repoUrl,contactSurface,contactSurfaces,pipelineUpdatedAt,nextOperatorStep,evidenceScore,evidence,motionLabel,whyNow,proofRule,cta,firstTouchDraft,painConfirmedFollowUpDraft,selfServeFollowUpDraft,checkoutCloseDraft,markContactedCommand,markRepliedCommand,markCallBookedCommand,markCheckoutStartedCommand,markSprintIntakeCommand,markPaidCommand/m);
+    assert.match(operatorSendNowCsv, /^rank,revenueState,billingVerification,billingSource,revenueWindow,sectionKey,sectionLabel,temperature,source,channel,pipelineStage,pipelineLeadId,username,accountName,company,repoName,repoUrl,contactSurface,contactSurfaces,pipelineUpdatedAt,nextOperatorStep,evidenceScore,evidence,motionLabel,whyNow,proofRule,cta,firstTouchDraft,painConfirmedFollowUpDraft,selfServeFollowUpDraft,checkoutCloseDraft,markContactedCommand,markRepliedCommand,markCallBookedCommand,markCheckoutStartedCommand,markSprintIntakeCommand,markPaidCommand/m);
     assert.match(operatorSendNowCsv, /send_now_warm_discovery/);
+    assert.match(operatorSendNowCsv, /rank,revenueState,billingVerification,billingSource,revenueWindow/);
     assert.match(operatorSendNowCsv, /reddit_builder_production_mcp_server/);
     assert.match(operatorSendNowCsv, /Builder Labs/);
     assert.equal(operatorSendNowJson.rows[0].sectionKey, 'send_now_warm_discovery');
@@ -2420,10 +2421,15 @@ test('operator send-now export flattens ranked handoff rows for batch ops', () =
   const csv = renderOperatorSendNowCsv(report);
 
   assert.equal(payload.rows.length, 1);
+  assert.equal(payload.rows[0].revenueState, 'post-first-dollar');
+  assert.equal(payload.rows[0].billingVerification, 'Live hosted billing summary verified for this run.');
+  assert.equal(payload.rows[0].billingSource, 'local');
+  assert.equal(payload.rows[0].revenueWindow, 'today');
   assert.equal(payload.rows[0].sectionKey, 'send_now_warm_discovery');
   assert.equal(payload.rows[0].pipelineLeadId, 'reddit_builder_production_mcp_server');
   assert.equal(payload.rows[0].company, 'Builder Labs');
   assert.match(csv, /send_now_warm_discovery/);
+  assert.match(csv, /Live hosted billing summary verified for this run\./);
   assert.match(csv, /Reddit DM: https:\/\/www\.reddit\.com\/user\/builder\//);
   assert.match(csv, /I can harden one workflow, then prove it\./);
 });

--- a/tests/pr-manager.test.js
+++ b/tests/pr-manager.test.js
@@ -195,6 +195,18 @@ test('PR Manager - getPrStatus returns null when current branch has no PR', () =
   assert.equal(getPrStatus('', runner), null);
 });
 
+test('PR Manager - getPrStatus returns null when running from detached HEAD', () => {
+  const runner = createRunner([
+    {
+      status: 1,
+      stdout: '',
+      stderr: 'could not determine current branch: failed to run git: not on any branch\n'
+    }
+  ]);
+
+  assert.equal(getPrStatus('', runner), null);
+});
+
 test('PR Manager - normalizePrNumber rejects unsafe values', () => {
   assert.equal(normalizePrNumber('123'), '123');
   assert.throws(() => normalizePrNumber('../665', { allowEmpty: false }), /Unsafe PR number/);
@@ -250,6 +262,31 @@ test('PR Manager - loadManagedPrs falls back to open PR list when branch has no 
       status: 1,
       stdout: '',
       stderr: 'no pull requests found for branch "codex/tech-debt-audit-20260320"\n'
+    },
+    {
+      status: 0,
+      stdout: JSON.stringify([mockPr]),
+      stderr: ''
+    }
+  ]);
+
+  assert.deepEqual(loadManagedPrs('', runner), [mockPr]);
+});
+
+test('PR Manager - loadManagedPrs falls back to open PR list from detached HEAD', () => {
+  const mockPr = {
+    number: 282,
+    title: 'Detached lane PR',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    isDraft: false,
+    statusCheckRollup: []
+  };
+  const runner = createRunner([
+    {
+      status: 1,
+      stdout: '',
+      stderr: 'could not determine current branch: failed to run git: not on any branch\n'
     },
     {
       status: 0,


### PR DESCRIPTION
## Summary
- let `scripts/pr-manager.js` treat detached-HEAD branch lookup failures like branchless runs so repo-wide PR inspection still works in automation worktrees
- add regression coverage for detached `gh pr view` failures and detached fallback loading
- include revenue state and billing verification metadata in `operator-send-now` rows so batch exports remain evidence-backed when viewed standalone

## Verification
- `node --test tests/pr-manager.test.js`
- `node --test --test-name-pattern "writeRevenueLoopOutputs writes markdown, json, and csv artifacts for operator import|operator send-now export flattens ranked handoff rows for batch ops" tests/gtm-revenue-loop.test.js`
- clean worktree: `npm ci`
- clean worktree: `npm test`