### PR TITLE
fix(security): update Anthropic SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.92.0",
         "@google/genai": "1.49.0",
         "@huggingface/transformers": "^4.1.0",
         "@lancedb/lancedb": "^0.27.2",
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -604,7 +604,7 @@
     "node": ">=18.18.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/sdk": "^0.92.0",
     "@google/genai": "1.49.0",
     "@huggingface/transformers": "^4.1.0",
     "@lancedb/lancedb": "^0.27.2",


### PR DESCRIPTION
## Summary
- Updates `@anthropic-ai/sdk` from `^0.90.0` to `^0.92.0`.
- Clears npm advisory GHSA-p7fg-763f-g4gf from the dependency tree.
- Keeps the change scoped to `package.json` and `package-lock.json`.

## Verification
- `npm ci`
- `npm test` -> 4,865 tests; 4,861 pass; 0 fail; 4 skipped
- `npm run test:coverage` -> 87.21% line coverage, 72.60% branch coverage, 88.75% function coverage
- `npm run prove:adapters` -> 48/48 pass
- `npm run prove:automation` -> 55/55 pass
- `npm run self-heal:check` -> HEALTHY, 6/6 checks
- `npm audit --json` -> 0 vulnerabilities

## Security
`npm audit` reports 0 info, 0 low, 0 moderate, 0 high, and 0 critical vulnerabilities after the dependency bump.