### PR TITLE
chore(release): version thumbgate 1.16.9

### DIFF
--- a/.changeset/aiventyx-revenue-loop-bundle.md
+++ b/.changeset/aiventyx-revenue-loop-bundle.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Include the Aiventyx marketplace plan in the autonomous GTM revenue-loop bundle and refresh the checked-in operator sales assets from the unified automation flow.

--- a/.changeset/buyer-intent-routing-hardening.md
+++ b/.changeset/buyer-intent-routing-hardening.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Harden the GTM revenue-loop buyer-intent routing so low-intent educational targets are filtered from the operator queue and first-touch Pro outreach stays discovery-first until pain is confirmed.

--- a/.changeset/codex-follow-up-sequences.md
+++ b/.changeset/codex-follow-up-sequences.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add Codex plugin follow-up sequences to the revenue pack and refresh the operator sales asset.

--- a/.changeset/codex-ready-target-queue.md
+++ b/.changeset/codex-ready-target-queue.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a Codex-ready target queue export to the revenue pack and refresh the operator-facing Codex sales asset.

--- a/.changeset/evidence-backed-outreach-targets.md
+++ b/.changeset/evidence-backed-outreach-targets.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the GTM outreach renderer so operator-ready follow-up, warm discovery, and cold GitHub targets are generated from the current evidence-backed revenue queue instead of a stale static draft.

--- a/.changeset/gemini-channel-outreach-pack.md
+++ b/.changeset/gemini-channel-outreach-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add evidence-backed Gemini CLI channel outreach exports to the GTM demand pack, including active social drafts and a dedicated operator CSV artifact.

--- a/.changeset/github-outreach-automation-refresh.md
+++ b/.changeset/github-outreach-automation-refresh.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the autonomous GTM runner so it regenerates the GitHub outreach asset from the current revenue-loop queue and keeps the checked-in outreach targets aligned with the latest evidence-backed pipeline state.

--- a/.changeset/gitlab-discovery-lane.md
+++ b/.changeset/gitlab-discovery-lane.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the GTM revenue loop with a live GitLab review-automation discovery lane, keep self-serve hook prospects on the guide-first close path, and regenerate the operator outreach pack from the updated evidence set.

--- a/.changeset/gitlab-review-guide-first-gtm.md
+++ b/.changeset/gitlab-review-guide-first-gtm.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Broaden GTM discovery toward GitLab review workflows and keep self-serve hook prospects on the guide-first outreach lane.

--- a/.changeset/governance-discovery-policy-queries.md
+++ b/.changeset/governance-discovery-policy-queries.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Expand the revenue loop's GitHub discovery into ServiceNow agent workflow, approval-policy, and workflow-guardrail repos, then refresh the checked-in operator handoff assets from the stronger governance-focused evidence mix.

--- a/.changeset/gtm-contact-surfaces-local-fastpath.md
+++ b/.changeset/gtm-contact-surfaces-local-fastpath.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Enrich the GTM revenue-loop prospect queue with public GitHub website and company surfaces, carry the extra contact metadata into the generated operator assets, and skip the hosted revenue-status audit when local metrics are explicitly requested so local evidence-backed artifact refreshes complete quickly.

--- a/.changeset/gtm-discovery-artifact-contract.md
+++ b/.changeset/gtm-discovery-artifact-contract.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Align the customer discovery sprint guide with the actual revenue-loop artifact pack, including the default `docs/marketing` outputs, warm-outreach handoff files, and ChatGPT acquisition assets.

--- a/.changeset/gtm-gh-auth-fallback.md
+++ b/.changeset/gtm-gh-auth-fallback.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Restore authenticated GitHub prospecting in the GTM revenue loop by falling back to the local `gh` login when explicit GitHub API tokens are not set, and refresh the checked-in operator acquisition assets with the recovered cold-target queue.

--- a/.changeset/gtm-pipeline-commands.md
+++ b/.changeset/gtm-pipeline-commands.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Emit stable lead IDs and per-target sales pipeline commands in the GTM revenue loop operator assets.

--- a/.changeset/gtm-secondary-cta-fallback.md
+++ b/.changeset/gtm-secondary-cta-fallback.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Preserve the canonical Pro checkout CTA in generated GTM marketplace assets when the current target set is sprint-only.

--- a/.changeset/gtm-workflow-discovery-broadening.md
+++ b/.changeset/gtm-workflow-discovery-broadening.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Broaden the revenue loop's GitHub discovery toward workflow approval, review, incident, and Jira control-surface repos while filtering portfolio-style false positives, then refresh the checked-in operator handoff assets from the new evidence mix.

--- a/.changeset/hosted-revenue-loop-truth-refresh.md
+++ b/.changeset/hosted-revenue-loop-truth-refresh.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Harden the GTM revenue loop so operator assets distinguish live hosted billing proof from historical or local fallback data before they claim current revenue traction.

--- a/.changeset/hosted-revenue-loop-truth.md
+++ b/.changeset/hosted-revenue-loop-truth.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Prefer hosted revenue-status truth in the GTM revenue loop when the local operational summary falls back, and refresh the generated marketplace and outreach assets with the verified hosted billing snapshot.

--- a/.changeset/landing-path-clarity.md
+++ b/.changeset/landing-path-clarity.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Clarify the public landing-page buying paths so Sprint, Solo Pro, and free OSS routing match the repo's current commercial truth.

--- a/.changeset/linkedin-workflow-hardening-pack.md
+++ b/.changeset/linkedin-workflow-hardening-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a queue-backed LinkedIn workflow hardening pack to the GTM revenue loop, including tracked founder-post, comment, DM, and self-serve follow-on assets.

--- a/.changeset/machine-readable-buyer-paths.md
+++ b/.changeset/machine-readable-buyer-paths.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add machine-readable landing-page buyer paths for the install guide, Pro checkout, and Workflow Hardening Sprint so search parsers and operators can route buyers to the right conversion path.

--- a/.changeset/marketplace-proof-refresh.md
+++ b/.changeset/marketplace-proof-refresh.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the GTM marketplace generator so the operator pack always surfaces an evidence-backed self-serve tooling lane alongside warm workflow-hardening targets, and keep the generated marketplace copy, handoff notes, and sample targets aligned with that mixed acquisition motion.

--- a/.changeset/marketplace-variant-assets.md
+++ b/.changeset/marketplace-variant-assets.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add evidence-backed marketplace listing variants to the GTM revenue loop, regenerate the operator queue artifacts, and keep the marketplace copy pack aligned to proof-backed sprint versus guide-to-Pro motions.

--- a/.changeset/mcp-directory-repair-pack.md
+++ b/.changeset/mcp-directory-repair-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add an operator-ready MCP directory repair pack that captures live ThumbGate vs legacy listing drift, wire it into the autonomous sales loop, and keep the discovery sprint artifact list plus workflow test coverage in sync.

--- a/.changeset/mcp-directory-tracked-ctas.md
+++ b/.changeset/mcp-directory-tracked-ctas.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Track MCP directory follow-on offers with machine-readable UTM attribution and add a dedicated ThumbGate Pro CTA so self-serve paid intent is measurable alongside the guide and workflow sprint motions.

--- a/.changeset/offer-split-surface-alignment.md
+++ b/.changeset/offer-split-surface-alignment.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Align the public FAQ and GTM revenue-loop assets around the current Pro versus Workflow Hardening Sprint offer split so operator copy stays consistent across discovery and conversion surfaces.

--- a/.changeset/operator-handoff-json.md
+++ b/.changeset/operator-handoff-json.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a machine-readable `operator-priority-handoff.json` revenue-loop artifact so operators and automations can consume the ranked outreach queue, CTA, proof rules, and sales pipeline commands without scraping markdown.

--- a/.changeset/operator-handoff-markdown-fallback.md
+++ b/.changeset/operator-handoff-markdown-fallback.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Keep operator handoff markdown aligned with the GTM revenue-loop JSON summary by preserving summary contact surfaces and why-now fields during rendering.

--- a/.changeset/operator-pack-sidecars.md
+++ b/.changeset/operator-pack-sidecars.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Persist the GTM operator pack sidecar JSON and CSV artifacts in `docs/marketing` when the revenue loop writes checked-in docs, so the machine-readable queues and listing metadata stay aligned with the published Markdown packs.

--- a/.changeset/operator-self-serve-close-segmentation.md
+++ b/.changeset/operator-self-serve-close-segmentation.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Split self-serve Pro prospects out of the generic operator cold queue so GTM handoff assets preserve the selected motion and make self-serve closes explicit.

--- a/.changeset/operator-send-now-export.md
+++ b/.changeset/operator-send-now-export.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a flattened operator send-now CSV and JSON export to the GTM revenue loop so operators can batch outreach and sales-pipeline updates without reformatting the ranked handoff output.

--- a/.changeset/outreach-self-serve-handoff-refresh.md
+++ b/.changeset/outreach-self-serve-handoff-refresh.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the outreach handoff generator so self-serve Pro prospects render in their own operator lane instead of being mixed into the generic cold GitHub queue.

--- a/.changeset/pipeline-aware-followups.md
+++ b/.changeset/pipeline-aware-followups.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Prioritize active revenue follow-ups in the GTM loop, suppress terminal leads from operator queues, and refresh the evidence-backed outreach bundle.

--- a/.changeset/production-rollout-queue.md
+++ b/.changeset/production-rollout-queue.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Surface production-rollout buyers as a first-class GTM queue lane and regenerate the operator handoff, send-now export, and marketplace copy from the live evidence-backed revenue loop.

--- a/.changeset/public-proof-hygiene.md
+++ b/.changeset/public-proof-hygiene.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Keep public dashboard and numbers surfaces proof-safe by removing fabricated demo revenue copy, refreshing the generated numbers snapshot wording, and pinning both behaviors with regression tests.

--- a/.changeset/queue-csv-pipeline-actions.md
+++ b/.changeset/queue-csv-pipeline-actions.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Export pipeline lead ids, next-operator actions, and ready-to-run sales stage commands in the GTM target queue CSV so operators can execute outreach and stage advances directly from the flat queue artifact.

--- a/.changeset/readme-live-surfaces.md
+++ b/.changeset/readme-live-surfaces.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Keep README buyer CTAs on live ThumbGate surfaces so checkout, dashboard, and guide links preserve the intended path and UTM attribution.

--- a/.changeset/reddit-dm-workflow-hardening-pack.md
+++ b/.changeset/reddit-dm-workflow-hardening-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add an evidence-backed Reddit DM workflow hardening pack to the autonomous revenue loop so warm Reddit leads ship with tracked operator queues, proof-timed follow-ups, and copy-paste close drafts.

--- a/.changeset/revenue-loop-live-target-refresh.md
+++ b/.changeset/revenue-loop-live-target-refresh.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the checked-in GTM revenue-loop assets from the latest hosted billing snapshot and live GitHub discovery so operator handoff copy, marketplace listing themes, and target queues stay aligned with current buyer signals.

--- a/.changeset/revenue-loop-self-serve-lane.md
+++ b/.changeset/revenue-loop-self-serve-lane.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Diversify the GTM revenue loop so operator assets surface both workflow-hardening targets and self-serve tooling prospects, route Pro-oriented first touch through the proof-backed setup guide, and keep generated sales-command notes aligned with the selected motion.

--- a/.changeset/revenue-loop-window-stability.md
+++ b/.changeset/revenue-loop-window-stability.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Stabilize the hosted GTM revenue loop by retrying transient hosted-summary fallbacks, selecting the freshest hosted billing window with real commercial signal, and regenerating the operator outreach assets from that verified state.

--- a/.changeset/revenue-marketplace-truth-ctas.md
+++ b/.changeset/revenue-marketplace-truth-ctas.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Keep GTM revenue-loop marketplace assets evidence-backed by tightening the post-revenue headline language and preserving canonical sprint and Pro CTAs after rebases.

--- a/.changeset/revenue-queue-command-sanitizer.md
+++ b/.changeset/revenue-queue-command-sanitizer.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the evidence-backed GTM revenue queue and sanitize generated sales-command notes so operator artifacts do not leak outreach-instruction phrasing.

--- a/.changeset/revenue-queue-refresh.md
+++ b/.changeset/revenue-queue-refresh.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Refresh the autonomous GTM revenue-loop prospecting queries and regenerate the operator sales asset bundle with direct owner contact surfaces.

--- a/.changeset/self-serve-close-pack.md
+++ b/.changeset/self-serve-close-pack.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Extend the GTM revenue loop with self-serve tool-path follow-ups, checkout-close drafts, and paid-stage sales commands so operator handoff artifacts carry proof-backed conversion copy from first touch through purchase.

--- a/.changeset/self-serve-revenue-queue.md
+++ b/.changeset/self-serve-revenue-queue.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Widen the autonomous GTM revenue queue toward stronger self-serve plugin and hook targets, and refresh the operator handoff assets around those evidence-backed prospects.

--- a/.changeset/truthful-pack-refresh.md
+++ b/.changeset/truthful-pack-refresh.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Keep the Claude, Gemini CLI, LinkedIn, and ChatGPT sales packs aligned with the live GTM revenue loop so operator copy stays cold-start truthful and the generated docs stop implying verified revenue before it exists.

--- a/.changeset/visible-team-intake-security.md
+++ b/.changeset/visible-team-intake-security.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Make the Team workflow sprint intake visible on the landing page, add first-party telemetry for Team intake starts and submit attempts, and upgrade `@anthropic-ai/sdk` to a non-vulnerable version.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -13,7 +13,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.16.8",
+      "version": "1.16.9",
       "author": {
         "name": "Igor Ganapolsky"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action checks, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.16.8"
+    "version": "1.16.9"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,105 @@
 # Changelog
 
+## 1.16.9
+
+### Patch Changes
+
+- [#1361](https://github.com/IgorGanapolsky/ThumbGate/pull/1361) [`20c6eeb`](https://github.com/IgorGanapolsky/ThumbGate/commit/20c6eeb262b61a82b811606f1785c342c3f64f52) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Include the Aiventyx marketplace plan in the autonomous GTM revenue-loop bundle and refresh the checked-in operator sales assets from the unified automation flow.
+
+- [#1365](https://github.com/IgorGanapolsky/ThumbGate/pull/1365) [`5d331f9`](https://github.com/IgorGanapolsky/ThumbGate/commit/5d331f9aa9fad7d785f1dbd32ef178dd04529f0f) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Harden the GTM revenue-loop buyer-intent routing so low-intent educational targets are filtered from the operator queue and first-touch Pro outreach stays discovery-first until pain is confirmed.
+
+- [#1367](https://github.com/IgorGanapolsky/ThumbGate/pull/1367) [`24fc667`](https://github.com/IgorGanapolsky/ThumbGate/commit/24fc6675734e5e30a4f5096f9fdd22ea13ba5d27) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add Codex plugin follow-up sequences to the revenue pack and refresh the operator sales asset.
+
+- [#1421](https://github.com/IgorGanapolsky/ThumbGate/pull/1421) [`69ec01a`](https://github.com/IgorGanapolsky/ThumbGate/commit/69ec01a8d19b3c7f1dff37cc82fdc74f98d24cf8) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a Codex-ready target queue export to the revenue pack and refresh the operator-facing Codex sales asset.
+
+- [#1392](https://github.com/IgorGanapolsky/ThumbGate/pull/1392) [`2c26dcd`](https://github.com/IgorGanapolsky/ThumbGate/commit/2c26dcd75221d0e461f8bf4bc8329c8b531c2d3d) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the GTM outreach renderer so operator-ready follow-up, warm discovery, and cold GitHub targets are generated from the current evidence-backed revenue queue instead of a stale static draft.
+
+- [#1354](https://github.com/IgorGanapolsky/ThumbGate/pull/1354) [`aa0e652`](https://github.com/IgorGanapolsky/ThumbGate/commit/aa0e652cbd6eae2cf57268905f15064a102d9db8) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add evidence-backed Gemini CLI channel outreach exports to the GTM demand pack, including active social drafts and a dedicated operator CSV artifact.
+
+- [#1413](https://github.com/IgorGanapolsky/ThumbGate/pull/1413) [`433ae05`](https://github.com/IgorGanapolsky/ThumbGate/commit/433ae056348de81fc8d50ee293eea613bdd3f949) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the autonomous GTM runner so it regenerates the GitHub outreach asset from the current revenue-loop queue and keeps the checked-in outreach targets aligned with the latest evidence-backed pipeline state.
+
+- [#1455](https://github.com/IgorGanapolsky/ThumbGate/pull/1455) [`8c39c59`](https://github.com/IgorGanapolsky/ThumbGate/commit/8c39c590015f39ea3eee74032b2b76555731d8b0) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the GTM revenue loop with a live GitLab review-automation discovery lane, keep self-serve hook prospects on the guide-first close path, and regenerate the operator outreach pack from the updated evidence set.
+
+- [#1457](https://github.com/IgorGanapolsky/ThumbGate/pull/1457) [`2b6a352`](https://github.com/IgorGanapolsky/ThumbGate/commit/2b6a352dcebff52f5f37d0acc735d1d006629b60) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Broaden GTM discovery toward GitLab review workflows and keep self-serve hook prospects on the guide-first outreach lane.
+
+- [#1448](https://github.com/IgorGanapolsky/ThumbGate/pull/1448) [`40f4077`](https://github.com/IgorGanapolsky/ThumbGate/commit/40f4077f37af099877c77cc30dfd0102cad1b278) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Expand the revenue loop's GitHub discovery into ServiceNow agent workflow, approval-policy, and workflow-guardrail repos, then refresh the checked-in operator handoff assets from the stronger governance-focused evidence mix.
+
+- [#1387](https://github.com/IgorGanapolsky/ThumbGate/pull/1387) [`9e3e724`](https://github.com/IgorGanapolsky/ThumbGate/commit/9e3e72432816673449f6127a836b29a461eaade2) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Enrich the GTM revenue-loop prospect queue with public GitHub website and company surfaces, carry the extra contact metadata into the generated operator assets, and skip the hosted revenue-status audit when local metrics are explicitly requested so local evidence-backed artifact refreshes complete quickly.
+
+- [#1358](https://github.com/IgorGanapolsky/ThumbGate/pull/1358) [`c5a3606`](https://github.com/IgorGanapolsky/ThumbGate/commit/c5a3606fc8474f30cef2a9bbcb72fa0942d804b2) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Align the customer discovery sprint guide with the actual revenue-loop artifact pack, including the default `docs/marketing` outputs, warm-outreach handoff files, and ChatGPT acquisition assets.
+
+- [#1390](https://github.com/IgorGanapolsky/ThumbGate/pull/1390) [`277bfd6`](https://github.com/IgorGanapolsky/ThumbGate/commit/277bfd6b2e8d292f44480da83a59e87dc17ff552) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Restore authenticated GitHub prospecting in the GTM revenue loop by falling back to the local `gh` login when explicit GitHub API tokens are not set, and refresh the checked-in operator acquisition assets with the recovered cold-target queue.
+
+- [#1373](https://github.com/IgorGanapolsky/ThumbGate/pull/1373) [`3c60cef`](https://github.com/IgorGanapolsky/ThumbGate/commit/3c60cefc013de43d18be86ffb0485329e521d505) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Emit stable lead IDs and per-target sales pipeline commands in the GTM revenue loop operator assets.
+
+- [#1383](https://github.com/IgorGanapolsky/ThumbGate/pull/1383) [`86415db`](https://github.com/IgorGanapolsky/ThumbGate/commit/86415db82b8eae7fd399162f5cbc6e2f300f344e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Preserve the canonical Pro checkout CTA in generated GTM marketplace assets when the current target set is sprint-only.
+
+- [#1444](https://github.com/IgorGanapolsky/ThumbGate/pull/1444) [`39ee871`](https://github.com/IgorGanapolsky/ThumbGate/commit/39ee8710aef72374c4c48523e13029744b2b4d8a) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Broaden the revenue loop's GitHub discovery toward workflow approval, review, incident, and Jira control-surface repos while filtering portfolio-style false positives, then refresh the checked-in operator handoff assets from the new evidence mix.
+
+- [#1441](https://github.com/IgorGanapolsky/ThumbGate/pull/1441) [`46b816a`](https://github.com/IgorGanapolsky/ThumbGate/commit/46b816ac43554ae6c2cf2d7924ea9b82eb38450c) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Harden the GTM revenue loop so operator assets distinguish live hosted billing proof from historical or local fallback data before they claim current revenue traction.
+
+- [#1377](https://github.com/IgorGanapolsky/ThumbGate/pull/1377) [`2d5b20c`](https://github.com/IgorGanapolsky/ThumbGate/commit/2d5b20cdcacf95f5ca007d6d13f4e824b8709648) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Prefer hosted revenue-status truth in the GTM revenue loop when the local operational summary falls back, and refresh the generated marketplace and outreach assets with the verified hosted billing snapshot.
+
+- [#1465](https://github.com/IgorGanapolsky/ThumbGate/pull/1465) [`8578d03`](https://github.com/IgorGanapolsky/ThumbGate/commit/8578d0336161354d3cc2a0865b3d405446403f3d) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Clarify the public landing-page buying paths so Sprint, Solo Pro, and free OSS routing match the repo's current commercial truth.
+
+- [#1396](https://github.com/IgorGanapolsky/ThumbGate/pull/1396) [`e7b993f`](https://github.com/IgorGanapolsky/ThumbGate/commit/e7b993f0c5ea3f79ee9a8a8aa916caa3363eb091) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a queue-backed LinkedIn workflow hardening pack to the GTM revenue loop, including tracked founder-post, comment, DM, and self-serve follow-on assets.
+
+- [#1467](https://github.com/IgorGanapolsky/ThumbGate/pull/1467) [`cb884a4`](https://github.com/IgorGanapolsky/ThumbGate/commit/cb884a4b1206e08401b86d15ae5adb399058d196) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add machine-readable landing-page buyer paths for the install guide, Pro checkout, and Workflow Hardening Sprint so search parsers and operators can route buyers to the right conversion path.
+
+- [#1431](https://github.com/IgorGanapolsky/ThumbGate/pull/1431) [`bc72c63`](https://github.com/IgorGanapolsky/ThumbGate/commit/bc72c6314b2653557f1d99d302d31bccbec13a6d) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the GTM marketplace generator so the operator pack always surfaces an evidence-backed self-serve tooling lane alongside warm workflow-hardening targets, and keep the generated marketplace copy, handoff notes, and sample targets aligned with that mixed acquisition motion.
+
+- [#1461](https://github.com/IgorGanapolsky/ThumbGate/pull/1461) [`55c2002`](https://github.com/IgorGanapolsky/ThumbGate/commit/55c200251489cb8e2c5fc3337488d86b96f5d1d3) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add evidence-backed marketplace listing variants to the GTM revenue loop, regenerate the operator queue artifacts, and keep the marketplace copy pack aligned to proof-backed sprint versus guide-to-Pro motions.
+
+- [#1428](https://github.com/IgorGanapolsky/ThumbGate/pull/1428) [`d0577b6`](https://github.com/IgorGanapolsky/ThumbGate/commit/d0577b6fbda73a9d74b1966973da7c317ef79570) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add an operator-ready MCP directory repair pack that captures live ThumbGate vs legacy listing drift, wire it into the autonomous sales loop, and keep the discovery sprint artifact list plus workflow test coverage in sync.
+
+- [#1475](https://github.com/IgorGanapolsky/ThumbGate/pull/1475) [`b3edbe8`](https://github.com/IgorGanapolsky/ThumbGate/commit/b3edbe83d2a4bab2abd14a43dfdacc3b2ea63b8d) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Track MCP directory follow-on offers with machine-readable UTM attribution and add a dedicated ThumbGate Pro CTA so self-serve paid intent is measurable alongside the guide and workflow sprint motions.
+
+- [#1446](https://github.com/IgorGanapolsky/ThumbGate/pull/1446) [`5bcaf85`](https://github.com/IgorGanapolsky/ThumbGate/commit/5bcaf856e0088ab69500fa6830cee842d6335bdb) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Align the public FAQ and GTM revenue-loop assets around the current Pro versus Workflow Hardening Sprint offer split so operator copy stays consistent across discovery and conversion surfaces.
+
+- [#1394](https://github.com/IgorGanapolsky/ThumbGate/pull/1394) [`b9abbc6`](https://github.com/IgorGanapolsky/ThumbGate/commit/b9abbc6e545318c91ddcce3f377ec7428e54cf28) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a machine-readable `operator-priority-handoff.json` revenue-loop artifact so operators and automations can consume the ranked outreach queue, CTA, proof rules, and sales pipeline commands without scraping markdown.
+
+- [#1399](https://github.com/IgorGanapolsky/ThumbGate/pull/1399) [`3493fa7`](https://github.com/IgorGanapolsky/ThumbGate/commit/3493fa7fb010d5aee1e898bb11e87068baf40436) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Keep operator handoff markdown aligned with the GTM revenue-loop JSON summary by preserving summary contact surfaces and why-now fields during rendering.
+
+- [#1436](https://github.com/IgorGanapolsky/ThumbGate/pull/1436) [`bbdc183`](https://github.com/IgorGanapolsky/ThumbGate/commit/bbdc183c77500306177363d3059b5c7f08444b9b) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Persist the GTM operator pack sidecar JSON and CSV artifacts in `docs/marketing` when the revenue loop writes checked-in docs, so the machine-readable queues and listing metadata stay aligned with the published Markdown packs.
+
+- [#1408](https://github.com/IgorGanapolsky/ThumbGate/pull/1408) [`d002036`](https://github.com/IgorGanapolsky/ThumbGate/commit/d0020368cb4ca35add78d2a35ee1f47aad51145c) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Split self-serve Pro prospects out of the generic operator cold queue so GTM handoff assets preserve the selected motion and make self-serve closes explicit.
+
+- [#1463](https://github.com/IgorGanapolsky/ThumbGate/pull/1463) [`c593d66`](https://github.com/IgorGanapolsky/ThumbGate/commit/c593d6679d5b5e92321b7a0cfc986870f3019466) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a flattened operator send-now CSV and JSON export to the GTM revenue loop so operators can batch outreach and sales-pipeline updates without reformatting the ranked handoff output.
+
+- [#1418](https://github.com/IgorGanapolsky/ThumbGate/pull/1418) [`eb53f67`](https://github.com/IgorGanapolsky/ThumbGate/commit/eb53f6705012975b0c1fa23bd6976ef146858155) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the outreach handoff generator so self-serve Pro prospects render in their own operator lane instead of being mixed into the generic cold GitHub queue.
+
+- [#1371](https://github.com/IgorGanapolsky/ThumbGate/pull/1371) [`80f0c2f`](https://github.com/IgorGanapolsky/ThumbGate/commit/80f0c2fdebc788001cf86727167bcce7d50bbbc9) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Prioritize active revenue follow-ups in the GTM loop, suppress terminal leads from operator queues, and refresh the evidence-backed outreach bundle.
+
+- [#1473](https://github.com/IgorGanapolsky/ThumbGate/pull/1473) [`8c0f2a9`](https://github.com/IgorGanapolsky/ThumbGate/commit/8c0f2a97ac1951dc31ea78f12e399db2da0c992f) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Surface production-rollout buyers as a first-class GTM queue lane and regenerate the operator handoff, send-now export, and marketplace copy from the live evidence-backed revenue loop.
+
+- [#1375](https://github.com/IgorGanapolsky/ThumbGate/pull/1375) [`ffd08ea`](https://github.com/IgorGanapolsky/ThumbGate/commit/ffd08eaa5111c42c4c78279419d7e1a1cb9aeb93) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Keep public dashboard and numbers surfaces proof-safe by removing fabricated demo revenue copy, refreshing the generated numbers snapshot wording, and pinning both behaviors with regression tests.
+
+- [#1410](https://github.com/IgorGanapolsky/ThumbGate/pull/1410) [`546531c`](https://github.com/IgorGanapolsky/ThumbGate/commit/546531cffc8630cc414ab8122185d0ad5b7be7a7) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Export pipeline lead ids, next-operator actions, and ready-to-run sales stage commands in the GTM target queue CSV so operators can execute outreach and stage advances directly from the flat queue artifact.
+
+- [#1369](https://github.com/IgorGanapolsky/ThumbGate/pull/1369) [`15d37db`](https://github.com/IgorGanapolsky/ThumbGate/commit/15d37db42304346cd4d1147467e52f834d20b7f3) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Keep README buyer CTAs on live ThumbGate surfaces so checkout, dashboard, and guide links preserve the intended path and UTM attribution.
+
+- [#1426](https://github.com/IgorGanapolsky/ThumbGate/pull/1426) [`ce17de0`](https://github.com/IgorGanapolsky/ThumbGate/commit/ce17de00cee978b12fa2185bf921c7d67fdd6fa6) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add an evidence-backed Reddit DM workflow hardening pack to the autonomous revenue loop so warm Reddit leads ship with tracked operator queues, proof-timed follow-ups, and copy-paste close drafts.
+
+- [#1453](https://github.com/IgorGanapolsky/ThumbGate/pull/1453) [`9eaeb3b`](https://github.com/IgorGanapolsky/ThumbGate/commit/9eaeb3b4db00ce0696308c799457e838a1d57861) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the checked-in GTM revenue-loop assets from the latest hosted billing snapshot and live GitHub discovery so operator handoff copy, marketplace listing themes, and target queues stay aligned with current buyer signals.
+
+- [#1403](https://github.com/IgorGanapolsky/ThumbGate/pull/1403) [`f0871f5`](https://github.com/IgorGanapolsky/ThumbGate/commit/f0871f5af4b1f7b4de3e27b8a3c22975a6424047) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Diversify the GTM revenue loop so operator assets surface both workflow-hardening targets and self-serve tooling prospects, route Pro-oriented first touch through the proof-backed setup guide, and keep generated sales-command notes aligned with the selected motion.
+
+- [#1433](https://github.com/IgorGanapolsky/ThumbGate/pull/1433) [`ed8460a`](https://github.com/IgorGanapolsky/ThumbGate/commit/ed8460ae8e3c4426f2c4670babf16e4daafbd7b9) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Stabilize the hosted GTM revenue loop by retrying transient hosted-summary fallbacks, selecting the freshest hosted billing window with real commercial signal, and regenerating the operator outreach assets from that verified state.
+
+- [#1385](https://github.com/IgorGanapolsky/ThumbGate/pull/1385) [`0c2f70d`](https://github.com/IgorGanapolsky/ThumbGate/commit/0c2f70d20c680bccb817a85489c0bf5aa9ac8e47) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Keep GTM revenue-loop marketplace assets evidence-backed by tightening the post-revenue headline language and preserving canonical sprint and Pro CTAs after rebases.
+
+- [#1459](https://github.com/IgorGanapolsky/ThumbGate/pull/1459) [`db9557b`](https://github.com/IgorGanapolsky/ThumbGate/commit/db9557babb5f249e680c261b115565e5757bb348) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the evidence-backed GTM revenue queue and sanitize generated sales-command notes so operator artifacts do not leak outreach-instruction phrasing.
+
+- [#1363](https://github.com/IgorGanapolsky/ThumbGate/pull/1363) [`a978550`](https://github.com/IgorGanapolsky/ThumbGate/commit/a9785500d5adea8244d08d5aa2dc6c6d8efdf5bf) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Refresh the autonomous GTM revenue-loop prospecting queries and regenerate the operator sales asset bundle with direct owner contact surfaces.
+
+- [#1406](https://github.com/IgorGanapolsky/ThumbGate/pull/1406) [`d397402`](https://github.com/IgorGanapolsky/ThumbGate/commit/d3974021ac580ede844279917c59827de5093fa9) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Extend the GTM revenue loop with self-serve tool-path follow-ups, checkout-close drafts, and paid-stage sales commands so operator handoff artifacts carry proof-backed conversion copy from first touch through purchase.
+
+- [#1471](https://github.com/IgorGanapolsky/ThumbGate/pull/1471) [`702a3da`](https://github.com/IgorGanapolsky/ThumbGate/commit/702a3da1cbb816a3bd26181564d3e29da27d326d) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Widen the autonomous GTM revenue queue toward stronger self-serve plugin and hook targets, and refresh the operator handoff assets around those evidence-backed prospects.
+
+- [#1424](https://github.com/IgorGanapolsky/ThumbGate/pull/1424) [`daed1ab`](https://github.com/IgorGanapolsky/ThumbGate/commit/daed1abe016c92537efb02e6b72956757b4364c6) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Keep the Claude, Gemini CLI, LinkedIn, and ChatGPT sales packs aligned with the live GTM revenue loop so operator copy stays cold-start truthful and the generated docs stop implying verified revenue before it exists.
+
+- [#1561](https://github.com/IgorGanapolsky/ThumbGate/pull/1561) [`c56b223`](https://github.com/IgorGanapolsky/ThumbGate/commit/c56b223171d9879edc868e9373fb3cfd16d0334a) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Make the Team workflow sprint intake visible on the landing page, add first-party telemetry for Team intake starts and submit attempts, and upgrade `@anthropic-ai/sdk` to a non-vulnerable version.
+
 ## 1.16.8
 
 ### Patch Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,7 +3,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.16.8 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.16.9 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.16.8", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.16.9", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.16.8", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.16.9", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -201,7 +201,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.16.8' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.16.9' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.16.8",
+        "thumbgate@1.16.9",
         "thumbgate",
         "serve"
       ],

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.16.8 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.16.9 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.16.8 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.16.9 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1562,7 +1562,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.16.8 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.16.9 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2779,7 +2779,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.16.8 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.16.9 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.16.8`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.16.9`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/marketing/codex-marketplace-revenue-pack.json
+++ b/docs/marketing/codex-marketplace-revenue-pack.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-30T02:05:36.833Z",
+  "generatedAt": "2026-05-03T13:03:55.182Z",
   "channel": "Codex",
   "objective": "Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and qualified workflow sprint conversations.",
   "canonicalIdentity": {
@@ -29,7 +29,7 @@
       "key": "standalone_bundle",
       "name": "Standalone bundle download",
       "url": "https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip",
-      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.8/thumbgate-codex-plugin-v1.16.8.zip",
+      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.9/thumbgate-codex-plugin-v1.16.9.zip",
       "supportUrl": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/README.md",
       "evidenceSource": "plugins/codex-profile/README.md",
       "operatorUse": "Portable plugin path for buyers who want a direct asset instead of a repo checkout.",

--- a/docs/marketing/codex-marketplace-revenue-pack.md
+++ b/docs/marketing/codex-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Operator Revenue Pack
 
-Updated: 2026-04-30T02:05:36.833Z
+Updated: 2026-05-03T13:03:55.182Z
 
 This is a sales operator artifact. It is not proof of installs, revenue, or marketplace approval by itself.
 
@@ -26,7 +26,7 @@ Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and 
 
 ### Standalone bundle download
 - URL: https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip
-- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.8/thumbgate-codex-plugin-v1.16.8.zip
+- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.9/thumbgate-codex-plugin-v1.16.9.zip
 - Operator use: Portable plugin path for buyers who want a direct asset instead of a repo checkout.
 - Buyer signal: Warm buyers ready to install now if the runtime, update policy, and proof links are explicit.
 - Evidence source: plugins/codex-profile/README.md

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.16.8 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.16.9 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.16.8", "serve"],
+      "args": ["-y", "thumbgate@1.16.9", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.16.8", "serve"],
+      "args": ["-y", "thumbgate@1.16.9", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.16.8 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.16.9 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.16.8
+1.16.9
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.16.8"
+version: "1.16.9"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.16.8",
+      "version": "1.16.9",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "description": "Self-improving agent governance: type thumbs-up or thumbs-down on any AI agent action. ThumbGate turns every mistake into a prevention rule and blocks the pattern from repeating. One thumbs-down, never again. 33 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.16.8",
+        "thumbgate@1.16.9",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.16.8", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.16.9", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/proof/runtime-report.json
+++ b/proof/runtime-report.json
@@ -1,6 +1,6 @@
 {
   "phase": "12-interruptible-runtime",
-  "generatedAt": "2026-04-24T23:54:31.400Z",
+  "generatedAt": "2026-05-03T12:58:55.066Z",
   "passed": 7,
   "failed": 0,
   "total": 7,

--- a/proof/runtime-report.md
+++ b/proof/runtime-report.md
@@ -1,6 +1,6 @@
 # Interruptible Runtime Proof Report
 
-Generated: 2026-04-24T23:54:31.400Z
+Generated: 2026-05-03T12:58:55.066Z
 Result: 7/7 passed
 
 ## Requirements

--- a/public/index.html
+++ b/public/index.html
@@ -1164,7 +1164,7 @@ __GA_BOOTSTRAP__
 <!-- HOW IT WORKS -->
 <section class="how-it-works" id="how-it-works">
   <div class="container">
-    <div class="section-label">New in v1.16.8</div>
+    <div class="section-label">New in v1.16.9</div>
     <h2 class="section-title">Three steps to stop repeated AI failures</h2>
     <div class="steps">
       <div class="step">
@@ -1534,7 +1534,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.16.8</span>
+    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.16.9</span>
   </div>
 </footer>
 

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,9 +25,9 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.16.8",
+  "softwareVersion": "1.16.9",
   "url": "https://thumbgate-production.up.railway.app/numbers",
-  "dateModified": "2026-04-27",
+  "dateModified": "2026-05-03",
   "creator": {
     "@type": "Person",
     "name": "Igor Ganapolsky",
@@ -57,8 +57,8 @@
       "https://www.linkedin.com/in/igorganapolsky"
     ]
   },
-  "dateModified": "2026-04-27",
-  "datePublished": "2026-04-27",
+  "dateModified": "2026-05-03",
+  "datePublished": "2026-05-03",
   "keywords": [
     "AI agent gates",
     "LLM token savings",
@@ -70,7 +70,7 @@
     {
       "@type": "PropertyValue",
       "name": "active_gates",
-      "value": 36
+      "value": 37
     },
     {
       "@type": "PropertyValue",
@@ -101,7 +101,7 @@
     {
       "@type": "PropertyValue",
       "name": "bayes_error_rate",
-      "value": null
+      "value": 0
     }
   ]
 }
@@ -190,14 +190,14 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational data from the ThumbGate runtime. No surveys or projections — this page is a release-time snapshot produced by the same local scripts that power the CLI and dashboard.</p>
-  <div class="freshness">Updated: 2026-04-27 · Version 1.16.8</div>
+  <div class="freshness">Updated: 2026-05-03 · Version 1.16.9</div>
 
   <h2>Gate enforcement</h2>
   <div class="stats-grid">
     <div class="stat-card">
       <div class="stat-label">Active gates</div>
-      <div class="stat-value">36</div>
-      <div class="stat-sub">36 manual · 0 auto-promoted</div>
+      <div class="stat-value">37</div>
+      <div class="stat-sub">36 manual · 1 auto-promoted</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
@@ -242,7 +242,7 @@
     </div>
     <div class="stat-card">
       <div class="stat-label">Scorer Bayes error</div>
-      <div class="stat-value">n/a (no feedback sequences recorded yet)</div>
+      <div class="stat-value">0.0%</div>
       <div class="stat-sub">irreducible error given current feature set</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/bayes-optimal-gate.js">source: bayes-optimal-gate.js</a>
     </div>
@@ -264,7 +264,7 @@
   <div class="cta">
     <a href="https://www.npmjs.com/package/thumbgate">Install ThumbGate — npx thumbgate init</a>
     <div class="footer-note">Prefer the raw feed? See <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a> or run <code>npm run gate:stats</code> locally.</div>
-    <div class="footer-note">Generated at 2026-04-27T08:42:59.023Z UTC.</div>
+    <div class="footer-note">Generated at 2026-05-03T13:08:12.498Z UTC.</div>
   </div>
 </main>
 </body>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.16.8",
+  "version": "1.16.9",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.16.8",
+      "version": "1.16.9",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Consume the pending ThumbGate changesets and bump the package/versioned manifests to 1.16.9.
- Refresh CHANGELOG.md and runtime proof evidence for the release.
- Keep npm publish on the audited GitHub Actions publish workflow with provenance.

## Verification
- node scripts/sync-version.js --check
- npm audit --json
- npm pack --dry-run
- npm run test:deployment
- npm run test:postinstall
- npm run prove:runtime
- pre-commit guards
- pre-push guards