### PR TITLE
fix(gtm): honor hosted revenue audit timeout

### DIFF
--- a/.changeset/fresh-hats-learn.md
+++ b/.changeset/fresh-hats-learn.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Fix hosted revenue status audits so the Railway fallback honors CLI fetch timeout overrides before falling back to local zero-revenue diagnostics.

--- a/scripts/revenue-status.js
+++ b/scripts/revenue-status.js
@@ -363,11 +363,15 @@ async function probePublicRuntime(appOrigin, { fetchImpl = fetch, timeoutMs = DE
   };
 }
 
-function buildRailwayAuditSnippet({ appOrigin, timeZone }) {
+function buildRailwayAuditSnippet({
+  appOrigin,
+  timeZone,
+  fetchTimeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+}) {
   return `
     (async () => {
       const base = ${JSON.stringify(appOrigin)};
-      const fetchTimeoutMs = ${JSON.stringify(DEFAULT_FETCH_TIMEOUT_MS)};
+      const fetchTimeoutMs = ${JSON.stringify(fetchTimeoutMs)};
       async function fetchWithTimeout(url, options = {}) {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), fetchTimeoutMs);
@@ -425,10 +429,11 @@ function getHostedAuditViaRailway({
   service = DEFAULT_RAILWAY_SERVICE,
   appOrigin = DEFAULT_PUBLIC_APP_ORIGIN,
   timeZone = 'America/New_York',
+  fetchTimeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
   runCommandFn = runCommand,
   commandTimeoutMs = DEFAULT_COMMAND_TIMEOUT_MS,
 } = {}) {
-  const snippet = buildRailwayAuditSnippet({ appOrigin, timeZone });
+  const snippet = buildRailwayAuditSnippet({ appOrigin, timeZone, fetchTimeoutMs });
   const stdout = requireCommandSuccess(
     'railway run',
     runCommandFn('railway', [
@@ -595,6 +600,7 @@ async function generateRevenueStatusReport({
       service: repoVars.RAILWAY_SERVICE || DEFAULT_RAILWAY_SERVICE,
       appOrigin: hostedApiOrigin,
       timeZone,
+      fetchTimeoutMs,
       runCommandFn,
       commandTimeoutMs,
     });

--- a/tests/revenue-status.test.js
+++ b/tests/revenue-status.test.js
@@ -136,6 +136,7 @@ test('generateRevenueStatusReport uses hosted railway audit when available', asy
   const report = await generateRevenueStatusReport({
     repo: 'IgorGanapolsky/ThumbGate',
     timeZone: 'America/New_York',
+    fetchTimeoutMs: 45000,
     apiKey: '',
     runCommandFn(command, args) {
       runCalls.push([command, ...args]);
@@ -273,6 +274,9 @@ test('generateRevenueStatusReport uses hosted railway audit when available', asy
   assert.equal(report.diagnosis.primaryIssue, 'operator_blind_spot_local_fallback');
   assert.equal(report.hostedAudit.summaries['30d'].revenue.bookedRevenueCents, 2000);
   assert.ok(runCalls.some((call) => call[0] === 'railway' && call.includes('run')));
+  assert.ok(
+    runCalls.some((call) => call[0] === 'railway' && call.some((arg) => String(arg).includes('const fetchTimeoutMs = 45000;')))
+  );
 
   const formatted = formatReport(report);
   assert.match(formatted, /Source: hosted-via-railway-env/);


### PR DESCRIPTION
## Summary\n- pass the revenue status fetch timeout override into Railway-hosted billing audits\n- cover the Railway fallback regression so hosted paid-order data does not collapse to local zeroes\n- add a patch changeset for the CLI/runtime fix\n\n## Verification\n- npm ci --onnxruntime-node-install-cuda=skip\n- node --test tests/revenue-status.test.js tests/gtm-revenue-loop.test.js\n- git diff --check\n- npm audit --audit-level=moderate\n- npm test\n- npm run test:coverage\n- npm run prove:adapters\n- npm run prove:automation\n- npm run self-heal:check\n- npm run revenue:status -- --json --fetch-timeout-ms=60000 --command-timeout-ms=120000\n\n## Evidence\n- clean npm audit: 0 vulnerabilities\n- targeted tests: 68/68 passing\n- full suite and coverage passed locally before PR\n- hosted revenue status now reports source hosted-via-railway-env instead of local-fallback when Railway owns THUMBGATE_API_KEY\n