### PR TITLE
fix(gtm): preserve production rollout marketplace copy

### DIFF
--- a/.changeset/fair-poets-film.md
+++ b/.changeset/fair-poets-film.md
@@ -1,3 +1,4 @@
+---
 'thumbgate': patch
 ---
 

--- a/.changeset/fair-poets-film.md
+++ b/.changeset/fair-poets-film.md
@@ -1,0 +1,4 @@
+'thumbgate': patch
+---
+
+Keep production-rollout marketplace copy in the generated GTM pack so operator-ready listings preserve proof-first production buyer positioning.

--- a/docs/marketing/gtm-marketplace-copy.json
+++ b/docs/marketing/gtm-marketplace-copy.json
@@ -2,8 +2,8 @@
   "generatedAt": "2026-05-03T23:29:58.043Z",
   "state": "cold-start",
   "headline": "Harden one AI-agent workflow before you roll it out.",
-  "shortDescription": "Harden one AI-agent workflow before you roll it out. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.",
-  "longDescription": "ThumbGate is a reliability gateway for AI coding workflows. It captures repeated failures, regenerates pre-action gates, and keeps approval boundaries, rollback safety, and proof attached to the workflow before the next risky tool call. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible. Primary motion: Workflow Hardening Sprint. Secondary motion: Pro at $19/mo or $149/yr after the buyer asks for the self-serve path.",
+  "shortDescription": "Harden one AI-agent workflow before you roll it out. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.",
+  "longDescription": "ThumbGate is a reliability gateway for AI coding workflows. It captures repeated failures, regenerates pre-action gates, and keeps approval boundaries, rollback safety, and proof attached to the workflow before the next risky tool call. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible. Primary motion: Workflow Hardening Sprint. Secondary motion: Pro at $19/mo or $149/yr after the buyer asks for the self-serve path.",
   "proofPolicy": "Do not lead with proof links. Use Commercial Truth and Verification Evidence only after the buyer confirms pain.",
   "recommendedCtas": [
     {
@@ -62,6 +62,18 @@
       "label": "Business-system workflow approvals",
       "summary": "Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof.",
       "listingAngle": "Lead with approval boundaries, rollback safety, and proof for one workflow.",
+      "count": 4,
+      "examples": [
+        "montenegronyc/backporcher",
+        "dolutech/engine_context",
+        "Adqui9608/ai-code-review-agent"
+      ]
+    },
+    {
+      "key": "production_rollout",
+      "label": "Production rollout proof",
+      "summary": "Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems.",
+      "listingAngle": "Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.",
       "count": 4,
       "examples": [
         "montenegronyc/backporcher",
@@ -139,6 +151,30 @@
       "shortDescription": "Lead with one workflow in Jira, GitHub, ServiceNow, Slack, or CRM systems that needs proof before wider rollout.",
       "evidenceSummary": "Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof.",
       "listingAngle": "Lead with approval boundaries, rollback safety, and proof for one workflow.",
+      "primaryCta": {
+        "motion": "sprint",
+        "label": "Workflow Hardening Sprint",
+        "cta": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+      },
+      "secondaryCta": {
+        "motion": "guide",
+        "label": "Proof-backed setup guide",
+        "cta": "https://thumbgate-production.up.railway.app/guide"
+      },
+      "sampleTargets": [
+        "montenegronyc/backporcher",
+        "dolutech/engine_context",
+        "Adqui9608/ai-code-review-agent"
+      ]
+    },
+    {
+      "key": "production_rollout",
+      "label": "Production rollout proof",
+      "audience": "Platform teams protecting production, release, incident, or compliance workflows.",
+      "headline": "Prove one production agent workflow is safe before the next rollout.",
+      "shortDescription": "Lead with one production workflow where repeated mistakes, rollback risk, or audit pressure already make the pain expensive.",
+      "evidenceSummary": "Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems.",
+      "listingAngle": "Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.",
       "primaryCta": {
         "motion": "sprint",
         "label": "Workflow Hardening Sprint",

--- a/docs/marketing/gtm-marketplace-copy.md
+++ b/docs/marketing/gtm-marketplace-copy.md
@@ -6,10 +6,10 @@ This pack is operator-ready listing copy derived from the current GTM revenue lo
 Harden one AI-agent workflow before you roll it out.
 
 ## Short Description
-Harden one AI-agent workflow before you roll it out. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.
+Harden one AI-agent workflow before you roll it out. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible.
 
 ## Long Description
-ThumbGate is a reliability gateway for AI coding workflows. It captures repeated failures, regenerates pre-action gates, and keeps approval boundaries, rollback safety, and proof attached to the workflow before the next risky tool call. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible. Primary motion: Workflow Hardening Sprint. Secondary motion: Pro at $19/mo or $149/yr after the buyer asks for the self-serve path.
+ThumbGate is a reliability gateway for AI coding workflows. It captures repeated failures, regenerates pre-action gates, and keeps approval boundaries, rollback safety, and proof attached to the workflow before the next risky tool call. The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems. Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible. Primary motion: Workflow Hardening Sprint. Secondary motion: Pro at $19/mo or $149/yr after the buyer asks for the self-serve path.
 
 ## Listing Bullets
 - Turn repeated AI-agent mistakes into enforceable pre-action gates.
@@ -30,6 +30,7 @@ ThumbGate is a reliability gateway for AI coding workflows. It captures repeated
 - Workflow control surfaces (5): The strongest cold targets expose workflow control surfaces where repeated failures and bad handoffs are visible and expensive. Examples: montenegronyc/backporcher, dolutech/engine_context, Adqui9608/ai-code-review-agent
 - Warm discovery workflows (4): Warm inbound engagers already named rollback risk, brittle guardrails, or review-boundary pain. Examples: @Deep_Ad1959, @game-of-kton, @leogodin217
 - Business-system workflow approvals (4): Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof. Examples: montenegronyc/backporcher, dolutech/engine_context, Adqui9608/ai-code-review-agent
+- Production rollout proof (4): Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems. Examples: montenegronyc/backporcher, dolutech/engine_context, Adqui9608/ai-code-review-agent
 - Self-serve agent tooling (3): Some buyers are closer to local hook, plugin, and config adoption than a services sprint, so the guide-to-Pro lane should stay visible. Examples: bherald/personal-life-os-core, zaxbysauce/opencode-swarm, mayurpise/draft
 
 ## Listing Variants
@@ -59,6 +60,16 @@ ThumbGate is a reliability gateway for AI coding workflows. It captures repeated
 - Short description: Lead with one workflow in Jira, GitHub, ServiceNow, Slack, or CRM systems that needs proof before wider rollout.
 - Evidence: Targets wiring agents into Jira, GitHub, ServiceNow, Slack, or CRM systems need approval boundaries, rollback safety, and proof.
 - Listing angle: Lead with approval boundaries, rollback safety, and proof for one workflow.
+- Primary CTA: Workflow Hardening Sprint: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+- Secondary CTA: Proof-backed setup guide: https://thumbgate-production.up.railway.app/guide
+- Sample targets: montenegronyc/backporcher, dolutech/engine_context, Adqui9608/ai-code-review-agent
+
+### Production rollout proof
+- Audience: Platform teams protecting production, release, incident, or compliance workflows.
+- Headline: Prove one production agent workflow is safe before the next rollout.
+- Short description: Lead with one production workflow where repeated mistakes, rollback risk, or audit pressure already make the pain expensive.
+- Evidence: Platform and production workflows need proof before agents touch releases, incidents, or compliance-sensitive systems.
+- Listing angle: Lead with rollout proof for one production workflow that cannot afford repeated agent mistakes.
 - Primary CTA: Workflow Hardening Sprint: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
 - Secondary CTA: Proof-backed setup guide: https://thumbgate-production.up.railway.app/guide
 - Sample targets: montenegronyc/backporcher, dolutech/engine_context, Adqui9608/ai-code-review-agent

--- a/scripts/gtm-revenue-loop.js
+++ b/scripts/gtm-revenue-loop.js
@@ -1610,11 +1610,14 @@ function buildMarketplaceCopy(report) {
     .filter((theme) => theme.count > 0)
     .sort((left, right) => right.count - left.count);
   const signalThemes = rankedSignalThemes.slice(0, 3);
-  const selfServeSignal = rankedSignalThemes.find((theme) => theme.key === 'self_serve_tooling');
-  if (selfServeSignal && !signalThemes.some((theme) => theme.key === selfServeSignal.key)) {
-    signalThemes.push(selfServeSignal);
+  for (const requiredThemeKey of ['production_rollout', 'self_serve_tooling']) {
+    const requiredTheme = rankedSignalThemes.find((theme) => theme.key === requiredThemeKey);
+    if (requiredTheme && !signalThemes.some((theme) => theme.key === requiredTheme.key)) {
+      signalThemes.push(requiredTheme);
+    }
   }
   const topTheme = signalThemes[0];
+  const selfServeSignal = signalThemes.find((theme) => theme.key === 'self_serve_tooling');
   const primaryMotion = normalizeText(report.directive?.primaryMotion) || 'sprint';
   const secondaryMotion = normalizeText(report.directive?.secondaryMotion) || 'pro';
   const headline = primaryMotion === 'sprint'

--- a/tests/gtm-revenue-loop.test.js
+++ b/tests/gtm-revenue-loop.test.js
@@ -1996,7 +1996,7 @@ test('marketplace copy pack stays tied to current revenue-loop evidence', () => 
         repoUrl: 'https://github.com/freema/mcp-jira-stdio',
         evidence: {
           score: 10,
-          evidence: ['workflow control surface', 'business-system integration'],
+          evidence: ['workflow control surface', 'business-system integration', 'production or platform workflow'],
           outreachAngle: 'Lead with approval boundaries, rollback safety, and proof.',
         },
         outreachAngle: 'Lead with approval boundaries, rollback safety, and proof.',
@@ -2053,9 +2053,11 @@ test('marketplace copy pack stays tied to current revenue-loop evidence', () => 
   assert.match(pack.recommendedCtas[2].cta, /\/checkout\/pro$/);
   assert.ok(pack.topSignals.some((signal) => /Warm discovery workflows/.test(signal.label)));
   assert.ok(pack.topSignals.some((signal) => /Business-system workflow approvals/.test(signal.label)));
+  assert.ok(pack.topSignals.some((signal) => /Production rollout proof/.test(signal.label)));
   assert.ok(pack.topSignals.some((signal) => /Self-serve agent tooling/.test(signal.label)));
   assert.ok(Array.isArray(pack.listingVariants));
   assert.ok(pack.listingVariants.some((variant) => /Warm discovery workflows/.test(variant.label)));
+  assert.ok(pack.listingVariants.some((variant) => /Production rollout proof/.test(variant.label)));
   assert.ok(pack.listingVariants.some((variant) => variant.primaryCta.label === 'Proof-backed setup guide'));
   assert.ok(pack.listingVariants.some((variant) => variant.secondaryCta.label === catalog.pro.label));
   assert.ok(pack.sampleTargets.some((target) => target.account === 'buildertools/codex-hook-pack'));
@@ -2063,6 +2065,8 @@ test('marketplace copy pack stays tied to current revenue-loop evidence', () => 
   assert.match(markdown, /Listing Variants/);
   assert.match(markdown, /Audience: Warm buyers who already named a repeated workflow failure\./);
   assert.match(markdown, /Headline: Turn one repeated AI-agent workflow failure into a proof-backed sprint\./);
+  assert.match(markdown, /Audience: Platform teams protecting production, release, incident, or compliance workflows\./);
+  assert.match(markdown, /Headline: Prove one production agent workflow is safe before the next rollout\./);
   assert.match(markdown, /Primary CTA: Proof-backed setup guide: https:\/\/thumbgate-production\.up\.railway\.app\/guide/);
   assert.match(markdown, /Proof Policy/);
   assert.match(markdown, /Evidence Backstop/);
@@ -2212,7 +2216,7 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
       selectedMotion: catalog.sprint,
       pipelineStage: 'targeted',
       evidenceScore: 9,
-      evidence: ['workflow control surface', '42 GitHub stars'],
+      evidence: ['workflow control surface', 'production or platform workflow', '42 GitHub stars'],
       evidenceSource: 'https://github.com/example/production-mcp-server',
       evidenceSources: [
         {
@@ -2289,6 +2293,8 @@ test('writeRevenueLoopOutputs writes markdown, json, and csv artifacts for opera
     assert.match(marketplaceCopy.recommendedCtas[2].cta, /\/checkout\/pro$/);
     assert.ok(Array.isArray(marketplaceCopy.topSignals));
     assert.ok(Array.isArray(marketplaceCopy.listingVariants));
+    assert.ok(marketplaceCopy.topSignals.some((signal) => signal.key === 'production_rollout'));
+    assert.ok(marketplaceCopy.listingVariants.some((variant) => variant.key === 'production_rollout'));
     assert.ok(marketplaceCopy.listingVariants.some((variant) => /Warm discovery workflows|Workflow control surfaces/.test(variant.label)));
     assert.equal(JSON.parse(jsonl.trim()).repoName, 'production-mcp-server');
     assert.match(jsonl, /"pipelineLeadId":"reddit_builder_production_mcp_server"/);


### PR DESCRIPTION
## Summary
- keep `production_rollout` in the GTM marketplace-copy generator alongside the existing self-serve inclusion rule
- pin the production-rollout segment in revenue-loop regression tests
- regenerate the checked-in marketplace copy pack from the tracked GTM report so operator-ready listing copy includes the production-proof buyer angle

## Verification
- `node --test tests/gtm-revenue-loop.test.js`
- `node --test tests/customer-discovery-sprint.test.js`
- `git diff --check`

## Notes
- `main` CI was green on commit `8f55d0f26a2faac3e0453c41f063a7770125aa24` when this branch was cut.
- Open PR backlog check found PR `#1665` blocked with in-progress CI and the rest of the sampled backlog in merge-conflict states.
