### PR TITLE
fix(deploy): sync checkout fallback to Railway

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -33,6 +33,7 @@ jobs:
       THUMBGATE_BILLING_API_BASE_URL: ${{ vars.THUMBGATE_BILLING_API_BASE_URL || vars.THUMBGATE_PUBLIC_APP_ORIGIN || 'https://thumbgate-production.up.railway.app' }}
       THUMBGATE_FEEDBACK_DIR: ${{ vars.THUMBGATE_FEEDBACK_DIR }}
       THUMBGATE_GA_MEASUREMENT_ID: ${{ vars.THUMBGATE_GA_MEASUREMENT_ID }}
+      THUMBGATE_CHECKOUT_FALLBACK_URL: ${{ vars.THUMBGATE_CHECKOUT_FALLBACK_URL }}
       THUMBGATE_GOOGLE_SITE_VERIFICATION: ${{ vars.THUMBGATE_GOOGLE_SITE_VERIFICATION }}
       RAILWAY_TOKEN_ROTATED_AT: ${{ vars.RAILWAY_TOKEN_ROTATED_AT }}
       THUMBGATE_API_KEY_ROTATED_AT: ${{ vars.THUMBGATE_API_KEY_ROTATED_AT }}
@@ -48,7 +49,7 @@ jobs:
           BEFORE_SHA='${{ github.event.before }}'
           CHANGED_FILES=''
           SHOULD_DEPLOY=true
-          DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
+          DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
 
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
             CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" | sed '/^$/d')"
@@ -155,6 +156,9 @@ jobs:
           fi
           if [ -n "$THUMBGATE_GA_MEASUREMENT_ID" ]; then
             retry_railway "set THUMBGATE_GA_MEASUREMENT_ID" railway variables set --skip-deploys THUMBGATE_GA_MEASUREMENT_ID="$THUMBGATE_GA_MEASUREMENT_ID" "${SERVICE_ARGS[@]}"
+          fi
+          if [ -n "$THUMBGATE_CHECKOUT_FALLBACK_URL" ]; then
+            retry_railway "set THUMBGATE_CHECKOUT_FALLBACK_URL" railway variables set --skip-deploys THUMBGATE_CHECKOUT_FALLBACK_URL="$THUMBGATE_CHECKOUT_FALLBACK_URL" "${SERVICE_ARGS[@]}"
           fi
           if [ -n "$THUMBGATE_GOOGLE_SITE_VERIFICATION" ]; then
             retry_railway "set THUMBGATE_GOOGLE_SITE_VERIFICATION" railway variables set --skip-deploys THUMBGATE_GOOGLE_SITE_VERIFICATION="$THUMBGATE_GOOGLE_SITE_VERIFICATION" "${SERVICE_ARGS[@]}"

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -232,6 +232,7 @@ test('Deploy to Railway workflow is the single authoritative Railway deploy lane
   assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS/);
   assert.match(workflow, /RAILWAY_LOG_LINES/);
   assert.match(workflow, /RAILWAY_HTTP_LOG_LINES/);
+  assert.match(workflow, /DEPLOYABLE_PATTERN=.*\\\.github\/workflows\/deploy-railway\\\.yml/);
   assert.match(workflow, /secrets\.THUMBGATE_API_KEY/);
   assert.match(workflow, /RESEND_API_KEY:\s*\$\{\{\s*secrets\.RESEND_API_KEY\s*\}\}/);
   assert.match(workflow, /THUMBGATE_TRIAL_EMAIL_FROM:\s*\$\{\{\s*secrets\.THUMBGATE_TRIAL_EMAIL_FROM\s*\|\|\s*vars\.THUMBGATE_TRIAL_EMAIL_FROM\s*\}\}/);
@@ -239,11 +240,13 @@ test('Deploy to Railway workflow is the single authoritative Railway deploy lane
   assert.match(workflow, /vars\.THUMBGATE_BILLING_API_BASE_URL \|\| vars\.THUMBGATE_PUBLIC_APP_ORIGIN \|\| 'https:\/\/thumbgate-production\.up\.railway\.app'/);
   assert.match(workflow, /THUMBGATE_PUBLIC_APP_ORIGIN/);
   assert.match(workflow, /THUMBGATE_BILLING_API_BASE_URL/);
+  assert.match(workflow, /THUMBGATE_CHECKOUT_FALLBACK_URL:\s*\$\{\{\s*vars\.THUMBGATE_CHECKOUT_FALLBACK_URL\s*\}\}/);
   assert.match(workflow, /railway variables set --skip-deploys THUMBGATE_API_KEY=/);
   assert.match(workflow, /railway variables set --skip-deploys THUMBGATE_BUILD_SHA=/);
   assert.match(workflow, /railway variables set --skip-deploys STRIPE_WEBHOOK_SECRET=/);
   assert.match(workflow, /railway variables set --skip-deploys RESEND_API_KEY=/);
   assert.match(workflow, /railway variables set --skip-deploys THUMBGATE_TRIAL_EMAIL_FROM=/);
+  assert.match(workflow, /railway variables set --skip-deploys THUMBGATE_CHECKOUT_FALLBACK_URL=/);
   assert.match(workflow, /railway up/);
   assert.match(workflow, /--ci/);
   assert.match(workflow, /--detach/);


### PR DESCRIPTION
## Summary
- Pass THUMBGATE_CHECKOUT_FALLBACK_URL from GitHub repo variables into the Railway deploy workflow.
- Set the Railway runtime variable when present, matching the existing GA/site verification pattern.
- Treat deploy-railway.yml changes as deployable so this env-sync fix actually runs after merge.

## Revenue impact
- Hosted revenue status reported checkout fallback missing in Railway runtime.
- GitHub repo variable THUMBGATE_CHECKOUT_FALLBACK_URL is now set to the documented Stripe fallback URL.
- This PR closes the workflow gap that prevented that value from reaching Railway.

## Verification
- npm ci
- npm run test:deployment (105 tests, 0 failures)
- npm audit --audit-level=moderate (0 vulnerabilities)
- git diff --check
- forbidden scan: rg -n --hidden --glob '!node_modules/**' --glob '!.git/**' --glob '!coverage/**' 'Subway|Subway_RN_Demo|subway' . (no matches)

## Notes
- GA4 remains unresolved because THUMBGATE_GA_MEASUREMENT_ID is not present in repo variables; no fake GA ID was invented.
- npm run self-heal:check was stopped after it produced no output for over two minutes and generated unrelated runtime artifacts; those side effects were removed before commit.