### PR TITLE
fix(gtm): clarify Team intake versus Pro trial

### DIFF
--- a/.changeset/homepage-team-intake-truth.md
+++ b/.changeset/homepage-team-intake-truth.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Clarify on the homepage that the 7-day free trial applies to Pro, while Team starts through the Workflow Hardening Sprint intake instead of a self-serve trial.

--- a/public/index.html
+++ b/public/index.html
@@ -1392,7 +1392,7 @@ __GA_BOOTSTRAP__
         <div class="price-sub">3-seat minimum · One engineer's correction protects the whole team</div>
         <p style="font-size:13px;color:var(--green);margin-bottom:16px;font-weight:500;">When one engineer teaches the agent not to delete staging data, that lesson applies to every agent on the team. Stop paying the same mistake tax across different developers.</p>
         <div class="pro-upgrade-triggers" style="font-size:12px;color:#aaa;margin-bottom:12px;">
-          Start with one repo, one workflow, one repeat failure at $49/seat.
+          No self-serve trial. Start with one repo, one workflow, and one repeated failure through the sprint intake.
         </div>
         <ul>
           <li>Workflow hardening sprint — map one painful workflow, one repeated failure, and one buyer proof review before wider rollout</li>
@@ -1523,7 +1523,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What does Pro cost?</div>
-        <div class="faq-a">Pro is $19/mo or $149/yr for individual operators. Team is $49/seat/mo with a 3-seat minimum. Both start with a 7-day free trial, no credit card required.</div>
+        <div class="faq-a">Pro is $19/mo or $149/yr for individual operators and starts with a 7-day free trial, no credit card required. Team is $49/seat/mo with a 3-seat minimum and starts with the Workflow Hardening Sprint intake, not a self-serve trial.</div>
       </div>
     </div>
   </div>

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -609,6 +609,14 @@ test('public landing page includes 7-day free trial and email capture gate', () 
   assert.doesNotMatch(landingPage, /props:\s*\{\s*email:/);
 });
 
+test('public landing page keeps Team on an intake-led start instead of a trial claim', () => {
+  const landingPage = readLandingPage();
+
+  assert.match(landingPage, /No self-serve trial\./);
+  assert.match(landingPage, /Team is \$49\/seat\/mo with a 3-seat minimum and starts with the Workflow Hardening Sprint intake, not a self-serve trial\./);
+  assert.doesNotMatch(landingPage, /Both start with a 7-day free trial/);
+});
+
 test('public landing page includes dashboard preview in Pro card', () => {
   const landingPage = readLandingPage();
   assert.match(landingPage, /dashboard-preview/);


### PR DESCRIPTION
## Summary
- clarify on the homepage that the 7-day free trial applies to Pro only
- state that Team starts through the Workflow Hardening Sprint intake, not a self-serve trial
- add a landing-page regression test and changeset entry for the public copy fix

## Verification
- npm ci
- npm test
- npm run test:coverage
- npm run prove:adapters
- npm run prove:automation
- npm run self-heal:check
