### PR TITLE
fix(revenue): prioritize actionable status gaps

### DIFF
--- a/.changeset/revenue-status-actionable-gap.md
+++ b/.changeset/revenue-status-actionable-gap.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Prioritize actionable hosted revenue-status configuration gaps over stale local-fallback labels when hosted signals are visible.

--- a/scripts/revenue-status.js
+++ b/scripts/revenue-status.js
@@ -149,10 +149,23 @@ function buildDiagnosis({ publicProbe, hostedAudit }) {
   const hostedSummaryWorking = Boolean(today?.status === 200 && trailing30?.status === 200);
   const hostedTrafficObserved = Number(traffic30.visitors || 0) > 0 || Number(traffic30.pageViews || 0) > 0;
   const hostedRevenueObserved = Number(revenue30.paidOrders || 0) > 0 || Number(revenue30.bookedRevenueCents || 0) > 0;
+  const gaRuntimeMissing = runtimePresenceKnown && !runtimePresence.THUMBGATE_GA_MEASUREMENT_ID;
+  const sprintCheckoutRuntimeMissing = runtimePresenceKnown && (
+    !runtimePresence.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL ||
+    !runtimePresence.THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL
+  );
 
   let primaryIssue = 'inconclusive';
   if (trackingImplemented && telemetryIngressWorking && hostedSummaryWorking && hostedTrafficObserved) {
-    primaryIssue = 'operator_blind_spot_local_fallback';
+    if (gaRuntimeMissing) {
+      primaryIssue = 'ga4_runtime_config_gap';
+    } else if (sprintCheckoutRuntimeMissing) {
+      primaryIssue = 'paid_sprint_checkout_config_gap';
+    } else if (hostedRevenueObserved) {
+      primaryIssue = 'hosted_revenue_observed';
+    } else {
+      primaryIssue = 'conversion_or_pricing_gap';
+    }
   } else if (trackingImplemented && telemetryIngressWorking && hostedSummaryWorking) {
     primaryIssue = 'low_traffic';
   } else if (trackingImplemented && telemetryIngressWorking) {
@@ -165,7 +178,7 @@ function buildDiagnosis({ publicProbe, hostedAudit }) {
   if (publicProbe?.error) {
     gaps.push(`Public runtime probe failed: ${publicProbe.error}`);
   }
-  if (runtimePresenceKnown && !runtimePresence.THUMBGATE_GA_MEASUREMENT_ID) {
+  if (gaRuntimeMissing) {
     gaps.push('GA4 runtime env is missing in Railway');
   }
   if (runtimePresenceKnown && !runtimePresence.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL) {

--- a/tests/revenue-status.test.js
+++ b/tests/revenue-status.test.js
@@ -79,7 +79,7 @@ test('parseHtmlSignals detects telemetry and tracking hooks', () => {
   assert.equal(signals.workflowSprintIntake, true);
 });
 
-test('buildDiagnosis identifies local fallback blind spot and runtime gaps', () => {
+test('buildDiagnosis prioritizes GA4 runtime config over stale local fallback labels', () => {
   const diagnosis = buildDiagnosis({
     publicProbe: {
       root: {
@@ -120,7 +120,7 @@ test('buildDiagnosis identifies local fallback blind spot and runtime gaps', () 
     },
   });
 
-  assert.equal(diagnosis.primaryIssue, 'operator_blind_spot_local_fallback');
+  assert.equal(diagnosis.primaryIssue, 'ga4_runtime_config_gap');
   assert.equal(diagnosis.trackingImplemented, true);
   assert.equal(diagnosis.telemetryIngressWorking, true);
   assert.equal(diagnosis.hostedSummaryWorking, true);
@@ -271,7 +271,7 @@ test('generateRevenueStatusReport uses hosted railway audit when available', asy
   });
 
   assert.equal(report.source, 'hosted-via-railway-env');
-  assert.equal(report.diagnosis.primaryIssue, 'operator_blind_spot_local_fallback');
+  assert.equal(report.diagnosis.primaryIssue, 'ga4_runtime_config_gap');
   assert.equal(report.hostedAudit.summaries['30d'].revenue.bookedRevenueCents, 2000);
   assert.ok(runCalls.some((call) => call[0] === 'railway' && call.includes('run')));
   assert.ok(


### PR DESCRIPTION
## Summary
- Prioritize GA4 runtime configuration as the primary revenue-status issue when hosted traffic and revenue are already visible.
- Preserve lower-priority labels for sprint checkout config, conversion/pricing, and fully observed hosted revenue states.
- Update revenue-status tests so operator guidance does not regress to the stale local-fallback label.

## Verification
- npm ci
- node --test tests/revenue-status.test.js (11 tests, 0 failures)
- npm audit --audit-level=moderate (0 vulnerabilities)
- git diff --check
- forbidden scan: rg -n --hidden --glob '!node_modules/**' --glob '!.git/**' --glob '!coverage/**' 'Subway|Subway_RN_Demo|subway' . (no matches)

## Revenue context
- Hosted revenue status currently shows traffic and booked revenue, but Railway still lacks THUMBGATE_GA_MEASUREMENT_ID.
- This PR makes the operator loop point at that actionable GA4 gap instead of reporting operator_blind_spot_local_fallback after hosted truth is already visible.
