### PR TITLE
ci: stop duplicate feature branch runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, feat/**]
+    # Pull requests already run this full suite. Running it again on every
+    # feature-branch push doubles PR latency and spend without adding signal.
+    branches: [main]
   pull_request:
     branches: [main]
   merge_group:

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -472,6 +472,8 @@ test('CI workflow supports merge queue and cancels stale non-main runs', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
 
   assert.match(workflow, /permissions:\s+contents:\s+read\s+pull-requests:\s+read/s);
+  assert.match(workflow, /push:\s+#[\s\S]*?branches:\s*\[main\]/);
+  assert.doesNotMatch(workflow, /branches:\s*\[main,\s*feat\/\*\*\]/);
   assert.match(workflow, /merge_group:/);
   assert.match(workflow, /types:\s*\[checks_requested\]/);
   assert.match(workflow, /group:\s*ci-\$\{\{\s*github\.workflow\s*\}\}-\$\{\{\s*github\.event\.pull_request\.number \|\| github\.ref\s*\}\}/);


### PR DESCRIPTION
## Summary
- stop running the full CI suite on direct feature-branch pushes
- keep CI on pull_request, merge_group, main pushes, and manual dispatch
- add a regression assertion so feat/** push CI does not come back silently

## Why
Feature PR updates were running the same full CI twice: once for push on feat/** and once for pull_request. That reset/duplicated expensive test jobs and slowed PR readiness. PR and merge queue protections still run before merge.

## Verification
- node --test tests/deployment.test.js tests/sonarcloud-workflow.test.js
- git diff --check
- npm audit --audit-level=moderate