### PR TITLE
Add AI agent governance sprint conversion page

### DIFF
--- a/.changeset/agent-governance-sprint-conversion.md
+++ b/.changeset/agent-governance-sprint-conversion.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add the AI Agent Governance Sprint conversion path with a generated guide, homepage routing, Team intake CTA coverage, and SEO tests for the bottom-funnel governance sprint offer.

--- a/public/guides/ai-agent-governance-sprint.html
+++ b/public/guides/ai-agent-governance-sprint.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Agent Governance Sprint | 48-Hour Workflow Hardening</title>
+  <meta name="description" content="ThumbGate turns one repeated AI-agent failure into approval boundaries, pre-action checks, rollback safety, and rollout proof in a focused 48-hour Workflow H..." />
+  <meta property="og:title" content="AI Agent Governance Sprint | 48-Hour Workflow Hardening" />
+  <meta property="og:description" content="ThumbGate turns one repeated AI-agent failure into approval boundaries, pre-action checks, rollback safety, and rollout proof in a focused 48-hour Workflow H..." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/ai-agent-governance-sprint" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/ai-agent-governance-sprint" />
+  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
+  <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
+  <meta property="og:image" content="/og.png" />
+  <style>
+    :root {
+      --bg: #0a0a0b;
+      --bg-raised: #111113;
+      --bg-card: #161618;
+      --line: #222225;
+      --text: #e8e8ec;
+      --muted: #8b8b96;
+      --cyan: #22d3ee;
+      --green: #4ade80;
+      --red: #f87171;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.65;
+    }
+    a { color: var(--cyan); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .container { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      backdrop-filter: blur(12px);
+      background: rgba(10, 10, 11, 0.88);
+      border-bottom: 1px solid var(--line);
+    }
+    .topbar .container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-top: 14px;
+      padding-bottom: 14px;
+    }
+    .brand {
+      font-weight: 700;
+      color: var(--text);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+    }
+    .brand .logo-mark { width: 28px; height: 28px; display: block; }
+    .hero { padding: 72px 0 32px; }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(34, 211, 238, 0.22);
+      background: rgba(34, 211, 238, 0.1);
+      color: var(--cyan);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    h1 {
+      font-size: clamp(34px, 5vw, 56px);
+      line-height: 1.06;
+      letter-spacing: -0.04em;
+      margin: 16px 0;
+      max-width: 760px;
+    }
+    .hero p {
+      max-width: 720px;
+      color: var(--muted);
+      font-size: 18px;
+    }
+    .signal-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin: 28px 0 0;
+    }
+    .signal-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--bg-raised);
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .signal-pill.up {
+      border-color: rgba(74, 222, 128, 0.28);
+      color: #b8f7c8;
+      background: rgba(74, 222, 128, 0.1);
+    }
+    .signal-pill.down {
+      border-color: rgba(248, 113, 113, 0.28);
+      color: #ffc0c0;
+      background: rgba(248, 113, 113, 0.1);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+      gap: 24px;
+      padding-bottom: 72px;
+    }
+    .card, .detail-section, .sidebar-card {
+      background: var(--bg-card);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+    }
+    .card { padding: 24px; }
+    .detail-section { padding: 24px; margin-bottom: 18px; }
+    .detail-section h2 { margin: 0 0 12px; font-size: 24px; letter-spacing: -0.03em; }
+    .detail-section p { color: var(--muted); }
+    .detail-section ul, .card ul { padding-left: 18px; color: var(--muted); }
+    .card h2 { margin-top: 0; }
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+    .sidebar-card {
+      padding: 20px;
+    }
+    /* Only the first sidebar card sticks. Stacking multiple stickies at the
+       same top offset makes them overlap each other on scroll. The related-
+       pages card flows normally below. */
+    .sidebar-card:first-child {
+      position: sticky;
+      top: 84px;
+      max-height: calc(100vh - 104px);
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .proof-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 16px;
+    }
+    .cta-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 18px;
+      padding: 12px 16px;
+      border-radius: 10px;
+      background: var(--cyan);
+      color: #071116;
+      font-weight: 700;
+      text-decoration: none;
+    }
+    .faq-item {
+      border-top: 1px solid var(--line);
+      padding: 14px 0;
+    }
+    .faq-item summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .faq-item p {
+      color: var(--muted);
+    }
+    .related-card {
+      display: block;
+      padding: 14px;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: var(--bg-raised);
+      margin-top: 12px;
+      color: var(--text);
+    }
+    .related-label {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 4px;
+    }
+    @media (max-width: 860px) {
+      .grid {
+        grid-template-columns: 1fr;
+      }
+      .sidebar-card:first-child {
+        position: static;
+        max-height: none;
+        overflow: visible;
+      }
+    }
+  </style>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "AI Agent Governance Sprint for One Risky Workflow",
+  "description": "ThumbGate turns one repeated AI-agent failure into approval boundaries, pre-action checks, rollback safety, and rollout proof in a focused 48-hour Workflow H...",
+  "about": [
+    "claude code masterclass guardrails",
+    "cursor prevent repeated mistakes",
+    "claude code prevent repeated mistakes",
+    "codex cli guardrails"
+  ],
+  "url": "https://thumbgate.ai/guides/ai-agent-governance-sprint",
+  "publisher": {
+    "@type": "Organization",
+    "name": "ThumbGate",
+    "url": "https://thumbgate.ai"
+  },
+  "mainEntityOfPage": "https://thumbgate.ai/guides/ai-agent-governance-sprint"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is included in the AI Agent Governance Sprint?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A focused 48-hour implementation around one workflow: intake, governance mapping, pre-action checks, background-agent risk routing, rollback notes, and a proof pack for the buyer review."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is this different from the Workflow Hardening Sprint?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It is the same Team conversion path positioned for buyers searching for AI agent governance. The deliverable remains narrow: one repeated failure hardened with approval boundaries, rollback safety, and rollout proof."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do we need to migrate every agent workflow first?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Start with one repeated failure that already costs review time or rollout confidence. After it proves value, reuse the checks, lesson database, and proof workflow across Team seats."
+      }
+    }
+  ]
+}
+  </script>
+</head>
+<body>
+  <div class="topbar">
+    <div class="container">
+      <a class="brand" href="/"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence</a>
+    </div>
+  </div>
+
+  <main class="container">
+    <section class="hero">
+      <div class="eyebrow">guide | ai agent governance sprint</div>
+      <h1>AI Agent Governance Sprint for One Risky Workflow</h1>
+      <p>ThumbGate turns one repeated AI-agent failure into approval boundaries, pre-action checks, rollback safety, and rollout proof in a focused 48-hour Workflow Hardening Sprint.</p>
+      <div class="signal-row">
+        <div class="signal-pill up">👍 Thumbs up reinforces good behavior</div>
+        <div class="signal-pill down">👎 Thumbs down blocks repeated mistakes</div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div>
+        <div class="card">
+          <h2>Why this page exists</h2>
+          <ul><li>The fastest paid wedge is not a broad platform migration; it is one repo, one workflow owner, and one repeated failure that already has budget pressure.</li><li>A governance sprint should ship evidence: rule inventory, pre-action checks, review routing, rollback notes, and a buyer-ready proof pack.</li><li>ThumbGate keeps the promise narrow enough to sell quickly while creating the path to Team seats and recurring governance.</li></ul>
+        </div>
+
+      <section class="detail-section">
+        <h2>Who this is for</h2>
+        <p>The right buyer is already running Claude Code, Codex, Cursor, Gemini, or another agent against real code and has one failure they no longer want to review manually. Examples include unsafe migrations, noisy background-agent PRs, deploy approval bypasses, credential-adjacent commands, and repeated generated-artifact edits.</p><p>The sprint works because it avoids generic AI consulting. The scope is one workflow that can be observed, hardened, and reviewed in front of the buyer before a wider team rollout.</p>
+
+      </section>
+      <section class="detail-section">
+        <h2>What the sprint ships</h2>
+
+        <ul><li>Intake: one repo, one owner, one repeated failure, one target rollout date, and the current agent/runtime surface.</li><li>Governance map: approval boundaries, risky commands, protected files, branch rules, review tiers, and rollback expectations.</li><li>Pre-action checks: concrete blocks or warnings for the repeated failure and adjacent high-risk actions.</li><li>Background-agent review routing: npx thumbgate background-governance --check --json to label risk before dispatch or PR review.</li><li>Proof pack: verification evidence, run reports, blocked-repeat examples, and rollout notes the buyer can share internally.</li></ul>
+      </section>
+      <section class="detail-section">
+        <h2>Where this creates ROI</h2>
+        <p>This page is the service conversion layer for the governance guides. Readers who already understand background-agent risk need a next step that is smaller than procurement and more concrete than a demo.</p><p>The offer stays defensible: ThumbGate does not claim to make agents autonomous without review. It makes one expensive review failure measurable, enforceable, and easier to roll out across Team seats.</p>
+
+      </section>
+        <div class="detail-section">
+          <h2>FAQ</h2>
+
+      <details class="faq-item">
+        <summary>What is included in the AI Agent Governance Sprint?</summary>
+        <p>A focused 48-hour implementation around one workflow: intake, governance mapping, pre-action checks, background-agent risk routing, rollback notes, and a proof pack for the buyer review.</p>
+      </details>
+      <details class="faq-item">
+        <summary>How is this different from the Workflow Hardening Sprint?</summary>
+        <p>It is the same Team conversion path positioned for buyers searching for AI agent governance. The deliverable remains narrow: one repeated failure hardened with approval boundaries, rollback safety, and rollout proof.</p>
+      </details>
+      <details class="faq-item">
+        <summary>Do we need to migrate every agent workflow first?</summary>
+        <p>No. Start with one repeated failure that already costs review time or rollout confidence. After it proves value, reuse the checks, lesson database, and proof workflow across Team seats.</p>
+      </details>
+        </div>
+      </div>
+
+      <aside class="sidebar">
+
+
+
+
+        <div class="sidebar-card">
+          <h2>GSD execution brief</h2>
+          <p>This page was prioritized because it captures high-intent demand around ai agent governance sprint and feeds directly into ThumbGate's proof-led conversion path.</p>
+          <p><strong>Opportunity score:</strong> 83</p>
+          <p><strong>Primary persona:</strong> engineering-lead</p>
+          <p><strong>Keyword cluster:</strong> claude code masterclass guardrails, cursor prevent repeated mistakes, claude code prevent repeated mistakes, codex cli guardrails</p>
+          <p><strong>Pricing:</strong> Pro $19/mo or $149/yr. Team $49/seat/mo.</p>
+          <div class="proof-links"><a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence</a><a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/proof/automation/report.json" target="_blank" rel="noopener">Automation proof</a><a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub repository</a></div>
+          <a class="cta-button" href="/?utm_source=website&amp;utm_medium=seo_page&amp;utm_campaign=ai_agent_governance_sprint&amp;cta_placement=seo_brief&amp;plan_id=team#workflow-sprint-intake" target="_blank" rel="noopener">Start the governance sprint</a>
+        </div>
+        <div class="sidebar-card">
+          <h2>Related pages</h2>
+
+        <a class="related-card" href="/guides/background-agent-governance">
+          <span class="related-label">Related page</span>
+          <strong>Background Agent Governance for Agent PRs</strong>
+        </a>
+        <a class="related-card" href="/guides/pre-action-checks">
+          <span class="related-label">Related page</span>
+          <strong>What Are Pre-Action Checks?</strong>
+        </a>
+        <a class="related-card" href="/guides/best-tools-stop-ai-agents-breaking-production">
+          <span class="related-label">Related page</span>
+          <strong>Best Tools to Stop AI Agents From Breaking Production</strong>
+        </a>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -713,15 +713,16 @@ __GA_BOOTSTRAP__
       <p style="margin:14px 0 0;font-size:11px;color:var(--text-muted);text-align:center;">No credit card for 7-day trial · cancel anytime · your rules and captures stay local. <a href="/go/install" style="color:var(--cyan);text-decoration:none;">Prefer free? Install CLI →</a></p>
     </div>
 
-    <div class="hero-paid-path" aria-label="Paid workflow hardening checkout options">
+    <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
       <div>
         <strong>Need buyer-ready proof today?</strong>
-        <span>Send one messy AI-agent workflow. We turn it into clear rules, examples, and pre-action checks before it touches developer-machine risk surfaces.</span>
+        <span>Send one messy AI-agent workflow. We turn it into clear rules, examples, and pre-action checks, plus AI Agent Governance Sprint approval boundaries and rollback safety before it touches developer-machine risk surfaces.</span>
       </div>
       <div class="hero-paid-actions">
         <a class="starter" href="https://buy.stripe.com/7sY4gzgH24r49G17mb3sI0g" onclick="sendFirstPartyTelemetry('founder_workflow_diagnostic_checkout_started',{ctaId:'hero_founder_workflow_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'founder_workflow_diagnostic',price:99});sendGa4Event('begin_checkout',{currency:'USD',value:99,items:[{item_id:'founder_workflow_diagnostic',item_name:'Founder Workflow Diagnostic'}]});">Pay $99 diagnostic &rarr;</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>
         <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars,items:[{item_id:'workflow_hardening_sprint',item_name:'Workflow Hardening Sprint'}]});">Pay $1500 sprint &rarr;</a>
+        <a class="starter" href="/guides/ai-agent-governance-sprint">See sprint scope &rarr;</a>
       </div>
     </div>
 
@@ -1175,6 +1176,12 @@ __GA_BOOTSTRAP__
         <p>Turn unattended agent PRs into a governed queue with run ledgers, pre-dispatch checks, isolated task lanes, and risk-tiered review.</p>
         <div class="card-arrow">Govern agent PRs →</div>
       </a>
+      <a class="seo-card" href="/guides/ai-agent-governance-sprint">
+        <div class="seo-kicker">Team Sprint</div>
+        <h3>AI Agent Governance Sprint</h3>
+        <p>Package one repo, one workflow owner, and one repeated failure into approval boundaries, rollback safety, and buyer-ready rollout proof.</p>
+        <div class="card-arrow">Start with one workflow →</div>
+      </a>
       <a class="seo-card" href="/guides/gpt-5-5-model-evaluation">
         <div class="seo-kicker">Model Routing</div>
         <h3>GPT-5.5 Model Evaluation</h3>
@@ -1506,7 +1513,7 @@ __GA_BOOTSTRAP__
           No self-serve trial. Start with one repo, one workflow, and one repeated failure through the sprint intake.
         </div>
         <ul>
-          <li>Workflow hardening sprint — map one painful workflow, one repeated failure, and one buyer proof review before wider rollout</li>
+          <li>AI Agent Governance Sprint — map one painful workflow, one repeated failure, approval boundaries, rollback safety, and one buyer proof review before wider rollout</li>
           <li>Shared enforcement memory — a shared lesson database where one developer's 👎 on a bad migration protects every agent on the team</li>
           <li>Team lesson export/import — export lessons from one project, import into another. Deduplication, provenance tracking, and <code>team-import</code> tagging built in. One team's hard-won lessons become every team's prevention rules</li>
           <li>Org dashboard — active agents, check hit rates, risk agents, and proof-backed team metrics in one place</li>
@@ -1527,8 +1534,8 @@ __GA_BOOTSTRAP__
 <section class="compatibility" id="workflow-sprint-intake">
   <div class="container">
     <div class="section-label">Team Pilot</div>
-    <h2 class="section-title">Start with one repo, one workflow, one repeat failure</h2>
-    <p style="color:var(--text-dim);max-width:720px;margin:0 auto 16px;">This is the fastest path to first paid value for teams. Start with one workflow, one owner, and one blocker. The intake is designed to prove that ThumbGate reduces review churn, rollout risk, or repeated agent mistakes before a wider rollout.</p>
+    <h2 class="section-title">Start the AI Agent Governance Sprint with one repeat failure</h2>
+    <p style="color:var(--text-dim);max-width:720px;margin:0 auto 16px;">This is the fastest path to first paid value for teams. Start with one repo, one workflow owner, and one blocker. The intake is designed to prove that ThumbGate reduces review churn, rollout risk, or repeated agent mistakes before a wider rollout.</p>
     <div class="team-intake-panel">
       <div class="team-intake-panel-head">
         <div>
@@ -1550,8 +1557,8 @@ __GA_BOOTSTRAP__
         </div>
         <div class="team-paid-card">
           <div>
-            <h4>Workflow Hardening Sprint</h4>
-            <p>48-hour implementation sprint for one workflow owner, one blocker, one proof review, and one hardened rollout path.</p>
+            <h4>AI Agent Governance Sprint</h4>
+            <p>48-hour Workflow Hardening Sprint for one workflow owner, one blocker, approval boundaries, rollback safety, one proof review, and one hardened rollout path.</p>
           </div>
           <div>
             <div class="team-paid-price">$<span data-workflow-sprint-price>1500</span></div>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -173,6 +173,7 @@ npx thumbgate dashboard
 - Marketing site: https://thumbgate.ai
 - Browser automation safety guide: https://thumbgate.ai/guides/browser-automation-safety
 - Native messaging host security guide: https://thumbgate.ai/guides/native-messaging-host-security
+- AI Agent Governance Sprint guide: https://thumbgate.ai/guides/ai-agent-governance-sprint
 - GitHub: https://github.com/IgorGanapolsky/ThumbGate
 - npm: https://www.npmjs.com/package/thumbgate
 - Documentation: https://thumbgate.ai/guide

--- a/scripts/seo-gsd.js
+++ b/scripts/seo-gsd.js
@@ -114,6 +114,11 @@ const HIGH_ROI_QUERY_SEEDS = [
     'New team-buying query for unattended agent PRs where alignment context, isolated execution, risk-tiered review, and audit evidence create immediate ROI.',
   ),
   querySeed(
+    'ai agent governance sprint',
+    95,
+    'Bottom-of-funnel service query that turns background-agent governance demand into a paid 48-hour Team intake and implementation wedge.',
+  ),
+  querySeed(
     'gpt-5.5 model evaluation',
     94,
     'Fresh frontier-model upgrade query that maps to ThumbGate model candidate benchmarking, dashboard-analysis workloads, and routing governance before teams move expensive work.',
@@ -994,6 +999,69 @@ function buildBackgroundAgentGovernanceGuide() {
   });
 }
 
+const AI_AGENT_GOVERNANCE_SPRINT_GUIDE_SPEC = Object.freeze({
+  slug: 'ai-agent-governance-sprint',
+  meta: {
+    query: 'ai agent governance sprint',
+    title: 'AI Agent Governance Sprint | 48-Hour Workflow Hardening',
+    heroTitle: 'AI Agent Governance Sprint for One Risky Workflow',
+    heroSummary: 'ThumbGate turns one repeated AI-agent failure into approval boundaries, pre-action checks, rollback safety, and rollout proof in a focused 48-hour Workflow Hardening Sprint.',
+  },
+  takeaways: [
+    'The fastest paid wedge is not a broad platform migration; it is one repo, one workflow owner, and one repeated failure that already has budget pressure.',
+    'A governance sprint should ship evidence: rule inventory, pre-action checks, review routing, rollback notes, and a buyer-ready proof pack.',
+    'ThumbGate keeps the promise narrow enough to sell quickly while creating the path to Team seats and recurring governance.',
+  ],
+  sections: [
+    ['paragraphs', 'Who this is for', [
+      'The right buyer is already running Claude Code, Codex, Cursor, Gemini, or another agent against real code and has one failure they no longer want to review manually. Examples include unsafe migrations, noisy background-agent PRs, deploy approval bypasses, credential-adjacent commands, and repeated generated-artifact edits.',
+      'The sprint works because it avoids generic AI consulting. The scope is one workflow that can be observed, hardened, and reviewed in front of the buyer before a wider team rollout.',
+    ]],
+    ['bullets', 'What the sprint ships', [
+      'Intake: one repo, one owner, one repeated failure, one target rollout date, and the current agent/runtime surface.',
+      'Governance map: approval boundaries, risky commands, protected files, branch rules, review tiers, and rollback expectations.',
+      'Pre-action checks: concrete blocks or warnings for the repeated failure and adjacent high-risk actions.',
+      'Background-agent review routing: npx thumbgate background-governance --check --json to label risk before dispatch or PR review.',
+      'Proof pack: verification evidence, run reports, blocked-repeat examples, and rollout notes the buyer can share internally.',
+    ]],
+    ['paragraphs', 'Where this creates ROI', [
+      'This page is the service conversion layer for the governance guides. Readers who already understand background-agent risk need a next step that is smaller than procurement and more concrete than a demo.',
+      'The offer stays defensible: ThumbGate does not claim to make agents autonomous without review. It makes one expensive review failure measurable, enforceable, and easier to roll out across Team seats.',
+    ]],
+  ],
+  faq: [
+    [
+      'What is included in the AI Agent Governance Sprint?',
+      'A focused 48-hour implementation around one workflow: intake, governance mapping, pre-action checks, background-agent risk routing, rollback notes, and a proof pack for the buyer review.',
+    ],
+    [
+      'How is this different from the Workflow Hardening Sprint?',
+      'It is the same Team conversion path positioned for buyers searching for AI agent governance. The deliverable remains narrow: one repeated failure hardened with approval boundaries, rollback safety, and rollout proof.',
+    ],
+    [
+      'Do we need to migrate every agent workflow first?',
+      'No. Start with one repeated failure that already costs review time or rollout confidence. After it proves value, reuse the checks, lesson database, and proof workflow across Team seats.',
+    ],
+  ],
+  relatedPaths: ['/guides/background-agent-governance', '/guides/pre-action-checks', '/guides/best-tools-stop-ai-agents-breaking-production'],
+});
+
+function buildAiAgentGovernanceSprintGuide() {
+  return {
+    ...preActionGuide(AI_AGENT_GOVERNANCE_SPRINT_GUIDE_SPEC.slug, {
+      ...AI_AGENT_GOVERNANCE_SPRINT_GUIDE_SPEC.meta,
+      takeaways: AI_AGENT_GOVERNANCE_SPRINT_GUIDE_SPEC.takeaways,
+      sections: AI_AGENT_GOVERNANCE_SPRINT_GUIDE_SPEC.sections.map(([kind, heading, entries]) => buildSectionFromSpec(kind, heading, entries)),
+      faq: AI_AGENT_GOVERNANCE_SPRINT_GUIDE_SPEC.faq.map(([question, text]) => answer(question, text)),
+      relatedPaths: AI_AGENT_GOVERNANCE_SPRINT_GUIDE_SPEC.relatedPaths,
+    }),
+    cta: {
+      label: 'Start the governance sprint',
+      href: '/?utm_source=website&utm_medium=seo_page&utm_campaign=ai_agent_governance_sprint&cta_placement=seo_brief&plan_id=team#workflow-sprint-intake',
+    },
+  };
+}
+
 const MODEL_UPGRADE_EVALUATION_GUIDE_SPEC = Object.freeze({
   slug: 'gpt-5-5-model-evaluation',
   meta: {
@@ -1519,6 +1587,7 @@ const PAGE_BLUEPRINTS = [
   buildDeveloperMachineSupplyChainGuardrailsGuide(),
   buildPromptTricksToWorkflowRulesGuide(),
   buildBackgroundAgentGovernanceGuide(),
+  buildAiAgentGovernanceSprintGuide(),
   buildModelUpgradeEvaluationGuide(),
   {
     query: 'stop ai coding agents from repeating mistakes',
@@ -2031,7 +2100,7 @@ function classifyIntent(query) {
   if (!normalized) return 'informational';
   if (/\b(vs|versus|alternative|compare|comparison|better than)\b/.test(normalized)) return 'comparison';
   if (/\b(price|pricing|buy|checkout|purchase|cost)\b/.test(normalized)) return 'transactional';
-  if (/\b(autoresearch|self-improving|benchmark|reward hacking|agent safety)\b/.test(normalized)) return 'commercial';
+  if (/\b(autoresearch|self-improving|benchmark|reward hacking|agent safety|governance|sprint)\b/.test(normalized)) return 'commercial';
   if (/\b(claude code|cursor|codex|gemini|amp|opencode|integration|plugin|setup|install)\b/.test(normalized)) {
     return 'commercial';
   }
@@ -2050,7 +2119,7 @@ function inferPillar(query) {
   if (/\b(rag|retrieval|proxy pointer|multimodal answer|document rag)\b/.test(normalized)) return 'document-rag-safety';
   if (/\b(topical presence|relational knowledge|recommend(?:ation|ed)? brands?|ai search visibility)\b/.test(normalized)) return 'ai-agent-reliability';
   if (/\b(browser automation|native messaging|browser bridge|prompt injection)\b/.test(normalized)) return 'pre-action-checks';
-  if (/\b(autoresearch|self-improving|benchmark|reward hacking|harness optimization|long running agent|context management|reasoning compression)\b/.test(normalized)) return 'pre-action-checks';
+  if (/\b(autoresearch|self-improving|benchmark|reward hacking|harness optimization|long running agent|context management|reasoning compression|governance|sprint)\b/.test(normalized)) return 'pre-action-checks';
   if (/\b(pre-action checks|guardrails|block|prevent repeated mistakes|repeating mistakes)\b/.test(normalized)) return 'pre-action-checks';
   if (/\b(claude code|cursor|codex|gemini|amp|opencode|integration|plugin)\b/.test(normalized)) return 'agent-workflows';
   return 'ai-agent-reliability';
@@ -2067,7 +2136,7 @@ function inferPersona(query) {
   if (/\b(programmatic seo|pseo|semantic seo|ai search|topical presence|seo agent)\b/.test(normalized)) return 'growth-engineer';
   if (/\b(rag|retrieval|proxy pointer|multimodal answer|document rag)\b/.test(normalized)) return 'rag-engineer';
   if (/\b(vs|alternative|compare)\b/.test(normalized)) return 'tool-evaluator';
-  if (/\b(guardrails|pre-action checks)\b/.test(normalized)) return 'engineering-lead';
+  if (/\b(guardrails|pre-action checks|governance|sprint)\b/.test(normalized)) return 'engineering-lead';
   return 'ai-engineer';
 }
 
@@ -2329,7 +2398,7 @@ function createPageSpec(blueprint, row) {
     sections: blueprint.sections,
     faq: blueprint.faq,
     relatedPages,
-    cta: {
+    cta: blueprint.cta || {
       label: 'Go Pro — $19/mo',
       href: `/checkout/pro?utm_source=website&utm_medium=seo_page&utm_campaign=${blueprint.path.split('/').filter(Boolean).join('_')}&cta_placement=seo_brief&plan_id=pro`,
     },

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -439,6 +439,7 @@ test('public landing page internally links to comparison and guide pages without
   assert.match(landingPage, /href="\/guides\/long-running-agent-context-management"/);
   assert.match(landingPage, /href="\/guides\/reasoning-compression-guardrails"/);
   assert.match(landingPage, /href="\/guides\/background-agent-governance"/);
+  assert.match(landingPage, /href="\/guides\/ai-agent-governance-sprint"/);
   assert.match(landingPage, /href="\/guides\/gpt-5-5-model-evaluation"/);
   assert.match(landingPage, /href="\/guides\/ai-search-topical-presence"/);
   assert.match(landingPage, /href="\/guides\/relational-knowledge-ai-recommendations"/);
@@ -464,6 +465,8 @@ test('public landing page internally links to comparison and guide pages without
   assert.match(landingPage, /Reasoning Compression Guardrails/);
   assert.match(landingPage, /Background Agent Governance/);
   assert.match(landingPage, /risk-tiered review/);
+  assert.match(landingPage, /AI Agent Governance Sprint/);
+  assert.match(landingPage, /approval boundaries, rollback safety/);
   assert.match(landingPage, /AI Search Topical Presence/);
   assert.match(landingPage, /Relational Knowledge in AI Recommendations/);
   // No internal marketing jargon visible to customers

--- a/tests/seo-gsd.test.js
+++ b/tests/seo-gsd.test.js
@@ -339,6 +339,27 @@ test('background agent governance page is discoverable and commercially classifi
   assert.match(html, /risk-tiered review/i);
 });
 
+test('AI agent governance sprint page routes bottom-funnel buyers into Team intake', () => {
+  const page = findSeoPageByPath('/guides/ai-agent-governance-sprint');
+  const sitemapEntry = THUMBGATE_SEO_SITEMAP_ENTRIES.find((entry) => entry.path === '/guides/ai-agent-governance-sprint');
+  const html = renderSeoPageHtml(page, { appOrigin: 'https://app.example.com' });
+
+  assert.ok(page);
+  assert.equal(page.query, 'ai agent governance sprint');
+  assert.equal(page.intent, 'commercial');
+  assert.equal(page.pageType, 'guide');
+  assert.equal(page.pillar, 'pre-action-checks');
+  assert.deepEqual(sitemapEntry, {
+    path: '/guides/ai-agent-governance-sprint',
+    changefreq: 'monthly',
+    priority: '0.8',
+  });
+  assert.match(html, /AI Agent Governance Sprint/);
+  assert.match(html, /48-hour Workflow Hardening Sprint/);
+  assert.match(html, /npx thumbgate background-governance --check --json/);
+  assert.match(html, /workflow-sprint-intake/);
+});
+
 test('GPT-5.5 model evaluation page is discoverable and commercially classified', () => {
   const page = findSeoPageByPath('/guides/gpt-5-5-model-evaluation');
   const sitemapEntry = THUMBGATE_SEO_SITEMAP_ENTRIES.find((entry) => entry.path === '/guides/gpt-5-5-model-evaluation');
@@ -482,6 +503,7 @@ test('writePlanOutputs persists machine-readable GSD artifacts', () => {
     assert.ok(pages.some((page) => page.path === '/guides/long-running-agent-context-management'));
     assert.ok(pages.some((page) => page.path === '/guides/reasoning-compression-guardrails'));
     assert.ok(pages.some((page) => page.path === '/guides/background-agent-governance'));
+    assert.ok(pages.some((page) => page.path === '/guides/ai-agent-governance-sprint'));
     assert.ok(pages.some((page) => page.path === '/guides/gpt-5-5-model-evaluation'));
     assert.ok(pages.some((page) => page.path === '/guides/ai-search-topical-presence'));
     assert.ok(pages.some((page) => page.path === '/guides/best-tools-stop-ai-agents-breaking-production'));

--- a/tests/seo-guides.test.js
+++ b/tests/seo-guides.test.js
@@ -23,6 +23,7 @@ const GUIDE_FILES = [
   'guides/reasoning-compression-guardrails.html',
   'guides/deepseek-v4-runtime-guardrails.html',
   'guides/background-agent-governance.html',
+  'guides/ai-agent-governance-sprint.html',
   'guides/gpt-5-5-model-evaluation.html',
   'guides/browser-automation-safety.html',
   'guides/native-messaging-host-security.html',
@@ -133,6 +134,18 @@ describe('SEO guide and comparison pages', () => {
     assert.ok(html.includes('pre-dispatch governance check'));
     assert.ok(html.includes('risk-tiered review'));
     assert.ok(html.includes('Workflow Hardening Sprint'));
+  });
+
+  it('AI agent governance sprint guide routes buyers into the Team intake', () => {
+    const html = fs.readFileSync(
+      path.join(PUBLIC_DIR, 'guides/ai-agent-governance-sprint.html'),
+      'utf-8'
+    );
+
+    assert.ok(html.includes('AI Agent Governance Sprint'));
+    assert.ok(html.includes('48-hour Workflow Hardening Sprint'));
+    assert.ok(html.includes('npx thumbgate background-governance --check --json'));
+    assert.ok(html.includes('workflow-sprint-intake'));
   });
 
   it('GPT-5.5 model evaluation guide routes teams into benchmark-first model routing', () => {


### PR DESCRIPTION
## Summary
- add a bottom-funnel AI Agent Governance Sprint guide routed into the Team workflow sprint intake
- update the landing page paid sprint path with governance-sprint proof, scope, and guide links
- wire the new query into SEO GSD generation, LLM context, sitemap/page tests, and static guide coverage

## Verification
- node --check scripts/seo-gsd.js
- node --test tests/public-landing.test.js tests/seo-gsd.test.js tests/seo-guides.test.js
- pre-commit public package parity/version/congruence/claims guards
- pre-push npm pack dry-run, public HTML internal link validation, regression-guard tests