### PR TITLE
Add checkout recovery intake path

### DIFF
--- a/.changeset/checkout-recovery-sprint-intake.md
+++ b/.changeset/checkout-recovery-sprint-intake.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a no-card checkout recovery path from paid sprint CTAs into workflow sprint intake so interested buyers can send the workflow before paying.

--- a/public/index.html
+++ b/public/index.html
@@ -405,6 +405,7 @@ __GA_BOOTSTRAP__
   .hero-paid-actions .starter { background: #facc15; color: #17110a; border: 1px solid rgba(250,204,21,0.55); }
   .hero-paid-actions .diagnostic { background: var(--green); color: #06120a; border: 1px solid rgba(74,222,128,0.45); }
   .hero-paid-actions .sprint { color: var(--green); border: 1px solid rgba(74,222,128,0.45); background: rgba(17,17,19,0.72); }
+  .hero-paid-actions .intake { color: var(--cyan); border: 1px solid rgba(34,211,238,0.45); background: rgba(34,211,238,0.1); }
   .hero-paid-note { font-size: 14px; color: var(--text-muted); max-width: 720px; margin: 0 auto 24px; }
   .hero-paid-note strong { color: var(--text); }
   .hero-install { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 10px; padding: 14px 24px; display: inline-flex; align-items: center; gap: 12px; font-family: var(--mono); font-size: 15px; margin-bottom: 40px; cursor: pointer; transition: border-color 0.2s; position: relative; max-width: 100%; overflow-x: auto; }
@@ -560,6 +561,10 @@ __GA_BOOTSTRAP__
   .team-paid-price { color: var(--green); font-weight: 800; font-size: 18px; }
   .team-paid-link { display: block; text-align: center; padding: 10px 12px; background: rgba(74,222,128,0.16); color: var(--green); border: 1px solid rgba(74,222,128,0.45); border-radius: 8px; text-decoration: none; font-size: 13px; font-weight: 700; }
   .team-paid-link:hover { border-color: var(--green); transform: translateY(-1px); }
+  .team-intake-recovery { margin: 0 0 16px; padding: 13px 14px; border: 1px solid rgba(34,211,238,0.28); border-radius: 12px; background: rgba(34,211,238,0.08); display: flex; align-items: center; justify-content: space-between; gap: 14px; text-align: left; }
+  .team-intake-recovery strong { display: block; color: var(--text); font-size: 13px; margin-bottom: 2px; }
+  .team-intake-recovery span { display: block; color: var(--text-dim); font-size: 12px; line-height: 1.45; }
+  .team-intake-recovery a { flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; min-height: 34px; padding: 8px 12px; border-radius: 999px; border: 1px solid rgba(34,211,238,0.45); color: var(--cyan); background: rgba(17,17,19,0.68); text-decoration: none; font-size: 12px; font-weight: 800; white-space: nowrap; }
   .team-form { max-width: 860px; margin: 24px auto 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
   .team-intake-panel .team-form { max-width: none; margin: 0; }
   .team-form .full { grid-column: 1 / -1; }
@@ -626,6 +631,8 @@ __GA_BOOTSTRAP__
     .team-intake-panel-head { display: block; }
     .team-intake-badge { display: inline-block; margin-bottom: 10px; }
     .team-paid-path { grid-template-columns: 1fr; }
+    .team-intake-recovery { align-items: stretch; flex-direction: column; text-align: center; }
+    .team-intake-recovery a { width: 100%; }
     .team-form { grid-template-columns: 1fr; }
     .hero { padding: 72px 0 56px; }
     .hero-actions { flex-direction: column; }
@@ -722,6 +729,7 @@ __GA_BOOTSTRAP__
         <a class="starter" href="https://buy.stripe.com/7sY4gzgH24r49G17mb3sI0g" onclick="sendFirstPartyTelemetry('founder_workflow_diagnostic_checkout_started',{ctaId:'hero_founder_workflow_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'founder_workflow_diagnostic',price:99});sendGa4Event('begin_checkout',{currency:'USD',value:99,items:[{item_id:'founder_workflow_diagnostic',item_name:'Founder Workflow Diagnostic'}]});">Pay $99 diagnostic &rarr;</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>
         <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars,items:[{item_id:'workflow_hardening_sprint',item_name:'Workflow Hardening Sprint'}]});">Pay $1500 sprint &rarr;</a>
+        <a class="intake" href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'hero_workflow_sprint_recovery_intake',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',reason:'not_ready_to_pay'});sendGa4Event('generate_lead',{currency:'USD',value:0,method:'workflow_sprint_recovery_intake'});">Send workflow first &rarr;</a>
         <a class="starter" href="/guides/ai-agent-governance-sprint">See sprint scope &rarr;</a>
       </div>
     </div>
@@ -1565,6 +1573,13 @@ __GA_BOOTSTRAP__
             <a class="team-paid-link" data-workflow-sprint-link href="__WORKFLOW_SPRINT_CHECKOUT_URL__">Pay for sprint</a>
           </div>
         </div>
+      </div>
+      <div class="team-intake-recovery" aria-label="Checkout recovery path for workflow sprint buyers">
+        <div>
+          <strong>Not ready to pay from a checkout page?</strong>
+          <span>Send the workflow first. We can qualify the blocker, confirm the proof plan, and route you to the $499 diagnostic or $1500 sprint only when the scope is real.</span>
+        </div>
+        <a href="#team-pilot-intake-form" onclick="sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'team_workflow_sprint_recovery_intake',ctaPlacement:'team_paid_path_recovery',planId:'team',offer:'workflow_hardening_sprint',reason:'checkout_abandon'});sendGa4Event('generate_lead',{currency:'USD',value:0,method:'workflow_sprint_recovery_intake'});">Send workflow first</a>
       </div>
       <form id="team-pilot-intake-form" class="team-form" action="/v1/intake/workflow-sprint" method="POST" data-team-intake-form>
         <input type="hidden" name="ctaId" value="workflow_sprint_intake">

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -117,12 +117,16 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.match(landingPage, /https:\/\/buy\.stripe\.com\/7sY4gzgH24r49G17mb3sI0g/);
   assert.match(landingPage, /Pay \$499 diagnostic/);
   assert.match(landingPage, /Pay \$1500 sprint/);
+  assert.match(landingPage, /Send workflow first/);
   assert.match(landingPage, /Pay for diagnostic/);
   assert.match(landingPage, /Pay for sprint/);
   assert.match(landingPage, /hero_workflow_sprint_diagnostic_checkout/);
   assert.match(landingPage, /hero_workflow_sprint_checkout/);
+  assert.match(landingPage, /hero_workflow_sprint_recovery_intake/);
   assert.match(landingPage, /workflow_sprint_diagnostic_checkout_started/);
   assert.match(landingPage, /workflow_sprint_checkout_started/);
+  assert.match(landingPage, /workflow_sprint_recovery_intake_clicked/);
+  assert.match(landingPage, /workflow_sprint_recovery_intake/);
 });
 
 test('public landing page includes Plausible analytics and search engine proof bar', () => {
@@ -301,6 +305,9 @@ test('public landing page includes an explicit Team rollout lane with shared wor
   assert.match(landingPage, /name="utmMedium" value="visible_team_intake"/);
   assert.match(landingPage, /name="planId" value="team"/);
   assert.match(landingPage, /name="ctaId" value="workflow_sprint_intake"/);
+  assert.match(landingPage, /Not ready to pay from a checkout page\?/);
+  assert.match(landingPage, /team_workflow_sprint_recovery_intake/);
+  assert.match(landingPage, /checkout_abandon/);
   assert.match(landingPage, /workflow_sprint_intake_started/);
   assert.match(landingPage, /workflow_sprint_intake_submit_attempted/);
   assert.doesNotMatch(


### PR DESCRIPTION
## Summary

- Adds a no-card "Send workflow first" path beside the paid diagnostic and sprint CTAs.
- Adds a checkout-recovery panel above the Team sprint intake form for buyers who are interested but not ready to pay from checkout.
- Tracks recovery clicks with `workflow_sprint_recovery_intake_clicked` and GA4 `generate_lead` so checkout hesitation becomes measurable.

## Why

Revenue status showed checkout starts without paid orders and zero sprint leads. This gives hesitant buyers a lower-friction conversion path without weakening the paid $99/$499/$1500 offers.

## Validation

- `node --test tests/public-landing.test.js tests/workflow-sprint-intake.test.js`
- `CHANGESET_BASE_REF=origin/main npm run changeset:check`
- `git diff --check HEAD~1..HEAD`
- pre-push guards
