### PR TITLE
Fix revenue machine payment-link readiness

### DIFF
--- a/.changeset/revenue-machine-payment-link-state.md
+++ b/.changeset/revenue-machine-payment-link-state.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Teach the May 2026 revenue machine to treat configured sprint payment links as an agent-ready promotion path instead of a blocked setup item.

--- a/scripts/may-2026-revenue-machine.js
+++ b/scripts/may-2026-revenue-machine.js
@@ -122,6 +122,8 @@ function buildRevenueMetrics(report) {
   return {
     runtime,
     runtimeKnown,
+    hasSprintDiagnosticPaymentLink: Boolean(runtime.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL),
+    hasWorkflowSprintPaymentLink: Boolean(runtime.THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL),
     todayVisitors: number(today.trafficMetrics?.visitors),
     visitors,
     checkoutStarts,
@@ -164,8 +166,22 @@ function buildRuntimeGapActions({ runtime, runtimeKnown }) {
   ].filter(Boolean);
 }
 
-function buildSprintPathAction({ visitors, checkoutStarts, sprintLeads }) {
+function buildSprintPathAction({
+  visitors,
+  checkoutStarts,
+  sprintLeads,
+  hasSprintDiagnosticPaymentLink,
+  hasWorkflowSprintPaymentLink,
+}) {
   if (sprintLeads === 0 && visitors >= 500) {
+    if (hasSprintDiagnosticPaymentLink && hasWorkflowSprintPaymentLink) {
+      return agentReadyAction(
+        'Promote the live paid diagnostic/sprint path',
+        `${visitors} visitors and ${checkoutStarts} checkout starts in 30d produced 0 sprint leads, and both high-ticket Stripe links are configured; the remaining agent work is to keep paid CTAs above intake and route high-intent traffic to them.`,
+        'Keep the paid diagnostic/sprint card above the unpaid intake, track begin_checkout for both offers, and prioritize traffic sources already producing checkout starts.'
+      );
+    }
+
     return humanBlockedAction(
       'blocked_on_payment_links',
       'Activate paid high-ticket path above the sprint intake',

--- a/tests/may-2026-revenue-machine.test.js
+++ b/tests/may-2026-revenue-machine.test.js
@@ -82,6 +82,23 @@ test('formatPlan gives the operator exact next steps', () => {
   assert.match(output, /Top leaking source: website/);
 });
 
+test('buildRevenuePlan treats configured sprint payment links as agent-ready', () => {
+  const plan = buildRevenuePlan(report({
+    hostedAudit: {
+      runtimePresence: {
+        THUMBGATE_GA_MEASUREMENT_ID: true,
+        THUMBGATE_CHECKOUT_FALLBACK_URL: true,
+        THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL: true,
+        THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL: true,
+      },
+      summaries: report().hostedAudit.summaries,
+    },
+  }));
+
+  assert.ok(!plan.actions.some((action) => action.status === 'blocked_on_payment_links'));
+  assert.ok(plan.actions.some((action) => action.title === 'Promote the live paid diagnostic/sprint path'));
+});
+
 test('buildRevenuePlan avoids blocked account actions when runtime presence is unknown', () => {
   const plan = buildRevenuePlan(report({
     diagnosis: {


### PR DESCRIPTION
## Summary
- Treat configured sprint diagnostic and workflow sprint payment links as an agent-ready promotion path
- Keep the blocked payment-link action only when those env links are actually missing
- Add regression coverage for the configured-link state

## Tests
- node --check scripts/may-2026-revenue-machine.js
- node --test tests/may-2026-revenue-machine.test.js tests/revenue-status.test.js
- git diff --check