### PR TITLE
Expose hosted runtime presence to revenue audit

### DIFF
--- a/.changeset/hosted-revenue-runtime-presence.md
+++ b/.changeset/hosted-revenue-runtime-presence.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Expose non-secret hosted runtime presence in the billing summary so the revenue machine can recognize configured sprint payment links over the HTTP audit path.

--- a/scripts/revenue-status.js
+++ b/scripts/revenue-status.js
@@ -493,6 +493,7 @@ async function getHostedAuditViaHttp({
   }
 
   const summaries = {};
+  let runtimePresence = null;
   for (const window of HOSTED_WINDOWS) {
     const url = new URL('/v1/billing/summary', appOrigin);
     url.searchParams.set('window', window);
@@ -507,13 +508,16 @@ async function getHostedAuditViaHttp({
     if (!response.ok) {
       throw new Error(`Hosted billing summary ${window} returned ${response.status}`);
     }
+    if (!runtimePresence && payload.runtimePresence && typeof payload.runtimePresence === 'object') {
+      runtimePresence = payload.runtimePresence;
+    }
     summaries[window] = normalizeWindowSummary(response.status, payload);
   }
 
   return {
     auditMethod: 'hosted-http-api',
-    runtimePresenceKnown: false,
-    runtimePresence: {
+    runtimePresenceKnown: Boolean(runtimePresence),
+    runtimePresence: runtimePresence || {
       THUMBGATE_OPERATOR_KEY: Boolean(process.env.THUMBGATE_OPERATOR_KEY),
       THUMBGATE_API_KEY: true,
     },

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2439,6 +2439,21 @@ function renderSitemapXml(runtimeConfig) {
   ].join('\n');
 }
 
+function buildHostedRuntimePresence(hostedConfig, { expectedApiKey, expectedOperatorKey } = {}) {
+  return {
+    THUMBGATE_FEEDBACK_DIR: Boolean(process.env.THUMBGATE_FEEDBACK_DIR),
+    THUMBGATE_OPERATOR_KEY: Boolean(expectedOperatorKey),
+    THUMBGATE_API_KEY: Boolean(expectedApiKey),
+    THUMBGATE_PUBLIC_APP_ORIGIN: Boolean(hostedConfig.appOrigin),
+    THUMBGATE_BILLING_API_BASE_URL: Boolean(hostedConfig.billingApiBaseUrl),
+    THUMBGATE_GA_MEASUREMENT_ID: Boolean(hostedConfig.gaMeasurementId),
+    THUMBGATE_CHECKOUT_FALLBACK_URL: Boolean(hostedConfig.checkoutFallbackUrl),
+    THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL: Boolean(hostedConfig.sprintDiagnosticCheckoutUrl),
+    THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL: Boolean(hostedConfig.workflowSprintCheckoutUrl),
+    STRIPE_SECRET_KEY: Boolean(process.env.STRIPE_SECRET_KEY),
+  };
+}
+
 function isSeoAttributionSource(source) {
   return source === 'organic_search' || source === 'ai_search';
 }
@@ -6288,7 +6303,13 @@ async function addContext(){
         }
 
         const summary = await getBillingSummaryLive(summaryOptions);
-        sendJson(res, 200, summary);
+        sendJson(res, 200, {
+          ...summary,
+          runtimePresence: buildHostedRuntimePresence(hostedConfig, {
+            expectedApiKey,
+            expectedOperatorKey,
+          }),
+        });
         return;
       }
 

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -2656,6 +2656,8 @@ test('billing summary returns admin-only operational proxy', async () => {
   assert.equal(body.pipeline.workflowSprintLeads.total, 1);
   assert.equal(body.pipeline.workflowSprintLeads.bySource.linkedin, 1);
   assert.equal(body.pipeline.qualifiedWorkflowSprintLeads.total, 1);
+  assert.equal(body.runtimePresence.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL, true);
+  assert.equal(body.runtimePresence.THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL, true);
   assert.equal(body.attribution.bookedRevenueByCampaignCents.pro_pack, 4900);
   assert.ok(body.trafficMetrics.visitors >= 1);
   assert.equal(body.operatorGeneratedAcquisition.uniqueLeads, 0);

--- a/tests/revenue-status.test.js
+++ b/tests/revenue-status.test.js
@@ -347,6 +347,36 @@ test('getHostedAuditViaHttp reads hosted billing summary without Railway CLI', a
   assert.equal(hostedAudit.summaries['30d'].attribution.paidBySource.website, 1);
 });
 
+test('getHostedAuditViaHttp carries hosted runtime presence when exposed', async () => {
+  const hostedAudit = await getHostedAuditViaHttp({
+    appOrigin: 'https://example.com',
+    apiKey: 'tg_test_key',
+    timeZone: 'America/New_York',
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        runtimePresence: {
+          THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL: true,
+          THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL: true,
+        },
+        trafficMetrics: {
+          visitors: 3,
+          checkoutStarts: 1,
+        },
+        revenue: {
+          paidOrders: 0,
+          bookedRevenueCents: 0,
+        },
+      }),
+    }),
+  });
+
+  assert.equal(hostedAudit.runtimePresenceKnown, true);
+  assert.equal(hostedAudit.runtimePresence.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL, true);
+  assert.equal(hostedAudit.runtimePresence.THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL, true);
+});
+
 test('generateRevenueStatusReport prefers hosted HTTP API when THUMBGATE_API_KEY is available', async () => {
   const runCalls = [];
   const report = await generateRevenueStatusReport({


### PR DESCRIPTION
## Summary
- Add non-secret runtime presence booleans to the operator billing summary response
- Let hosted HTTP revenue audits carry those booleans into the revenue machine
- Cover both API summary output and HTTP audit ingestion

## Tests
- node --check src/api/server.js
- node --check scripts/revenue-status.js
- node --test tests/revenue-status.test.js tests/may-2026-revenue-machine.test.js tests/api-server.test.js
- git diff --check