### PR TITLE
Route checkout intent before Stripe

### DIFF
--- a/.changeset/checkout-intent-router.md
+++ b/.changeset/checkout-intent-router.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Route unconfirmed Pro checkout traffic through an intent page with Pro, workflow intake, and diagnostic/sprint options before creating Stripe sessions.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1453,6 +1453,87 @@ function buildCheckoutFallbackUrl(baseUrl, metadata = {}) {
   return restoreStripeCheckoutPlaceholder(url.toString());
 }
 
+function buildCheckoutIntentHref(baseUrl, metadata = {}, overrides = {}) {
+  return buildCheckoutFallbackUrl(baseUrl, {
+    ...metadata,
+    ...overrides,
+  });
+}
+
+function renderCheckoutIntentPage({ confirmHref, workflowIntakeHref, teamOptionsHref, botClassification }) {
+  const safeConfirmHref = escapeHtmlAttribute(confirmHref);
+  const safeWorkflowIntakeHref = escapeHtmlAttribute(workflowIntakeHref);
+  const safeTeamOptionsHref = escapeHtmlAttribute(teamOptionsHref);
+  const classification = botClassification?.isBot ? 'bot_deflected' : 'human_confirm_required';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>ThumbGate Pro - Confirm checkout</title>
+  <style>
+    *{box-sizing:border-box}
+    body{background:#0a0a0a;color:#e5e5e5;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:20px}
+    .card{background:#141414;border:1px solid #222;border-radius:8px;padding:40px;max-width:560px;width:100%;box-shadow:0 8px 32px rgba(0,0,0,.5)}
+    h1{margin:0 0 12px;font-size:24px;color:#22d3ee}
+    p{color:#9ca3af;font-size:14px;line-height:1.55;margin:0 0 18px}
+    .actions{display:grid;gap:12px;margin-top:22px}
+    .btn{display:block;text-align:center;text-decoration:none;font-weight:800;padding:14px 18px;border-radius:8px;font-size:15px;border:1px solid transparent}
+    .primary{background:#22d3ee;color:#000}
+    .secondary{background:#1f2937;color:#f9fafb;border-color:#374151}
+    .ghost{background:transparent;color:#e5e5e5;border-color:#374151}
+    .sub{margin-top:16px;font-size:12px;color:#6b7280;text-align:center}
+    .back{color:#6b7280;font-size:13px;text-decoration:underline}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Choose the right paid path.</h1>
+    <p>ThumbGate Pro is $19/mo for a solo operator. If the real problem is a team workflow, send that workflow first so we can route you to the $499 diagnostic or $1500 sprint only when the scope is real.</p>
+    <div class="actions">
+      <a class="btn primary" data-checkout-intent="pro_checkout_confirmed" href="${safeConfirmHref}" rel="noopener">Continue to Stripe</a>
+      <a class="btn secondary" data-checkout-intent="workflow_sprint_intake" href="${safeWorkflowIntakeHref}">Send workflow first</a>
+      <a class="btn ghost" data-checkout-intent="team_paid_path" href="${safeTeamOptionsHref}">See diagnostic and sprint options</a>
+    </div>
+    <div class="sub">Payments handled by Stripe. Pro includes a 7-day trial. Card required; no charge today.</div>
+    <div class="sub"><a class="back" href="/">Back to homepage</a></div>
+  </div>
+  <script>
+    (function () {
+      function sendTelemetry(eventType, extra) {
+        var payload = Object.assign({
+          eventType: eventType,
+          clientType: 'web',
+          page: '/checkout/pro',
+          checkoutIntentClassification: '${classification}'
+        }, extra || {});
+        var body = JSON.stringify(payload);
+        if (navigator.sendBeacon) {
+          navigator.sendBeacon('/v1/telemetry/ping', new Blob([body], { type: 'application/json' }));
+          return;
+        }
+        fetch('/v1/telemetry/ping', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: body,
+          keepalive: true
+        }).catch(function () {});
+      }
+      document.querySelectorAll('[data-checkout-intent]').forEach(function (link) {
+        link.addEventListener('click', function () {
+          sendTelemetry('checkout_interstitial_cta_clicked', {
+            ctaId: link.getAttribute('data-checkout-intent'),
+            ctaPlacement: 'checkout_interstitial'
+          });
+        });
+      });
+    }());
+  </script>
+</body>
+</html>`;
+}
+
 function buildCheckoutBootstrapBody(parsed, req, journeyState = resolveJourneyState(req, parsed)) {
   const params = parsed.searchParams;
   const traceId = pickFirstText(params.get('trace_id')) || createJourneyId('checkout');
@@ -4386,33 +4467,59 @@ async function addContext(){
         ? { 'Set-Cookie': journeyState.setCookieHeaders }
         : {};
 
-      // ── Bot guard ────────────────────────────────────────────────────
+      // ── Intent confirmation ──────────────────────────────────────────
       // Creating a Stripe Checkout session on every GET means crawlers,
-      // link-preview fetchers, and LLM scrapers inflate "sessions opened"
-      // while completions stay at zero. Serve bots an interstitial HTML
-      // page instead — no Stripe session created, no funnel pollution.
-      // The `?confirm=1` query param or POST below is the real-user path.
+      // link-preview fetchers, LLM scrapers, and low-intent humans inflate
+      // "sessions opened" while completions stay at zero. Serve an
+      // interstitial first, then create the payment session only after the
+      // buyer confirms the Pro path.
       const botClassification = classifyRequester(req.headers);
       const confirmParam = parsed?.searchParams?.get('confirm') ?? null;
       const isConfirmedCheckout = confirmParam === '1'
         || confirmParam === 'true'
         || req.method === 'POST';
-      if (botClassification.isBot && !isConfirmedCheckout) {
+      if (!isConfirmedCheckout) {
+        const eventType = botClassification.isBot ? 'checkout_bot_deflected' : 'checkout_interstitial_view';
         appendBestEffortTelemetry(FEEDBACK_DIR, {
-          eventType: 'checkout_bot_deflected',
+          eventType,
           clientType: 'web',
           traceId,
+          acquisitionId: analyticsMetadata.acquisitionId,
+          visitorId: analyticsMetadata.visitorId,
+          sessionId: analyticsMetadata.sessionId,
           utmSource: analyticsMetadata.utmSource,
           utmMedium: analyticsMetadata.utmMedium,
           utmCampaign: analyticsMetadata.utmCampaign,
+          utmContent: analyticsMetadata.utmContent,
+          utmTerm: analyticsMetadata.utmTerm,
           referrer: analyticsMetadata.referrer,
           referrerHost: analyticsMetadata.referrerHost,
           page: '/checkout/pro',
+          ctaId: analyticsMetadata.ctaId,
+          ctaPlacement: analyticsMetadata.ctaPlacement,
           planId: analyticsMetadata.planId,
           reason: botClassification.reason,
-        }, req.headers, 'checkout_bot_deflected');
-        const confirmHref = escapeHtmlAttribute(buildCheckoutConfirmHref(parsed));
-        const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>ThumbGate Pro \u2014 Confirm checkout</title><style>*{box-sizing:border-box}body{background:#0a0a0a;color:#e5e5e5;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:20px}.card{background:#141414;border:1px solid #222;border-radius:16px;padding:48px 40px;max-width:460px;width:100%;text-align:center;box-shadow:0 8px 32px rgba(0,0,0,.5)}h1{margin:0 0 12px;font-size:22px;color:#22d3ee}p{color:#9ca3af;font-size:14px;line-height:1.55;margin:0 0 24px}.btn{display:inline-block;background:#22d3ee;color:#000;text-decoration:none;font-weight:700;padding:14px 32px;border-radius:999px;font-size:16px;cursor:pointer;border:none}.btn:hover{opacity:.9}.sub{margin-top:16px;font-size:12px;color:#6b7280}a.back{color:#6b7280;font-size:13px;text-decoration:underline}</style></head><body><div class="card"><h1>Continue to secure checkout</h1><p>You're one click from ThumbGate Pro at $19/mo. We create the payment session only after you confirm \u2014 keeps your path clean and our funnel honest.</p><a class="btn" href="${confirmHref}" rel="noopener">Continue to Stripe \u2192</a><div class="sub">Payments handled by Stripe. 7-day trial. Card required; no charge today. Cancel anytime.</div><div class="sub"><a class="back" href="/">\u2190 Back to homepage</a></div></div></body></html>`;
+        }, req.headers, eventType);
+        const workflowIntakeHref = buildCheckoutIntentHref(`${hostedConfig.appOrigin}/#workflow-sprint-intake`, analyticsMetadata, {
+          utmMedium: 'checkout_interstitial_recovery',
+          utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_workflow_sprint',
+          ctaId: 'checkout_interstitial_workflow_sprint_intake',
+          ctaPlacement: 'checkout_interstitial',
+          planId: 'team',
+        });
+        const teamOptionsHref = buildCheckoutIntentHref(`${hostedConfig.appOrigin}/#workflow-sprint-intake`, analyticsMetadata, {
+          utmMedium: 'checkout_interstitial_paid_path',
+          utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_team_paid_path',
+          ctaId: 'checkout_interstitial_team_paid_path',
+          ctaPlacement: 'checkout_interstitial',
+          planId: 'team',
+        });
+        const html = renderCheckoutIntentPage({
+          confirmHref: buildCheckoutConfirmHref(parsed),
+          workflowIntakeHref,
+          teamOptionsHref,
+          botClassification,
+        });
         sendHtml(res, 200, html, responseHeaders);
         return;
       }

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1309,7 +1309,7 @@ test('checkout fallback URLs preserve Stripe session placeholders while carrying
 
 test('checkout bootstrap route preserves attribution and records first-party telemetry in local mode', async () => {
   const res = await fetch(
-    apiUrl('/checkout/pro?acquisition_id=acq_bootstrap&visitor_id=visitor_bootstrap&session_id=session_bootstrap&install_id=inst_bootstrap&utm_source=reddit&utm_medium=organic_social&utm_campaign=reddit_launch&utm_term=agentic+feedback&creator=reach_vb&community=ClaudeCode&post_id=1rsudq0&comment_id=oa9mqjf&campaign_variant=comment_problem_solution&offer_code=REDDIT-EARLY&cta_id=pricing_pro&cta_placement=pricing&plan_id=pro&landing_path=%2Fpricing'),
+    apiUrl('/checkout/pro?confirm=1&acquisition_id=acq_bootstrap&visitor_id=visitor_bootstrap&session_id=session_bootstrap&install_id=inst_bootstrap&utm_source=reddit&utm_medium=organic_social&utm_campaign=reddit_launch&utm_term=agentic+feedback&creator=reach_vb&community=ClaudeCode&post_id=1rsudq0&comment_id=oa9mqjf&campaign_variant=comment_problem_solution&offer_code=REDDIT-EARLY&cta_id=pricing_pro&cta_placement=pricing&plan_id=pro&landing_path=%2Fpricing'),
     {
       redirect: 'manual',
       headers: {
@@ -1377,7 +1377,7 @@ test('checkout bootstrap falls back to seeded journey cookies when query IDs are
     'thumbgate_acquisition_id=acq_cookie_checkout',
   ].join('; ');
   const res = await fetch(
-    apiUrl('/checkout/pro?utm_source=reddit&utm_medium=organic_social&utm_campaign=reddit_launch&cta_id=pricing_pro&cta_placement=pricing&plan_id=pro'),
+    apiUrl('/checkout/pro?confirm=1&utm_source=reddit&utm_medium=organic_social&utm_campaign=reddit_launch&cta_id=pricing_pro&cta_placement=pricing&plan_id=pro'),
     {
       redirect: 'manual',
       headers: {

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -2,8 +2,8 @@
 
 /**
  * Integration tests: GET /checkout/pro must not create Stripe sessions for
- * bots. Browsers hit the session-create path as before; bots get an HTML
- * interstitial that only creates the session on explicit confirm.
+ * bots or humans. Everyone gets an HTML interstitial first; only explicit
+ * checkout confirmation creates a payment session.
  */
 
 const { describe, it, before, after } = require('node:test');
@@ -78,7 +78,10 @@ describe('/checkout/pro bot guard', () => {
     });
     assert.equal(res.status, 200);
     const body = await res.text();
-    assert.match(body, /Continue to secure checkout/);
+    assert.match(body, /Choose the right paid path/);
+    assert.match(body, /Send workflow first/);
+    assert.match(body, /checkout_interstitial_workflow_sprint_intake/);
+    assert.match(body, /checkout_interstitial_cta_clicked/);
     assert.match(body, /\/checkout\/pro\?confirm=1/);
     assert.doesNotMatch(body, /stripe\.com/);
   });
@@ -97,6 +100,8 @@ describe('/checkout/pro bot guard', () => {
     assert.match(body, /&amp;cta_id=pricing_pro/);
     assert.match(body, /&amp;billing_cycle=annual/);
     assert.match(body, /&amp;landing_path=%2Fpricing/);
+    assert.match(body, /utm_medium=checkout_interstitial_recovery/);
+    assert.match(body, /cta_id=checkout_interstitial_workflow_sprint_intake/);
   });
 
   it('returns HTML interstitial for curl (missing browser headers)', async () => {
@@ -109,7 +114,7 @@ describe('/checkout/pro bot guard', () => {
     });
     assert.equal(res.status, 200);
     const body = await res.text();
-    assert.match(body, /Continue to secure checkout/);
+    assert.match(body, /Choose the right paid path/);
   });
 
   it('returns HTML interstitial for LLM crawlers (ClaudeBot, GPTBot)', async () => {
@@ -124,7 +129,7 @@ describe('/checkout/pro bot guard', () => {
       });
       assert.equal(res.status, 200, `expected 200 interstitial for ${ua}`);
       const body = await res.text();
-      assert.match(body, /Continue to secure checkout/);
+      assert.match(body, /Choose the right paid path/);
     }
   });
 
@@ -141,11 +146,11 @@ describe('/checkout/pro bot guard', () => {
       });
       assert.equal(res.status, 200);
       const body = await res.text();
-      assert.match(body, /Continue to secure checkout/);
+      assert.match(body, /Choose the right paid path/);
     }
   });
 
-  it('proceeds with checkout flow for a real browser user-agent', async () => {
+  it('requires checkout confirmation for a real browser user-agent', async () => {
     const res = await fetch(`${origin}/checkout/pro`, {
       redirect: 'manual',
       headers: {
@@ -153,17 +158,15 @@ describe('/checkout/pro bot guard', () => {
         accept: BROWSER_ACCEPT,
       },
     });
-    // Expect either 302 to a Stripe URL / local fallback OR 200 with stripe URL content.
-    // With STRIPE_SECRET_KEY='' the local-mode fallback is used, which 302s to a /success URL.
-    assert.ok(
-      res.status === 302 || res.status === 200,
-      `expected redirect or success page, got ${res.status}`,
-    );
-    if (res.status === 200) {
-      const body = await res.text();
-      assert.doesNotMatch(body, /Continue to secure checkout/,
-        'browser should skip the interstitial');
-    }
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /Choose the right paid path/);
+    assert.match(body, /Continue to Stripe/);
+    assert.match(body, /Send workflow first/);
+    assert.match(body, /See diagnostic and sprint options/);
+    assert.match(body, /checkout_interstitial_workflow_sprint_intake/);
+    assert.match(body, /checkout_interstitial_team_paid_path/);
+    assert.doesNotMatch(body, /stripe\.com/);
   });
 
   it('proceeds with checkout when ?confirm=1 is passed even from a bot UA', async () => {
@@ -198,5 +201,23 @@ describe('/checkout/pro bot guard', () => {
       deflected[0].reasonCode || deflected[0].reason,
       'deflection reason should be populated',
     );
+  });
+
+  it('logs checkout_interstitial_view telemetry events for browsers before confirmed checkout', async () => {
+    try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
+    await fetch(`${origin}/checkout/pro?utm_source=pricing_page&cta_id=pricing_pro`, {
+      redirect: 'manual',
+      headers: {
+        'user-agent': BROWSER_UA,
+        accept: BROWSER_ACCEPT,
+      },
+    });
+    const events = readFunnelEvents();
+    const interstitial = events.filter((e) => e.eventType === 'checkout_interstitial_view');
+    const bootstrapped = events.filter((e) => e.eventType === 'checkout_bootstrap');
+    assert.ok(interstitial.length >= 1, `expected at least 1 interstitial event, got ${interstitial.length}`);
+    assert.equal(bootstrapped.length, 0, 'unconfirmed browser should not reach checkout_bootstrap');
+    assert.equal(interstitial[0].ctaId, 'pricing_pro');
+    assert.equal(interstitial[0].utmSource, 'pricing_page');
   });
 });


### PR DESCRIPTION
## Summary
- route unconfirmed /checkout/pro visits through a buyer-choice page before creating Stripe sessions
- keep the Pro confirmation link intact while adding no-card workflow sprint intake and team paid-path CTAs
- preserve attribution into the recovery links and track interstitial CTA clicks

## Why
Live hosted revenue status shows 28 checkout starts today, 0 paid orders, and 0 sprint leads. This makes checkout intent cleaner and gives team-intent buyers a path before they abandon.

## Tests
- node --check src/api/server.js
- node --test tests/checkout-bot-guard.test.js tests/api-server.test.js
- git diff --check