### PR TITLE
Make Pro checkout charge immediately

### DIFF
--- a/.changeset/pro-paid-checkout-immediate-charge.md
+++ b/.changeset/pro-paid-checkout-immediate-charge.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Charge Pro subscription checkout immediately and replace trial/no-charge buyer copy with paid Pro access messaging.

--- a/public/pro.html
+++ b/public/pro.html
@@ -1026,7 +1026,7 @@ __GA_BOOTSTRAP__
       <h2>Stop losing time to the same AI-agent failure.</h2>
       <p>Start Pro, harden one repeated mistake, and keep the proof trail: blocked action, lesson, prevention rule, and export path.</p>
       <div class="hero-actions" style="justify-content:center;">
-        <a class="btn-primary btn-pro-checkout" href="/checkout/pro?utm_source=website&utm_medium=pro_page_final&utm_campaign=pro_pack&cta_id=final_go_pro&cta_placement=final&plan_id=pro&landing_path=%2Fpro">Start 7-Day Free Trial</a>
+        <a class="btn-primary btn-pro-checkout" href="/checkout/pro?utm_source=website&utm_medium=pro_page_final&utm_campaign=pro_pack&cta_id=final_go_pro&cta_placement=final&plan_id=pro&landing_path=%2Fpro">Start Pro Now</a>
         <a class="btn-secondary btn-demo" href="/dashboard?utm_source=website&utm_medium=pro_page_final&utm_campaign=pro_pack">Open dashboard demo</a>
       </div>
     </div>

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -532,9 +532,9 @@ function buildTrialActivationEmail({ customerEmail, apiKey, sessionId, planId, a
   const docsUrl = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md';
   const supportEmail = process.env.THUMBGATE_SUPPORT_EMAIL || CONFIG.TRIAL_EMAIL_REPLY_TO || 'igor.ganapolsky@gmail.com';
   const command = `npx thumbgate pro --activate --key=${apiKey || ''}`;
-  const subject = 'Your 7-day ThumbGate Pro trial is live';
+  const subject = 'Your ThumbGate Pro subscription is live';
   const preheader = 'Activate Pro in one command, open the dashboard, and start blocking repeated AI coding mistakes.';
-  const headline = 'Your 7-day ThumbGate Pro trial is live.';
+  const headline = 'Your ThumbGate Pro subscription is live.';
   const intro = 'ThumbGate turns thumbs up/down feedback into Pre-Action Checks that stop repeated AI coding mistakes before the next tool call. It keeps lessons local and turns repeated mistakes into Reliability Gateway blocks.';
   const exampleFeedback = 'thumbs down: the answer skipped exact files and tests; next time include paths, commands, and verification evidence.';
   const safeDashboardUrl = escapeHtml(dashboardUrl);
@@ -561,7 +561,7 @@ function buildTrialActivationEmail({ customerEmail, apiKey, sessionId, planId, a
       '3. Give one concrete thumbs up or thumbs down:',
       exampleFeedback,
       '',
-      'Your trial key:',
+      'Your Pro key:',
       apiKey,
       '',
       `Verification evidence: ${docsUrl}`,
@@ -594,7 +594,7 @@ function buildTrialActivationEmail({ customerEmail, apiKey, sessionId, planId, a
                 <h2 style="margin:0 0 8px;font-size:17px;line-height:1.3;color:#17212b;">1. Activate Pro locally</h2>
                 <pre style="margin:0 0 22px;background:#081016;color:#d8f7e4;border:1px solid #23343d;border-radius:6px;padding:14px;font-size:13px;line-height:1.45;white-space:pre-wrap;word-break:break-word;"><code>${safeCommand}</code></pre>
 
-                <h2 style="margin:0 0 8px;font-size:17px;line-height:1.3;color:#17212b;">2. Save your trial key</h2>
+                <h2 style="margin:0 0 8px;font-size:17px;line-height:1.3;color:#17212b;">2. Save your Pro key</h2>
                 <pre style="margin:0 0 22px;background:#eef6f7;color:#0b343c;border:1px solid #c7e2e7;border-radius:6px;padding:14px;font-size:13px;line-height:1.45;white-space:pre-wrap;word-break:break-word;"><code>${safeApiKey}</code></pre>
 
                 <h2 style="margin:0 0 8px;font-size:17px;line-height:1.3;color:#17212b;">3. Give one concrete thumbs up or thumbs down</h2>

--- a/scripts/mailer/resend-mailer.js
+++ b/scripts/mailer/resend-mailer.js
@@ -331,13 +331,12 @@ function formatTrialEndDate(trialEndAt) {
   return `${month} ${day}, ${year}`;
 }
 
-function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialEndAt } = {}) {
+function renderTrialWelcomeBodies({ licenseKey, customerId, customerName } = {}) {
   const activationCommand = `npx thumbgate pro --activate --key=${licenseKey}`;
   const name = firstName(customerName);
   const greeting = name ? `Hi ${name},` : 'Hi there,';
-  const trialEndLabel = formatTrialEndDate(trialEndAt);
-  const headline = 'Your ThumbGate Pro trial is live.';
-  const subhead = `You have 7 days of Pro access. Trial ends ${trialEndLabel}.`;
+  const headline = 'Your ThumbGate Pro subscription is live.';
+  const subhead = 'Your paid Pro access is active. Activate the local dashboard whenever you are ready.';
   const description =
     'ThumbGate turns thumbs up/down feedback into Pre-Action Checks that stop repeated AI coding mistakes ' +
     'before the next tool call. Lessons stay on your machine. Repeated failures become Reliability Gateway blocks.';
@@ -370,7 +369,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
     '3. Give one concrete thumbs up or thumbs down:',
     `   ${exampleFeedback}`,
     '',
-    'Your trial key (save this):',
+    'Your Pro key (save this):',
     `   ${licenseKey}`,
     '',
     `Verification evidence: ${proofUrl}`,
@@ -382,7 +381,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
     '— Igor, founder of ThumbGate',
     '',
     '---',
-    `You're getting this because you started a ${PRODUCT_NAME} trial. Don't want these emails? Unsubscribe: ${unsubscribeEmail}`,
+    `You're getting this because you started a paid ${PRODUCT_NAME} subscription. Don't want these emails? Unsubscribe: ${unsubscribeEmail}`,
     `${businessName} · ${businessAddress}`,
   ].join('\n');
 
@@ -440,7 +439,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
                 <p style="margin:0 0 8px;font-size:14px;line-height:1.55;color:#344451;"><strong>1. Activate Pro locally</strong></p>
                 <pre style="margin:0 0 20px;background:#081016;color:#d8f7e4;border:1px solid #23343d;border-radius:6px;padding:14px;font-size:13px;line-height:1.45;white-space:pre-wrap;word-break:break-word;"><code>${safeCmd}</code></pre>
 
-                <p style="margin:0 0 8px;font-size:14px;line-height:1.55;color:#344451;"><strong>2. Save your trial key</strong></p>
+                <p style="margin:0 0 8px;font-size:14px;line-height:1.55;color:#344451;"><strong>2. Save your Pro key</strong></p>
                 <pre style="margin:0 0 20px;background:#eef6f7;color:#0b343c;border:1px solid #c7e2e7;border-radius:6px;padding:14px;font-size:13px;line-height:1.45;white-space:pre-wrap;word-break:break-word;"><code>${safeKey}</code></pre>
 
                 <p style="margin:0 0 8px;font-size:14px;line-height:1.55;color:#344451;"><strong>3. Give one concrete thumbs up or thumbs down</strong></p>
@@ -461,7 +460,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
             <tr>
               <td style="padding:16px 28px 22px;border-top:1px solid #e2e8ec;background:#fafbfc;">
                 <p style="margin:0 0 6px;font-size:12px;line-height:1.5;color:#7a8790;">
-                  You're getting this one-time email because you started a ${escapeHtml(PRODUCT_NAME)} trial.
+                  You're getting this one-time email because you started a paid ${escapeHtml(PRODUCT_NAME)} subscription.
                   <a href="${safeUnsubscribeMailto}" style="color:#7a8790;text-decoration:underline;">Unsubscribe</a>
                   (${safeUnsubscribeEmail}).
                 </p>
@@ -478,7 +477,7 @@ function renderTrialWelcomeBodies({ licenseKey, customerId, customerName, trialE
   </body>
 </html>`;
 
-  return { html, text, activationCommand, trialEndLabel, greeting, unsubscribeEmail, businessName, businessAddress };
+  return { html, text, activationCommand, greeting, unsubscribeEmail, businessName, businessAddress };
 }
 
 /**

--- a/tests/billing.test.js
+++ b/tests/billing.test.js
@@ -389,7 +389,7 @@ describe('billing.js — funnel ledger', () => {
     assert.equal(result.status, 'sent');
     assert.equal(result.customerEmail, 'buyer@example.com');
     assert.equal(delivered.length, 1);
-    assert.equal(delivered[0].subject, 'Your 7-day ThumbGate Pro trial is live');
+    assert.equal(delivered[0].subject, 'Your ThumbGate Pro subscription is live');
     assert.match(delivered[0].text, /npx thumbgate pro --activate --key=tg_test_activation_key/);
     assert.match(delivered[0].text, /Pre-Action Checks/);
     assert.match(delivered[0].text, /Give one concrete thumbs up or thumbs down/);
@@ -532,7 +532,7 @@ describe('billing.js — funnel ledger', () => {
       assert.equal(sent.providerId, 'resend_email_001');
       assert.equal(acceptedBodies.length, 1);
       assert.deepEqual(acceptedBodies[0].to, ['buyer@example.com']);
-      assert.equal(acceptedBodies[0].subject, 'Your 7-day ThumbGate Pro trial is live');
+      assert.equal(acceptedBodies[0].subject, 'Your ThumbGate Pro subscription is live');
       assert.match(acceptedBodies[0].text, /npx thumbgate pro --activate --key=tg_resend_success/);
       assert.match(acceptedBodies[0].html, /Pre-Action Checks/);
     } finally {

--- a/tests/mailer.test.js
+++ b/tests/mailer.test.js
@@ -132,9 +132,11 @@ test('sendTrialWelcomeEmail POSTs to Resend with correct headers, reply_to, and 
   assert.ok(body.html.includes('Hi Igor,'), 'html greeting must use first name');
   assert.ok(body.text.includes('Hi Igor,'), 'text greeting must use first name');
 
-  // Trial end date is rendered.
-  assert.ok(body.html.includes('Apr 24, 2026'), 'html must show formatted trial end date');
-  assert.ok(body.text.includes('Apr 24, 2026'), 'text must show formatted trial end date');
+  // Immediate paid access is rendered without trial-end promises.
+  assert.ok(body.html.includes('Your paid Pro access is active'), 'html must describe active paid access');
+  assert.ok(body.text.includes('Your paid Pro access is active'), 'text must describe active paid access');
+  assert.ok(!body.html.includes('Apr 24, 2026'), 'html must not show a trial end date');
+  assert.ok(!body.text.includes('Apr 24, 2026'), 'text must not show a trial end date');
 
   // P.S. line present — highest-read section of any email.
   assert.ok(body.html.includes('first 10 minutes'), 'html must include the P.S. / first-10-min framing');
@@ -189,8 +191,8 @@ test('sendTrialWelcomeEmail falls back to "Hi there" greeting and generic subjec
   assert.equal(body.subject, 'Your ThumbGate Pro key is inside');
   assert.ok(body.html.includes('Hi there,'));
   assert.ok(body.text.includes('Hi there,'));
-  // Trial end is rendered from default (now + 7 days) — just assert the shape is a valid month label.
-  assert.match(body.html, /Trial ends [A-Z][a-z]{2} \d{1,2}, \d{4}/);
+  assert.ok(body.html.includes('Your paid Pro access is active'));
+  assert.doesNotMatch(body.html, /Trial ends [A-Z][a-z]{2} \d{1,2}, \d{4}/);
   restore();
 });
 
@@ -348,16 +350,15 @@ test('sendEmail catches network exceptions and returns structured failure', asyn
   restore();
 });
 
-test('renderTrialWelcomeBodies embeds license key, activation command, dashboard URL, trial-end, and CAN-SPAM footer', () => {
+test('renderTrialWelcomeBodies embeds license key, activation command, dashboard URL, paid access, and CAN-SPAM footer', () => {
   const { renderTrialWelcomeBodies } = freshMailer();
-  const { html, text, activationCommand, trialEndLabel, greeting, unsubscribeEmail, businessName, businessAddress } = renderTrialWelcomeBodies({
+  const { html, text, activationCommand, greeting, unsubscribeEmail, businessName, businessAddress } = renderTrialWelcomeBodies({
     licenseKey: 'tg_abc',
     customerId: 'cus_42',
     customerName: 'Ada Lovelace',
     trialEndAt: new Date(Date.UTC(2026, 3, 24)),
   });
   assert.equal(activationCommand, 'npx thumbgate pro --activate --key=tg_abc');
-  assert.equal(trialEndLabel, 'Apr 24, 2026');
   assert.equal(greeting, 'Hi Ada,');
   assert.equal(unsubscribeEmail, 'igor.ganapolsky@gmail.com');
   assert.equal(businessName, 'Max Smith KDP LLC');
@@ -367,13 +368,15 @@ test('renderTrialWelcomeBodies embeds license key, activation command, dashboard
     'npx thumbgate pro --activate --key=tg_abc',
     'https://thumbgate-production.up.railway.app/dashboard',
     'ThumbGate Pro',
-    'Apr 24, 2026',
+    'Your paid Pro access is active',
     'Hi Ada,',
     'Max Smith KDP LLC',
   ]) {
     assert.ok(html.includes(fragment), `html missing: ${fragment}`);
     assert.ok(text.includes(fragment), `text missing: ${fragment}`);
   }
+  assert.ok(!html.includes('Apr 24, 2026'));
+  assert.ok(!text.includes('Apr 24, 2026'));
   assert.ok(html.includes('igor.ganapolsky@gmail.com'));
   assert.ok(text.includes('igor.ganapolsky@gmail.com'));
   // Customer ID shows in the html footer only — not in the customer-visible body prose.


### PR DESCRIPTION
## Summary
- remove the 7-day trial from Stripe subscription checkout payloads so Pro charges immediately
- replace paid-path trial/no-charge copy with billed-today Pro checkout copy across /pro, homepage CTAs, cancel recovery, and checkout intent confirmation
- update Pro welcome email language from trial access to paid subscription access

## Verification
- node --test tests/billing.test.js tests/mailer.test.js tests/pro-landing.test.js tests/public-landing.test.js tests/api-server.test.js tests/checkout-bot-guard.test.js