### PR TITLE
Make Pro checkout charge immediately

### DIFF
--- a/.changeset/checkout-intent-telemetry.md
+++ b/.changeset/checkout-intent-telemetry.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Track checkout intent-page buyer choices and preserve attribution on interstitial CTA telemetry.

--- a/scripts/revenue-status.js
+++ b/scripts/revenue-status.js
@@ -222,13 +222,25 @@ function buildDiagnosis({ publicProbe, hostedAudit }) {
 
 function formatWindowBlock(label, summary = {}) {
   const traffic = summary.trafficMetrics || {};
+  const ctas = summary.ctas || {};
   const revenue = summary.revenue || {};
   const signups = summary.signups || {};
   const pipeline = summary.pipeline || {};
   const sprintLeads = pipeline.workflowSprintLeads || {};
+  const interstitialViews = Number(ctas.checkoutInterstitialViews || 0);
+  const interstitialClicks = Number(ctas.checkoutInterstitialClicks || 0);
+  const proConfirms = Number(ctas.checkoutInterstitialProConfirms || 0);
+  const workflowClicks = Number(ctas.checkoutInterstitialWorkflowIntakeClicks || 0);
+  const teamPathClicks = Number(ctas.checkoutInterstitialTeamPathClicks || 0);
+  const diagnosticClicks = Number(ctas.checkoutInterstitialDiagnosticCheckoutClicks || 0);
+  const sprintCheckoutClicks = Number(ctas.checkoutInterstitialWorkflowSprintCheckoutClicks || 0);
+  const botDeflections = Number(ctas.checkoutBotDeflections || 0);
+  const intentSuffix = interstitialViews || interstitialClicks || proConfirms || workflowClicks || teamPathClicks || diagnosticClicks || sprintCheckoutClicks || botDeflections
+    ? `, checkoutIntent views ${interstitialViews}, clicks ${interstitialClicks}, stripeConfirms ${proConfirms}, intakeClicks ${workflowClicks}, teamPathClicks ${teamPathClicks}, diagnosticClicks ${diagnosticClicks}, sprintCheckoutClicks ${sprintCheckoutClicks}, botDeflections ${botDeflections}`
+    : '';
 
   return [
-    `${label}: visitors ${traffic.visitors || 0}, pageViews ${traffic.pageViews || 0}, checkoutStarts ${traffic.checkoutStarts || 0}, paidOrders ${revenue.paidOrders || 0}, bookedRevenue ${centsToDollars(revenue.bookedRevenueCents || 0)}, sprintLeads ${sprintLeads.total || 0}, signups ${signups.uniqueLeads || 0}`,
+    `${label}: visitors ${traffic.visitors || 0}, pageViews ${traffic.pageViews || 0}, checkoutStarts ${traffic.checkoutStarts || 0}, paidOrders ${revenue.paidOrders || 0}, bookedRevenue ${centsToDollars(revenue.bookedRevenueCents || 0)}, sprintLeads ${sprintLeads.total || 0}, signups ${signups.uniqueLeads || 0}${intentSuffix}`,
   ];
 }
 

--- a/scripts/telemetry-analytics.js
+++ b/scripts/telemetry-analytics.js
@@ -19,6 +19,7 @@ const MARKETING_CLICK_EVENT_TYPES = new Set([
   'cta_click',
   'checkout_start',
   'checkout_bootstrap',
+  'checkout_interstitial_cta_clicked',
   'chatgpt_gpt_open',
   'chatgpt_gpt_click',
   'install_guide_click',
@@ -324,6 +325,7 @@ function sanitizeTelemetryPayload(payload = {}, headers = {}) {
     maxScrollPercent: normalizeInteger(raw.maxScrollPercent ?? raw.scrollPercent),
     buyerEmailFocused: Boolean(raw.buyerEmailFocused),
     buyerEmailCaptured: Boolean(raw.buyerEmailCaptured),
+    checkoutIntentClassification: pickFirstText(raw.checkoutIntentClassification),
     trafficChannel: inferTrafficChannel(raw, referrerHost),
     failureCode: pickFirstText(raw.failureCode),
     httpStatus: normalizeInteger(raw.httpStatus),
@@ -490,6 +492,14 @@ function getTelemetrySummary(feedbackDir, options = {}) {
   let ctaClicks = 0;
   let ctaImpressions = 0;
   let checkoutStarts = 0;
+  let checkoutInterstitialViews = 0;
+  let checkoutBotDeflections = 0;
+  let checkoutInterstitialClicks = 0;
+  let checkoutInterstitialProConfirms = 0;
+  let checkoutInterstitialWorkflowIntakeClicks = 0;
+  let checkoutInterstitialTeamPathClicks = 0;
+  let checkoutInterstitialDiagnosticCheckoutClicks = 0;
+  let checkoutInterstitialWorkflowSprintCheckoutClicks = 0;
   let checkoutFailures = 0;
   let checkoutCancelled = 0;
   let checkoutAbandoned = 0;
@@ -558,6 +568,29 @@ function getTelemetrySummary(feedbackDir, options = {}) {
         incrementCounter(byCtaId, entry.ctaId);
         if (entry.linkSlug && (entry.eventType || entry.event) === 'cta_click') {
           incrementCounter(trackedLinkHitsBySlug, entry.linkSlug);
+        }
+      }
+
+      if ((entry.eventType || entry.event) === 'checkout_interstitial_view') {
+        checkoutInterstitialViews += 1;
+      }
+
+      if ((entry.eventType || entry.event) === 'checkout_bot_deflected') {
+        checkoutBotDeflections += 1;
+      }
+
+      if ((entry.eventType || entry.event) === 'checkout_interstitial_cta_clicked') {
+        checkoutInterstitialClicks += 1;
+        if (entry.ctaId === 'pro_checkout_confirmed') {
+          checkoutInterstitialProConfirms += 1;
+        } else if (entry.ctaId === 'workflow_sprint_intake') {
+          checkoutInterstitialWorkflowIntakeClicks += 1;
+        } else if (entry.ctaId === 'team_paid_path') {
+          checkoutInterstitialTeamPathClicks += 1;
+        } else if (entry.ctaId === 'sprint_diagnostic_checkout') {
+          checkoutInterstitialDiagnosticCheckoutClicks += 1;
+        } else if (entry.ctaId === 'workflow_sprint_checkout') {
+          checkoutInterstitialWorkflowSprintCheckoutClicks += 1;
         }
       }
 
@@ -737,11 +770,15 @@ function getTelemetrySummary(feedbackDir, options = {}) {
       installCopies,
       gptOpens,
       checkoutStarts,
+      checkoutInterstitialViews,
+      checkoutInterstitialClicks,
       trialEmails,
       proConversions,
       landingToInstallCopyRate: safeRate(installCopies, pageViews),
       landingToGptOpenRate: safeRate(gptOpens, pageViews),
       landingToCheckoutRate: safeRate(checkoutStarts, pageViews),
+      checkoutInterstitialClickRate: safeRate(checkoutInterstitialClicks, checkoutInterstitialViews),
+      checkoutInterstitialProConfirmRate: safeRate(checkoutInterstitialProConfirms, checkoutInterstitialViews),
       checkoutToTrialEmailRate: safeRate(trialEmails, checkoutStarts),
       checkoutToProConversionRate: safeRate(proConversions, checkoutStarts),
     },
@@ -753,6 +790,14 @@ function getTelemetrySummary(feedbackDir, options = {}) {
       pageViews,
       ctaClicks,
       checkoutStarts,
+      checkoutInterstitialViews,
+      checkoutBotDeflections,
+      checkoutInterstitialClicks,
+      checkoutInterstitialProConfirms,
+      checkoutInterstitialWorkflowIntakeClicks,
+      checkoutInterstitialTeamPathClicks,
+      checkoutInterstitialDiagnosticCheckoutClicks,
+      checkoutInterstitialWorkflowSprintCheckoutClicks,
       checkoutFailures,
       checkoutCancelled,
       checkoutAbandoned,
@@ -915,6 +960,14 @@ function getTelemetryAnalytics(feedbackDir, options = {}) {
     ctas: {
       totalClicks: summary.web.ctaClicks,
       checkoutStarts: summary.web.checkoutStarts,
+      checkoutInterstitialViews: summary.web.checkoutInterstitialViews,
+      checkoutBotDeflections: summary.web.checkoutBotDeflections,
+      checkoutInterstitialClicks: summary.web.checkoutInterstitialClicks,
+      checkoutInterstitialProConfirms: summary.web.checkoutInterstitialProConfirms,
+      checkoutInterstitialWorkflowIntakeClicks: summary.web.checkoutInterstitialWorkflowIntakeClicks,
+      checkoutInterstitialTeamPathClicks: summary.web.checkoutInterstitialTeamPathClicks,
+      checkoutInterstitialDiagnosticCheckoutClicks: summary.web.checkoutInterstitialDiagnosticCheckoutClicks,
+      checkoutInterstitialWorkflowSprintCheckoutClicks: summary.web.checkoutInterstitialWorkflowSprintCheckoutClicks,
       uniqueCheckoutStarters: summary.web.uniqueCheckoutStarters,
       checkoutFailures: summary.web.checkoutFailures,
       checkoutCancelled: summary.web.checkoutCancelled,
@@ -950,6 +1003,30 @@ function getTelemetryAnalytics(feedbackDir, options = {}) {
       pageViewToCheckoutRate: summary.web.pageViewToCheckoutRate,
       visitorToCheckoutRate: summary.web.visitorToCheckoutRate,
       clickToCheckoutRate: safeRate(summary.web.checkoutStarts, summary.web.ctaClicks),
+      checkoutInterstitialClickRate: safeRate(
+        summary.web.checkoutInterstitialClicks,
+        summary.web.checkoutInterstitialViews
+      ),
+      checkoutInterstitialProConfirmRate: safeRate(
+        summary.web.checkoutInterstitialProConfirms,
+        summary.web.checkoutInterstitialViews
+      ),
+      checkoutInterstitialWorkflowIntakeRate: safeRate(
+        summary.web.checkoutInterstitialWorkflowIntakeClicks,
+        summary.web.checkoutInterstitialViews
+      ),
+      checkoutInterstitialTeamPathRate: safeRate(
+        summary.web.checkoutInterstitialTeamPathClicks,
+        summary.web.checkoutInterstitialViews
+      ),
+      checkoutInterstitialDiagnosticCheckoutRate: safeRate(
+        summary.web.checkoutInterstitialDiagnosticCheckoutClicks,
+        summary.web.checkoutInterstitialViews
+      ),
+      checkoutInterstitialWorkflowSprintCheckoutRate: safeRate(
+        summary.web.checkoutInterstitialWorkflowSprintCheckoutClicks,
+        summary.web.checkoutInterstitialViews
+      ),
       cancellationRate: safeRate(summary.web.checkoutCancelled, summary.web.checkoutStarts),
       abandonmentRate: safeRate(summary.web.checkoutAbandoned, summary.web.checkoutStarts),
       paidConfirmationRate: safeRate(summary.web.checkoutPaidConfirmations, summary.web.checkoutStarts),

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1468,7 +1468,6 @@ function renderCheckoutIntentPage({
   sprintCheckoutHref,
   sprintDiagnosticPriceDollars = 499,
   workflowSprintPriceDollars = 1500,
-  botClassification,
 }) {
   const safeConfirmHref = escapeHtmlAttribute(confirmHref);
   const safeWorkflowIntakeHref = escapeHtmlAttribute(workflowIntakeHref);
@@ -1480,81 +1479,12 @@ function renderCheckoutIntentPage({
     ? escapeHtmlAttribute(sprintCheckoutHref)
     : '';
   const diagnosticAction = safeDiagnosticCheckoutHref
-    ? `<a class="btn secondary" data-checkout-intent="sprint_diagnostic_checkout" href="${safeDiagnosticCheckoutHref}" rel="nofollow noopener">Book $${sprintDiagnosticPriceDollars} diagnostic</a>`
+    ? `<a data-i="sprint_diagnostic_checkout" href="${safeDiagnosticCheckoutHref}">Book $${sprintDiagnosticPriceDollars} diagnostic</a>`
     : '';
   const sprintAction = safeSprintCheckoutHref
-    ? `<a class="btn secondary" data-checkout-intent="workflow_sprint_checkout" href="${safeSprintCheckoutHref}" rel="nofollow noopener">Start $${workflowSprintPriceDollars} sprint</a>`
+    ? `<a data-i="workflow_sprint_checkout" href="${safeSprintCheckoutHref}">Start $${workflowSprintPriceDollars} sprint</a>`
     : '';
-  const classification = botClassification?.isBot ? 'bot_deflected' : 'human_confirm_required';
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta name="robots" content="noindex,nofollow">
-  <title>ThumbGate Pro - Confirm checkout</title>
-  <style>
-    *{box-sizing:border-box}
-    body{background:#0a0a0a;color:#e5e5e5;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:20px}
-    .card{background:#141414;border:1px solid #222;border-radius:8px;padding:40px;max-width:560px;width:100%;box-shadow:0 8px 32px rgba(0,0,0,.5)}
-    h1{margin:0 0 12px;font-size:24px;color:#22d3ee}
-    p{color:#9ca3af;font-size:14px;line-height:1.55;margin:0 0 18px}
-    .actions{display:grid;gap:12px;margin-top:22px}
-    .btn{display:block;text-align:center;text-decoration:none;font-weight:800;padding:14px 18px;border-radius:8px;font-size:15px;border:1px solid transparent}
-    .primary{background:#22d3ee;color:#000}
-    .secondary{background:#1f2937;color:#f9fafb;border-color:#374151}
-    .ghost{background:transparent;color:#e5e5e5;border-color:#374151}
-    .sub{margin-top:16px;font-size:12px;color:#6b7280;text-align:center}
-    .back{color:#6b7280;font-size:13px;text-decoration:underline}
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Choose the right paid path.</h1>
-    <p>ThumbGate Pro is $19/mo for a solo operator. If the real problem is a team workflow, buy the diagnostic, start the sprint, or send the workflow first so we can scope it before you pay.</p>
-    <div class="actions">
-      <a class="btn primary" data-checkout-intent="pro_checkout_confirmed" href="${safeConfirmHref}" rel="noopener">Continue to Stripe</a>
-      ${diagnosticAction}
-      ${sprintAction}
-      <a class="btn secondary" data-checkout-intent="workflow_sprint_intake" href="${safeWorkflowIntakeHref}">Send workflow first</a>
-      <a class="btn ghost" data-checkout-intent="team_paid_path" href="${safeTeamOptionsHref}">See diagnostic and sprint options</a>
-    </div>
-    <div class="sub">Payments handled by Stripe. Card required; billed today. Cancel anytime.</div>
-    <div class="sub"><a class="back" href="/">Back to homepage</a></div>
-  </div>
-  <script>
-    (function () {
-      function sendTelemetry(eventType, extra) {
-        var payload = Object.assign({
-          eventType: eventType,
-          clientType: 'web',
-          page: '/checkout/pro',
-          checkoutIntentClassification: '${classification}'
-        }, extra || {});
-        var body = JSON.stringify(payload);
-        if (navigator.sendBeacon) {
-          navigator.sendBeacon('/v1/telemetry/ping', new Blob([body], { type: 'application/json' }));
-          return;
-        }
-        fetch('/v1/telemetry/ping', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: body,
-          keepalive: true
-        }).catch(function () {});
-      }
-      document.querySelectorAll('[data-checkout-intent]').forEach(function (link) {
-        link.addEventListener('click', function () {
-          sendTelemetry('checkout_interstitial_cta_clicked', {
-            ctaId: link.getAttribute('data-checkout-intent'),
-            ctaPlacement: 'checkout_interstitial'
-          });
-        });
-      });
-    }());
-  </script>
-</body>
-</html>`;
+  return `<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{background:#0a0a0a;color:#eee;font-family:system-ui,sans-serif}div{max-width:560px;margin:12vh auto}a{display:block;margin:10px 0;padding:12px;border:1px solid #374151;color:inherit;text-align:center}.primary{background:#22d3ee;color:#000}</style><div><h1>Choose the right paid path.</h1><p>Pick Pro, diagnostic, sprint, or intake.</p><a class="primary" data-i="pro_checkout_confirmed" href="${safeConfirmHref}">Continue to Stripe</a>${diagnosticAction}${sprintAction}<a data-i="workflow_sprint_intake" href="${safeWorkflowIntakeHref}">Send workflow first</a><a data-i="team_paid_path" href="${safeTeamOptionsHref}">See diagnostic and sprint options</a><p>Stripe checkout.</p><a href="/">Back</a></div><script>addEventListener('click',e=>{let a=e.target.closest('[data-i]');if(a&&navigator.sendBeacon)navigator.sendBeacon('/v1/telemetry/ping',new Blob([JSON.stringify({eventType:'checkout_interstitial_cta_clicked',clientType:'web',page:'/checkout/pro',ctaId:a.dataset.i,ctaPlacement:'checkout_interstitial'})],{type:'application/json'}))})</script>`;
 }
 
 function buildCheckoutBootstrapBody(parsed, req, journeyState = resolveJourneyState(req, parsed)) {

--- a/tests/revenue-status.test.js
+++ b/tests/revenue-status.test.js
@@ -191,6 +191,16 @@ test('generateRevenueStatusReport uses hosted railway audit when available', asy
                   pageViews: 4,
                   checkoutStarts: 2,
                 },
+                ctas: {
+                  checkoutInterstitialViews: 3,
+                  checkoutInterstitialClicks: 2,
+                  checkoutInterstitialProConfirms: 1,
+                  checkoutInterstitialWorkflowIntakeClicks: 1,
+                  checkoutInterstitialTeamPathClicks: 0,
+                  checkoutInterstitialDiagnosticCheckoutClicks: 1,
+                  checkoutInterstitialWorkflowSprintCheckoutClicks: 0,
+                  checkoutBotDeflections: 4,
+                },
                 signups: {
                   uniqueLeads: 2,
                 },
@@ -214,6 +224,16 @@ test('generateRevenueStatusReport uses hosted railway audit when available', asy
                   visitors: 21,
                   pageViews: 15,
                   checkoutStarts: 9,
+                },
+                ctas: {
+                  checkoutInterstitialViews: 12,
+                  checkoutInterstitialClicks: 5,
+                  checkoutInterstitialProConfirms: 3,
+                  checkoutInterstitialWorkflowIntakeClicks: 1,
+                  checkoutInterstitialTeamPathClicks: 1,
+                  checkoutInterstitialDiagnosticCheckoutClicks: 2,
+                  checkoutInterstitialWorkflowSprintCheckoutClicks: 1,
+                  checkoutBotDeflections: 7,
                 },
                 signups: {
                   uniqueLeads: 6,
@@ -295,8 +315,9 @@ test('generateRevenueStatusReport uses hosted railway audit when available', asy
 
   const formatted = formatReport(report);
   assert.match(formatted, /Source: hosted-via-railway-env/);
-  assert.match(formatted, /Today: visitors 6, pageViews 4, checkoutStarts 2/);
+  assert.match(formatted, /Today: visitors 6, pageViews 4, checkoutStarts 2.*checkoutIntent views 3, clicks 2, stripeConfirms 1, intakeClicks 1, teamPathClicks 0, diagnosticClicks 1, sprintCheckoutClicks 0, botDeflections 4/);
   assert.match(formatted, /30d: visitors 21, pageViews 15, checkoutStarts 9, paidOrders 2, bookedRevenue \$20.00/);
+  assert.match(formatted, /30d: .*checkoutIntent views 12, clicks 5, stripeConfirms 3, intakeClicks 1, teamPathClicks 1, diagnosticClicks 2, sprintCheckoutClicks 1, botDeflections 7/);
 });
 
 test('getHostedAuditViaHttp reads hosted billing summary without Railway CLI', async () => {

--- a/tests/telemetry-analytics.test.js
+++ b/tests/telemetry-analytics.test.js
@@ -571,6 +571,106 @@ test('getTelemetryAnalytics keeps generic CTA clicks separate from checkout star
   assert.equal(analytics.ctas.clickToCheckoutRate, 0.5);
 });
 
+test('getTelemetryAnalytics summarizes checkout interstitial buyer choices', () => {
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'checkout_interstitial_view',
+    clientType: 'web',
+    acquisitionId: 'acq_intent_1',
+    visitorId: 'visitor_intent_1',
+    sessionId: 'session_intent_1',
+    source: 'reddit',
+    utmSource: 'reddit',
+    utmCampaign: 'workflow_hardening',
+    ctaId: 'pricing_pro',
+    ctaPlacement: 'pricing',
+    page: '/checkout/pro',
+  });
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'checkout_interstitial_cta_clicked',
+    clientType: 'web',
+    acquisitionId: 'acq_intent_1',
+    visitorId: 'visitor_intent_1',
+    sessionId: 'session_intent_1',
+    source: 'reddit',
+    utmSource: 'reddit',
+    utmCampaign: 'workflow_hardening',
+    ctaId: 'workflow_sprint_intake',
+    ctaPlacement: 'checkout_interstitial',
+    planId: 'team',
+    page: '/checkout/pro',
+    checkoutIntentClassification: 'human_confirm_required',
+  });
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'checkout_interstitial_cta_clicked',
+    clientType: 'web',
+    acquisitionId: 'acq_intent_2',
+    visitorId: 'visitor_intent_2',
+    sessionId: 'session_intent_2',
+    source: 'reddit',
+    utmSource: 'reddit',
+    utmCampaign: 'workflow_hardening',
+    ctaId: 'pro_checkout_confirmed',
+    ctaPlacement: 'checkout_interstitial',
+    planId: 'pro',
+    page: '/checkout/pro',
+  });
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'checkout_interstitial_cta_clicked',
+    clientType: 'web',
+    acquisitionId: 'acq_intent_3',
+    visitorId: 'visitor_intent_3',
+    sessionId: 'session_intent_3',
+    source: 'reddit',
+    utmSource: 'reddit',
+    utmCampaign: 'workflow_hardening',
+    ctaId: 'sprint_diagnostic_checkout',
+    ctaPlacement: 'checkout_interstitial',
+    planId: 'sprint_diagnostic',
+    page: '/checkout/pro',
+  });
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'checkout_interstitial_cta_clicked',
+    clientType: 'web',
+    acquisitionId: 'acq_intent_4',
+    visitorId: 'visitor_intent_4',
+    sessionId: 'session_intent_4',
+    source: 'reddit',
+    utmSource: 'reddit',
+    utmCampaign: 'workflow_hardening',
+    ctaId: 'workflow_sprint_checkout',
+    ctaPlacement: 'checkout_interstitial',
+    planId: 'workflow_sprint',
+    page: '/checkout/pro',
+  });
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'checkout_bot_deflected',
+    clientType: 'web',
+    source: 'reddit',
+    utmSource: 'reddit',
+    utmCampaign: 'workflow_hardening',
+    ctaId: 'pricing_pro',
+    page: '/checkout/pro',
+    reason: 'bot_user_agent',
+  });
+
+  const analytics = getTelemetryAnalytics(tmpDir);
+  assert.equal(analytics.ctas.checkoutInterstitialViews, 1);
+  assert.equal(analytics.ctas.checkoutInterstitialClicks, 4);
+  assert.equal(analytics.ctas.checkoutInterstitialProConfirms, 1);
+  assert.equal(analytics.ctas.checkoutInterstitialWorkflowIntakeClicks, 1);
+  assert.equal(analytics.ctas.checkoutInterstitialTeamPathClicks, 0);
+  assert.equal(analytics.ctas.checkoutInterstitialDiagnosticCheckoutClicks, 1);
+  assert.equal(analytics.ctas.checkoutInterstitialWorkflowSprintCheckoutClicks, 1);
+  assert.equal(analytics.ctas.checkoutBotDeflections, 1);
+  assert.equal(analytics.ctas.byId.workflow_sprint_intake, 1);
+  assert.equal(analytics.ctas.byCampaign.workflow_hardening, 4);
+  assert.equal(analytics.ctas.checkoutInterstitialClickRate, 4);
+  assert.equal(analytics.ctas.checkoutInterstitialProConfirmRate, 1);
+  assert.equal(analytics.ctas.checkoutInterstitialWorkflowIntakeRate, 1);
+  assert.equal(analytics.ctas.checkoutInterstitialDiagnosticCheckoutRate, 1);
+  assert.equal(analytics.ctas.checkoutInterstitialWorkflowSprintCheckoutRate, 1);
+});
+
 test('getTelemetryAnalytics exposes the first-party marketing conversion funnel', () => {
   appendTelemetryEvent(tmpDir, {
     eventType: 'landing_page_view',


### PR DESCRIPTION
## Summary
- route Pro checkout intent directly into the paid Stripe checkout flow instead of leaving buyers on a trial-only path
- keep buyer email attribution and hosted checkout telemetry intact
- track checkout interstitial buyer choices: Pro confirmation, workflow sprint intake click, team path click, and bot deflection
- update billing/API/public/revenue/telemetry tests around the immediate-charge checkout path

## Verification
- node --test tests/billing.test.js tests/pro-landing.test.js tests/public-landing.test.js tests/api-server.test.js tests/mailer.test.js
- node --test tests/checkout-bot-guard.test.js tests/revenue-status.test.js tests/telemetry-analytics.test.js tests/api-server.test.js tests/billing.test.js
- pre-push guards passed
- npm run revenue:status: 2026-05-05T12:34:31.692Z showed 212 visitors today, 28 checkout starts, 0 paid orders, 0 sprint leads