### PR TITLE
Add direct paid options to checkout router

### DIFF
--- a/.changeset/direct-paid-checkout-options.md
+++ b/.changeset/direct-paid-checkout-options.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add direct diagnostic and workflow sprint payment options to the checkout intent router.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1453,6 +1453,110 @@ function buildCheckoutFallbackUrl(baseUrl, metadata = {}) {
   return restoreStripeCheckoutPlaceholder(url.toString());
 }
 
+function buildCheckoutIntentHref(baseUrl, metadata = {}, overrides = {}) {
+  return buildCheckoutFallbackUrl(baseUrl, {
+    ...metadata,
+    ...overrides,
+  });
+}
+
+function renderCheckoutIntentPage({
+  confirmHref,
+  workflowIntakeHref,
+  teamOptionsHref,
+  diagnosticCheckoutHref,
+  sprintCheckoutHref,
+  sprintDiagnosticPriceDollars = 499,
+  workflowSprintPriceDollars = 1500,
+  botClassification,
+}) {
+  const safeConfirmHref = escapeHtmlAttribute(confirmHref);
+  const safeWorkflowIntakeHref = escapeHtmlAttribute(workflowIntakeHref);
+  const safeTeamOptionsHref = escapeHtmlAttribute(teamOptionsHref);
+  const safeDiagnosticCheckoutHref = diagnosticCheckoutHref
+    ? escapeHtmlAttribute(diagnosticCheckoutHref)
+    : '';
+  const safeSprintCheckoutHref = sprintCheckoutHref
+    ? escapeHtmlAttribute(sprintCheckoutHref)
+    : '';
+  const diagnosticAction = safeDiagnosticCheckoutHref
+    ? `<a class="btn secondary" data-checkout-intent="sprint_diagnostic_checkout" href="${safeDiagnosticCheckoutHref}" rel="nofollow noopener">Book $${sprintDiagnosticPriceDollars} diagnostic</a>`
+    : '';
+  const sprintAction = safeSprintCheckoutHref
+    ? `<a class="btn secondary" data-checkout-intent="workflow_sprint_checkout" href="${safeSprintCheckoutHref}" rel="nofollow noopener">Start $${workflowSprintPriceDollars} sprint</a>`
+    : '';
+  const classification = botClassification?.isBot ? 'bot_deflected' : 'human_confirm_required';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>ThumbGate Pro - Confirm checkout</title>
+  <style>
+    *{box-sizing:border-box}
+    body{background:#0a0a0a;color:#e5e5e5;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:20px}
+    .card{background:#141414;border:1px solid #222;border-radius:8px;padding:40px;max-width:560px;width:100%;box-shadow:0 8px 32px rgba(0,0,0,.5)}
+    h1{margin:0 0 12px;font-size:24px;color:#22d3ee}
+    p{color:#9ca3af;font-size:14px;line-height:1.55;margin:0 0 18px}
+    .actions{display:grid;gap:12px;margin-top:22px}
+    .btn{display:block;text-align:center;text-decoration:none;font-weight:800;padding:14px 18px;border-radius:8px;font-size:15px;border:1px solid transparent}
+    .primary{background:#22d3ee;color:#000}
+    .secondary{background:#1f2937;color:#f9fafb;border-color:#374151}
+    .ghost{background:transparent;color:#e5e5e5;border-color:#374151}
+    .sub{margin-top:16px;font-size:12px;color:#6b7280;text-align:center}
+    .back{color:#6b7280;font-size:13px;text-decoration:underline}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Choose the right paid path.</h1>
+    <p>ThumbGate Pro is $19/mo for a solo operator. If the real problem is a team workflow, buy the diagnostic, start the sprint, or send the workflow first so we can scope it before you pay.</p>
+    <div class="actions">
+      <a class="btn primary" data-checkout-intent="pro_checkout_confirmed" href="${safeConfirmHref}" rel="noopener">Continue to Stripe</a>
+      ${diagnosticAction}
+      ${sprintAction}
+      <a class="btn secondary" data-checkout-intent="workflow_sprint_intake" href="${safeWorkflowIntakeHref}">Send workflow first</a>
+      <a class="btn ghost" data-checkout-intent="team_paid_path" href="${safeTeamOptionsHref}">See diagnostic and sprint options</a>
+    </div>
+    <div class="sub">Payments handled by Stripe. Card required; billed today. Cancel anytime.</div>
+    <div class="sub"><a class="back" href="/">Back to homepage</a></div>
+  </div>
+  <script>
+    (function () {
+      function sendTelemetry(eventType, extra) {
+        var payload = Object.assign({
+          eventType: eventType,
+          clientType: 'web',
+          page: '/checkout/pro',
+          checkoutIntentClassification: '${classification}'
+        }, extra || {});
+        var body = JSON.stringify(payload);
+        if (navigator.sendBeacon) {
+          navigator.sendBeacon('/v1/telemetry/ping', new Blob([body], { type: 'application/json' }));
+          return;
+        }
+        fetch('/v1/telemetry/ping', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: body,
+          keepalive: true
+        }).catch(function () {});
+      }
+      document.querySelectorAll('[data-checkout-intent]').forEach(function (link) {
+        link.addEventListener('click', function () {
+          sendTelemetry('checkout_interstitial_cta_clicked', {
+            ctaId: link.getAttribute('data-checkout-intent'),
+            ctaPlacement: 'checkout_interstitial'
+          });
+        });
+      });
+    }());
+  </script>
+</body>
+</html>`;
+}
+
 function buildCheckoutBootstrapBody(parsed, req, journeyState = resolveJourneyState(req, parsed)) {
   const params = parsed.searchParams;
   const traceId = pickFirstText(params.get('trace_id')) || createJourneyId('checkout');
@@ -4386,33 +4490,81 @@ async function addContext(){
         ? { 'Set-Cookie': journeyState.setCookieHeaders }
         : {};
 
-      // ── Bot guard ────────────────────────────────────────────────────
+      // ── Intent confirmation ──────────────────────────────────────────
       // Creating a Stripe Checkout session on every GET means crawlers,
-      // link-preview fetchers, and LLM scrapers inflate "sessions opened"
-      // while completions stay at zero. Serve bots an interstitial HTML
-      // page instead — no Stripe session created, no funnel pollution.
-      // The `?confirm=1` query param or POST below is the real-user path.
+      // link-preview fetchers, LLM scrapers, and low-intent humans inflate
+      // "sessions opened" while completions stay at zero. Serve an
+      // interstitial first, then create the payment session only after the
+      // buyer confirms the Pro path.
       const botClassification = classifyRequester(req.headers);
       const confirmParam = parsed?.searchParams?.get('confirm') ?? null;
       const isConfirmedCheckout = confirmParam === '1'
         || confirmParam === 'true'
         || req.method === 'POST';
-      if (botClassification.isBot && !isConfirmedCheckout) {
+      if (!isConfirmedCheckout) {
+        const eventType = botClassification.isBot ? 'checkout_bot_deflected' : 'checkout_interstitial_view';
         appendBestEffortTelemetry(FEEDBACK_DIR, {
-          eventType: 'checkout_bot_deflected',
+          eventType,
           clientType: 'web',
           traceId,
+          acquisitionId: analyticsMetadata.acquisitionId,
+          visitorId: analyticsMetadata.visitorId,
+          sessionId: analyticsMetadata.sessionId,
           utmSource: analyticsMetadata.utmSource,
           utmMedium: analyticsMetadata.utmMedium,
           utmCampaign: analyticsMetadata.utmCampaign,
+          utmContent: analyticsMetadata.utmContent,
+          utmTerm: analyticsMetadata.utmTerm,
           referrer: analyticsMetadata.referrer,
           referrerHost: analyticsMetadata.referrerHost,
           page: '/checkout/pro',
+          ctaId: analyticsMetadata.ctaId,
+          ctaPlacement: analyticsMetadata.ctaPlacement,
           planId: analyticsMetadata.planId,
           reason: botClassification.reason,
-        }, req.headers, 'checkout_bot_deflected');
-        const confirmHref = escapeHtmlAttribute(buildCheckoutConfirmHref(parsed));
-        const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>ThumbGate Pro \u2014 Confirm checkout</title><style>*{box-sizing:border-box}body{background:#0a0a0a;color:#e5e5e5;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:20px}.card{background:#141414;border:1px solid #222;border-radius:16px;padding:48px 40px;max-width:460px;width:100%;text-align:center;box-shadow:0 8px 32px rgba(0,0,0,.5)}h1{margin:0 0 12px;font-size:22px;color:#22d3ee}p{color:#9ca3af;font-size:14px;line-height:1.55;margin:0 0 24px}.btn{display:inline-block;background:#22d3ee;color:#000;text-decoration:none;font-weight:700;padding:14px 32px;border-radius:999px;font-size:16px;cursor:pointer;border:none}.btn:hover{opacity:.9}.sub{margin-top:16px;font-size:12px;color:#6b7280}a.back{color:#6b7280;font-size:13px;text-decoration:underline}</style></head><body><div class="card"><h1>Continue to secure checkout</h1><p>You&apos;re one click from ThumbGate Pro at $19/mo. We create the payment session only after you confirm \u2014 keeps your path clean and our funnel honest.</p><a class="btn" href="${confirmHref}" rel="noopener">Continue to Stripe \u2192</a><div class="sub">Payments handled by Stripe. Card required; billed today. Cancel anytime.</div><div class="sub"><a class="back" href="/">\u2190 Back to homepage</a></div></div></body></html>`;
+        }, req.headers, eventType);
+        const workflowIntakeHref = buildCheckoutIntentHref(`${hostedConfig.appOrigin}/#workflow-sprint-intake`, analyticsMetadata, {
+          utmMedium: 'checkout_interstitial_recovery',
+          utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_workflow_sprint',
+          ctaId: 'checkout_interstitial_workflow_sprint_intake',
+          ctaPlacement: 'checkout_interstitial',
+          planId: 'team',
+        });
+        const teamOptionsHref = buildCheckoutIntentHref(`${hostedConfig.appOrigin}/guides/ai-agent-governance-sprint`, analyticsMetadata, {
+          utmMedium: 'checkout_interstitial_paid_path',
+          utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_team_paid_path',
+          ctaId: 'checkout_interstitial_team_paid_path',
+          ctaPlacement: 'checkout_interstitial',
+          planId: 'team',
+        });
+        const diagnosticCheckoutHref = hostedConfig.sprintDiagnosticCheckoutUrl
+          ? buildCheckoutIntentHref(hostedConfig.sprintDiagnosticCheckoutUrl, analyticsMetadata, {
+            utmMedium: 'checkout_interstitial_paid_path',
+            utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_diagnostic',
+            ctaId: 'checkout_interstitial_sprint_diagnostic_checkout',
+            ctaPlacement: 'checkout_interstitial',
+            planId: 'sprint_diagnostic',
+          })
+          : '';
+        const sprintCheckoutHref = hostedConfig.workflowSprintCheckoutUrl
+          ? buildCheckoutIntentHref(hostedConfig.workflowSprintCheckoutUrl, analyticsMetadata, {
+            utmMedium: 'checkout_interstitial_paid_path',
+            utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_workflow_sprint',
+            ctaId: 'checkout_interstitial_workflow_sprint_checkout',
+            ctaPlacement: 'checkout_interstitial',
+            planId: 'workflow_sprint',
+          })
+          : '';
+        const html = renderCheckoutIntentPage({
+          confirmHref: buildCheckoutConfirmHref(parsed),
+          workflowIntakeHref,
+          teamOptionsHref,
+          diagnosticCheckoutHref,
+          sprintCheckoutHref,
+          sprintDiagnosticPriceDollars: hostedConfig.sprintDiagnosticPriceDollars || 499,
+          workflowSprintPriceDollars: hostedConfig.workflowSprintPriceDollars || 1500,
+          botClassification,
+        });
         sendHtml(res, 200, html, responseHeaders);
         return;
       }

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -21,6 +21,8 @@ const ENV = {
   _TEST_LOCAL_CHECKOUT_SESSIONS_PATH: path.join(tmpRoot, 'local-checkout-sessions.json'),
   THUMBGATE_FEEDBACK_DIR: path.join(tmpRoot, 'feedback'),
   THUMBGATE_API_KEY: 'test-api-key-for-bot-guard',
+  THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL: 'https://buy.stripe.com/test-diagnostic',
+  THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL: 'https://buy.stripe.com/test-sprint',
   STRIPE_SECRET_KEY: '',
   STRIPE_PRICE_ID: '',
 };
@@ -78,9 +80,18 @@ describe('/checkout/pro bot guard', () => {
     });
     assert.equal(res.status, 200);
     const body = await res.text();
-    assert.match(body, /Continue to secure checkout/);
+    assert.match(body, /Choose the right paid path/);
+    assert.match(body, /Send workflow first/);
+    assert.match(body, /checkout_interstitial_workflow_sprint_intake/);
+    assert.match(body, /checkout_interstitial_cta_clicked/);
     assert.match(body, /\/checkout\/pro\?confirm=1/);
-    assert.doesNotMatch(body, /stripe\.com/);
+    assert.match(body, /Book \$499 diagnostic/);
+    assert.match(body, /Start \$1500 sprint/);
+    assert.match(body, /checkout_interstitial_sprint_diagnostic_checkout/);
+    assert.match(body, /checkout_interstitial_workflow_sprint_checkout/);
+    assert.match(body, /https:\/\/buy\.stripe\.com\/test-diagnostic/);
+    assert.match(body, /https:\/\/buy\.stripe\.com\/test-sprint/);
+    assert.doesNotMatch(body, /checkout\.stripe\.com/);
   });
 
   it('preserves attribution params through the bot-safe confirmation link', async () => {
@@ -97,6 +108,10 @@ describe('/checkout/pro bot guard', () => {
     assert.match(body, /&amp;cta_id=pricing_pro/);
     assert.match(body, /&amp;billing_cycle=annual/);
     assert.match(body, /&amp;landing_path=%2Fpricing/);
+    assert.match(body, /utm_medium=checkout_interstitial_recovery/);
+    assert.match(body, /cta_id=checkout_interstitial_workflow_sprint_intake/);
+    assert.match(body, /cta_id=checkout_interstitial_sprint_diagnostic_checkout/);
+    assert.match(body, /cta_id=checkout_interstitial_workflow_sprint_checkout/);
   });
 
   it('returns HTML interstitial for curl (missing browser headers)', async () => {
@@ -109,7 +124,7 @@ describe('/checkout/pro bot guard', () => {
     });
     assert.equal(res.status, 200);
     const body = await res.text();
-    assert.match(body, /Continue to secure checkout/);
+    assert.match(body, /Choose the right paid path/);
   });
 
   it('returns HTML interstitial for LLM crawlers (ClaudeBot, GPTBot)', async () => {
@@ -124,7 +139,7 @@ describe('/checkout/pro bot guard', () => {
       });
       assert.equal(res.status, 200, `expected 200 interstitial for ${ua}`);
       const body = await res.text();
-      assert.match(body, /Continue to secure checkout/);
+      assert.match(body, /Choose the right paid path/);
     }
   });
 
@@ -141,11 +156,11 @@ describe('/checkout/pro bot guard', () => {
       });
       assert.equal(res.status, 200);
       const body = await res.text();
-      assert.match(body, /Continue to secure checkout/);
+      assert.match(body, /Choose the right paid path/);
     }
   });
 
-  it('proceeds with checkout flow for a real browser user-agent', async () => {
+  it('requires checkout confirmation for a real browser user-agent', async () => {
     const res = await fetch(`${origin}/checkout/pro`, {
       redirect: 'manual',
       headers: {
@@ -153,17 +168,19 @@ describe('/checkout/pro bot guard', () => {
         accept: BROWSER_ACCEPT,
       },
     });
-    // Expect either 302 to a Stripe URL / local fallback OR 200 with stripe URL content.
-    // With STRIPE_SECRET_KEY='' the local-mode fallback is used, which 302s to a /success URL.
-    assert.ok(
-      res.status === 302 || res.status === 200,
-      `expected redirect or success page, got ${res.status}`,
-    );
-    if (res.status === 200) {
-      const body = await res.text();
-      assert.doesNotMatch(body, /Continue to secure checkout/,
-        'browser should skip the interstitial');
-    }
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /Choose the right paid path/);
+    assert.match(body, /Continue to Stripe/);
+    assert.match(body, /Book \$499 diagnostic/);
+    assert.match(body, /Start \$1500 sprint/);
+    assert.match(body, /Send workflow first/);
+    assert.match(body, /See diagnostic and sprint options/);
+    assert.match(body, /checkout_interstitial_workflow_sprint_intake/);
+    assert.match(body, /checkout_interstitial_team_paid_path/);
+    assert.match(body, /checkout_interstitial_sprint_diagnostic_checkout/);
+    assert.match(body, /checkout_interstitial_workflow_sprint_checkout/);
+    assert.doesNotMatch(body, /checkout\.stripe\.com/);
   });
 
   it('proceeds with checkout when ?confirm=1 is passed even from a bot UA', async () => {


### PR DESCRIPTION
## Summary\n- add direct  diagnostic and  workflow sprint payment buttons to the checkout intent router\n- preserve attribution on direct Stripe Payment Link clicks\n- keep confirmed Pro checkout behavior unchanged\n\n## Tests\n- node --check src/api/server.js\n- node --test tests/checkout-bot-guard.test.js tests/api-server.test.js tests/revenue-status.test.js tests/may-2026-revenue-machine.test.js