### PR TITLE
Skip checkout intent page for browsers

### DIFF
--- a/.changeset/browser-checkout-skip-intent.md
+++ b/.changeset/browser-checkout-skip-intent.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Send real browser checkout traffic directly to the Stripe email gate while keeping bot-safe checkout interstitials.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -4413,8 +4413,8 @@ async function addContext(){
       const isConfirmedCheckout = confirmParam === '1'
         || confirmParam === 'true'
         || req.method === 'POST';
-      if (!isConfirmedCheckout) {
-        const eventType = botClassification.isBot ? 'checkout_bot_deflected' : 'checkout_interstitial_view';
+      if (!isConfirmedCheckout && botClassification.isBot) {
+        const eventType = 'checkout_bot_deflected';
         appendBestEffortTelemetry(FEEDBACK_DIR, {
           eventType,
           clientType: 'web',

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -160,7 +160,8 @@ describe('/checkout/pro bot guard', () => {
     }
   });
 
-  it('requires checkout confirmation for a real browser user-agent', async () => {
+  it('asks real browsers for email without the extra intent interstitial', async () => {
+    try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
     const res = await fetch(`${origin}/checkout/pro`, {
       redirect: 'manual',
       headers: {
@@ -170,17 +171,22 @@ describe('/checkout/pro bot guard', () => {
     });
     assert.equal(res.status, 200);
     const body = await res.text();
-    assert.match(body, /Choose the right paid path/);
-    assert.match(body, /Continue to Stripe/);
-    assert.match(body, /Book \$499 diagnostic/);
-    assert.match(body, /Start \$1500 sprint/);
-    assert.match(body, /Send workflow first/);
-    assert.match(body, /See diagnostic and sprint options/);
-    assert.match(body, /checkout_interstitial_workflow_sprint_intake/);
-    assert.match(body, /checkout_interstitial_team_paid_path/);
-    assert.match(body, /checkout_interstitial_sprint_diagnostic_checkout/);
-    assert.match(body, /checkout_interstitial_workflow_sprint_checkout/);
+    assert.match(body, /Email for Stripe receipt/);
+    assert.match(body, /name="?customer_email"?/);
+    assert.match(body, /name="?confirm"? value="?1"?/);
+    assert.doesNotMatch(body, /Choose the right paid path/);
     assert.doesNotMatch(body, /checkout\.stripe\.com/);
+
+    const events = readFunnelEvents();
+    assert.equal(
+      events.filter((e) => e.eventType === 'checkout_interstitial_view').length,
+      0,
+      'real browsers should not be slowed by the intent interstitial',
+    );
+    assert.ok(
+      events.some((e) => e.eventType === 'checkout_email_gate_shown'),
+      'email gate should be tracked before checkout session creation',
+    );
   });
 
   it('asks confirmed real browsers for an email before creating Stripe sessions', async () => {


### PR DESCRIPTION
## Summary
- send real browser checkout traffic directly to the Stripe email gate
- keep bot, curl, link-preview, and LLM crawler traffic on the no-Stripe interstitial
- preserve the checkout interstitial as the bot-safe path while removing one human conversion click

## Tests
- node --test tests/checkout-bot-guard.test.js tests/api-server.test.js tests/telemetry-analytics.test.js tests/revenue-status.test.js tests/package-boundary.test.js
- node --test tests/checkout-bot-guard.test.js tests/api-server.test.js tests/package-boundary.test.js
- CHANGESET_BASE_REF=origin/main npm run changeset:check