### PR TITLE
Harden revenue engagement loop reporting

### DIFF
--- a/.changeset/revenue-engagement-reporting.md
+++ b/.changeset/revenue-engagement-reporting.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Keep Ralph Mode revenue engagement reporting honest by counting LinkedIn posts only after the platform returns a real published post id, and let Ralph Loop use the stronger GitHub token for traffic analytics when configured.

--- a/.github/workflows/ralph-loop.yml
+++ b/.github/workflows/ralph-loop.yml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 20
 
     env:
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.GH_PAT || github.token }}
       ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
       ZERNIO_INSTAGRAM_ACCOUNT_ID: ${{ secrets.ZERNIO_INSTAGRAM_ACCOUNT_ID }}
       ZERNIO_LINKEDIN_ACCOUNT_ID: ${{ secrets.ZERNIO_LINKEDIN_ACCOUNT_ID }}

--- a/scripts/ralph-mode-ci.js
+++ b/scripts/ralph-mode-ci.js
@@ -134,8 +134,24 @@ async function postLinkedIn(text) {
       visibility: { 'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC' },
     }),
   });
-  const j = await r.json();
-  return { id: j.id, status: r.status };
+  const j = await parseJsonResponse(r);
+  const id = j.id || '';
+  return {
+    id,
+    ok: r.ok && Boolean(id),
+    status: r.status,
+    error: id ? '' : extractApiError(j, r.status),
+  };
+}
+
+function recordLinkedInPost(report, result, log = console.log) {
+  if (result && result.ok && result.id) {
+    log('LinkedIn posted: ' + result.id);
+    report.linkedin++;
+    return true;
+  }
+  log('LinkedIn skipped: ' + (result?.error || `HTTP ${result?.status || 'unknown'}`));
+  return false;
 }
 
 async function ghApi(endpoint) {
@@ -251,9 +267,9 @@ async function main() {
           'Every AI agent framework ships memory. None ship enforcement.\n\nThumbGate adds PreToolUse hooks that block bad actions before execution. Thompson Sampling adapts. Self-distillation auto-learns.\n\nhttps://github.com/IgorGanapolsky/ThumbGate',
         ];
         const r = await postLinkedIn(angles[Math.floor(Date.now() / 14400000) % angles.length]);
-        console.log('LinkedIn posted: ' + (r.id || r.status));
-        state.lastLinkedinPost = new Date().toISOString();
-        report.linkedin++;
+        if (recordLinkedInPost(report, r)) {
+          state.lastLinkedinPost = new Date().toISOString();
+        }
       } else {
         console.log('LinkedIn: skipped (' + Math.round(4 - hoursSince) + 'hr until next)');
       }
@@ -425,8 +441,10 @@ module.exports = {
   extractApiError,
   main,
   parseJsonResponse,
+  postLinkedIn,
   postTweet,
   isDirectInvocation,
+  recordLinkedInPost,
   recordTweetPost,
   recordTweetReply,
   replyTweet,

--- a/tests/ralph-loop.test.js
+++ b/tests/ralph-loop.test.js
@@ -215,6 +215,7 @@ test('Ralph workflows are scheduled, stateful, and split outbound from reply eng
   assert.match(ralph, /actions\/cache\/restore@v[45]/);
   assert.match(ralph, /actions\/cache\/save@v[45]/);
   assert.match(ralph, /node scripts\/ralph-loop\.js --mode="\$MODE"/);
+  assert.match(ralph, /GITHUB_TOKEN:\s*\$\{\{\s*secrets\.GH_PAT\s*\|\|\s*github\.token\s*\}\}/);
   assert.match(ralph, /\.thumbgate\/reply-monitor-state\.json/);
   assert.match(ralph, /\.thumbgate\/reply-drafts\.jsonl/);
   assert.match(ralph, /\.thumbgate\/social-launch-assets\.json/);

--- a/tests/ralph-mode-ci.test.js
+++ b/tests/ralph-mode-ci.test.js
@@ -178,6 +178,69 @@ test('recordTweetReply increments only on successful reply creation', () => {
   assert.match(logs[1], /Replied to @somebody: reply_123/);
 });
 
+test('postLinkedIn and recorder only count real published LinkedIn ids', async () => {
+  const subject = loadRalphMode({
+    LINKEDIN_ACCESS_TOKEN: 'linkedin-token',
+    LINKEDIN_PERSON_URN: 'urn:li:person:abc',
+  });
+  const originalFetch = global.fetch;
+  const requests = [];
+  global.fetch = async (_url, options) => {
+    requests.push(JSON.parse(options.body));
+    if (requests.length === 1) {
+      return {
+        ok: false,
+        status: 401,
+        json: async () => ({ message: 'Expired token' }),
+      };
+    }
+    return {
+      ok: true,
+      status: 201,
+      json: async () => ({ id: 'urn:li:share:123' }),
+    };
+  };
+
+  try {
+    const blocked = await subject.postLinkedIn('blocked post');
+    assert.equal(blocked.ok, false);
+    assert.equal(blocked.id, '');
+    assert.equal(blocked.status, 401);
+    assert.equal(blocked.error, 'HTTP 401');
+
+    const posted = await subject.postLinkedIn('published post');
+    assert.deepEqual(posted, {
+      id: 'urn:li:share:123',
+      ok: true,
+      status: 201,
+      error: '',
+    });
+    assert.equal(requests[1].author, 'urn:li:person:abc');
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  const report = { linkedin: 0 };
+  const logs = [];
+  const skipped = subject.recordLinkedInPost(report, {
+    ok: false,
+    status: 401,
+    error: 'HTTP 401',
+  }, (line) => logs.push(line));
+  assert.equal(skipped, false);
+  assert.equal(report.linkedin, 0);
+  assert.match(logs[0], /LinkedIn skipped: HTTP 401/);
+
+  const counted = subject.recordLinkedInPost(report, {
+    ok: true,
+    status: 201,
+    id: 'urn:li:share:123',
+  }, (line) => logs.push(line));
+  assert.equal(counted, true);
+  assert.equal(report.linkedin, 1);
+  assert.match(logs[1], /LinkedIn posted: urn:li:share:123/);
+});
+
 test('Ralph Mode tweet angles advertise current Pro and Team pricing', () => {
   const subject = loadRalphMode();
   const joined = subject.TWEET_ANGLES.join('\n');


### PR DESCRIPTION
## Summary
- Use GH_PAT for Ralph Loop GitHub traffic polling when available so audience analytics can access repo traffic metrics.
- Stop Ralph Mode from counting LinkedIn 401/failed responses as published posts.
- Preserve the LinkedIn cooldown only after a real published post id is returned.

## Verification
- node --test tests/ralph-mode-ci.test.js tests/ralph-loop.test.js
- npm run test:workflow
- npm audit --audit-level=high
- git diff --check