### PR TITLE
feat(marketing): add guarded template channel listing pack

### DIFF
--- a/docs/marketing/guarded-template-channel-listings.json
+++ b/docs/marketing/guarded-template-channel-listings.json
@@ -1,0 +1,65 @@
+{
+  "generatedAt": "2026-05-05T15:50:00.000Z",
+  "objective": "Use external template and storefront channels to pull buyers into the current ThumbGate paid motions without inventing a new public pricing story.",
+  "commercialGuardrail": {
+    "publicSelfServeOffer": "ThumbGate Pro at $19/mo or $149/yr",
+    "primaryPaidMotion": "Workflow Hardening Sprint, then Team at $49/seat/mo with 3-seat minimum after qualification",
+    "gumroadRule": "Do not publish a new paid Gumroad SKU until docs/COMMERCIAL_TRUTH.md includes it."
+  },
+  "platforms": [
+    {
+      "key": "lindy",
+      "status": "publishable_once_template_exists",
+      "sourceUrl": "https://docs.lindy.ai/fundamentals/lindy-101/templates",
+      "operatorMotion": "Free template or community-shared workflow that routes serious operators to Pro or the Workflow Hardening Sprint.",
+      "listing": {
+        "title": "Guarded AI Lead Qualification",
+        "tagline": "Qualify inbound leads with approval boundaries before CRM writes.",
+        "shortDescription": "A Lindy workflow template that qualifies inbound leads, stops risky side effects before they run, and routes serious operators into ThumbGate for proof-backed workflow hardening.",
+        "cta": "https://thumbgate.ai/#workflow-sprint-intake",
+        "selfServeFollowOn": "https://thumbgate.ai/checkout/pro"
+      }
+    },
+    {
+      "key": "gumroad",
+      "status": "draft_only_until_commercial_truth_updates",
+      "sourceUrls": [
+        "https://gumroad.com/features",
+        "https://gumroad.com/pricing"
+      ],
+      "operatorMotion": "Draft storefront copy only, or use Gumroad as a lead magnet surface until the public commercial truth includes a Gumroad SKU.",
+      "listing": {
+        "title": "Guarded Automation Workflow Kit",
+        "subtitle": "Stop one automation from making the wrong side effect twice.",
+        "currentLiveCta": "https://thumbgate.ai/guide",
+        "soloFollowOn": "https://thumbgate.ai/checkout/pro",
+        "teamFollowOn": "https://thumbgate.ai/#workflow-sprint-intake"
+      }
+    },
+    {
+      "key": "gohighlevel",
+      "status": "publishable_once_snapshot_exists",
+      "sourceUrl": "https://help.gohighlevel.com/support/solutions/articles/155000003709-selling-snapshots-on-the-app-marketplace",
+      "operatorMotion": "Vertical-specific guarded Snapshot that routes agencies with real workflow risk into the Workflow Hardening Sprint.",
+      "listing": {
+        "title": "Guarded Client Intake Snapshot",
+        "tagline": "Reusable agency workflow with approval boundaries before client-facing actions.",
+        "shortDescription": "A HighLevel Snapshot for agencies that want a repeatable intake and nurture flow without repeating the same approval, CRM, or messaging mistake across accounts.",
+        "cta": "https://thumbgate.ai/#workflow-sprint-intake"
+      }
+    }
+  ],
+  "operatorRules": [
+    "Lindy.ai: publish only a narrow template with one workflow promise.",
+    "Gumroad: do not publish paid copy until public pricing and SKU truth are updated.",
+    "GoHighLevel: sell one vertical-specific Snapshot, not a vague AI automation system.",
+    "For every channel, keep ThumbGate positioned as the trust layer and route high-risk buyers to the Workflow Hardening Sprint."
+  ],
+  "metrics": [
+    "lindy_listing_clicks",
+    "gumroad_draft_reuse_events",
+    "ghl_snapshot_inquiries",
+    "channel_to_pro_checkout_starts",
+    "channel_to_sprint_intake_submissions"
+  ]
+}

--- a/docs/marketing/guarded-template-channel-listings.md
+++ b/docs/marketing/guarded-template-channel-listings.md
@@ -1,0 +1,89 @@
+# Guarded Template Channel Listings
+
+Updated: 2026-05-05T15:50:00.000Z
+
+This pack turns the guarded-workflow motion into platform-specific listing copy for Lindy.ai, Gumroad, and GoHighLevel.
+
+It is an operator artifact, not proof of live listings, installs, approvals, or revenue.
+
+## Objective
+Use external template and storefront channels to pull buyers into the current ThumbGate paid motions without inventing a new public pricing story.
+
+## Commercial Guardrail
+- Current public self-serve offer: ThumbGate Pro at $19/mo or $149/yr
+- Current primary paid motion: Workflow Hardening Sprint, then Team at $49/seat/mo with 3-seat minimum after qualification
+- Do not publish a new paid Gumroad SKU until `docs/COMMERCIAL_TRUTH.md` includes it
+
+## Platform Truth
+### Lindy.ai
+- Lindy documents a template library where users can browse, install, customize, and share templates.
+- Best ThumbGate motion: free template or community-shared workflow that routes serious operators to Pro or the Workflow Hardening Sprint.
+- Source: https://docs.lindy.ai/fundamentals/lindy-101/templates
+
+### Gumroad
+- Gumroad supports digital products, memberships, direct-link selling, and software-adjacent products.
+- Best ThumbGate motion right now: draft storefront copy only, or use Gumroad as a lead magnet surface until the public commercial truth includes a Gumroad SKU.
+- Sources:
+  - https://gumroad.com/features
+  - https://gumroad.com/pricing
+
+### GoHighLevel
+- HighLevel supports selling Snapshots in the App Marketplace with one-time, monthly, or yearly pricing.
+- Best ThumbGate motion: vertical-specific guarded Snapshot that routes agencies with real workflow risk into the Workflow Hardening Sprint.
+- Source: https://help.gohighlevel.com/support/solutions/articles/155000003709-selling-snapshots-on-the-app-marketplace
+
+## Listing Copy
+### Lindy.ai template
+- Status: publishable once the workflow exists
+- Listing title: Guarded AI Lead Qualification
+- Tagline: Qualify inbound leads with approval boundaries before CRM writes.
+- Short description: A Lindy workflow template that qualifies inbound leads, stops risky side effects before they run, and routes serious operators into ThumbGate for proof-backed workflow hardening.
+- Long description:
+  This template is for operators who already want AI lead qualification but do not want blind automation writing into customer systems. It starts with a useful workflow, then adds the real missing layer: a checkpoint before side effects, a clear review step, and a path to proof.
+
+  Use it when the team already has one workflow that feels valuable but still risky. If the template helps and the risk is larger than a solo install, the next step is the Workflow Hardening Sprint.
+- CTA inside description: https://thumbgate.ai/#workflow-sprint-intake
+- Self-serve follow-on: https://thumbgate.ai/checkout/pro
+- Proof links:
+  - https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md
+  - https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+### Gumroad storefront
+- Status: draft only until commercial truth includes a Gumroad SKU
+- Draft product title: Guarded Automation Workflow Kit
+- Draft subtitle: Stop one automation from making the wrong side effect twice.
+- Draft description:
+  This is not a generic template dump. It is a guarded workflow kit: one useful automation pattern, setup notes, and the ThumbGate checks that help stop the wrong action before it runs.
+
+  Publish this only if the commercial offer is updated first. Until then, use the copy as a draft or repurpose it for a free lead magnet that routes buyers to the current self-serve or sprint path.
+- Current live CTA instead of a Gumroad checkout: https://thumbgate.ai/guide
+- Current live paid follow-on:
+  - Solo: https://thumbgate.ai/checkout/pro
+  - Team: https://thumbgate.ai/#workflow-sprint-intake
+
+### GoHighLevel Snapshot listing
+- Status: publishable once the Snapshot exists
+- Listing title: Guarded Client Intake Snapshot
+- Tagline: Reusable agency workflow with approval boundaries before client-facing actions.
+- Short description: A HighLevel Snapshot for agencies that want a repeatable intake and nurture flow without repeating the same approval, CRM, or messaging mistake across accounts.
+- Long description:
+  This Snapshot is for agencies that already know the workflow they want to reuse. The value is not just speed. The value is getting a reusable configuration with a trust layer around the risky step.
+
+  Position ThumbGate as the reason the Snapshot is safer to use in real client operations: approval boundaries, reviewable proof, and a path to a Workflow Hardening Sprint when a live workflow is still brittle.
+- CTA inside description: https://thumbgate.ai/#workflow-sprint-intake
+- Proof links:
+  - https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/WORKFLOW_HARDENING_SPRINT.md
+  - https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+
+## Operator Rules
+- Lindy.ai: publish only a narrow template with one workflow promise.
+- Gumroad: do not publish paid copy until public pricing and SKU truth are updated.
+- GoHighLevel: sell one vertical-specific Snapshot, not a vague “AI automation system.”
+- For every channel, keep ThumbGate positioned as the trust layer and route high-risk buyers to the Workflow Hardening Sprint.
+
+## Metrics
+- `lindy_listing_clicks`
+- `gumroad_draft_reuse_events`
+- `ghl_snapshot_inquiries`
+- `channel_to_pro_checkout_starts`
+- `channel_to_sprint_intake_submissions`

--- a/docs/marketing/social-posts.md
+++ b/docs/marketing/social-posts.md
@@ -21,6 +21,7 @@ Use this kit instead of older memory-first launch copy when posting about the pr
 - X thread: [x-launch-thread.md](./x-launch-thread.md)
 - Reddit posts: [reddit-posts.md](./reddit-posts.md)
 - Cursor plugin launch kit: [cursor-plugin-launch.md](./cursor-plugin-launch.md)
+- Guarded template channel listings: [guarded-template-channel-listings.md](./guarded-template-channel-listings.md)
 - Zero-filming IG + TikTok ops: [social-automation.md](./social-automation.md)
 
 ## Asset Inventory

--- a/tests/social-marketing-assets.test.js
+++ b/tests/social-marketing-assets.test.js
@@ -129,3 +129,27 @@ test('zero-filming automation docs and canonical IG/TikTok assets exist', () => 
   assert.match(fs.readFileSync(htmlPath, 'utf8'), /15 Memory Tools\./);
   assert.match(fs.readFileSync(captionPath, 'utf8'), /Pre-Action Checks don't ask - they enforce\./);
 });
+
+test('guarded template channel listings stay operator-ready and commercially honest', () => {
+  const socialKit = read('docs/marketing/social-posts.md');
+  const markdown = read('docs/marketing/guarded-template-channel-listings.md');
+  const pack = JSON.parse(read('docs/marketing/guarded-template-channel-listings.json'));
+
+  assert.match(socialKit, /\[guarded-template-channel-listings\.md\]/);
+  assert.match(markdown, /Lindy\.ai/);
+  assert.match(markdown, /Gumroad/);
+  assert.match(markdown, /GoHighLevel/);
+  assert.match(markdown, /do not publish a new paid Gumroad SKU until `docs\/COMMERCIAL_TRUTH\.md` includes it/i);
+  assert.match(markdown, /ThumbGate Pro at \$19\/mo or \$149\/yr/);
+  assert.match(markdown, /Workflow Hardening Sprint/);
+  assert.match(markdown, /operator artifact, not proof of live listings/i);
+  assert.doesNotMatch(markdown, /guaranteed revenue|guaranteed installs|live listing approved/i);
+
+  assert.equal(pack.platforms.length, 3);
+  assert.equal(pack.platforms[0].key, 'lindy');
+  assert.equal(pack.platforms[1].key, 'gumroad');
+  assert.equal(pack.platforms[2].key, 'gohighlevel');
+  assert.equal(pack.commercialGuardrail.publicSelfServeOffer, 'ThumbGate Pro at $19/mo or $149/yr');
+  assert.ok(pack.operatorRules.some((entry) => /do not publish paid copy/i.test(entry)));
+  assert.ok(pack.metrics.includes('ghl_snapshot_inquiries'));
+});


### PR DESCRIPTION
## Summary
- add operator-ready Lindy, Gumroad, and GoHighLevel listing copy
- keep Gumroad explicitly draft-only until commercial truth includes a public SKU
- cover the new channel-listing pack inside the existing social marketing workflow suite

## Verification
- node --test tests/social-marketing-assets.test.js
- node --test tests/public-package-parity.test.js tests/test-suite-parity.test.js tests/landing-page-claims.test.js