### PR TITLE
feat(skool): add headless community reader

### DIFF
--- a/.agents/skills/skool-headless-reader/SKILL.md
+++ b/.agents/skills/skool-headless-reader/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when a task asks to inspect Skool communities, find revenue oppor
 
 - Do not use the user's Comet, Chrome, or Computer Use session first. Start with the headless reader.
 - Do not post, comment, DM, scrape private data, or take write actions. Draft replies or outreach only unless the user explicitly authorizes posting.
-- Use cookies only through `SKOOL_COOKIE` or `SKOOL_COOKIE_FILE` when a private group requires auth. Never print, commit, or persist cookies.
+- Use cookies only through the `SKOOL_COOKIE` environment variable when a private group requires auth. Never print, commit, or persist cookies.
 - Keep outputs focused on revenue: pain, buyer intent, possible ThumbGate angle, and a concrete next action.
 
 ## Quick Start
@@ -54,10 +54,10 @@ Useful MCP tools:
 
 ## Private Groups
 
-If a group is not publicly SSR-readable, supply an operator-provided cookie header without storing it:
+If a group is not publicly SSR-readable, supply an operator-provided cookie header through the environment without storing it:
 
 ```bash
-SKOOL_COOKIE_FILE=/path/to/cookie-header.txt node scripts/skool-reader.js --community private-community --signals
+SKOOL_COOKIE='skool_session=...' node scripts/skool-reader.js --community private-community --signals
 ```
 
 Never save that cookie in repo files, memories, PR text, logs, or test fixtures.

--- a/.agents/skills/skool-headless-reader/SKILL.md
+++ b/.agents/skills/skool-headless-reader/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: skool-headless-reader
+description: Read, monitor, and analyze Skool communities or posts headlessly for lead discovery, customer pain, acquisition opportunities, or ThumbGate revenue research without blocking the user's browser.
+---
+
+# Skool Headless Reader
+
+## Overview
+
+Use this skill when a task asks to inspect Skool communities, find revenue opportunities in Skool, summarize Skool posts, or mine AI automation communities for ThumbGate acquisition signals. It uses direct HTTP reads and the local MCP connector instead of the user's logged-in browser, so the user can keep working.
+
+## Operating Rules
+
+- Do not use the user's Comet, Chrome, or Computer Use session first. Start with the headless reader.
+- Do not post, comment, DM, scrape private data, or take write actions. Draft replies or outreach only unless the user explicitly authorizes posting.
+- Use cookies only through `SKOOL_COOKIE` or `SKOOL_COOKIE_FILE` when a private group requires auth. Never print, commit, or persist cookies.
+- Keep outputs focused on revenue: pain, buyer intent, possible ThumbGate angle, and a concrete next action.
+
+## Quick Start
+
+Read a public community:
+
+```bash
+node scripts/skool-reader.js --community ai-automation-society --limit 10 --format json
+```
+
+Rank ThumbGate revenue signals:
+
+```bash
+node scripts/skool-reader.js --url https://www.skool.com/ai-automation-society --category "Support Needed" --signals --format markdown
+```
+
+Use `--post-limit` to read more posts before returning the top `--limit` signals.
+
+Run the local MCP server:
+
+```bash
+node adapters/skool/server-stdio.js
+```
+
+Useful MCP tools:
+
+- `skool_read_community`: return normalized categories, posts, and engagement.
+- `skool_revenue_signals`: rank posts for ThumbGate acquisition opportunities.
+- `skool_post_detail`: read a single Skool post URL.
+
+## Revenue Workflow
+
+1. Read the community overview to identify categories, member count, and visible post volume.
+2. Prioritize `Support Needed`, `Hire Me / Looking For Hire`, `Wins`, and high-comment posts.
+3. Look for Claude Code, Codex, Cursor, MCP, n8n, GitHub, Supabase, Vercel, token cost, and broken automation workflows.
+4. Produce a lead list with post URL, pain, ThumbGate angle, and draft reply.
+5. Keep outreach non-spam: give useful diagnosis first, then mention ThumbGate only where the reliability problem is direct.
+
+## Private Groups
+
+If a group is not publicly SSR-readable, supply an operator-provided cookie header without storing it:
+
+```bash
+SKOOL_COOKIE_FILE=/path/to/cookie-header.txt node scripts/skool-reader.js --community private-community --signals
+```
+
+Never save that cookie in repo files, memories, PR text, logs, or test fixtures.

--- a/.agents/skills/skool-headless-reader/agents/openai.yaml
+++ b/.agents/skills/skool-headless-reader/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skool Headless Reader"
+  short_description: "Read Skool communities headlessly for revenue research."
+  default_prompt: "Read this Skool community headlessly and identify revenue opportunities for ThumbGate."

--- a/.changeset/skool-headless-reader.md
+++ b/.changeset/skool-headless-reader.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a headless Skool community reader and read-only MCP connector for revenue research without taking over the user's browser.

--- a/adapters/skool/server-stdio.js
+++ b/adapters/skool/server-stdio.js
@@ -1,0 +1,257 @@
+'use strict';
+
+const readline = require('node:readline');
+
+const {
+  buildSkoolDigest,
+  readSkoolCommunity,
+} = require('../../scripts/skool-reader');
+
+const TOOLS = [
+  {
+    name: 'skool_read_community',
+    description:
+      'Read a Skool community page headlessly and return normalized categories, posts, and engagement metadata. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Full Skool community URL. Use this or community.',
+        },
+        community: {
+          type: 'string',
+          description: 'Skool community slug, for example ai-automation-society.',
+        },
+        category: {
+          type: 'string',
+          description: 'Optional category name or Skool category id.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum posts to return.',
+          default: 20,
+        },
+        page: {
+          type: 'number',
+          description: 'Optional page number.',
+          default: 1,
+        },
+        sortType: {
+          type: 'string',
+          description: 'Optional Skool sort parameter.',
+        },
+      },
+      required: [],
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: 'skool_revenue_signals',
+    description:
+      'Rank Skool posts for ThumbGate acquisition opportunities, pain points, and high-intent outreach angles. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Full Skool community URL. Use this or community.',
+        },
+        community: {
+          type: 'string',
+          description: 'Skool community slug, for example ai-automation-society.',
+        },
+        category: {
+          type: 'string',
+          description: 'Optional category name or Skool category id.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum revenue signals to return.',
+          default: 20,
+        },
+        postLimit: {
+          type: 'number',
+          description: 'Maximum posts to read before ranking signals.',
+          default: 50,
+        },
+        signalLimit: {
+          type: 'number',
+          description: 'Maximum revenue signals to return. Overrides limit.',
+        },
+        focus: {
+          type: 'string',
+          description: 'Optional extra keyword or phrase to boost.',
+        },
+      },
+      required: [],
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: 'skool_post_detail',
+    description:
+      'Read a single Skool post URL headlessly and return normalized post metadata and content when available. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Full Skool post URL.',
+        },
+      },
+      required: ['url'],
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+  },
+];
+
+function successResponse(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function errorResponse(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+async function callTool(toolName, toolArgs, deps = {}) {
+  const args = toolArgs || {};
+
+  switch (toolName) {
+    case 'skool_read_community': {
+      return readSkoolCommunity(args, deps);
+    }
+    case 'skool_revenue_signals': {
+      const signalLimit = Number(args.signalLimit || args.limit || 10);
+      const postLimit = Number(args.postLimit || Math.max(signalLimit, 50));
+      const parsed = await readSkoolCommunity({ ...args, limit: postLimit }, deps);
+      const digest = buildSkoolDigest(parsed, { ...args, signalLimit });
+      return {
+        community: digest.community,
+        sourceUrl: digest.sourceUrl,
+        fetchedAt: digest.fetchedAt,
+        total: digest.total,
+        labels: digest.labels,
+        signals: digest.signals,
+      };
+    }
+    case 'skool_post_detail': {
+      if (!args.url) throw new Error('skool_post_detail requires url.');
+      const parsed = await readSkoolCommunity({ ...args, limit: 1 }, deps);
+      return {
+        community: parsed.community,
+        sourceUrl: parsed.sourceUrl,
+        fetchedAt: parsed.fetchedAt,
+        post: parsed.posts[0] || null,
+      };
+    }
+    default:
+      throw new Error(`Unknown tool: ${toolName}`);
+  }
+}
+
+async function handleRequest(request, deps = {}) {
+  const { id = null, method, params } = request || {};
+
+  try {
+    if (method === 'initialize') {
+      return successResponse(id, {
+        protocolVersion: '2024-11-05',
+        capabilities: {
+          tools: {},
+        },
+        serverInfo: {
+          name: 'thumbgate-skool-headless-reader',
+          version: '1.0.0',
+        },
+      });
+    }
+
+    if (method === 'notifications/initialized') {
+      return null;
+    }
+
+    if (method === 'tools/list') {
+      return successResponse(id, { tools: TOOLS });
+    }
+
+    if (method === 'tools/call') {
+      const { name: toolName, arguments: toolArgs } = params || {};
+      if (!toolName) {
+        return errorResponse(id, -32602, 'Missing required param: name');
+      }
+      const result = await callTool(toolName, toolArgs, deps);
+      return successResponse(id, {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      });
+    }
+
+    return errorResponse(id, -32601, `Method not found: ${method}`);
+  } catch (error) {
+    return errorResponse(id, -32603, error.message);
+  }
+}
+
+function startServer() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: null,
+    terminal: false,
+  });
+
+  process.stderr.write('[skool-headless-reader mcp-server] Listening on stdin...\n');
+
+  rl.on('line', async (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    let request;
+    try {
+      request = JSON.parse(trimmed);
+    } catch (_) {
+      const response = errorResponse(null, -32700, 'Parse error: invalid JSON');
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+      return;
+    }
+
+    const response = await handleRequest(request);
+    if (response) {
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+  });
+
+  rl.on('close', () => {
+    process.stderr.write('[skool-headless-reader mcp-server] stdin closed, shutting down.\n');
+  });
+
+  process.on('SIGINT', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+}
+
+module.exports = {
+  TOOLS,
+  callTool,
+  handleRequest,
+  startServer,
+};
+
+if (require.main === module) {
+  startServer();
+}

--- a/scripts/skool-reader.js
+++ b/scripts/skool-reader.js
@@ -1,0 +1,629 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SKOOL_ORIGIN = 'https://www.skool.com';
+const DEFAULT_LIMIT = 20;
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
+
+const KEYWORD_GROUPS = [
+  {
+    key: 'claude-code',
+    score: 10,
+    patterns: [/\bclaude code\b/i, /\bclaude\b/i, /\bcodex\b/i, /\bcursor\b/i],
+    reason: 'agentic coding workflow',
+  },
+  {
+    key: 'mcp',
+    score: 8,
+    patterns: [/\bmcp\b/i, /model context protocol/i],
+    reason: 'MCP adoption surface',
+  },
+  {
+    key: 'automation-build',
+    score: 7,
+    patterns: [/\bn8n\b/i, /\bworkflow\b/i, /\bautomation\b/i, /\bagent\b/i, /\bai solution\b/i],
+    reason: 'automation builder audience',
+  },
+  {
+    key: 'breakage-support',
+    score: 12,
+    patterns: [/\bhelp\b/i, /\bstuck\b/i, /\blost\b/i, /\berror\b/i, /\bfail/i, /\bbreak/i, /\bnot working\b/i],
+    reason: 'active pain and troubleshooting intent',
+  },
+  {
+    key: 'cost-control',
+    score: 8,
+    patterns: [/\bcredit/i, /\bcost\b/i, /\bexpensive\b/i, /\btoken/i, /\bbudget\b/i],
+    reason: 'cost and token governance pain',
+  },
+  {
+    key: 'deployment-stack',
+    score: 7,
+    patterns: [/\bgithub\b/i, /\bsupabase\b/i, /\bvercel\b/i, /\brailway\b/i, /\bdeploy/i],
+    reason: 'production-change risk',
+  },
+  {
+    key: 'buyer-intent',
+    score: 9,
+    patterns: [/\bhire\b/i, /\bclient\b/i, /\bpaid\b/i, /\bagency\b/i, /\bconsultant\b/i, /\baffiliate\b/i],
+    reason: 'commercial intent',
+  },
+];
+
+function asPositiveInt(value, defaultValue, maxValue = 100) {
+  if (value == null || value === '') return defaultValue;
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`Expected a positive number, got: ${value}`);
+  }
+  return Math.min(Math.floor(number), maxValue);
+}
+
+function normalizeText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function redactSensitive(value) {
+  return normalizeText(value).replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted-email]');
+}
+
+function truncateText(value, maxLength = 320) {
+  const text = normalizeText(value);
+  const chars = Array.from(text);
+  if (chars.length <= maxLength) return text;
+  return `${chars.slice(0, Math.max(0, maxLength - 3)).join('').trim()}...`;
+}
+
+function normalizeCategoryName(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseMaybeJson(value, fallback) {
+  if (value == null || value === '') return fallback;
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function normalizeCommunitySlug(value) {
+  const raw = normalizeText(value)
+    .replace(/^https?:\/\/[^/]+\//, '')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+  const [slug] = raw.split(/[/?#]/);
+  if (!slug) {
+    throw new Error('Missing Skool community slug.');
+  }
+  return slug;
+}
+
+function isLikelySkoolCategoryId(value) {
+  return /^[a-f0-9]{16,}$/i.test(String(value || ''));
+}
+
+function buildSkoolUrl(options = {}) {
+  const page = asPositiveInt(options.page, 1, 500);
+  const baseUrl = options.url
+    ? new URL(options.url)
+    : new URL(`/${normalizeCommunitySlug(options.community)}`, SKOOL_ORIGIN);
+
+  if (!baseUrl.hostname.endsWith('skool.com')) {
+    throw new Error(`Expected a skool.com URL, got: ${baseUrl.hostname}`);
+  }
+
+  if (options.categoryId) {
+    baseUrl.searchParams.set('c', options.categoryId);
+  }
+  if (options.sortType) {
+    baseUrl.searchParams.set('sort', String(options.sortType));
+  }
+  if (page > 1) {
+    baseUrl.searchParams.set('p', String(page));
+  }
+
+  return baseUrl.toString();
+}
+
+function loadCookieHeader(options = {}) {
+  if (options.cookie) return String(options.cookie).trim();
+  if (process.env.SKOOL_COOKIE) return process.env.SKOOL_COOKIE.trim();
+
+  const cookieFile = options.cookieFile || process.env.SKOOL_COOKIE_FILE;
+  if (!cookieFile) return '';
+
+  const resolved = path.resolve(cookieFile);
+  return fs.readFileSync(resolved, 'utf8').trim();
+}
+
+function extractNextData(html) {
+  const match = String(html || '').match(
+    /<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/,
+  );
+  if (!match) {
+    throw new Error('Skool page did not include __NEXT_DATA__. The page may require auth or changed shape.');
+  }
+  try {
+    return JSON.parse(match[1]);
+  } catch (error) {
+    throw new Error(`Could not parse Skool __NEXT_DATA__: ${error.message}`);
+  }
+}
+
+function resolvePageProps(nextData) {
+  return nextData && nextData.props && nextData.props.pageProps
+    ? nextData.props.pageProps
+    : {};
+}
+
+function normalizeLabel(label) {
+  const metadata = label.metadata || {};
+  return {
+    id: label.id,
+    name: redactSensitive(label.displayName || metadata.displayName || label.name || ''),
+    description: redactSensitive(metadata.description || label.description || ''),
+    postCount: Number(label.posts || metadata.posts || 0),
+  };
+}
+
+function buildLabelsById(currentGroup = {}) {
+  const labels = Array.isArray(currentGroup.labels) ? currentGroup.labels : [];
+  return labels.reduce((acc, label) => {
+    if (label && label.id) {
+      acc[label.id] = normalizeLabel(label);
+    }
+    return acc;
+  }, {});
+}
+
+function normalizeCommunity(currentGroup = {}, sourceUrl) {
+  const metadata = currentGroup.metadata || {};
+  const url = new URL(sourceUrl || SKOOL_ORIGIN);
+  const slug = currentGroup.name || url.pathname.split('/').filter(Boolean)[0] || '';
+  return {
+    id: currentGroup.id || '',
+    slug,
+    url: `${url.origin}/${slug}`,
+    name: redactSensitive(metadata.displayName || currentGroup.displayName || slug),
+    description: redactSensitive(metadata.description || ''),
+    totalMembers: Number(metadata.totalMembers || currentGroup.totalMembers || 0),
+    totalOnlineMembers: Number(metadata.totalOnlineMembers || 0),
+    totalAdmins: Number(metadata.totalAdmins || 0),
+    totalPosts: Number(metadata.totalPosts || 0),
+    links: Array.isArray(metadata.links)
+      ? metadata.links.map((link) => ({
+        label: redactSensitive(link.label || link.title || ''),
+        url: redactSensitive(link.url || link.href || ''),
+      }))
+      : [],
+  };
+}
+
+function normalizeUser(user = {}) {
+  const metadata = user.metadata || {};
+  const name = metadata.displayName || user.name || [user.firstName, user.lastName].filter(Boolean).join(' ');
+  return {
+    id: user.id || '',
+    name: redactSensitive(name),
+    handle: redactSensitive(user.username || metadata.username || ''),
+  };
+}
+
+function buildPostUrl(post, sourceUrl, communitySlug) {
+  if (!post || !post.name) return sourceUrl || '';
+  const url = new URL(sourceUrl || `${SKOOL_ORIGIN}/${communitySlug || ''}`);
+  const slug = communitySlug || url.pathname.split('/').filter(Boolean)[0] || '';
+  return `${url.origin}/${slug}/${post.name}`;
+}
+
+function normalizePostTree(postTree, labelsById, sourceUrl, communitySlug) {
+  const post = postTree && postTree.post ? postTree.post : postTree;
+  if (!post) return null;
+
+  const metadata = post.metadata || {};
+  const category = labelsById[post.labelId] || null;
+  const contributors = parseMaybeJson(metadata.contributors, []);
+  const content = redactSensitive(metadata.content || post.content || '');
+  const title = redactSensitive(metadata.title || post.title || post.name || '');
+  const children = Array.isArray(postTree.children) ? postTree.children : [];
+
+  return {
+    id: post.id || '',
+    slug: post.name || '',
+    url: buildPostUrl(post, sourceUrl, communitySlug),
+    title,
+    content,
+    excerpt: truncateText(content, 320),
+    author: normalizeUser(post.user || {}),
+    category: category ? category.name : '',
+    categoryId: post.labelId || '',
+    pinned: Boolean(metadata.pinned),
+    upvotes: Number(metadata.upvotes || post.upvotes || 0),
+    comments: Number(metadata.comments || post.comments || children.length || 0),
+    contributors: Array.isArray(contributors)
+      ? contributors.map((contributor) => normalizeUser(contributor))
+      : [],
+    createdAt: post.createdAt || '',
+    updatedAt: post.updatedAt || '',
+    lastCommentAt: metadata.lastComment && metadata.lastComment.createdAt
+      ? metadata.lastComment.createdAt
+      : '',
+    childCount: children.length,
+  };
+}
+
+function collectPostTrees(pageProps) {
+  const trees = [];
+  if (Array.isArray(pageProps.postTrees)) {
+    trees.push(...pageProps.postTrees);
+  }
+  if (pageProps.postTree) {
+    trees.push(pageProps.postTree);
+  }
+  return trees;
+}
+
+function dedupePosts(posts) {
+  const seen = new Set();
+  const result = [];
+  for (const post of posts) {
+    const key = post.id || post.slug || post.url;
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(post);
+  }
+  return result;
+}
+
+function parseSkoolHtml(html, options = {}) {
+  const nextData = extractNextData(html);
+  const pageProps = resolvePageProps(nextData);
+  const sourceUrl = options.sourceUrl || SKOOL_ORIGIN;
+  const currentGroup = pageProps.currentGroup || {};
+  const labelsById = buildLabelsById(currentGroup);
+  const community = normalizeCommunity(currentGroup, sourceUrl);
+  const labels = Object.values(labelsById);
+  const posts = dedupePosts(
+    collectPostTrees(pageProps)
+      .map((tree) => normalizePostTree(tree, labelsById, sourceUrl, community.slug))
+      .filter(Boolean),
+  );
+
+  return {
+    sourceUrl,
+    fetchedAt: new Date().toISOString(),
+    page: Number(pageProps.page || 1),
+    sortType: pageProps.sortType || '',
+    total: Number(pageProps.total || posts.length),
+    selectedCategoryId: pageProps.category || '',
+    community,
+    labels,
+    posts,
+    upcomingEvents: Array.isArray(pageProps.upcomingEvents)
+      ? pageProps.upcomingEvents.map((event) => ({
+        id: event.id || '',
+        title: redactSensitive(event.title || (event.metadata && event.metadata.title) || ''),
+        startsAt: event.startsAt || (event.metadata && event.metadata.startsAt) || '',
+      }))
+      : [],
+  };
+}
+
+function resolveCategoryId(parsed, category) {
+  if (!category) return '';
+  if (isLikelySkoolCategoryId(category)) return category;
+
+  const needle = normalizeCategoryName(category);
+  const exact = parsed.labels.find((label) => normalizeCategoryName(label.name) === needle);
+  if (exact) return exact.id;
+
+  const partial = parsed.labels.find((label) => normalizeCategoryName(label.name).includes(needle));
+  if (partial) return partial.id;
+
+  const names = parsed.labels.map((label) => label.name).filter(Boolean).join(', ');
+  throw new Error(`Could not find Skool category "${category}". Available categories: ${names}`);
+}
+
+async function fetchSkoolHtml(url, options = {}, deps = {}) {
+  const fetchImpl = deps.fetch || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('This Node runtime does not provide fetch(). Use Node 18+.');
+  }
+
+  const cookie = loadCookieHeader(options);
+  const controller = new AbortController();
+  const timeoutMs = asPositiveInt(options.timeoutMs, DEFAULT_TIMEOUT_MS, 120000);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const headers = {
+    accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'accept-language': 'en-US,en;q=0.9',
+    'cache-control': 'no-cache',
+    'user-agent': options.userAgent || DEFAULT_USER_AGENT,
+  };
+  if (cookie) headers.cookie = cookie;
+
+  try {
+    const response = await fetchImpl(url, {
+      headers,
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    if (!response || !response.ok) {
+      const status = response ? response.status : 'unknown';
+      throw new Error(`Skool request failed with status ${status}`);
+    }
+    return {
+      url: response.url || url,
+      html: await response.text(),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function limitParsedPosts(parsed, limit) {
+  const next = { ...parsed };
+  next.posts = parsed.posts.slice(0, asPositiveInt(limit, DEFAULT_LIMIT, 200));
+  return next;
+}
+
+async function readSkoolCommunity(options = {}, deps = {}) {
+  if (!options.url && !options.community) {
+    throw new Error('Provide --url or --community.');
+  }
+
+  const category = options.category || options.categoryId || '';
+  const categoryIsId = category && isLikelySkoolCategoryId(category);
+  const firstUrl = buildSkoolUrl({
+    ...options,
+    categoryId: categoryIsId ? category : options.categoryId,
+  });
+  const first = await fetchSkoolHtml(firstUrl, options, deps);
+  let parsed = parseSkoolHtml(first.html, { sourceUrl: first.url });
+
+  if (category && !categoryIsId) {
+    const categoryId = resolveCategoryId(parsed, category);
+    const categoryUrl = buildSkoolUrl({
+      ...options,
+      url: options.url || parsed.community.url,
+      categoryId,
+    });
+    const categoryResponse = await fetchSkoolHtml(categoryUrl, options, deps);
+    parsed = parseSkoolHtml(categoryResponse.html, { sourceUrl: categoryResponse.url });
+    parsed.selectedCategoryId = categoryId;
+  }
+
+  return limitParsedPosts(parsed, options.limit);
+}
+
+function scorePost(post, options = {}) {
+  const haystack = `${post.title} ${post.content} ${post.category}`.toLowerCase();
+  const matchedKeywords = [];
+  let score = 0;
+  const reasons = [];
+
+  for (const group of KEYWORD_GROUPS) {
+    if (group.patterns.some((pattern) => pattern.test(haystack))) {
+      matchedKeywords.push(group.key);
+      score += group.score;
+      reasons.push(group.reason);
+    }
+  }
+
+  const category = normalizeCategoryName(post.category);
+  if (category.includes('support')) score += 12;
+  if (category.includes('hire') || category.includes('looking for hire')) score += 9;
+  if (category.includes('wins')) score += 3;
+  if (post.pinned) score += 4;
+  score += Math.min(10, Math.floor(Number(post.comments || 0) / 10));
+  score += Math.min(8, Math.floor(Number(post.upvotes || 0) / 25));
+
+  const focus = normalizeText(options.focus).toLowerCase();
+  if (focus && haystack.includes(focus)) {
+    matchedKeywords.push('focus-match');
+    score += 12;
+    reasons.push(`matches focus "${focus}"`);
+  }
+
+  return {
+    score,
+    matchedKeywords: [...new Set(matchedKeywords)],
+    reasons: [...new Set(reasons)],
+  };
+}
+
+function buildSuggestedAction(post, matchedKeywords) {
+  if (matchedKeywords.includes('breakage-support') || matchedKeywords.includes('deployment-stack')) {
+    return 'Draft a helpful reply that diagnoses the workflow risk, then mention ThumbGate as a pre-action gate for Claude Code/Codex before production files, GitHub, Supabase, Vercel, or Railway are touched.';
+  }
+  if (matchedKeywords.includes('cost-control')) {
+    return 'Draft a reply about token and credit waste from repeated agent mistakes, then offer ThumbGate as a budget-aware Reliability Gateway for agent sessions.';
+  }
+  if (matchedKeywords.includes('buyer-intent')) {
+    return 'Add this person to the outreach queue with a concise ThumbGate workflow-hardening angle for AI consultants and automation builders.';
+  }
+  return 'Save this as a lead-discovery signal and draft a non-spam educational reply tied to pre-action gates and repeatable agent reliability.';
+}
+
+function isAdministrativePost(post) {
+  const title = normalizeText(post.title).toLowerCase();
+  return /please read|rules and guidelines|community rules|read this first|start here|welcome/.test(title);
+}
+
+function rankSkoolRevenueSignals(posts, options = {}) {
+  const limit = asPositiveInt(options.limit, 10, 100);
+  return posts
+    .filter((post) => options.includeAdministrative || !isAdministrativePost(post))
+    .map((post) => {
+      const score = scorePost(post, options);
+      return {
+        id: post.id,
+        score: score.score,
+        title: post.title,
+        url: post.url,
+        category: post.category,
+        author: post.author,
+        upvotes: post.upvotes,
+        comments: post.comments,
+        matchedKeywords: score.matchedKeywords,
+        whyThumbGate: score.reasons.length
+          ? `ThumbGate fit: ${score.reasons.join(', ')}.`
+          : 'ThumbGate fit: community member is discussing AI automation reliability.',
+        suggestedAction: buildSuggestedAction(post, score.matchedKeywords),
+        excerpt: post.excerpt,
+      };
+    })
+    .filter((signal) => signal.score > 0)
+    .sort((a, b) => b.score - a.score || b.comments - a.comments || b.upvotes - a.upvotes)
+    .slice(0, limit);
+}
+
+function buildSkoolDigest(parsed, options = {}) {
+  return {
+    community: parsed.community,
+    sourceUrl: parsed.sourceUrl,
+    fetchedAt: parsed.fetchedAt,
+    total: parsed.total,
+    page: parsed.page,
+    sortType: parsed.sortType,
+    labels: parsed.labels,
+    signals: rankSkoolRevenueSignals(parsed.posts, {
+      limit: options.signalLimit || options.limit || 10,
+      focus: options.focus,
+    }),
+    posts: parsed.posts,
+  };
+}
+
+function formatMarkdownDigest(digest) {
+  const lines = [
+    `# Skool Digest: ${digest.community.name}`,
+    '',
+    `Source: ${digest.sourceUrl}`,
+    `Members: ${digest.community.totalMembers}`,
+    `Visible posts on page: ${digest.posts.length}`,
+    '',
+    '## Revenue Signals',
+    '',
+  ];
+
+  if (!digest.signals.length) {
+    lines.push('No ranked revenue signals found on this page.', '');
+  } else {
+    digest.signals.forEach((signal, index) => {
+      lines.push(`${index + 1}. ${signal.title}`);
+      lines.push(`   - Score: ${signal.score}`);
+      lines.push(`   - Category: ${signal.category || 'uncategorized'}`);
+      lines.push(`   - Engagement: ${signal.upvotes} upvotes, ${signal.comments} comments`);
+      lines.push(`   - URL: ${signal.url}`);
+      lines.push(`   - Fit: ${signal.whyThumbGate}`);
+      lines.push(`   - Action: ${signal.suggestedAction}`);
+      if (signal.excerpt) lines.push(`   - Excerpt: ${signal.excerpt}`);
+      lines.push('');
+    });
+  }
+
+  lines.push('## Categories', '');
+  digest.labels.forEach((label) => {
+    lines.push(`- ${label.name}: ${label.postCount} posts`);
+  });
+
+  return `${lines.join('\n')}\n`;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) continue;
+    const [rawKey, inlineValue] = arg.slice(2).split(/=(.*)/s, 2);
+    const key = rawKey.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    if (inlineValue !== undefined) {
+      args[key] = inlineValue;
+    } else if (argv[index + 1] && !argv[index + 1].startsWith('--')) {
+      args[key] = argv[index + 1];
+      index += 1;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+function usage() {
+  return [
+    'Usage:',
+    '  node scripts/skool-reader.js --community ai-automation-society --limit 10 --format json',
+    '  node scripts/skool-reader.js --url https://www.skool.com/ai-automation-society --category "Support Needed" --signals --format markdown',
+    '',
+    'Options:',
+    '  --community <slug>       Skool community slug.',
+    '  --url <url>              Full Skool community or post URL.',
+    '  --category <name|id>     Optional category name or Skool category id.',
+    '  --limit <number>         Max raw posts or revenue signals to return.',
+    '  --post-limit <number>    Max posts to read before signal ranking.',
+    '  --format <json|markdown> Output format. Default: json.',
+    '  --signals                Return revenue-signal digest instead of raw parsed posts.',
+    '  --cookie-file <path>     Optional cookie header file for private groups.',
+    '  --out <path>             Optional output file path.',
+  ].join('\n');
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  const readOptions = { ...args };
+  if (args.signals) {
+    const signalLimit = asPositiveInt(args.limit, 10, 100);
+    readOptions.limit = args.postLimit || Math.max(signalLimit, 50);
+    args.signalLimit = args.signalLimit || signalLimit;
+  }
+
+  const parsed = await readSkoolCommunity(readOptions);
+  const format = args.format || 'json';
+  const payload = args.signals ? buildSkoolDigest(parsed, args) : parsed;
+  const output = format === 'markdown'
+    ? formatMarkdownDigest(args.signals ? payload : buildSkoolDigest(parsed, args))
+    : `${JSON.stringify(payload, null, 2)}\n`;
+
+  if (args.out) {
+    fs.writeFileSync(path.resolve(args.out), output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+module.exports = {
+  buildSkoolDigest,
+  buildSkoolUrl,
+  extractNextData,
+  formatMarkdownDigest,
+  loadCookieHeader,
+  parseArgs,
+  parseSkoolHtml,
+  rankSkoolRevenueSignals,
+  readSkoolCommunity,
+  resolveCategoryId,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`[skool-reader] ${error.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/skool-reader.js
+++ b/scripts/skool-reader.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const fs = require('node:fs');
-const path = require('node:path');
-
 const SKOOL_ORIGIN = 'https://www.skool.com';
 const DEFAULT_LIMIT = 20;
 const DEFAULT_TIMEOUT_MS = 15000;
@@ -59,17 +56,52 @@ function asPositiveInt(value, defaultValue, maxValue = 100) {
   if (value == null || value === '') return defaultValue;
   const number = Number(value);
   if (!Number.isFinite(number) || number <= 0) {
-    throw new Error(`Expected a positive number, got: ${value}`);
+    throw new TypeError(`Expected a positive number, got: ${value}`);
   }
   return Math.min(Math.floor(number), maxValue);
 }
 
 function normalizeText(value) {
-  return String(value || '').replace(/\s+/g, ' ').trim();
+  return String(value || '').replaceAll(/\s+/g, ' ').trim();
+}
+
+function isEmailTokenChar(char) {
+  if (!char) return false;
+  const code = char.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === '.'
+    || char === '_'
+    || char === '%'
+    || char === '+'
+    || char === '-'
+    || char === '@'
+  );
+}
+
+function looksLikeEmailToken(token) {
+  const at = token.indexOf('@');
+  if (at <= 0 || at !== token.lastIndexOf('@')) return false;
+  const dot = token.indexOf('.', at + 2);
+  if (dot === -1 || dot >= token.length - 2) return false;
+  return token.split('').every(isEmailTokenChar);
+}
+
+function redactEmailToken(token) {
+  let start = 0;
+  let end = token.length;
+  while (start < end && !isEmailTokenChar(token[start])) start += 1;
+  while (end > start && !isEmailTokenChar(token[end - 1])) end -= 1;
+
+  const candidate = token.slice(start, end);
+  if (!looksLikeEmailToken(candidate)) return token;
+  return `${token.slice(0, start)}[redacted-email]${token.slice(end)}`;
 }
 
 function redactSensitive(value) {
-  return normalizeText(value).replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted-email]');
+  return normalizeText(value).split(' ').map(redactEmailToken).join(' ');
 }
 
 function truncateText(value, maxLength = 320) {
@@ -82,8 +114,8 @@ function truncateText(value, maxLength = 320) {
 function normalizeCategoryName(value) {
   return normalizeText(value)
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .replace(/\s+/g, ' ')
+    .replaceAll(/[^a-z0-9]+/g, ' ')
+    .replaceAll(/\s+/g, ' ')
     .trim();
 }
 
@@ -92,25 +124,52 @@ function parseMaybeJson(value, fallback) {
   if (typeof value !== 'string') return value;
   try {
     return JSON.parse(value);
-  } catch (_) {
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
     return fallback;
   }
 }
 
 function normalizeCommunitySlug(value) {
-  const raw = normalizeText(value)
-    .replace(/^https?:\/\/[^/]+\//, '')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-  const [slug] = raw.split(/[/?#]/);
+  const raw = normalizeText(value);
+  const pathname = raw.startsWith('http://') || raw.startsWith('https://')
+    ? new URL(raw).pathname
+    : raw;
+  const stripped = stripOuterSlashes(pathname);
+  const slugEnd = firstIndexOfAny(stripped, ['/', '?', '#']);
+  const slug = slugEnd === -1 ? stripped : stripped.slice(0, slugEnd);
   if (!slug) {
     throw new Error('Missing Skool community slug.');
   }
   return slug;
 }
 
+function stripOuterSlashes(value) {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '/') start += 1;
+  while (end > start && value[end - 1] === '/') end -= 1;
+  return value.slice(start, end);
+}
+
+function firstIndexOfAny(value, needles) {
+  const indexes = needles
+    .map((needle) => value.indexOf(needle))
+    .filter((index) => index >= 0);
+  return indexes.length > 0 ? Math.min(...indexes) : -1;
+}
+
 function isLikelySkoolCategoryId(value) {
   return /^[a-f0-9]{16,}$/i.test(String(value || ''));
+}
+
+function isAllowedSkoolHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return host === 'skool.com' || host === 'www.skool.com' || host.endsWith('.skool.com');
+}
+
+function firstPathSegment(pathname) {
+  return String(pathname || '').split('/').find(Boolean) || '';
 }
 
 function buildSkoolUrl(options = {}) {
@@ -119,7 +178,7 @@ function buildSkoolUrl(options = {}) {
     ? new URL(options.url)
     : new URL(`/${normalizeCommunitySlug(options.community)}`, SKOOL_ORIGIN);
 
-  if (!baseUrl.hostname.endsWith('skool.com')) {
+  if (!isAllowedSkoolHost(baseUrl.hostname)) {
     throw new Error(`Expected a skool.com URL, got: ${baseUrl.hostname}`);
   }
 
@@ -139,32 +198,36 @@ function buildSkoolUrl(options = {}) {
 function loadCookieHeader(options = {}) {
   if (options.cookie) return String(options.cookie).trim();
   if (process.env.SKOOL_COOKIE) return process.env.SKOOL_COOKIE.trim();
-
-  const cookieFile = options.cookieFile || process.env.SKOOL_COOKIE_FILE;
-  if (!cookieFile) return '';
-
-  const resolved = path.resolve(cookieFile);
-  return fs.readFileSync(resolved, 'utf8').trim();
+  return '';
 }
 
 function extractNextData(html) {
-  const match = String(html || '').match(
-    /<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/,
-  );
-  if (!match) {
+  const text = String(html || '');
+  const markerIndex = findNextDataMarker(text);
+  if (markerIndex === -1) {
     throw new Error('Skool page did not include __NEXT_DATA__. The page may require auth or changed shape.');
   }
+  const openEnd = text.indexOf('>', markerIndex);
+  const closeStart = openEnd === -1 ? -1 : text.indexOf('</script>', openEnd + 1);
+  if (openEnd === -1 || closeStart === -1) {
+    throw new Error('Skool page included malformed __NEXT_DATA__. The page shape may have changed.');
+  }
+  const payload = text.slice(openEnd + 1, closeStart);
   try {
-    return JSON.parse(match[1]);
+    return JSON.parse(payload);
   } catch (error) {
     throw new Error(`Could not parse Skool __NEXT_DATA__: ${error.message}`);
   }
 }
 
+function findNextDataMarker(html) {
+  const doubleQuoted = html.indexOf('id="__NEXT_DATA__"');
+  if (doubleQuoted !== -1) return doubleQuoted;
+  return html.indexOf("id='__NEXT_DATA__'");
+}
+
 function resolvePageProps(nextData) {
-  return nextData && nextData.props && nextData.props.pageProps
-    ? nextData.props.pageProps
-    : {};
+  return nextData?.props?.pageProps || {};
 }
 
 function normalizeLabel(label) {
@@ -180,24 +243,25 @@ function normalizeLabel(label) {
 function buildLabelsById(currentGroup = {}) {
   const labels = Array.isArray(currentGroup.labels) ? currentGroup.labels : [];
   return labels.reduce((acc, label) => {
-    if (label && label.id) {
+    if (label?.id) {
       acc[label.id] = normalizeLabel(label);
     }
     return acc;
   }, {});
 }
 
-function normalizeCommunity(currentGroup = {}, sourceUrl) {
-  const metadata = currentGroup.metadata || {};
+function normalizeCommunity(currentGroup, sourceUrl) {
+  const group = currentGroup || {};
+  const metadata = group.metadata || {};
   const url = new URL(sourceUrl || SKOOL_ORIGIN);
-  const slug = currentGroup.name || url.pathname.split('/').filter(Boolean)[0] || '';
+  const slug = group.name || firstPathSegment(url.pathname);
   return {
-    id: currentGroup.id || '',
+    id: group.id || '',
     slug,
     url: `${url.origin}/${slug}`,
-    name: redactSensitive(metadata.displayName || currentGroup.displayName || slug),
+    name: redactSensitive(metadata.displayName || group.displayName || slug),
     description: redactSensitive(metadata.description || ''),
-    totalMembers: Number(metadata.totalMembers || currentGroup.totalMembers || 0),
+    totalMembers: Number(metadata.totalMembers || group.totalMembers || 0),
     totalOnlineMembers: Number(metadata.totalOnlineMembers || 0),
     totalAdmins: Number(metadata.totalAdmins || 0),
     totalPosts: Number(metadata.totalPosts || 0),
@@ -221,14 +285,14 @@ function normalizeUser(user = {}) {
 }
 
 function buildPostUrl(post, sourceUrl, communitySlug) {
-  if (!post || !post.name) return sourceUrl || '';
+  if (!post?.name) return sourceUrl || '';
   const url = new URL(sourceUrl || `${SKOOL_ORIGIN}/${communitySlug || ''}`);
-  const slug = communitySlug || url.pathname.split('/').filter(Boolean)[0] || '';
+  const slug = communitySlug || firstPathSegment(url.pathname);
   return `${url.origin}/${slug}/${post.name}`;
 }
 
 function normalizePostTree(postTree, labelsById, sourceUrl, communitySlug) {
-  const post = postTree && postTree.post ? postTree.post : postTree;
+  const post = postTree?.post || postTree;
   if (!post) return null;
 
   const metadata = post.metadata || {};
@@ -313,8 +377,8 @@ function parseSkoolHtml(html, options = {}) {
     upcomingEvents: Array.isArray(pageProps.upcomingEvents)
       ? pageProps.upcomingEvents.map((event) => ({
         id: event.id || '',
-        title: redactSensitive(event.title || (event.metadata && event.metadata.title) || ''),
-        startsAt: event.startsAt || (event.metadata && event.metadata.startsAt) || '',
+        title: redactSensitive(event.title || event.metadata?.title || ''),
+        startsAt: event.startsAt || event.metadata?.startsAt || '',
       }))
       : [],
   };
@@ -338,7 +402,7 @@ function resolveCategoryId(parsed, category) {
 async function fetchSkoolHtml(url, options = {}, deps = {}) {
   const fetchImpl = deps.fetch || globalThis.fetch;
   if (typeof fetchImpl !== 'function') {
-    throw new Error('This Node runtime does not provide fetch(). Use Node 18+.');
+    throw new TypeError('This Node runtime does not provide fetch(). Use Node 18+.');
   }
 
   const cookie = loadCookieHeader(options);
@@ -359,8 +423,8 @@ async function fetchSkoolHtml(url, options = {}, deps = {}) {
       redirect: 'follow',
       signal: controller.signal,
     });
-    if (!response || !response.ok) {
-      const status = response ? response.status : 'unknown';
+    if (!response?.ok) {
+      const status = response?.status || 'unknown';
       throw new Error(`Skool request failed with status ${status}`);
     }
     return {
@@ -518,20 +582,22 @@ function formatMarkdownDigest(digest) {
     '',
   ];
 
-  if (!digest.signals.length) {
-    lines.push('No ranked revenue signals found on this page.', '');
-  } else {
+  if (digest.signals.length > 0) {
     digest.signals.forEach((signal, index) => {
-      lines.push(`${index + 1}. ${signal.title}`);
-      lines.push(`   - Score: ${signal.score}`);
-      lines.push(`   - Category: ${signal.category || 'uncategorized'}`);
-      lines.push(`   - Engagement: ${signal.upvotes} upvotes, ${signal.comments} comments`);
-      lines.push(`   - URL: ${signal.url}`);
-      lines.push(`   - Fit: ${signal.whyThumbGate}`);
-      lines.push(`   - Action: ${signal.suggestedAction}`);
+      lines.push(
+        `${index + 1}. ${signal.title}`,
+        `   - Score: ${signal.score}`,
+        `   - Category: ${signal.category || 'uncategorized'}`,
+        `   - Engagement: ${signal.upvotes} upvotes, ${signal.comments} comments`,
+        `   - URL: ${signal.url}`,
+        `   - Fit: ${signal.whyThumbGate}`,
+        `   - Action: ${signal.suggestedAction}`,
+      );
       if (signal.excerpt) lines.push(`   - Excerpt: ${signal.excerpt}`);
       lines.push('');
     });
+  } else {
+    lines.push('No ranked revenue signals found on this page.', '');
   }
 
   lines.push('## Categories', '');
@@ -548,7 +614,7 @@ function parseArgs(argv) {
     const arg = argv[index];
     if (!arg.startsWith('--')) continue;
     const [rawKey, inlineValue] = arg.slice(2).split(/=(.*)/s, 2);
-    const key = rawKey.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    const key = rawKey.replaceAll(/-([a-z])/g, (_, letter) => letter.toUpperCase());
     if (inlineValue !== undefined) {
       args[key] = inlineValue;
     } else if (argv[index + 1] && !argv[index + 1].startsWith('--')) {
@@ -575,8 +641,7 @@ function usage() {
     '  --post-limit <number>    Max posts to read before signal ranking.',
     '  --format <json|markdown> Output format. Default: json.',
     '  --signals                Return revenue-signal digest instead of raw parsed posts.',
-    '  --cookie-file <path>     Optional cookie header file for private groups.',
-    '  --out <path>             Optional output file path.',
+    '  SKOOL_COOKIE             Optional cookie header environment variable for private groups.',
   ].join('\n');
 }
 
@@ -597,15 +662,19 @@ async function main(argv = process.argv.slice(2)) {
   const parsed = await readSkoolCommunity(readOptions);
   const format = args.format || 'json';
   const payload = args.signals ? buildSkoolDigest(parsed, args) : parsed;
-  const output = format === 'markdown'
-    ? formatMarkdownDigest(args.signals ? payload : buildSkoolDigest(parsed, args))
-    : `${JSON.stringify(payload, null, 2)}\n`;
-
-  if (args.out) {
-    fs.writeFileSync(path.resolve(args.out), output);
+  let output;
+  if (format === 'markdown') {
+    const digest = args.signals ? payload : buildSkoolDigest(parsed, args);
+    output = formatMarkdownDigest(digest);
   } else {
-    process.stdout.write(output);
+    output = `${JSON.stringify(payload, null, 2)}\n`;
   }
+
+  process.stdout.write(output);
+}
+
+function isCliEntrypoint(entryModule = require.main) {
+  return Boolean(entryModule && entryModule.filename === __filename);
 }
 
 module.exports = {
@@ -619,9 +688,10 @@ module.exports = {
   rankSkoolRevenueSignals,
   readSkoolCommunity,
   resolveCategoryId,
+  isCliEntrypoint,
 };
 
-if (require.main === module) {
+if (isCliEntrypoint()) {
   main().catch((error) => {
     process.stderr.write(`[skool-reader] ${error.message}\n`);
     process.exit(1);

--- a/tests/social-analytics.test.js
+++ b/tests/social-analytics.test.js
@@ -471,6 +471,9 @@ describe('Skool headless reader', () => {
     buildSkoolUrl,
     extractNextData,
     formatMarkdownDigest,
+    isCliEntrypoint,
+    loadCookieHeader,
+    parseArgs,
     parseSkoolHtml,
     rankSkoolRevenueSignals,
     readSkoolCommunity,
@@ -485,6 +488,54 @@ describe('Skool headless reader', () => {
     });
 
     assert.equal(url, 'https://www.skool.com/ai-automation-society?c=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&p=2');
+  });
+
+  it('rejects Skool lookalike hosts before fetching', () => {
+    assert.throws(
+      () => buildSkoolUrl({ url: 'https://attackerskool.com/ai-automation-society' }),
+      /Expected a skool\.com URL/,
+    );
+
+    assert.equal(
+      buildSkoolUrl({ url: 'https://www.skool.com/ai-automation-society' }),
+      'https://www.skool.com/ai-automation-society',
+    );
+  });
+
+  it('parses CLI arguments without enabling filesystem cookie reads', () => {
+    const args = parseArgs([
+      '--community=ai-automation-society',
+      '--post-limit',
+      '25',
+      '--signals',
+    ]);
+
+    assert.deepEqual(args, {
+      community: 'ai-automation-society',
+      postLimit: '25',
+      signals: true,
+    });
+
+    const oldCookie = process.env.SKOOL_COOKIE;
+    const oldCookieFile = process.env.SKOOL_COOKIE_FILE;
+    try {
+      process.env.SKOOL_COOKIE = 'skool_session=secret';
+      process.env.SKOOL_COOKIE_FILE = '/tmp/ignored-cookie-file';
+
+      assert.equal(loadCookieHeader({}), 'skool_session=secret');
+      assert.equal(loadCookieHeader({ cookie: 'override=yes' }), 'override=yes');
+    } finally {
+      if (oldCookie === undefined) {
+        delete process.env.SKOOL_COOKIE;
+      } else {
+        process.env.SKOOL_COOKIE = oldCookie;
+      }
+      if (oldCookieFile === undefined) {
+        delete process.env.SKOOL_COOKIE_FILE;
+      } else {
+        process.env.SKOOL_COOKIE_FILE = oldCookieFile;
+      }
+    }
   });
 
   it('extracts community, labels, and normalized posts from SSR data', () => {
@@ -504,6 +555,10 @@ describe('Skool headless reader', () => {
 
   it('reports missing Skool SSR data clearly', () => {
     assert.throws(() => extractNextData('<html></html>'), /did not include __NEXT_DATA__/);
+    assert.throws(
+      () => extractNextData('<script id="__NEXT_DATA__" type="application/json">{bad</script>'),
+      /Could not parse Skool __NEXT_DATA__/,
+    );
   });
 
   it('resolves category names and ids', () => {
@@ -514,6 +569,7 @@ describe('Skool headless reader', () => {
     assert.equal(resolveCategoryId(parsed, 'support needed'), 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     assert.equal(resolveCategoryId(parsed, 'youtube'), 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
     assert.equal(resolveCategoryId(parsed, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    assert.throws(() => resolveCategoryId(parsed, 'not here'), /Available categories/);
   });
 
   it('prioritizes Support Needed posts and filters administrative posts from revenue ranking', () => {
@@ -553,6 +609,68 @@ describe('Skool headless reader', () => {
     assert.equal(parsed.posts.length, 1);
   });
 
+  it('surfaces missing inputs and HTTP failures without browser automation', async () => {
+    await assert.rejects(
+      () => readSkoolCommunity({}, { fetch: async () => ({ ok: true, text: async () => buildSkoolFixtureHtml() }) }),
+      /Provide --url or --community/,
+    );
+
+    await assert.rejects(
+      () => readSkoolCommunity({
+        community: 'ai-automation-society',
+      }, {
+        fetch: async () => ({
+          ok: false,
+          status: 403,
+          text: async () => '',
+        }),
+      }),
+      /status 403/,
+    );
+  });
+
+  it('normalizes event metadata and post detail pages', () => {
+    const parsed = parseSkoolHtml(buildSkoolFixtureHtml({
+      currentGroup: {
+        id: 'group_1',
+        metadata: {
+          displayName: 'AI Automation Society',
+        },
+        labels: [],
+      },
+      postTrees: [],
+      postTree: {
+        post: {
+          id: 'post_detail',
+          name: 'detail-page',
+          user: { id: 'user_5', firstName: 'Detail', lastName: 'Author' },
+          metadata: {
+            title: 'Need client help with n8n automation',
+            content: 'Looking to hire an automation consultant.',
+          },
+        },
+        children: [{ id: 'comment_1' }],
+      },
+      upcomingEvents: [
+        {
+          id: 'event_1',
+          metadata: {
+            title: 'Q&A with Nate',
+            startsAt: '2026-05-11T15:00:00.000Z',
+          },
+        },
+      ],
+    }), {
+      sourceUrl: 'https://www.skool.com/ai-automation-society/detail-page',
+    });
+
+    assert.equal(parsed.community.slug, 'ai-automation-society');
+    assert.equal(parsed.posts.length, 1);
+    assert.equal(parsed.posts[0].comments, 1);
+    assert.equal(parsed.posts[0].author.name, 'Detail Author');
+    assert.equal(parsed.upcomingEvents[0].title, 'Q&A with Nate');
+  });
+
   it('formats Markdown digests without leaking email addresses', () => {
     const parsed = parseSkoolHtml(buildSkoolFixtureHtml(), {
       sourceUrl: 'https://www.skool.com/ai-automation-society',
@@ -562,6 +680,19 @@ describe('Skool headless reader', () => {
     assert.match(markdown, /Revenue Signals/);
     assert.match(markdown, /ThumbGate/);
     assert.equal(markdown.includes('builder@example.com'), false);
+  });
+
+  it('formats empty signal digests and exposes a testable CLI entrypoint guard', () => {
+    const markdown = formatMarkdownDigest({
+      community: { name: 'Quiet Community', totalMembers: 3 },
+      sourceUrl: 'https://www.skool.com/quiet-community',
+      posts: [],
+      signals: [],
+      labels: [],
+    });
+
+    assert.match(markdown, /No ranked revenue signals/);
+    assert.equal(isCliEntrypoint({ filename: __filename }), false);
   });
 });
 

--- a/tests/social-analytics.test.js
+++ b/tests/social-analytics.test.js
@@ -354,3 +354,302 @@ describe('social-analytics poll-all', () => {
     }
   });
 });
+
+function buildSkoolFixtureHtml(pagePropsOverride = {}) {
+  const pageProps = {
+    page: 1,
+    sortType: 'newest-cm',
+    total: 2,
+    currentGroup: {
+      id: 'group_1',
+      name: 'ai-automation-society',
+      metadata: {
+        displayName: 'AI Automation Society',
+        description: 'Learn to get paid for AI solutions.',
+        totalMembers: 356800,
+        totalOnlineMembers: 2000,
+        totalAdmins: 16,
+        totalPosts: 16384,
+      },
+      labels: [
+        {
+          id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          displayName: 'Support Needed',
+          posts: 2634,
+          metadata: {
+            description: 'Get automation questions answered.',
+          },
+        },
+        {
+          id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          displayName: 'YouTube Resources',
+          posts: 233,
+          metadata: {},
+        },
+      ],
+    },
+    postTrees: [
+      {
+        post: {
+          id: 'post_support',
+          name: 'help-im-so-lost',
+          labelId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          createdAt: '2026-05-05T10:00:00.000Z',
+          updatedAt: '2026-05-05T11:00:00.000Z',
+          user: {
+            id: 'user_1',
+            name: 'Builder One',
+            email: 'builder@example.com',
+          },
+          metadata: {
+            title: 'HELP! I am lost with Claude Code, GitHub, Supabase, and Vercel',
+            content:
+              'Claude Code keeps making risky changes and burning credits before I can ship my automation workflow.',
+            upvotes: 12,
+            comments: 9,
+          },
+        },
+        children: [],
+      },
+      {
+        post: {
+          id: 'post_video',
+          name: 'new-video-claude-code-skills',
+          labelId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          createdAt: '2026-05-04T10:00:00.000Z',
+          updatedAt: '2026-05-04T11:00:00.000Z',
+          user: {
+            id: 'user_2',
+            name: 'Creator Two',
+          },
+          metadata: {
+            title: 'New Video: Claude Code Skills That Agencies Keep Paying For',
+            content: 'MCP and agent workflow skills for consultants and clients.',
+            upvotes: 300,
+            comments: 160,
+            pinned: true,
+            contributors: '[{"id":"user_3","name":"Contributor Three"}]',
+          },
+        },
+        children: [],
+      },
+      {
+        post: {
+          id: 'post_rules',
+          name: 'please-read-rules-and-guidelines',
+          labelId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          createdAt: '2026-05-03T10:00:00.000Z',
+          updatedAt: '2026-05-03T11:00:00.000Z',
+          user: {
+            id: 'user_4',
+            name: 'Admin Four',
+          },
+          metadata: {
+            title: 'Please Read | Rules and Guidelines',
+            content: 'Search for help before posting automation questions.',
+            upvotes: 4000,
+            comments: 2000,
+          },
+        },
+        children: [],
+      },
+    ],
+    ...pagePropsOverride,
+  };
+
+  const nextData = {
+    props: {
+      pageProps,
+    },
+  };
+  return `<html><body><script id="__NEXT_DATA__" type="application/json">${JSON.stringify(nextData)}</script></body></html>`;
+}
+
+describe('Skool headless reader', () => {
+  const {
+    buildSkoolDigest,
+    buildSkoolUrl,
+    extractNextData,
+    formatMarkdownDigest,
+    parseSkoolHtml,
+    rankSkoolRevenueSignals,
+    readSkoolCommunity,
+    resolveCategoryId,
+  } = require('../scripts/skool-reader');
+
+  it('normalizes community URLs and category parameters', () => {
+    const url = buildSkoolUrl({
+      community: 'ai-automation-society',
+      categoryId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      page: 2,
+    });
+
+    assert.equal(url, 'https://www.skool.com/ai-automation-society?c=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&p=2');
+  });
+
+  it('extracts community, labels, and normalized posts from SSR data', () => {
+    const parsed = parseSkoolHtml(buildSkoolFixtureHtml(), {
+      sourceUrl: 'https://www.skool.com/ai-automation-society',
+    });
+
+    assert.equal(parsed.community.name, 'AI Automation Society');
+    assert.equal(parsed.community.totalMembers, 356800);
+    assert.equal(parsed.labels.length, 2);
+    assert.equal(parsed.posts.length, 3);
+    assert.equal(parsed.posts[0].category, 'Support Needed');
+    assert.equal(parsed.posts[0].author.name, 'Builder One');
+    assert.match(parsed.posts[0].url, /\/ai-automation-society\/help-im-so-lost$/);
+    assert.equal(parsed.posts[0].content.includes('builder@example.com'), false);
+  });
+
+  it('reports missing Skool SSR data clearly', () => {
+    assert.throws(() => extractNextData('<html></html>'), /did not include __NEXT_DATA__/);
+  });
+
+  it('resolves category names and ids', () => {
+    const parsed = parseSkoolHtml(buildSkoolFixtureHtml(), {
+      sourceUrl: 'https://www.skool.com/ai-automation-society',
+    });
+
+    assert.equal(resolveCategoryId(parsed, 'support needed'), 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    assert.equal(resolveCategoryId(parsed, 'youtube'), 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    assert.equal(resolveCategoryId(parsed, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  });
+
+  it('prioritizes Support Needed posts and filters administrative posts from revenue ranking', () => {
+    const parsed = parseSkoolHtml(buildSkoolFixtureHtml(), {
+      sourceUrl: 'https://www.skool.com/ai-automation-society',
+    });
+    const signals = rankSkoolRevenueSignals(parsed.posts, { limit: 2 });
+
+    assert.equal(signals[0].id, 'post_support');
+    assert.ok(signals[0].score > signals[1].score);
+    assert.equal(signals.some((signal) => signal.id === 'post_rules'), false);
+    assert.ok(signals[0].matchedKeywords.includes('breakage-support'));
+    assert.ok(signals[0].matchedKeywords.includes('deployment-stack'));
+    assert.match(signals[0].suggestedAction, /ThumbGate/);
+  });
+
+  it('resolves category names without browser automation', async () => {
+    const requests = [];
+    const fetch = async (url) => {
+      requests.push(url);
+      return {
+        ok: true,
+        status: 200,
+        url,
+        text: async () => buildSkoolFixtureHtml(),
+      };
+    };
+
+    const parsed = await readSkoolCommunity({
+      community: 'ai-automation-society',
+      category: 'Support Needed',
+      limit: 1,
+    }, { fetch });
+
+    assert.equal(requests.length, 2);
+    assert.match(requests[1], /[?&]c=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/);
+    assert.equal(parsed.posts.length, 1);
+  });
+
+  it('formats Markdown digests without leaking email addresses', () => {
+    const parsed = parseSkoolHtml(buildSkoolFixtureHtml(), {
+      sourceUrl: 'https://www.skool.com/ai-automation-society',
+    });
+    const markdown = formatMarkdownDigest(buildSkoolDigest(parsed, { limit: 2 }));
+
+    assert.match(markdown, /Revenue Signals/);
+    assert.match(markdown, /ThumbGate/);
+    assert.equal(markdown.includes('builder@example.com'), false);
+  });
+});
+
+describe('Skool headless MCP server', () => {
+  const {
+    TOOLS,
+    handleRequest,
+  } = require('../adapters/skool/server-stdio');
+
+  const fetch = async (url) => ({
+    ok: true,
+    status: 200,
+    url,
+    text: async () => buildSkoolFixtureHtml({
+      postTrees: [
+        {
+          post: {
+            id: 'post_support',
+            name: 'help-with-claude-code',
+            labelId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            user: { id: 'user_1', name: 'Builder One' },
+            metadata: {
+              title: 'Help with Claude Code and Vercel deployment',
+              content: 'Claude Code keeps breaking my GitHub deployment workflow.',
+              upvotes: 10,
+              comments: 5,
+            },
+          },
+          children: [],
+        },
+      ],
+    }),
+  });
+
+  it('exposes only read-only tools', () => {
+    assert.deepEqual(
+      TOOLS.map((tool) => tool.name),
+      ['skool_read_community', 'skool_revenue_signals', 'skool_post_detail'],
+    );
+    for (const tool of TOOLS) {
+      assert.equal(tool.annotations.readOnlyHint, true);
+      assert.equal(tool.annotations.destructiveHint, false);
+      assert.equal(/comment|message|send|create|update|delete/.test(tool.name), false);
+    }
+  });
+
+  it('lists Skool tools through MCP', async () => {
+    const response = await handleRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+
+    assert.equal(response.id, 1);
+    assert.equal(response.result.tools.length, 3);
+  });
+
+  it('returns ranked ThumbGate acquisition signals through MCP', async () => {
+    const response = await handleRequest({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'skool_revenue_signals',
+        arguments: {
+          community: 'ai-automation-society',
+          limit: 5,
+        },
+      },
+    }, { fetch });
+
+    assert.equal(response.id, 2);
+    assert.equal(response.error, undefined);
+    const payload = JSON.parse(response.result.content[0].text);
+    assert.equal(payload.community.name, 'AI Automation Society');
+    assert.equal(payload.signals.length, 1);
+    assert.equal(payload.signals[0].id, 'post_support');
+    assert.match(payload.signals[0].suggestedAction, /ThumbGate/);
+  });
+
+  it('requires a URL for post detail reads', async () => {
+    const response = await handleRequest({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'skool_post_detail',
+        arguments: {},
+      },
+    }, { fetch });
+
+    assert.equal(response.error.code, -32603);
+    assert.match(response.error.message, /requires url/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dependency-free Skool SSR reader for public/headless community and post reads
- add a read-only stdio MCP server for Skool community reads, revenue signal ranking, and post details
- add a Codex skill that directs agents to use the headless Skool path instead of the user's browser
- cover parser, ranking, category resolution, MCP tools, and secret-redaction behavior in the existing social analytics test suite

## Verification
- node --test tests/social-analytics.test.js tests/test-suite-parity.test.js
- node --test tests/package-boundary.test.js tests/public-package-boundary.test.js
- node --check scripts/skool-reader.js && node --check adapters/skool/server-stdio.js
- python3 /Users/ganapolsky_i/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/skool-headless-reader
- git diff --check
- live smoke: node scripts/skool-reader.js --community ai-automation-society --category "Support Needed" --limit 3 --signals --format markdown
- MCP smoke: tools/list and skool_revenue_signals over stdio
