### PR TITLE
Enable Stripe checkout recovery

### DIFF
--- a/.changeset/stripe-checkout-recovery.md
+++ b/.changeset/stripe-checkout-recovery.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Enable Stripe Checkout recovery URLs and promotion-code entry for paid sessions so abandoned buyers can resume checkout.

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -412,9 +412,7 @@ function resolveCheckoutBrandUrls(appOrigin) {
   };
 }
 
-// Resolve the per-tier product image that ships to Stripe `product_data.images`.
-// Keeping three distinct URLs means the Stripe dashboard and checkout surface
-// never show twins for Free/Pro/Team; see tests/billing-tier-icons.test.js.
+// Resolve the per-tier product image used by Stripe Checkout.
 function resolveTierIconUrl(planId, appOrigin) {
   const brandUrls = resolveCheckoutBrandUrls(appOrigin);
   const normalized = typeof planId === 'string' ? planId.toLowerCase() : '';
@@ -2546,6 +2544,8 @@ function buildCheckoutSessionPayload({ successUrl, cancelUrl, customerEmail, che
     payment_method_types: ['card', 'link'],
     mode: pack ? 'payment' : 'subscription',
     line_items: lineItems,
+    allow_promotion_codes: true,
+    after_expiration: { recovery: { enabled: true, allow_promotion_codes: true } },
     branding_settings: buildCheckoutBrandingSettings(appOrigin),
     metadata: serializeStripeMetadata({
       ...checkoutMetadata,

--- a/tests/billing.test.js
+++ b/tests/billing.test.js
@@ -270,6 +270,13 @@ describe('billing.js — funnel ledger', () => {
     assert.equal(withEmail.customer_email, 'buyer@example.com');
     assert.equal(withoutEmail.mode, 'subscription');
     assert.equal(withoutEmail.payment_method_collection, 'always');
+    assert.equal(withoutEmail.allow_promotion_codes, true);
+    assert.deepEqual(withoutEmail.after_expiration, {
+      recovery: {
+        enabled: true,
+        allow_promotion_codes: true,
+      },
+    });
     assert.equal(Object.prototype.hasOwnProperty.call(withoutEmail, 'subscription_data'), false);
     assert.equal(withoutEmail.metadata.priceId, billing.CONFIG.STRIPE_PRICE_ID_PRO_MONTHLY);
     assert.equal(withoutEmail.line_items[0].price_data.unit_amount, 1900);


### PR DESCRIPTION
## Summary\n- enable Stripe Checkout recovery URLs for expired paid sessions\n- allow promotion code entry on initial and recovered Checkout Sessions\n- keep package boundary under the npm size guard\n\n## Evidence\n- Stripe documents `after_expiration.recovery.enabled` as generating a recovery URL when a Checkout Session expires before successful payment: https://docs.stripe.com/api/checkout/sessions/create\n\n## Tests\n- node --test tests/billing.test.js tests/package-boundary.test.js\n- npm run test:api\n- npm audit --audit-level=high\n- npm pack --dry-run --json --ignore-scripts\n