### PR TITLE
Add paid sprint Zernio campaign offer

### DIFF
--- a/.changeset/paid-sprint-zernio-offer.md
+++ b/.changeset/paid-sprint-zernio-offer.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a paid workflow-sprint Zernio campaign option for direct diagnostic and implementation-sprint revenue posts.

--- a/.github/workflows/thumbgate-creator-platform-promo.yml
+++ b/.github/workflows/thumbgate-creator-platform-promo.yml
@@ -24,6 +24,10 @@ on:
         description: 'IANA timezone for schedule mode'
         required: false
         default: 'America/New_York'
+      offer:
+        description: 'Campaign offer to publish'
+        required: false
+        default: 'operator-lab'
 
 permissions:
   contents: read
@@ -61,14 +65,14 @@ jobs:
         run: |
           npm run social:publish:launch -- \
             --dry-run \
-            --offer=operator-lab \
+            --offer="${{ github.event.inputs.offer }}" \
             --platforms="${{ github.event.inputs.platforms }}"
 
       - name: Publish campaign
         if: github.event.inputs.mode == 'publish'
         run: |
           npm run social:publish:launch -- \
-            --offer=operator-lab \
+            --offer="${{ github.event.inputs.offer }}" \
             --platforms="${{ github.event.inputs.platforms }}"
 
       - name: Schedule campaign
@@ -80,7 +84,7 @@ jobs:
           fi
 
           npm run social:publish:launch -- \
-            --offer=operator-lab \
+            --offer="${{ github.event.inputs.offer }}" \
             --platforms="${{ github.event.inputs.platforms }}" \
             --schedule="${{ github.event.inputs.schedule }}" \
             --timezone="${{ github.event.inputs.timezone }}"

--- a/scripts/social-analytics/publish-thumbgate-launch.js
+++ b/scripts/social-analytics/publish-thumbgate-launch.js
@@ -200,6 +200,15 @@ function buildOperatorLabUrl(platform, content) {
   });
 }
 
+function buildPaidSprintUrl(platform, content) {
+  return buildUTMLink(`${APP_ORIGIN}/pro`, {
+    source: platform,
+    medium: 'organic_social',
+    campaign: 'paid_workflow_sprint',
+    content,
+  });
+}
+
 function renderTrackedPost(spec, platform, urlBuilder) {
   if (spec.raw) return spec.raw;
   const lines = Array.isArray(spec.lines) ? spec.lines : [];
@@ -222,9 +231,63 @@ function buildOperatorLabPost(platform) {
   }, fallbackKey, buildOperatorLabUrl);
 }
 
+function buildPaidSprintPost(platform) {
+  const normalized = String(platform || '').trim().toLowerCase();
+  const key = normalized === 'x' ? 'twitter' : normalized;
+  const url = buildPaidSprintUrl(key || 'zernio', `paid_sprint_${key || 'generic'}`);
+  const compact = [
+    'I opened a paid ThumbGate workflow-hardening lane for teams running AI coding agents in real repos.',
+    '$499 diagnostic: map one repeated Claude Code/Codex/Cursor failure into prevention rules and a hardening plan.',
+    '$1500 sprint: implement the first guardrails and verify the same failure gets blocked.',
+    url,
+  ];
+
+  if (key === 'linkedin') {
+    return [
+      'I opened a paid ThumbGate workflow-hardening lane for teams running Claude Code, Codex, Cursor, Gemini, Amp, OpenCode, or MCP agents in real repos.',
+      '',
+      'The offer is intentionally narrow:',
+      '',
+      '- $499 diagnostic: one risky AI-agent workflow, failure-pattern review, prevention-rule map, and concrete hardening plan',
+      '- $1500 sprint: implement the first guardrails and prove the same failure gets blocked',
+      '',
+      'This is for teams seeing repeated agent mistakes: unsafe file edits, bad deploy steps, ignored repo rules, or risky tool calls that keep coming back across sessions.',
+      '',
+      url,
+    ].join('\n');
+  }
+
+  if (key === 'instagram') {
+    return [
+      'Stop repeated AI-agent mistakes.',
+      '',
+      '$499 diagnostic: map one risky workflow.',
+      '$1500 sprint: implement the first guardrails.',
+      '',
+      'For Claude Code, Codex, Cursor, Gemini, Amp, OpenCode, and MCP teams.',
+      '',
+      url,
+    ].join('\n');
+  }
+
+  if (key === 'bluesky') {
+    return [
+      'Paid ThumbGate workflow hardening is open.',
+      '$499 diagnostic. $1500 implementation sprint.',
+      'For repeated Claude/Codex/Cursor failures.',
+      'https://thumbgate.ai/pro',
+    ].join(' ');
+  }
+
+  return compact.join(' ');
+}
+
 function buildPlatformPost(platform, offer = 'launch') {
   if (offer === 'operator-lab') {
     return buildOperatorLabPost(platform);
+  }
+  if (offer === 'paid-sprint') {
+    return buildPaidSprintPost(platform);
   }
 
   const normalized = String(platform || '').trim().toLowerCase();
@@ -401,6 +464,8 @@ module.exports = {
   buildOperatorLabPost,
   buildOperatorLabUrl,
   buildPlatformPost,
+  buildPaidSprintPost,
+  buildPaidSprintUrl,
   defaultCampaignSchedule,
   parseArgs,
   publishLaunchCampaign,


### PR DESCRIPTION
## Summary
- add a `paid-sprint` offer path for the Zernio creator platform promo workflow
- add direct paid diagnostic/sprint copy for LinkedIn, Threads, Bluesky, and Instagram
- keep the workflow operator-lab default while allowing manual paid-offer dispatches

## Verification
- node --test tests/publish-thumbgate-launch.test.js tests/social-marketing-assets.test.js
- CHANGESET_BASE_REF=origin/main npm run changeset:check
- git diff --check
- pre-push guards passed

## Live dispatch proof
- Ran workflow 25392844143 from this branch with `offer=paid-sprint` and `platforms=linkedin,threads,bluesky,instagram`. Zernio published all four platforms successfully.