### PR TITLE
fix(gtm): make marketing autopilot publish paid post

### DIFF
--- a/.changeset/marketing-autopilot-post-file.md
+++ b/.changeset/marketing-autopilot-post-file.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix marketing autopilot text publishing by generating a paid-offer post file before invoking post-everywhere, limiting the text step to text/image-capable channels, and preserving campaign UTM attribution.

--- a/.github/workflows/marketing-autopilot.yml
+++ b/.github/workflows/marketing-autopilot.yml
@@ -1,7 +1,8 @@
 name: Marketing Autopilot
 
 # Text content autopilot — fires every 4 hours.
-# Posts to LinkedIn, Threads, Bluesky, Instagram, YouTube via Zernio.
+# Posts text/image content to LinkedIn, Threads, Bluesky, and Instagram.
+# YouTube remains video-only via the video autopilot.
 # Posts to Reddit via the configured OAuth publisher.
 # Posts Dev.to articles on a separate slower cadence.
 # Marketing DB dedup prevents double-posting within configured windows.
@@ -30,9 +31,9 @@ on:
         type: boolean
         default: false
       platforms:
-        description: 'Comma-separated Zernio platforms (default: linkedin,threads,bluesky,instagram,youtube)'
+        description: 'Comma-separated text-capable platforms (default: linkedin,threads,bluesky,instagram)'
         required: false
-        default: 'linkedin,threads,bluesky,instagram,youtube'
+        default: 'linkedin,threads,bluesky,instagram'
 
 permissions:
   contents: write
@@ -110,13 +111,13 @@ jobs:
             echo "PERPLEXITY_API_KEY not set — skipping AI content generation"
           fi
 
-      - name: Post text content via Zernio (LinkedIn, Threads, Bluesky, Instagram, YouTube)
+      - name: Post text content via Zernio (LinkedIn, Threads, Bluesky, Instagram)
         if: |
           github.event_name == 'schedule' ||
           github.event.inputs.action == 'text-posts' ||
           github.event.inputs.action == 'full'
         env:
-          INPUT_PLATFORMS: ${{ github.event.inputs.platforms || 'linkedin,threads,bluesky,instagram,youtube' }}
+          INPUT_PLATFORMS: ${{ github.event.inputs.platforms || 'linkedin,threads,bluesky,instagram' }}
           INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           PLATFORMS="$INPUT_PLATFORMS"
@@ -124,7 +125,24 @@ jobs:
           if [ "$INPUT_DRY_RUN" = "true" ]; then DRY_RUN_FLAG="--dry-run"; fi
           WEEK=$(date +%Y-W%V)
           HOUR=$(date +%H)
+          mkdir -p scripts/marketing-output
+          POST_FILE="scripts/marketing-output/autopilot-paid-sprint-$WEEK-h$HOUR.md"
+          cat > "$POST_FILE" <<'POST'
+          # LinkedIn Post: paid workflow hardening sprint
+          **Title:** Opening two workflow hardening sprint slots
+          **Body:**
+          I am opening two paid Workflow Hardening Sprint slots for teams running coding agents in production repos.
+
+          The scope is intentionally narrow: one repeated failure, one prevention rule, one proof run, and a rollout note your team can inspect.
+
+          Use the $499 diagnostic if you want the failure mapped first, or the $1500 sprint if the workflow is already known.
+
+          Diagnostic: https://buy.stripe.com/00w14neyUcXA5pL5e33sI0e
+          Sprint: https://buy.stripe.com/fZu9AT76saPsg4pbCr3sI0f
+          Scope: https://thumbgate.ai/#workflow-sprint-intake
+          POST
           node scripts/post-everywhere.js \
+            "$POST_FILE" \
             --platforms="$PLATFORMS" \
             --campaign="autopilot-text-$WEEK-h$HOUR" \
             $DRY_RUN_FLAG \

--- a/scripts/post-everywhere.js
+++ b/scripts/post-everywhere.js
@@ -187,7 +187,11 @@ async function postToLinkedIn(parsed, dryRun) {
   }
 
   const zernio = require('./social-analytics/publishers/zernio');
-  return zernio.publishToAllPlatforms(text, { platforms: ['linkedin'] });
+  return zernio.publishToAllPlatforms(text, {
+    platforms: ['linkedin'],
+    campaign: parsed.utmCampaign || 'organic',
+    medium: parsed.utmMedium || 'social',
+  });
 }
 
 async function postToDevTo(parsed, dryRun) {
@@ -262,7 +266,15 @@ async function postToInstagram(parsed, dryRun, deps = {}) {
 
   const postThumbGateToInstagram = deps.postThumbGateToInstagram
     || require('./social-analytics/instagram-thumbgate-post').postThumbGateToInstagram;
-  return postThumbGateToInstagram({ caption, imagePath });
+  return postThumbGateToInstagram({
+    caption,
+    imagePath,
+    utm: {
+      source: 'instagram',
+      medium: parsed.utmMedium || 'social',
+      campaign: parsed.utmCampaign || 'organic',
+    },
+  });
 }
 
 async function postToThreads(parsed, dryRun) {
@@ -275,7 +287,11 @@ async function postToThreads(parsed, dryRun) {
   }
 
   const zernio = require('./social-analytics/publishers/zernio');
-  return zernio.publishToAllPlatforms(text, { platforms: ['threads'] });
+  return zernio.publishToAllPlatforms(text, {
+    platforms: ['threads'],
+    campaign: parsed.utmCampaign || 'organic',
+    medium: parsed.utmMedium || 'social',
+  });
 }
 
 async function postToBluesky(parsed, dryRun) {
@@ -288,7 +304,11 @@ async function postToBluesky(parsed, dryRun) {
   }
 
   const zernio = getPublisher('bluesky');
-  return zernio.publishToAllPlatforms(text, { platforms: ['bluesky'] });
+  return zernio.publishToAllPlatforms(text, {
+    platforms: ['bluesky'],
+    campaign: parsed.utmCampaign || 'organic',
+    medium: parsed.utmMedium || 'social',
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -306,7 +326,7 @@ const DISPATCHERS = {
   bluesky: postToBluesky,
 };
 
-async function postEverywhere(filePath, { platforms, dryRun, deps = {} } = {}) {
+async function postEverywhere(filePath, { platforms, dryRun, campaign = 'organic', deps = {} } = {}) {
   const parsed = parsePostFile(filePath);
   console.log(`[post-everywhere] Parsed: platform=${parsed.platform}, subreddit=${parsed.subreddit}, title="${parsed.title}"`);
 
@@ -334,7 +354,9 @@ async function postEverywhere(filePath, { platforms, dryRun, deps = {} } = {}) {
   // Tag trackable URLs with per-platform UTM parameters before dispatching
   const results = {};
   for (const platform of targetPlatforms) {
-    const utmOpts = { source: platform, medium: 'social', campaign: 'organic' };
+    const utmOpts = { source: platform, medium: 'social', campaign };
+    parsed.utmCampaign = campaign;
+    parsed.utmMedium = 'social';
     parsed.body = originalBody ? tagUrlsInText(originalBody, utmOpts) : originalBody;
     parsed.comment = originalComment ? tagUrlsInText(originalComment, utmOpts) : originalComment;
 
@@ -402,6 +424,7 @@ if (require.main === module) {
 
   const platformsArg = getArg('--platforms');
   const platforms = platformsArg ? platformsArg.split(',').map((p) => p.trim()) : null;
+  const campaign = getArg('--campaign') || 'organic';
 
   if (!filePath) {
     console.error('Usage: node scripts/post-everywhere.js <post-file.md> [--dry-run] [--platforms=reddit,linkedin,threads,bluesky,instagram,youtube]');
@@ -430,7 +453,7 @@ if (require.main === module) {
     }
   }
 
-  postEverywhere(resolved, { platforms, dryRun })
+  postEverywhere(resolved, { platforms, dryRun, campaign })
     .then((results) => {
       console.log('\n[post-everywhere] Results:', JSON.stringify(results, null, 2));
       const failed = Object.values(results).filter((r) => r.error);

--- a/scripts/social-analytics/utm.js
+++ b/scripts/social-analytics/utm.js
@@ -62,6 +62,7 @@ function buildSocialLinks(baseUrl, campaign) {
  * Known trackable domains — URLs matching these will have UTM params injected.
  */
 const TRACKABLE_DOMAINS = [
+  'thumbgate.ai',
   'thumbgate-production.up.railway.app',
   'github.com/IgorGanapolsky/ThumbGate',
   'github.com/IgorGanapolsky/thumbgate',

--- a/tests/post-everywhere-channels.test.js
+++ b/tests/post-everywhere-channels.test.js
@@ -18,7 +18,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { DEFAULT_PLATFORMS, DISPATCHERS, parsePostFile } = require('../scripts/post-everywhere');
+const { DEFAULT_PLATFORMS, DISPATCHERS, parsePostFile, postEverywhere } = require('../scripts/post-everywhere');
 
 const FOCUS_CHANNELS = Object.freeze([
   'reddit',
@@ -193,28 +193,40 @@ function withZernioSpy(fn) {
 
 test('postToLinkedIn routes through zernio.publishToAllPlatforms with {platforms:["linkedin"]}', async () => {
   await withZernioSpy(async (calls) => {
-    await DISPATCHERS.linkedin({ body: 'Hello from LinkedIn.' }, false);
+    await DISPATCHERS.linkedin({ body: 'Hello from LinkedIn.', utmCampaign: 'unit-campaign' }, false);
     assert.equal(calls.length, 1, 'publishToAllPlatforms must be called exactly once');
     assert.equal(calls[0].content, 'Hello from LinkedIn.');
-    assert.deepEqual(calls[0].options, { platforms: ['linkedin'] });
+    assert.deepEqual(calls[0].options, {
+      platforms: ['linkedin'],
+      campaign: 'unit-campaign',
+      medium: 'social',
+    });
   });
 });
 
 test('postToThreads routes through zernio.publishToAllPlatforms with {platforms:["threads"]}', async () => {
   await withZernioSpy(async (calls) => {
-    await DISPATCHERS.threads({ title: 'T', body: 'Short threads body.' }, false);
+    await DISPATCHERS.threads({ title: 'T', body: 'Short threads body.', utmCampaign: 'unit-campaign' }, false);
     assert.equal(calls.length, 1);
     assert.ok(calls[0].content.includes('Short threads body.'));
-    assert.deepEqual(calls[0].options, { platforms: ['threads'] });
+    assert.deepEqual(calls[0].options, {
+      platforms: ['threads'],
+      campaign: 'unit-campaign',
+      medium: 'social',
+    });
   });
 });
 
 test('postToBluesky routes through zernio.publishToAllPlatforms with {platforms:["bluesky"]}', async () => {
   await withZernioSpy(async (calls) => {
-    await DISPATCHERS.bluesky({ title: 'B', body: 'Short bluesky body.' }, false);
+    await DISPATCHERS.bluesky({ title: 'B', body: 'Short bluesky body.', utmCampaign: 'unit-campaign' }, false);
     assert.equal(calls.length, 1);
     assert.ok(calls[0].content.includes('Short bluesky body.'));
-    assert.deepEqual(calls[0].options, { platforms: ['bluesky'] });
+    assert.deepEqual(calls[0].options, {
+      platforms: ['bluesky'],
+      campaign: 'unit-campaign',
+      medium: 'social',
+    });
   });
 });
 
@@ -263,17 +275,61 @@ test('threads publisher module exposes postTextThread, not publishPost', () => {
     'threads.publishPost must not exist — it was an invented name that broke silently');
 });
 
-test('marketing-autopilot workflow default platforms match focus channels', () => {
+test('postEverywhere applies the requested campaign to tracked URLs', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'post-everywhere-campaign-'));
+  const originalLinkedIn = DISPATCHERS.linkedin;
+  try {
+    const filePath = path.join(tmp, 'linkedin.md');
+    fs.writeFileSync(
+      filePath,
+      [
+        '# LinkedIn Post: campaign attribution',
+        '**Title:** Campaign attribution check',
+        '**Body:**',
+        'One repeated workflow failure is enough to justify a proof run.',
+        'https://thumbgate.ai/#workflow-sprint-intake',
+        '',
+      ].join('\n')
+    );
+
+    let capturedBody = '';
+    DISPATCHERS.linkedin = async (parsed) => {
+      capturedBody = parsed.body;
+      return { ok: true };
+    };
+
+    await postEverywhere(filePath, {
+      platforms: ['linkedin'],
+      dryRun: true,
+      campaign: 'autopilot-text-test',
+    });
+
+    assert.match(capturedBody, /utm_source=linkedin/);
+    assert.match(capturedBody, /utm_campaign=autopilot-text-test/);
+  } finally {
+    DISPATCHERS.linkedin = originalLinkedIn;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('marketing-autopilot workflow generates a post file before invoking post-everywhere', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'marketing-autopilot.yml'),
     'utf8'
   );
 
-  // The default platform list must contain all six focus channels.
-  for (const platform of FOCUS_CHANNELS) {
-    // Reddit goes through a dedicated OAuth step, so it doesn't need to be
-    // in the Zernio-side default list. The other five must be.
-    if (platform === 'reddit') continue;
+  assert.match(
+    workflow,
+    /POST_FILE="scripts\/marketing-output\/autopilot-paid-sprint-\$WEEK-h\$HOUR\.md"/,
+    'marketing-autopilot must create a concrete post file for post-everywhere'
+  );
+  assert.match(
+    workflow,
+    /node scripts\/post-everywhere\.js\s+\\\n\s+"\$POST_FILE"/,
+    'post-everywhere requires the post file as its first CLI argument'
+  );
+
+  for (const platform of ['linkedin', 'threads', 'bluesky', 'instagram']) {
     assert.match(
       workflow,
       new RegExp(`default:\\s*['"][^'"]*${platform}`),
@@ -281,7 +337,11 @@ test('marketing-autopilot workflow default platforms match focus channels', () =
     );
   }
 
-  // Must NOT default to twitter/X.
+  assert.doesNotMatch(
+    workflow,
+    /default:\s*['"][^'"]*youtube/,
+    'marketing-autopilot text step must not default to YouTube because YouTube posts require video content'
+  );
   assert.doesNotMatch(
     workflow,
     /default:\s*['"][^'"]*twitter/,

--- a/tests/post-everywhere-instagram.test.js
+++ b/tests/post-everywhere-instagram.test.js
@@ -130,11 +130,17 @@ describe('post-everywhere (Instagram dispatcher)', () => {
     const results = await postEverywhere(filePath, {
       platforms: ['instagram'],
       dryRun: false,
+      campaign: 'instagram-unit-campaign',
       deps: { instagram: deps },
     });
 
     assert.equal(deps.postCalls.length, 1, 'poster invoked exactly once');
     assert.equal(deps.postCalls[0].imagePath, imagePath, 'imagePath passed through unchanged');
+    assert.deepEqual(deps.postCalls[0].utm, {
+      source: 'instagram',
+      medium: 'social',
+      campaign: 'instagram-unit-campaign',
+    });
     assert.match(deps.postCalls[0].caption, /Live test/);
     assert.match(deps.postCalls[0].caption, /sufficiently long live/);
     assert.equal(deps.cardCalls.length, 0, 'no auto-generation when imagePath supplied');

--- a/tests/post-everywhere-zernio-default.test.js
+++ b/tests/post-everywhere-zernio-default.test.js
@@ -125,8 +125,16 @@ test('DISPATCHERS.linkedin and DISPATCHERS.threads route through zernio.publishT
     assert.equal(linkedinResult.via, 'zernio-stub');
     assert.equal(threadsResult.via, 'zernio-stub');
     assert.equal(calls.length, 2);
-    assert.deepEqual(calls[0].options, { platforms: ['linkedin'] });
-    assert.deepEqual(calls[1].options, { platforms: ['threads'] });
+    assert.deepEqual(calls[0].options, {
+      platforms: ['linkedin'],
+      campaign: 'organic',
+      medium: 'social',
+    });
+    assert.deepEqual(calls[1].options, {
+      platforms: ['threads'],
+      campaign: 'organic',
+      medium: 'social',
+    });
     assert.equal(calls[0].content, 'hello-linkedin');
     assert.ok(calls[1].content.includes('hello-threads'));
   } finally {


### PR DESCRIPTION
## Summary
- generate a concrete paid Workflow Hardening Sprint post file before calling post-everywhere
- limit marketing-autopilot text defaults to text/image-capable channels instead of YouTube text posts
- preserve the workflow campaign in UTM tagging and track thumbgate.ai URLs

## Tests
- node --test tests/post-everywhere-channels.test.js tests/post-everywhere-instagram.test.js tests/post-everywhere-zernio-default.test.js tests/utm.test.js
- CHANGESET_BASE_REF=origin/main npm run changeset:check
- git diff --check
- node scripts/post-everywhere.js <tmp-post> --platforms=linkedin,threads,bluesky --campaign=autopilot-text-local --dry-run

## Revenue guardrail
This fixes a silent no-op in marketing-autopilot. It does not claim new revenue was booked.