### PR TITLE
fix(gtm): preserve paid sprint attribution

### DIFF
--- a/.changeset/paid-sprint-attribution.md
+++ b/.changeset/paid-sprint-attribution.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Preserve paid sprint campaign attribution and route paid workflow-hardening social links through the public ThumbGate domain.

--- a/scripts/social-analytics/publish-thumbgate-launch.js
+++ b/scripts/social-analytics/publish-thumbgate-launch.js
@@ -18,6 +18,8 @@ const APP_ORIGIN = resolveHostedBillingConfig({
 const DEFAULT_TIMEZONE = 'America/New_York';
 const LAUNCH_CAMPAIGN = 'first_customer_push';
 const OPERATOR_LAB_CAMPAIGN = 'operator_lab_launch';
+const PAID_SPRINT_CAMPAIGN = 'paid_workflow_sprint';
+const PAID_SPRINT_ORIGIN = 'https://thumbgate.ai';
 const SKOOL_OPERATOR_LAB_URL = 'https://www.skool.com/thumbgate-operator-lab-6000';
 const DEFAULT_LAUNCH_PLATFORMS = ['twitter', 'linkedin', 'instagram'];
 
@@ -201,12 +203,22 @@ function buildOperatorLabUrl(platform, content) {
 }
 
 function buildPaidSprintUrl(platform, content) {
-  return buildUTMLink(`${APP_ORIGIN}/pro`, {
+  return buildUTMLink(`${PAID_SPRINT_ORIGIN}/pro`, {
     source: platform,
     medium: 'organic_social',
-    campaign: 'paid_workflow_sprint',
+    campaign: PAID_SPRINT_CAMPAIGN,
     content,
   });
+}
+
+function mediumForOffer(offer) {
+  return offer === 'operator-lab' ? 'community_course' : 'organic_social';
+}
+
+function campaignForOffer(offer) {
+  if (offer === 'operator-lab') return OPERATOR_LAB_CAMPAIGN;
+  if (offer === 'paid-sprint') return PAID_SPRINT_CAMPAIGN;
+  return LAUNCH_CAMPAIGN;
 }
 
 function renderTrackedPost(spec, platform, urlBuilder) {
@@ -402,8 +414,8 @@ async function publishLaunchCampaign(options = {}, publisher = {}) {
 
     const utm = {
       source: normalizedPlatform === 'twitter' ? 'x' : normalizedPlatform,
-      medium: offer === 'operator-lab' ? 'community_course' : 'organic_social',
-      campaign: offer === 'operator-lab' ? OPERATOR_LAB_CAMPAIGN : LAUNCH_CAMPAIGN,
+      medium: mediumForOffer(offer),
+      campaign: campaignForOffer(offer),
     };
 
     try {
@@ -458,6 +470,8 @@ module.exports = {
   DEFAULT_TIMEZONE,
   LAUNCH_CAMPAIGN,
   OPERATOR_LAB_CAMPAIGN,
+  PAID_SPRINT_CAMPAIGN,
+  PAID_SPRINT_ORIGIN,
   SKOOL_OPERATOR_LAB_URL,
   buildCampaignEntries,
   buildLandingUrl,

--- a/tests/publish-thumbgate-launch.test.js
+++ b/tests/publish-thumbgate-launch.test.js
@@ -7,6 +7,7 @@ const {
   DEFAULT_LAUNCH_PLATFORMS,
   LAUNCH_CAMPAIGN,
   OPERATOR_LAB_CAMPAIGN,
+  PAID_SPRINT_CAMPAIGN,
   buildPlatformPost,
   parseArgs,
   publishLaunchCampaign,
@@ -47,6 +48,16 @@ test('buildPlatformPost can create Skool operator lab copy', () => {
   assert.match(post, /utm_content=operator_lab_linkedin/);
   assert.ok(xPost.length <= 280, `X operator-lab post should fit 280 chars; got ${xPost.length}`);
   assert.match(xPost, /utm_content=operator_lab_twitter/);
+});
+
+test('buildPlatformPost can create paid sprint copy with paid sprint attribution', () => {
+  const post = buildPlatformPost('linkedin', 'paid-sprint');
+
+  assert.match(post, /\$499 diagnostic/);
+  assert.match(post, /\$1500 sprint/);
+  assert.match(post, /https:\/\/thumbgate\.ai\/pro/);
+  assert.match(post, /utm_campaign=paid_workflow_sprint/);
+  assert.match(post, /utm_content=paid_sprint_linkedin/);
 });
 
 test('publishLaunchCampaign previews default platforms in dry run mode', async () => {
@@ -102,6 +113,34 @@ test('publishLaunchCampaign uses operator lab UTM settings when requested', asyn
   assert.equal(calls[0].options.utm.medium, 'community_course');
   assert.equal(calls[0].options.utm.campaign, OPERATOR_LAB_CAMPAIGN);
   assert.match(calls[0].content, /skool\.com\/thumbgate-operator-lab-6000/);
+});
+
+test('publishLaunchCampaign uses paid sprint UTM settings when requested', async () => {
+  const calls = [];
+  const fakePublisher = {
+    getConnectedAccounts: async () => ([
+      { platform: 'linkedin', accountId: 'acc_l1' },
+    ]),
+    groupAccountsByPlatform(accounts) {
+      return new Map([['linkedin', accounts]]);
+    },
+    publishPost: async (content, platforms, options) => {
+      calls.push({ content, platforms, options });
+      return { id: 'linkedin_post_1' };
+    },
+  };
+
+  const result = await publishLaunchCampaign({
+    platforms: ['linkedin'],
+    offer: 'paid-sprint',
+  }, fakePublisher);
+
+  assert.equal(result.published.length, 1);
+  assert.equal(calls[0].options.utm.source, 'linkedin');
+  assert.equal(calls[0].options.utm.medium, 'organic_social');
+  assert.equal(calls[0].options.utm.campaign, PAID_SPRINT_CAMPAIGN);
+  assert.match(calls[0].content, /https:\/\/thumbgate\.ai\/pro/);
+  assert.match(calls[0].content, /utm_campaign=paid_workflow_sprint/);
 });
 
 test('publishLaunchCampaign publishes requested platforms with per-platform UTM settings', async () => {


### PR DESCRIPTION
## Summary
- keep paid-sprint Zernio publisher UTM campaign aligned to paid_workflow_sprint
- add tests for paid sprint post copy and publisher UTM options

## Tests
- node --test tests/publish-thumbgate-launch.test.js tests/post-everywhere-zernio-default.test.js tests/platform-limits.test.js
- CHANGESET_BASE_REF=origin/main npm run changeset:check