### PR TITLE
feat(gtm): add Zernio offer dispatch workflow

### DIFF
--- a/.changeset/zernio-offer-dispatch.md
+++ b/.changeset/zernio-offer-dispatch.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a guarded Zernio offer dispatch workflow with campaign tracking for manual paid-offer pushes.

--- a/.github/workflows/zernio-offer-dispatch.yml
+++ b/.github/workflows/zernio-offer-dispatch.yml
@@ -1,0 +1,107 @@
+name: Zernio Offer Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      text:
+        description: 'Offer post body. Include the paid CTA and intake link.'
+        required: true
+        type: string
+      platforms:
+        description: 'Comma-separated Zernio platforms to publish to.'
+        required: false
+        type: string
+        default: 'linkedin,threads,bluesky,instagram'
+      campaign:
+        description: 'UTM campaign slug.'
+        required: false
+        type: string
+        default: 'manual_offer_dispatch'
+      medium:
+        description: 'UTM medium.'
+        required: false
+        type: string
+        default: 'social'
+      dry_run:
+        description: 'Validate only; do not publish.'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zernio-offer-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
+      THUMBGATE_ANALYTICS_DB: .thumbgate/marketing-analytics.sqlite
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --onnxruntime-node-install-cuda=skip
+
+      - name: Validate offer copy
+        env:
+          OFFER_TEXT: ${{ github.event.inputs.text }}
+          OFFER_PLATFORMS: ${{ github.event.inputs.platforms }}
+        run: |
+          node - <<'NODE'
+          const { validateContentForPlatforms } = require('./scripts/social-analytics/platform-limits');
+          const qualityGate = require('./scripts/social-quality-gate');
+
+          const text = process.env.OFFER_TEXT || '';
+          const platforms = (process.env.OFFER_PLATFORMS || '')
+            .split(',')
+            .map((platform) => platform.trim())
+            .filter(Boolean)
+            .map((platform) => ({ platform, accountId: 'validation' }));
+
+          if (!text.trim()) {
+            throw new Error('Offer text is required.');
+          }
+          if (!/https:\/\/(thumbgate\.ai|buy\.stripe\.com)\//.test(text)) {
+            throw new Error('Offer text must include a ThumbGate or Stripe CTA.');
+          }
+          const gate = qualityGate.gatePost(text);
+          if (!gate.allowed) {
+            throw new Error(`Offer blocked by quality gate: ${gate.findings.map((f) => f.reason).join(', ')}`);
+          }
+          const limits = validateContentForPlatforms(text, platforms);
+          if (limits.valid.length === 0 && limits.rejected.length > 0) {
+            throw new Error(`Offer exceeds every requested platform limit: ${JSON.stringify(limits.rejected)}`);
+          }
+          for (const rejected of limits.rejected) {
+            console.log(`::warning::${rejected.platform} will be skipped: ${rejected.length}/${rejected.limit} chars`);
+          }
+          NODE
+
+      - name: Publish offer via Zernio
+        if: github.event.inputs.dry_run != 'true'
+        env:
+          OFFER_TEXT: ${{ github.event.inputs.text }}
+          OFFER_PLATFORMS: ${{ github.event.inputs.platforms }}
+          OFFER_CAMPAIGN: ${{ github.event.inputs.campaign }}
+          OFFER_MEDIUM: ${{ github.event.inputs.medium }}
+        run: |
+          node scripts/social-analytics/publishers/zernio.js \
+            --text="$OFFER_TEXT" \
+            --platforms="$OFFER_PLATFORMS" \
+            --campaign="$OFFER_CAMPAIGN" \
+            --medium="$OFFER_MEDIUM"

--- a/scripts/social-analytics/publishers/zernio.js
+++ b/scripts/social-analytics/publishers/zernio.js
@@ -613,9 +613,15 @@ if (require.main === module) {
   const text = getArg('--text');
   const schedule = getArg('--schedule');
   const timezone = getArg('--timezone') || 'UTC';
+  const platformsArg = getArg('--platforms');
+  const campaign = getArg('--campaign') || ZERNIO_UTM.campaign;
+  const medium = getArg('--medium') || ZERNIO_UTM.medium;
+  const requestedPlatforms = platformsArg
+    ? platformsArg.split(',').map((platform) => platform.trim()).filter(Boolean)
+    : [];
 
   if (!text) {
-    console.error('Usage: node zernio.js --text="..." [--schedule="2026-04-01T10:00:00Z" --timezone="America/New_York"]');
+    console.error('Usage: node zernio.js --text="..." [--platforms="linkedin,threads"] [--campaign="spring_offer"] [--medium="social"] [--schedule="2026-04-01T10:00:00Z" --timezone="America/New_York"]');
     process.exit(1);
   }
 
@@ -623,12 +629,24 @@ if (require.main === module) {
     try {
       if (schedule) {
         const accounts = await getConnectedAccounts();
-        const platforms = accounts.map((a) => ({ platform: a.platform, accountId: a.accountId }));
-        const result = await schedulePost(text, platforms, schedule, timezone);
+        const platformFilter = requestedPlatforms.length > 0 ? new Set(requestedPlatforms) : null;
+        const platforms = accounts
+          .filter((account) => !platformFilter || platformFilter.has(account.platform))
+          .map((a) => ({ platform: a.platform, accountId: a.accountId }));
+        const result = await schedulePost(text, platforms, schedule, timezone, {
+          utm: { source: 'zernio', medium, campaign },
+        });
         console.log(`[zernio:publisher] Scheduled. id=${result.id ?? 'unknown'}`);
       } else {
-        const result = await publishToAllPlatforms(text);
+        const result = await publishToAllPlatforms(text, {
+          campaign,
+          medium,
+          platforms: requestedPlatforms,
+        });
         console.log(`[zernio:publisher] Done. published=${result.published.length} errors=${result.errors.length}`);
+        if (result.errors.length > 0) {
+          process.exit(1);
+        }
       }
     } catch (err) {
       console.error('[zernio:publisher] Failed:', err.message);

--- a/scripts/social-analytics/utm.js
+++ b/scripts/social-analytics/utm.js
@@ -62,6 +62,7 @@ function buildSocialLinks(baseUrl, campaign) {
  * Known trackable domains — URLs matching these will have UTM params injected.
  */
 const TRACKABLE_DOMAINS = [
+  'thumbgate.ai',
   'thumbgate-production.up.railway.app',
   'github.com/IgorGanapolsky/ThumbGate',
   'github.com/IgorGanapolsky/thumbgate',

--- a/tests/utm.test.js
+++ b/tests/utm.test.js
@@ -1,6 +1,15 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { buildUTMLink } = require('../scripts/social-analytics/utm');
+const { buildUTMLink, tagUrlsInText } = require('../scripts/social-analytics/utm');
 test('adds utm params', () => { const r = buildUTMLink('https://x.com', { source: 'twitter', campaign: 'launch' }); assert.ok(r.includes('utm_source=twitter')); });
 test('requires source', () => { assert.throws(() => buildUTMLink('https://x.com', {}), /source/i); });
 test('instagram source', () => { assert.ok(buildUTMLink('https://x.com', { source: 'instagram', campaign: 'x' }).includes('instagram')); });
+test('tags thumbgate.ai revenue links', () => {
+  const tagged = tagUrlsInText('Buy at https://thumbgate.ai/#workflow-sprint-intake', {
+    source: 'linkedin',
+    medium: 'social',
+    campaign: 'voice_agent_reliability_diagnostic',
+  });
+  assert.match(tagged, /utm_source=linkedin/);
+  assert.match(tagged, /utm_campaign=voice_agent_reliability_diagnostic/);
+});

--- a/tests/zernio-integration.test.js
+++ b/tests/zernio-integration.test.js
@@ -292,6 +292,60 @@ describe('zernio publisher', () => {
     assert.match(publishedBodies[1].content, /utm_source=instagram/);
   });
 
+  it('publishToAllPlatforms honors requested platforms and campaign attribution', async () => {
+    const publishedBodies = [];
+
+    global.fetch = async (url, options) => {
+      if (url.includes('/accounts')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [
+              { platform: 'linkedin', accountId: 'acc_l1', name: 'LinkedIn' },
+              { platform: 'threads', accountId: 'acc_t1', name: 'Threads' },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/posts')) {
+        publishedBodies.push(JSON.parse(options.body));
+        return {
+          ok: true,
+          json: async () => ({ data: { id: 'offer_post_123', status: 'published' } }),
+        };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+
+    const result = await publishToAllPlatforms(
+      'Voice agent reliability diagnostic is open now at https://thumbgate.ai/#workflow-sprint-intake',
+      {
+        campaign: 'voice_agent_reliability_diagnostic',
+        medium: 'social',
+        platforms: ['linkedin'],
+      }
+    );
+
+    assert.equal(result.published.length, 1);
+    assert.equal(result.published[0].platform, 'linkedin');
+    assert.equal(publishedBodies.length, 1);
+    assert.deepEqual(publishedBodies[0].platforms, [{ platform: 'linkedin', accountId: 'acc_l1' }]);
+    assert.match(publishedBodies[0].content, /utm_source=linkedin/);
+    assert.match(publishedBodies[0].content, /utm_campaign=voice_agent_reliability_diagnostic/);
+  });
+
+  it('Zernio offer dispatch workflow validates CTA and passes campaign inputs to CLI', () => {
+    const workflowPath = path.join(__dirname, '..', '.github', 'workflows', 'zernio-offer-dispatch.yml');
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+    assert.match(workflow, /workflow_dispatch:/);
+    assert.match(workflow, /ZERNIO_API_KEY: \$\{\{ secrets\.ZERNIO_API_KEY \}\}/);
+    assert.match(workflow, /thumbgate\\\.ai\|buy\\\.stripe\\\.com/);
+    assert.match(workflow, /--platforms="\$OFFER_PLATFORMS"/);
+    assert.match(workflow, /--campaign="\$OFFER_CAMPAIGN"/);
+    assert.match(workflow, /--medium="\$OFFER_MEDIUM"/);
+  });
+
   it('schedulePost includes scheduledFor and timezone in body', async () => {
     let capturedBody;
 


### PR DESCRIPTION
## Summary
- add a manual Zernio offer dispatch workflow for paid CTA posts
- let the Zernio publisher CLI accept platform, campaign, and medium inputs
- include thumbgate.ai in UTM tagging and cover campaign/platform behavior in tests

## Verification
- node --test tests/utm.test.js tests/zernio-integration.test.js
- CHANGESET_BASE_REF=origin/main npm run changeset:check
- git diff --check
- pre-push guards passed

## Revenue note
This gives us a reusable multi-platform path for fresh paid offers using the known-good Zernio secret channel. The LinkedIn-only dispatch path is currently blocked by a revoked LinkedIn token.