### PR TITLE
fix(marketing): warn on revoked LinkedIn token

### DIFF
--- a/.changeset/linkedin-auth-soft-fail.md
+++ b/.changeset/linkedin-auth-soft-fail.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Warn instead of failing the LinkedIn post-dispatch workflow when LinkedIn credentials are missing or revoked.

--- a/.github/workflows/linkedin-post-dispatch.yml
+++ b/.github/workflows/linkedin-post-dispatch.yml
@@ -43,6 +43,7 @@ jobs:
     env:
       LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
       LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
+      LINKEDIN_AUTH_FAILURE_MODE: warn
 
     steps:
       - name: Checkout

--- a/scripts/social-analytics/publishers/linkedin.js
+++ b/scripts/social-analytics/publishers/linkedin.js
@@ -13,6 +13,36 @@
  */
 
 const LI_REST_BASE = 'https://api.linkedin.com/rest';
+const AUTH_FAILURE_MODE_ENV = 'LINKEDIN_AUTH_FAILURE_MODE';
+
+function normalizeAuthFailureMode(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function isRecoverableLinkedInCredentialError(error) {
+  const message = String(error && error.message ? error.message : error || '');
+  return /HTTP\s+(401|403)\b/.test(message)
+    || /REVOKED_ACCESS_TOKEN/i.test(message)
+    || /LINKEDIN_ACCESS_TOKEN is not set/i.test(message)
+    || /LINKEDIN_PERSON_URN is not set/i.test(message);
+}
+
+function shouldWarnOnCredentialError(error, env = process.env) {
+  return normalizeAuthFailureMode(env[AUTH_FAILURE_MODE_ENV]) === 'warn'
+    && isRecoverableLinkedInCredentialError(error);
+}
+
+function warnAndSkipCredentialError(error) {
+  const message = String(error && error.message ? error.message : error || '');
+  const status = /HTTP\s+(401|403)\b/.exec(message)?.[1];
+  const summary = status
+    ? `LinkedIn credential rejected with HTTP ${status}; refresh LINKEDIN_ACCESS_TOKEN.`
+    : 'LinkedIn credentials are missing or unusable; refresh LINKEDIN_ACCESS_TOKEN and LINKEDIN_PERSON_URN.';
+  console.warn(`[linkedin:publisher] Skipped: ${summary}`);
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    console.warn(`::warning::LinkedIn publish skipped. ${summary}`);
+  }
+}
 
 /**
  * Build standard headers for the LinkedIn Posts API.
@@ -240,7 +270,13 @@ async function publishArticlePost(token, personUrn, text, articleUrl, title) {
   return postUrn;
 }
 
-module.exports = { publishTextPost, publishImagePost, publishArticlePost };
+module.exports = {
+  isRecoverableLinkedInCredentialError,
+  publishTextPost,
+  publishImagePost,
+  publishArticlePost,
+  shouldWarnOnCredentialError,
+};
 
 // ---------------------------------------------------------------------------
 // Stand-alone execution
@@ -269,11 +305,21 @@ if (require.main === module) {
   const personUrn = process.env.LINKEDIN_PERSON_URN;
 
   if (!token) {
-    console.error('LINKEDIN_ACCESS_TOKEN is not set');
+    const err = new Error('LINKEDIN_ACCESS_TOKEN is not set');
+    if (shouldWarnOnCredentialError(err)) {
+      warnAndSkipCredentialError(err);
+      process.exit(0);
+    }
+    console.error(err.message);
     process.exit(1);
   }
   if (!personUrn) {
-    console.error('LINKEDIN_PERSON_URN is not set');
+    const err = new Error('LINKEDIN_PERSON_URN is not set');
+    if (shouldWarnOnCredentialError(err)) {
+      warnAndSkipCredentialError(err);
+      process.exit(0);
+    }
+    console.error(err.message);
     process.exit(1);
   }
 
@@ -287,6 +333,10 @@ if (require.main === module) {
       }
       console.log(`[linkedin:publisher] Done. Post URN: ${postUrn}`);
     } catch (err) {
+      if (shouldWarnOnCredentialError(err)) {
+        warnAndSkipCredentialError(err);
+        process.exit(0);
+      }
       console.error('[linkedin:publisher] Failed:', err.message);
       process.exit(1);
     }

--- a/tests/post-everywhere-channels.test.js
+++ b/tests/post-everywhere-channels.test.js
@@ -265,6 +265,29 @@ test('linkedin publisher module does not export a {text}-options-bag publishPost
     'publishTextPost(token, personUrn, text) is the canonical direct-API entry');
 });
 
+test('linkedin publisher can soft-fail revoked or missing credentials only when configured', () => {
+  const linkedin = require('../scripts/social-analytics/publishers/linkedin');
+  const revoked = new Error('publishArticlePost HTTP 401: {"code":"REVOKED_ACCESS_TOKEN"}');
+  const badPayload = new Error('publishArticlePost HTTP 422: invalid article URL');
+
+  assert.equal(linkedin.isRecoverableLinkedInCredentialError(revoked), true);
+  assert.equal(linkedin.isRecoverableLinkedInCredentialError(new Error('LINKEDIN_ACCESS_TOKEN is not set')), true);
+  assert.equal(linkedin.isRecoverableLinkedInCredentialError(badPayload), false);
+  assert.equal(linkedin.shouldWarnOnCredentialError(revoked, { LINKEDIN_AUTH_FAILURE_MODE: 'warn' }), true);
+  assert.equal(linkedin.shouldWarnOnCredentialError(revoked, {}), false);
+  assert.equal(linkedin.shouldWarnOnCredentialError(badPayload, { LINKEDIN_AUTH_FAILURE_MODE: 'warn' }), false);
+});
+
+test('linkedin dispatch workflow warns on auth failure without hiding content bugs', () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, '..', '.github', 'workflows', 'linkedin-post-dispatch.yml'),
+    'utf8'
+  );
+
+  assert.match(workflow, /LINKEDIN_AUTH_FAILURE_MODE:\s*warn/);
+  assert.doesNotMatch(workflow, /continue-on-error:\s*true/);
+});
+
 test('threads publisher module exposes postTextThread, not publishPost', () => {
   // Regression guard for the 2026-04-22 discovery: threads.publishPost({text})
   // was called but does not exist. The real entry is postTextThread({text, token, userId}).


### PR DESCRIPTION
## Summary
- soft-fail LinkedIn post-dispatch auth failures only when `LINKEDIN_AUTH_FAILURE_MODE=warn`
- keep payload/API errors failing so content bugs stay visible
- add regression coverage for revoked-token detection and workflow configuration

## Verification
- `node --test tests/post-everywhere-channels.test.js`
- `CHANGESET_BASE_REF=origin/main npm run changeset:check`
- `git diff --check origin/main...HEAD`
- strict CLI smoke: missing `LINKEDIN_ACCESS_TOKEN` exits 1
- warn-mode CLI smoke: missing credentials exits 0 with GitHub Actions warning

Main failure addressed: LinkedIn Post Dispatch run 25394755096 failed on `REVOKED_ACCESS_TOKEN`.