### PR TITLE
fix(checkout): send buyer CTAs directly to Stripe

### DIFF
--- a/.changeset/direct-confirmed-pro-checkout.md
+++ b/.changeset/direct-confirmed-pro-checkout.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Send hydrated Pro buyer CTAs directly to confirmed Stripe checkout while preserving attribution and bot-safe fallback routes.

--- a/public/js/buyer-intent.js
+++ b/public/js/buyer-intent.js
@@ -1,6 +1,6 @@
 (function(global) {
   var BUYER_EMAIL_STORAGE_KEY = 'thumbgateBuyerEmail';
-  var CHECKOUT_LINK_SELECTOR = 'a[href*="/checkout/pro"]';
+  var CHECKOUT_LINK_SELECTOR = 'a[href*="/checkout/pro"], a[href*="/go/pro"]';
   var BUYER_EMAIL_SELECTOR = '[data-buyer-email]';
 
   function normalizeBuyerEmail(value) {
@@ -47,9 +47,13 @@
       ? global.location.origin
       : 'https://thumbgate.invalid';
     var checkoutUrl = new URL(String(urlValue || '/checkout/pro'), origin);
-    if (checkoutUrl.origin !== origin || checkoutUrl.pathname !== '/checkout/pro') {
+    var isHostedProRoute = checkoutUrl.origin === origin
+      && (checkoutUrl.pathname === '/checkout/pro' || checkoutUrl.pathname === '/go/pro');
+    if (!isHostedProRoute) {
       checkoutUrl = new URL('/checkout/pro', origin);
     }
+    checkoutUrl.pathname = '/checkout/pro';
+    checkoutUrl.searchParams.set('confirm', '1');
     if (isValidBuyerEmail(email)) {
       checkoutUrl.searchParams.set('customer_email', normalizeBuyerEmail(email));
     } else {

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -113,6 +113,7 @@ test('pro landing page captures buyer email and reuses it for checkout', () => {
   assert.match(proPage, /data-buyer-email/);
   assert.match(proPage, /\/js\/buyer-intent\.js/);
   assert.match(buyerIntentScript, /customer_email/);
+  assert.match(buyerIntentScript, /searchParams\.set\('confirm', '1'\)/);
   assert.match(buyerIntentScript, /initializeEmailCheckoutButtons/);
   assert.match(buyerIntentScript, /initializeBehaviorAnalytics/);
   assert.match(proPage, /sendFirstPartyTelemetry/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -657,6 +657,8 @@ test('public landing page includes pay-now Pro path and email capture gate', () 
   assert.match(landingPage, /handleProTrial/);
   assert.match(landingPage, /\/js\/buyer-intent\.js/);
   assert.match(buyerIntentScript, /customer_email/);
+  assert.match(buyerIntentScript, /\/go\/pro/);
+  assert.match(buyerIntentScript, /searchParams\.set\('confirm', '1'\)/);
   assert.match(buyerIntentScript, /submitNewsletterSignup/);
   assert.match(buyerIntentScript, /initializeBehaviorAnalytics/);
   assert.match(buyerIntentScript, /buyer_email_abandon/);


### PR DESCRIPTION
## Summary
- Hydrates JS-enabled Pro checkout CTAs to include confirm=1 so buyers skip the extra interstitial click.
- Normalizes /go/pro CTAs to /checkout/pro while preserving attribution and buyer email params.
- Keeps server bot/crawler guard tests in place for unconfirmed requests.

## Revenue rationale
Today's hosted metrics showed checkout intent without paid conversion: 55 checkout starts, 6 checkout-intent views, 0 clicks, 0 Stripe confirms, and 0 booked revenue. Live ?confirm=1 already reaches Stripe Checkout, so this removes friction for high-intent buyers while leaving crawler-safe routes protected.

## Tests
- node --test tests/pro-landing.test.js tests/public-landing.test.js tests/checkout-bot-guard.test.js