### PR TITLE
fix(gtm): remove archived paid diagnostic CTA

### DIFF
--- a/.changeset/remove-archived-diagnostic-cta.md
+++ b/.changeset/remove-archived-diagnostic-cta.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Remove the archived $99 hero diagnostic CTA and focus the paid homepage path on the current $499 diagnostic and $1500 workflow sprint offers.

--- a/public/index.html
+++ b/public/index.html
@@ -723,10 +723,9 @@ __GA_BOOTSTRAP__
     <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
       <div>
         <strong>Need buyer-ready proof today?</strong>
-        <span>Send one messy AI-agent workflow. We turn it into clear rules, examples, and pre-action checks, plus AI Agent Governance Sprint approval boundaries and rollback safety before it touches developer-machine risk surfaces.</span>
+        <span>One clear paid path: send a messy AI-agent workflow and get a $499 hardening diagnostic with failure map, clear rules, examples, and pre-action checks. Use the $1500 sprint only when you want implementation help.</span>
       </div>
       <div class="hero-paid-actions">
-        <a class="starter" href="https://buy.stripe.com/7sY4gzgH24r49G17mb3sI0g" onclick="sendFirstPartyTelemetry('founder_workflow_diagnostic_checkout_started',{ctaId:'hero_founder_workflow_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'founder_workflow_diagnostic',price:99});sendGa4Event('begin_checkout',{currency:'USD',value:99,items:[{item_id:'founder_workflow_diagnostic',item_name:'Founder Workflow Diagnostic'}]});">Pay $99 diagnostic &rarr;</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>
         <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars,items:[{item_id:'workflow_hardening_sprint',item_name:'Workflow Hardening Sprint'}]});">Pay $1500 sprint &rarr;</a>
         <a class="intake" href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'hero_workflow_sprint_recovery_intake',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',reason:'not_ready_to_pay'});sendGa4Event('generate_lead',{currency:'USD',value:0,method:'workflow_sprint_recovery_intake'});">Send workflow first &rarr;</a>
@@ -2011,6 +2010,9 @@ function copyInstall(el) {
       { selector: '#pro-checkout-link', ctaId: 'pricing_pro_trial', ctaPlacement: 'pricing', planId: 'pro' },
       { selector: '.price-card.pro .btn-pro', ctaId: 'pricing_pro_monthly', ctaPlacement: 'pricing', planId: 'pro' },
       { selector: '.hero-actions .btn-pro-page', ctaId: 'hero_go_pro', ctaPlacement: 'hero', planId: 'pro' },
+      { selector: '.hero-paid-actions .diagnostic', ctaId: 'hero_workflow_sprint_diagnostic_checkout', ctaPlacement: 'hero_paid_path', planId: 'team' },
+      { selector: '.hero-paid-actions .sprint', ctaId: 'hero_workflow_sprint_checkout', ctaPlacement: 'hero_paid_path', planId: 'team' },
+      { selector: '.hero-paid-actions .intake', ctaId: 'hero_workflow_sprint_recovery_intake', ctaPlacement: 'hero_paid_path', planId: 'team' },
       { selector: '.sticky-cta .btn-pro', ctaId: 'sticky_go_pro', ctaPlacement: 'sticky_cta', planId: 'pro' },
       { selector: '.price-card.team .btn-team', ctaId: 'team_workflow_sprint', ctaPlacement: 'pricing', planId: 'team' },
       { selector: '#team-pilot-intake-form', ctaId: 'workflow_sprint_intake', ctaPlacement: 'team_visible_intake', planId: 'team' }

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -112,9 +112,9 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.match(landingPage, /Need buyer-ready proof today\?/);
   assert.match(landingPage, /href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__"/);
   assert.match(landingPage, /href="__WORKFLOW_SPRINT_CHECKOUT_URL__"/);
-  assert.match(landingPage, /founder_workflow_diagnostic_checkout_started/);
-  assert.match(landingPage, /Pay \$99 diagnostic/);
-  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/7sY4gzgH24r49G17mb3sI0g/);
+  assert.doesNotMatch(landingPage, /founder_workflow_diagnostic_checkout_started/);
+  assert.doesNotMatch(landingPage, /Pay \$99 diagnostic/);
+  assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/7sY4gzgH24r49G17mb3sI0g/);
   assert.match(landingPage, /Pay \$499 diagnostic/);
   assert.match(landingPage, /Pay \$1500 sprint/);
   assert.match(landingPage, /Send workflow first/);
@@ -127,6 +127,9 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.match(landingPage, /workflow_sprint_checkout_started/);
   assert.match(landingPage, /workflow_sprint_recovery_intake_clicked/);
   assert.match(landingPage, /workflow_sprint_recovery_intake/);
+  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_diagnostic_checkout'/);
+  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_checkout'/);
+  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_recovery_intake'/);
 });
 
 test('public landing page includes Plausible analytics and search engine proof bar', () => {


### PR DESCRIPTION
## Summary
- remove the archived $99 hero diagnostic CTA from the homepage paid path
- focus the paid hero path on the current $499 diagnostic and $1500 workflow sprint offers
- add hero paid CTA impression tracking for diagnostic, sprint, and intake actions

## Verification
- node --test tests/public-landing.test.js
- pre-commit guards passed
- pre-push guards passed