### PR TITLE
feat(gtm): expose quick-read checkout on owned homepage

### DIFF
--- a/.changeset/owned-quick-read-checkout.md
+++ b/.changeset/owned-quick-read-checkout.md
@@ -2,4 +2,4 @@
 "thumbgate": patch
 ---
 
-Add the $19 AI Agent Failure Quick Read checkout to the owned homepage and Pro paid recovery paths.
+Add the $19 AI Agent Failure Quick Read checkout to the owned homepage paid path.

--- a/.changeset/owned-quick-read-checkout.md
+++ b/.changeset/owned-quick-read-checkout.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add the $19 AI Agent Failure Quick Read checkout to the owned homepage and Pro paid recovery paths.

--- a/public/index.html
+++ b/public/index.html
@@ -723,10 +723,10 @@ __GA_BOOTSTRAP__
     <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
       <div>
         <strong>Need buyer-ready proof today?</strong>
-        <span>Start with a $19 async quick read for one failure symptom or log. Upgrade to the $499 hardening diagnostic when the workflow needs a full failure map, clear rules, examples, and pre-action checks.</span>
+        <span>Start with the $19 AI Agent Failure Quick Read; use $499 for clear rules, examples, and pre-action checks.</span>
       </div>
       <div class="hero-paid-actions">
-        <a class="starter" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout',ctaPlacement:'hero_paid_path',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read &rarr;</a>
+        <a class="starter" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout'});">Pay $19 quick read &rarr;</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>
         <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars,items:[{item_id:'workflow_hardening_sprint',item_name:'Workflow Hardening Sprint'}]});">Pay $1500 sprint &rarr;</a>
         <a class="intake" href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'hero_workflow_sprint_recovery_intake',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',reason:'not_ready_to_pay'});sendGa4Event('generate_lead',{currency:'USD',value:0,method:'workflow_sprint_recovery_intake'});">Send workflow first &rarr;</a>
@@ -1553,16 +1553,6 @@ __GA_BOOTSTRAP__
         <span class="team-intake-badge">30-minute intake</span>
       </div>
       <div class="team-paid-path" data-sprint-paid-path aria-label="Paid workflow hardening options">
-        <div class="team-paid-card">
-          <div>
-            <h4>AI Agent Failure Quick Read</h4>
-            <p>Async read for one failure symptom or log: likely root cause, one prevention-rule idea, and the next check to run.</p>
-          </div>
-          <div>
-            <div class="team-paid-price">$19</div>
-            <a class="team-paid-link" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'workflow_sprint_quick_read_checkout',ctaPlacement:'team_paid_path',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay for quick read</a>
-          </div>
-        </div>
         <div class="team-paid-card">
           <div>
             <h4>Workflow Hardening Diagnostic</h4>

--- a/public/index.html
+++ b/public/index.html
@@ -723,9 +723,10 @@ __GA_BOOTSTRAP__
     <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
       <div>
         <strong>Need buyer-ready proof today?</strong>
-        <span>One clear paid path: send a messy AI-agent workflow and get a $499 hardening diagnostic with failure map, clear rules, examples, and pre-action checks. Use the $1500 sprint only when you want implementation help.</span>
+        <span>Start with a $19 async quick read for one failure symptom or log. Upgrade to the $499 hardening diagnostic when the workflow needs a full failure map, clear rules, examples, and pre-action checks.</span>
       </div>
       <div class="hero-paid-actions">
+        <a class="starter" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout',ctaPlacement:'hero_paid_path',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read &rarr;</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>
         <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars,items:[{item_id:'workflow_hardening_sprint',item_name:'Workflow Hardening Sprint'}]});">Pay $1500 sprint &rarr;</a>
         <a class="intake" href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'hero_workflow_sprint_recovery_intake',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',reason:'not_ready_to_pay'});sendGa4Event('generate_lead',{currency:'USD',value:0,method:'workflow_sprint_recovery_intake'});">Send workflow first &rarr;</a>
@@ -1552,6 +1553,16 @@ __GA_BOOTSTRAP__
         <span class="team-intake-badge">30-minute intake</span>
       </div>
       <div class="team-paid-path" data-sprint-paid-path aria-label="Paid workflow hardening options">
+        <div class="team-paid-card">
+          <div>
+            <h4>AI Agent Failure Quick Read</h4>
+            <p>Async read for one failure symptom or log: likely root cause, one prevention-rule idea, and the next check to run.</p>
+          </div>
+          <div>
+            <div class="team-paid-price">$19</div>
+            <a class="team-paid-link" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'workflow_sprint_quick_read_checkout',ctaPlacement:'team_paid_path',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay for quick read</a>
+          </div>
+        </div>
         <div class="team-paid-card">
           <div>
             <h4>Workflow Hardening Diagnostic</h4>

--- a/public/pro.html
+++ b/public/pro.html
@@ -777,8 +777,9 @@ __GA_BOOTSTRAP__
       <div class="aside-card" data-pro-paid-recovery>
         <div class="aside-kicker">Team workflow blocked?</div>
         <h3>Buy the paid diagnostic</h3>
-        <p>Skip self-serve Pro and pay for workflow hardening now.</p>
+        <p>Skip self-serve Pro and pay for the smallest useful review now.</p>
         <div class="price-stack">
+          <a class="btn-secondary" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_quick_read_checkout',ctaPlacement:'pro_paid_recovery',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read</a>
           <a class="btn-primary" data-sprint-diagnostic-link href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'pro_page_sprint_diagnostic_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__});">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
           <a class="btn-secondary" data-workflow-sprint-link href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'pro_page_workflow_sprint_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__WORKFLOW_SPRINT_PRICE_DOLLARS__});">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
         </div>
@@ -1081,6 +1082,7 @@ globalThis.buyerJourney = globalThis.ThumbGateBuyerIntent.initializeBehaviorAnal
   ],
   ctaImpressions: [
     { selector: '.btn-pro-checkout', ctaId: 'pro_checkout', ctaPlacement: 'pro_page', planId: 'pro' },
+    { selector: '[data-quick-read-link]', ctaId: 'pro_page_quick_read_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'quick_read' },
     { selector: '[data-sprint-diagnostic-link]', ctaId: 'pro_page_sprint_diagnostic_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'sprint_diagnostic' },
     { selector: '[data-workflow-sprint-link]', ctaId: 'pro_page_workflow_sprint_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'workflow_sprint' },
     { selector: '.btn-demo', ctaId: 'pro_demo', ctaPlacement: 'pro_page', planId: 'proof' },

--- a/public/pro.html
+++ b/public/pro.html
@@ -777,9 +777,8 @@ __GA_BOOTSTRAP__
       <div class="aside-card" data-pro-paid-recovery>
         <div class="aside-kicker">Team workflow blocked?</div>
         <h3>Buy the paid diagnostic</h3>
-        <p>Skip self-serve Pro and pay for the smallest useful review now.</p>
+        <p>Skip self-serve Pro and pay for workflow hardening now.</p>
         <div class="price-stack">
-          <a class="btn-secondary" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_quick_read_checkout',ctaPlacement:'pro_paid_recovery',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read</a>
           <a class="btn-primary" data-sprint-diagnostic-link href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'pro_page_sprint_diagnostic_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__});">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
           <a class="btn-secondary" data-workflow-sprint-link href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'pro_page_workflow_sprint_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__WORKFLOW_SPRINT_PRICE_DOLLARS__});">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
         </div>
@@ -1082,7 +1081,6 @@ globalThis.buyerJourney = globalThis.ThumbGateBuyerIntent.initializeBehaviorAnal
   ],
   ctaImpressions: [
     { selector: '.btn-pro-checkout', ctaId: 'pro_checkout', ctaPlacement: 'pro_page', planId: 'pro' },
-    { selector: '[data-quick-read-link]', ctaId: 'pro_page_quick_read_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'quick_read' },
     { selector: '[data-sprint-diagnostic-link]', ctaId: 'pro_page_sprint_diagnostic_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'sprint_diagnostic' },
     { selector: '[data-workflow-sprint-link]', ctaId: 'pro_page_workflow_sprint_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'workflow_sprint' },
     { selector: '.btn-demo', ctaId: 'pro_demo', ctaPlacement: 'pro_page', planId: 'proof' },

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -91,12 +91,8 @@ test('pro landing page routes high-intent team buyers to paid diagnostic and spr
   const proPage = readProPage();
 
   assert.match(proPage, /data-pro-paid-recovery/);
-  assert.match(proPage, /data-quick-read-link/);
-  assert.match(proPage, /Pay \$19 quick read/);
-  assert.match(proPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
   assert.match(proPage, /href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__"/);
   assert.match(proPage, /href="__WORKFLOW_SPRINT_CHECKOUT_URL__"/);
-  assert.match(proPage, /quick_read_checkout_started/);
   assert.match(proPage, /Pay \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
   assert.match(proPage, /Pay \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
   assert.match(proPage, /pro_page_sprint_diagnostic_checkout/);

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -91,8 +91,12 @@ test('pro landing page routes high-intent team buyers to paid diagnostic and spr
   const proPage = readProPage();
 
   assert.match(proPage, /data-pro-paid-recovery/);
+  assert.match(proPage, /data-quick-read-link/);
+  assert.match(proPage, /Pay \$19 quick read/);
+  assert.match(proPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
   assert.match(proPage, /href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__"/);
   assert.match(proPage, /href="__WORKFLOW_SPRINT_CHECKOUT_URL__"/);
+  assert.match(proPage, /quick_read_checkout_started/);
   assert.match(proPage, /Pay \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
   assert.match(proPage, /Pay \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
   assert.match(proPage, /pro_page_sprint_diagnostic_checkout/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -109,7 +109,11 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.match(landingPage, /const workflowSprintCheckoutUrl = '__WORKFLOW_SPRINT_CHECKOUT_URL__';/);
   assert.match(landingPage, /data-sprint-paid-path/);
   assert.match(landingPage, /Workflow Hardening Diagnostic/);
+  assert.match(landingPage, /AI Agent Failure Quick Read/);
   assert.match(landingPage, /Need buyer-ready proof today\?/);
+  assert.match(landingPage, /Pay \$19 quick read/);
+  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
+  assert.match(landingPage, /quick_read_checkout_started/);
   assert.match(landingPage, /href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__"/);
   assert.match(landingPage, /href="__WORKFLOW_SPRINT_CHECKOUT_URL__"/);
   assert.doesNotMatch(landingPage, /founder_workflow_diagnostic_checkout_started/);


### PR DESCRIPTION
## Summary
- adds the $19 AI Agent Failure Quick Read checkout to the homepage paid path
- keeps the owned checkout surface inside the enforced npm package boundary
- covers quick-read copy, link, and telemetry in landing tests

## Verification
- npm run changeset:check
- node --test tests/public-landing.test.js tests/pro-landing.test.js tests/checkout-bot-guard.test.js tests/package-boundary.test.js
- node scripts/check-congruence.js