### PR TITLE
Add  quick-read CTAs to landing pages

### DIFF
--- a/.changeset/quick-read-checkout-cta.md
+++ b/.changeset/quick-read-checkout-cta.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add $19 AI Agent Failure Quick Read checkout calls to action on the homepage and Pro paid recovery path.

--- a/public/index.html
+++ b/public/index.html
@@ -723,10 +723,10 @@ __GA_BOOTSTRAP__
     <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
       <div>
         <strong>Need buyer-ready proof today?</strong>
-        <span>Start with the $19 AI Agent Failure Quick Read, use $99 for same-day teardown, or choose $499 for clear rules, examples, and pre-action checks.</span>
+        <span>Same-day Workflow Teardown: start with the $19 AI Agent Failure Quick Read, use $99 for teardown, or choose $499 for clear rules, examples, and pre-action checks.</span>
       </div>
       <div class="hero-paid-actions">
-        <a class="starter" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout',price:19});">Pay $19 quick read &rarr;</a>
+        <a class="starter" title="AI Agent Failure Quick Read" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout',price:19});">Pay $19 quick read &rarr;</a>
         <a class="starter" href="https://buy.stripe.com/7sYfZhgH29LodWhdKz3sI0v" onclick="sendFirstPartyTelemetry('workflow_teardown_checkout_started',{ctaId:'hero_workflow_teardown_checkout'})">Pay $99 teardown</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>
         <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars,items:[{item_id:'workflow_hardening_sprint',item_name:'Workflow Hardening Sprint'}]});">Pay $1500 sprint &rarr;</a>
@@ -1554,16 +1554,6 @@ __GA_BOOTSTRAP__
         <span class="team-intake-badge">30-minute intake</span>
       </div>
       <div class="team-paid-path" data-sprint-paid-path aria-label="Paid workflow hardening options">
-        <div class="team-paid-card">
-          <div>
-            <h4>AI Agent Failure Quick Read</h4>
-            <p>Async read for one failure symptom or log: likely root cause, one prevention-rule idea, and the next check to run.</p>
-          </div>
-          <div>
-            <div class="team-paid-price">$19</div>
-            <a class="team-paid-link" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'workflow_sprint_quick_read_checkout',ctaPlacement:'team_paid_path',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay for quick read</a>
-          </div>
-        </div>
         <div class="team-paid-card">
           <div>
             <h4>Workflow Hardening Diagnostic</h4>

--- a/public/index.html
+++ b/public/index.html
@@ -723,9 +723,10 @@ __GA_BOOTSTRAP__
     <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
       <div>
         <strong>Need buyer-ready proof today?</strong>
-        <span>Same-day Workflow Teardown: pay $99 for failure map. Choose $499 diagnostic for clear rules, examples, and pre-action checks, or $1500 sprint for implementation</span>
+        <span>Start with the $19 AI Agent Failure Quick Read, use $99 for same-day teardown, or choose $499 for clear rules, examples, and pre-action checks.</span>
       </div>
       <div class="hero-paid-actions">
+        <a class="starter" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout',price:19});">Pay $19 quick read &rarr;</a>
         <a class="starter" href="https://buy.stripe.com/7sYfZhgH29LodWhdKz3sI0v" onclick="sendFirstPartyTelemetry('workflow_teardown_checkout_started',{ctaId:'hero_workflow_teardown_checkout'})">Pay $99 teardown</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>
         <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_sprint',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars,items:[{item_id:'workflow_hardening_sprint',item_name:'Workflow Hardening Sprint'}]});">Pay $1500 sprint &rarr;</a>
@@ -1553,6 +1554,16 @@ __GA_BOOTSTRAP__
         <span class="team-intake-badge">30-minute intake</span>
       </div>
       <div class="team-paid-path" data-sprint-paid-path aria-label="Paid workflow hardening options">
+        <div class="team-paid-card">
+          <div>
+            <h4>AI Agent Failure Quick Read</h4>
+            <p>Async read for one failure symptom or log: likely root cause, one prevention-rule idea, and the next check to run.</p>
+          </div>
+          <div>
+            <div class="team-paid-price">$19</div>
+            <a class="team-paid-link" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'workflow_sprint_quick_read_checkout',ctaPlacement:'team_paid_path',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay for quick read</a>
+          </div>
+        </div>
         <div class="team-paid-card">
           <div>
             <h4>Workflow Hardening Diagnostic</h4>

--- a/public/pro.html
+++ b/public/pro.html
@@ -777,8 +777,9 @@ __GA_BOOTSTRAP__
       <div class="aside-card" data-pro-paid-recovery>
         <div class="aside-kicker">Team workflow blocked?</div>
         <h3>Buy the paid diagnostic</h3>
-        <p>Skip self-serve Pro and pay for workflow hardening now.</p>
+        <p>Skip self-serve Pro and pay for the smallest useful review now.</p>
         <div class="price-stack">
+          <a class="btn-secondary" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_quick_read_checkout',ctaPlacement:'pro_paid_recovery',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read</a>
           <a class="btn-primary" data-sprint-diagnostic-link href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'pro_page_sprint_diagnostic_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__});">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
           <a class="btn-secondary" data-workflow-sprint-link href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'pro_page_workflow_sprint_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__WORKFLOW_SPRINT_PRICE_DOLLARS__});">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
         </div>
@@ -1081,6 +1082,7 @@ globalThis.buyerJourney = globalThis.ThumbGateBuyerIntent.initializeBehaviorAnal
   ],
   ctaImpressions: [
     { selector: '.btn-pro-checkout', ctaId: 'pro_checkout', ctaPlacement: 'pro_page', planId: 'pro' },
+    { selector: '[data-quick-read-link]', ctaId: 'pro_page_quick_read_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'quick_read' },
     { selector: '[data-sprint-diagnostic-link]', ctaId: 'pro_page_sprint_diagnostic_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'sprint_diagnostic' },
     { selector: '[data-workflow-sprint-link]', ctaId: 'pro_page_workflow_sprint_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'workflow_sprint' },
     { selector: '.btn-demo', ctaId: 'pro_demo', ctaPlacement: 'pro_page', planId: 'proof' },

--- a/public/pro.html
+++ b/public/pro.html
@@ -779,7 +779,7 @@ __GA_BOOTSTRAP__
         <h3>Buy the paid diagnostic</h3>
         <p>Skip self-serve Pro and pay for the smallest useful review now.</p>
         <div class="price-stack">
-          <a class="btn-secondary" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_quick_read_checkout',ctaPlacement:'pro_paid_recovery',planId:'quick_read',offer:'agent_failure_quick_read',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'agent_failure_quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read</a>
+          <a class="btn-secondary" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_quick_read_checkout',price:19});">Pay $19 quick read</a>
           <a class="btn-primary" data-sprint-diagnostic-link href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'pro_page_sprint_diagnostic_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__});">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
           <a class="btn-secondary" data-workflow-sprint-link href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'pro_page_workflow_sprint_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__WORKFLOW_SPRINT_PRICE_DOLLARS__});">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
         </div>

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -266,9 +266,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 3.36 MB → 3.44 MB (2026-05-04) after finishing the remaining
   // high-ROI runtime planners: DeepSeek sparse-attention guardrails, upstream
   // contribution planning, reward-hacking checks, and ChatGPT ads readiness.
+  // Bumped 3.44 MB → 3.45 MB (2026-05-05) for the live $19 quick-read
+  // checkout CTA on public buyer paths. The observed package is ~3.440 MB.
   assert.ok(
-    manifest.unpackedSize <= 3_440_000,
-    `npm package should stay <= 3.44 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 3_450_000,
+    `npm package should stay <= 3.45 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -91,12 +91,16 @@ test('pro landing page routes high-intent team buyers to paid diagnostic and spr
   const proPage = readProPage();
 
   assert.match(proPage, /data-pro-paid-recovery/);
+  assert.match(proPage, /data-quick-read-link/);
   assert.match(proPage, /href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__"/);
   assert.match(proPage, /href="__WORKFLOW_SPRINT_CHECKOUT_URL__"/);
+  assert.match(proPage, /Pay \$19 quick read/);
+  assert.match(proPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
   assert.match(proPage, /Pay \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
   assert.match(proPage, /Pay \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
   assert.match(proPage, /pro_page_sprint_diagnostic_checkout/);
   assert.match(proPage, /pro_page_workflow_sprint_checkout/);
+  assert.match(proPage, /quick_read_checkout_started/);
   assert.match(proPage, /workflow_sprint_diagnostic_checkout_started/);
   assert.match(proPage, /workflow_sprint_checkout_started/);
   assert.match(proPage, /initializeProPaidRecovery/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -118,6 +118,10 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/7sY4gzgH24r49G17mb3sI0g/);
   assert.match(landingPage, /https:\/\/buy\.stripe\.com\/7sYfZhgH29LodWhdKz3sI0v/);
   assert.match(landingPage, /Pay \$99 teardown/);
+  assert.match(landingPage, /AI Agent Failure Quick Read/);
+  assert.match(landingPage, /Pay \$19 quick read/);
+  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
+  assert.match(landingPage, /quick_read_checkout_started/);
   assert.match(landingPage, /Pay \$499 diagnostic/);
   assert.match(landingPage, /Pay \$1500 sprint/);
   assert.match(landingPage, /Send workflow first/);


### PR DESCRIPTION
## Summary
- Add the live  AI Agent Failure Quick Read checkout to the homepage paid path and Team offer cards
- Add the same quick-read checkout to the Pro paid recovery stack with telemetry impressions
- Cover the quick-read Stripe URL and telemetry event in landing page tests

## Tests
- node --test tests/public-landing.test.js tests/pro-landing.test.js