### PR TITLE
Add first-dollar CTA to buyer paths

### DIFF
--- a/.changeset/first-dollar-owned-cta.md
+++ b/.changeset/first-dollar-owned-cta.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Add a first-dollar failure-rule checkout CTA to the homepage and Pro buyer paths.

--- a/public/index.html
+++ b/public/index.html
@@ -723,9 +723,10 @@ __GA_BOOTSTRAP__
     <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
       <div>
         <strong>Need buyer-ready proof today?</strong>
-        <span>Same-day Workflow Teardown: start with the $19 AI Agent Failure Quick Read, use $99 for teardown, or choose $499 for clear rules, examples, and pre-action checks.</span>
+        <span>Same-day Workflow Teardown: start with a $1 first failure rule, use $19 for the AI Agent Failure Quick Read, use $99 for teardown, or choose $499 for clear rules, examples, and pre-action checks.</span>
       </div>
       <div class="hero-paid-actions">
+        <a class="starter" title="First AI Agent Failure Rule" href="https://buy.stripe.com/4gM6oHgH2bTw4lH6i73sI0z" onclick="sendFirstPartyTelemetry('first_failure_rule_checkout_started',{ctaId:'hero_first_failure_rule_checkout',price:1});sendGa4Event('begin_checkout',{currency:'USD',value:1,items:[{item_id:'first_failure_rule',item_name:'First AI Agent Failure Rule'}]});">Pay $1 first rule &rarr;</a>
         <a class="starter" title="AI Agent Failure Quick Read" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout',price:19});">Pay $19 quick read &rarr;</a>
         <a class="starter" href="https://buy.stripe.com/7sYfZhgH29LodWhdKz3sI0v" onclick="sendFirstPartyTelemetry('workflow_teardown_checkout_started',{ctaId:'hero_workflow_teardown_checkout'})">Pay $99 teardown</a>
         <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero_paid_path',planId:'team',offer:'workflow_hardening_diagnostic',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars,items:[{item_id:'workflow_hardening_diagnostic',item_name:'Workflow Hardening Diagnostic'}]});">Pay $499 diagnostic &rarr;</a>

--- a/public/pro.html
+++ b/public/pro.html
@@ -779,6 +779,7 @@ __GA_BOOTSTRAP__
         <h3>Buy the paid diagnostic</h3>
         <p>Skip self-serve Pro and pay for the smallest useful review now.</p>
         <div class="price-stack">
+          <a class="btn-secondary" data-first-rule-link href="https://buy.stripe.com/4gM6oHgH2bTw4lH6i73sI0z" onclick="sendFirstPartyTelemetry('first_failure_rule_checkout_started',{ctaId:'pro_page_first_failure_rule_checkout',price:1});sendGa4Event('begin_checkout',{currency:'USD',value:1,items:[{item_id:'first_failure_rule',item_name:'First AI Agent Failure Rule'}]});">Pay $1 first rule</a>
           <a class="btn-secondary" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_quick_read_checkout',price:19});">Pay $19 quick read</a>
           <a class="btn-primary" data-sprint-diagnostic-link href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'pro_page_sprint_diagnostic_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__});">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
           <a class="btn-secondary" data-workflow-sprint-link href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'pro_page_workflow_sprint_checkout'});sendGa4Event('begin_checkout',{currency:'USD',value:__WORKFLOW_SPRINT_PRICE_DOLLARS__});">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
@@ -1082,6 +1083,7 @@ globalThis.buyerJourney = globalThis.ThumbGateBuyerIntent.initializeBehaviorAnal
   ],
   ctaImpressions: [
     { selector: '.btn-pro-checkout', ctaId: 'pro_checkout', ctaPlacement: 'pro_page', planId: 'pro' },
+    { selector: '[data-first-rule-link]', ctaId: 'pro_page_first_failure_rule_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'first_failure_rule' },
     { selector: '[data-quick-read-link]', ctaId: 'pro_page_quick_read_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'quick_read' },
     { selector: '[data-sprint-diagnostic-link]', ctaId: 'pro_page_sprint_diagnostic_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'sprint_diagnostic' },
     { selector: '[data-workflow-sprint-link]', ctaId: 'pro_page_workflow_sprint_checkout', ctaPlacement: 'pro_paid_recovery', planId: 'workflow_sprint' },

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -91,15 +91,19 @@ test('pro landing page routes high-intent team buyers to paid diagnostic and spr
   const proPage = readProPage();
 
   assert.match(proPage, /data-pro-paid-recovery/);
+  assert.match(proPage, /data-first-rule-link/);
   assert.match(proPage, /data-quick-read-link/);
   assert.match(proPage, /href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__"/);
   assert.match(proPage, /href="__WORKFLOW_SPRINT_CHECKOUT_URL__"/);
+  assert.match(proPage, /Pay \$1 first rule/);
+  assert.match(proPage, /https:\/\/buy\.stripe\.com\/4gM6oHgH2bTw4lH6i73sI0z/);
   assert.match(proPage, /Pay \$19 quick read/);
   assert.match(proPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
   assert.match(proPage, /Pay \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
   assert.match(proPage, /Pay \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
   assert.match(proPage, /pro_page_sprint_diagnostic_checkout/);
   assert.match(proPage, /pro_page_workflow_sprint_checkout/);
+  assert.match(proPage, /first_failure_rule_checkout_started/);
   assert.match(proPage, /quick_read_checkout_started/);
   assert.match(proPage, /workflow_sprint_diagnostic_checkout_started/);
   assert.match(proPage, /workflow_sprint_checkout_started/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -116,6 +116,10 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.doesNotMatch(landingPage, /founder_workflow_diagnostic_checkout_started/);
   assert.doesNotMatch(landingPage, /Pay \$99 diagnostic/);
   assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/7sY4gzgH24r49G17mb3sI0g/);
+  assert.match(landingPage, /First AI Agent Failure Rule/);
+  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/4gM6oHgH2bTw4lH6i73sI0z/);
+  assert.match(landingPage, /Pay \$1 first rule/);
+  assert.match(landingPage, /first_failure_rule_checkout_started/);
   assert.match(landingPage, /https:\/\/buy\.stripe\.com\/7sYfZhgH29LodWhdKz3sI0v/);
   assert.match(landingPage, /Pay \$99 teardown/);
   assert.match(landingPage, /AI Agent Failure Quick Read/);
@@ -135,6 +139,7 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.match(landingPage, /workflow_sprint_checkout_started/);
   assert.match(landingPage, /workflow_sprint_recovery_intake_clicked/);
   assert.match(landingPage, /workflow_sprint_recovery_intake/);
+  assert.match(landingPage, /ctaId:'hero_first_failure_rule_checkout'/);
   assert.match(landingPage, /ctaId:'hero_workflow_teardown_checkout'/);
   assert.match(landingPage, /ctaId: 'hero_workflow_sprint_diagnostic_checkout'/);
   assert.match(landingPage, /ctaId: 'hero_workflow_sprint_checkout'/);


### PR DESCRIPTION
## Summary
- add the live  first-failure-rule Stripe checkout to the homepage paid path
- add the same first-dollar CTA to the Pro paid recovery card
- track first_failure_rule checkout telemetry and cover it in landing tests

## Verification
- node --test tests/public-landing.test.js tests/pro-landing.test.js tests/package-boundary.test.js
- node --test tests/checkout-bot-guard.test.js tests/api-server.test.js tests/public-package-parity.test.js tests/test-suite-parity.test.js
- curl https://buy.stripe.com/4gM6oHgH2bTw4lH6i73sI0z -> HTTP 200
- pre-commit/pre-push guards passed