### PR TITLE
fix(gtm): make promo publishing idempotent

### DIFF
--- a/.changeset/promo-publisher-idempotent-skips.md
+++ b/.changeset/promo-publisher-idempotent-skips.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Treat recent duplicate social publishes and Reddit text-post restrictions as skipped promo outcomes instead of fatal ThumbGate Creator Platform Promo failures.

--- a/scripts/social-analytics/publish-thumbgate-launch.js
+++ b/scripts/social-analytics/publish-thumbgate-launch.js
@@ -441,14 +441,64 @@ function getPlatformFailures(result) {
   return failures;
 }
 
+function classifyPublishFailure(failure) {
+  const platform = String(failure?.platform || '').trim().toLowerCase();
+  const error = String(failure?.error || '').trim();
+  const normalizedError = error.toLowerCase();
+
+  if (
+    normalizedError.includes('zernio api 409')
+    || (
+      normalizedError.includes('already')
+      && (
+        normalizedError.includes('within the last 24 hours')
+        || normalizedError.includes('scheduled')
+        || normalizedError.includes('publishing')
+        || normalizedError.includes('posted')
+      )
+    )
+  ) {
+    return {
+      fatal: false,
+      reason: 'duplicate_recent_post',
+    };
+  }
+
+  if (
+    platform === 'reddit'
+    && normalizedError.includes('no_selfs')
+    && normalizedError.includes("doesn't allow text posts")
+  ) {
+    return {
+      fatal: false,
+      reason: 'unsupported_reddit_text_post',
+    };
+  }
+
+  return {
+    fatal: true,
+    reason: 'publish_failed',
+  };
+}
+
 function recordPublishResult(results, normalizedPlatform, result, bucket = 'published') {
   const failures = getPlatformFailures(result);
   if (failures.length > 0) {
     for (const failure of failures) {
-      results.errors.push({
-        platform: failure.platform === 'unknown' ? normalizedPlatform : failure.platform,
+      const platform = failure.platform === 'unknown' ? normalizedPlatform : failure.platform;
+      const classification = classifyPublishFailure({ ...failure, platform });
+      const entry = {
+        platform,
         error: failure.error,
-      });
+      };
+      if (classification.fatal) {
+        results.errors.push(entry);
+      } else {
+        results.skipped.push({
+          ...entry,
+          reason: classification.reason,
+        });
+      }
     }
     return;
   }
@@ -610,6 +660,7 @@ module.exports = {
   buildPaidSprintCheckoutUrls,
   buildPaidSprintPost,
   buildPaidSprintUrl,
+  classifyPublishFailure,
   defaultCampaignSchedule,
   getPlatformFailures,
   parseArgs,

--- a/tests/publish-thumbgate-launch.test.js
+++ b/tests/publish-thumbgate-launch.test.js
@@ -12,6 +12,7 @@ const {
   PAID_SPRINT_IMPLEMENTATION_PAYMENT_URL,
   buildPaidSprintCheckoutUrls,
   buildPlatformPost,
+  classifyPublishFailure,
   getPlatformFailures,
   parseArgs,
   publishLaunchCampaign,
@@ -281,7 +282,17 @@ test('getPlatformFailures extracts Zernio platform-level publish failures', () =
   assert.match(failures[0].error, /NO_SELFS/);
 });
 
-test('publishLaunchCampaign reports Zernio platform failures as errors', async () => {
+test('classifyPublishFailure treats duplicate Zernio posts as nonfatal', () => {
+  const classification = classifyPublishFailure({
+    platform: 'linkedin',
+    error: 'Zernio API 409: This exact content is already scheduled, publishing, or was posted to this account within the last 24 hours.',
+  });
+
+  assert.equal(classification.fatal, false);
+  assert.equal(classification.reason, 'duplicate_recent_post');
+});
+
+test('publishLaunchCampaign skips unsupported Reddit text posts', async () => {
   const fakePublisher = {
     getConnectedAccounts: async () => ([
       { platform: 'reddit', accountId: 'acc_r1' },
@@ -313,7 +324,40 @@ test('publishLaunchCampaign reports Zernio platform failures as errors', async (
   const result = await publishLaunchCampaign({ platforms: ['reddit'], offer: 'paid-sprint' }, fakePublisher);
 
   assert.equal(result.published.length, 0);
-  assert.equal(result.errors.length, 1);
-  assert.equal(result.errors[0].platform, 'reddit');
-  assert.match(result.errors[0].error, /NO_SELFS/);
+  assert.equal(result.errors.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.equal(result.skipped[0].platform, 'reddit');
+  assert.equal(result.skipped[0].reason, 'unsupported_reddit_text_post');
+  assert.match(result.skipped[0].error, /NO_SELFS/);
+});
+
+test('publishLaunchCampaign skips recent duplicate Zernio posts', async () => {
+  const fakePublisher = {
+    getConnectedAccounts: async () => ([
+      { platform: 'linkedin', accountId: 'acc_l1' },
+    ]),
+    groupAccountsByPlatform(accounts) {
+      return new Map([['linkedin', accounts]]);
+    },
+    publishPost: async () => ({
+      post: {
+        status: 'failed',
+        platforms: [
+          {
+            platform: 'linkedin',
+            status: 'failed',
+            errorMessage: 'Zernio API 409: This exact content is already scheduled, publishing, or was posted to this account within the last 24 hours.',
+          },
+        ],
+      },
+    }),
+  };
+
+  const result = await publishLaunchCampaign({ platforms: ['linkedin'], offer: 'paid-sprint' }, fakePublisher);
+
+  assert.equal(result.published.length, 0);
+  assert.equal(result.errors.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.equal(result.skipped[0].platform, 'linkedin');
+  assert.equal(result.skipped[0].reason, 'duplicate_recent_post');
 });


### PR DESCRIPTION
## Summary
- classify duplicate Zernio 409 responses as skipped instead of fatal errors
- classify Reddit NO_SELFS text-post restrictions as skipped instead of fatal errors
- cover both cases in the ThumbGate promo publisher tests

## Tests
- node --test tests/publish-thumbgate-launch.test.js
- git diff --check
- pre-push package/link/regression guards