### PR TITLE
fix(gtm): skip duplicate promo exceptions

### DIFF
--- a/.changeset/promo-publisher-duplicate-exceptions.md
+++ b/.changeset/promo-publisher-duplicate-exceptions.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Treat thrown Zernio duplicate-post responses as skipped promo outcomes so idempotent paid-offer reruns stay green.

--- a/scripts/social-analytics/publish-thumbgate-launch.js
+++ b/scripts/social-analytics/publish-thumbgate-launch.js
@@ -607,10 +607,23 @@ async function publishLaunchCampaign(options = {}, publisher = {}) {
         recordPublishResult(results, normalizedPlatform, publishResult, 'published');
       }
     } catch (error) {
-      results.errors.push({
+      const errorMessage = error && error.message ? error.message : String(error);
+      const classification = classifyPublishFailure({
         platform: normalizedPlatform,
-        error: error && error.message ? error.message : String(error),
+        error: errorMessage,
       });
+      if (classification.fatal) {
+        results.errors.push({
+          platform: normalizedPlatform,
+          error: errorMessage,
+        });
+      } else {
+        results.skipped.push({
+          platform: normalizedPlatform,
+          error: errorMessage,
+          reason: classification.reason,
+        });
+      }
     }
   }
 

--- a/tests/publish-thumbgate-launch.test.js
+++ b/tests/publish-thumbgate-launch.test.js
@@ -361,3 +361,25 @@ test('publishLaunchCampaign skips recent duplicate Zernio posts', async () => {
   assert.equal(result.skipped[0].platform, 'linkedin');
   assert.equal(result.skipped[0].reason, 'duplicate_recent_post');
 });
+
+test('publishLaunchCampaign skips recent duplicate Zernio exceptions', async () => {
+  const fakePublisher = {
+    getConnectedAccounts: async () => ([
+      { platform: 'bluesky', accountId: 'acc_b1' },
+    ]),
+    groupAccountsByPlatform(accounts) {
+      return new Map([['bluesky', accounts]]);
+    },
+    publishPost: async () => {
+      throw new Error('Zernio API 409 for POST /posts: {"error":"This exact content is already scheduled, publishing, or was posted to this account within the last 24 hours.","details":{"platform":"bluesky"}}');
+    },
+  };
+
+  const result = await publishLaunchCampaign({ platforms: ['bluesky'], offer: 'paid-sprint' }, fakePublisher);
+
+  assert.equal(result.published.length, 0);
+  assert.equal(result.errors.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.equal(result.skipped[0].platform, 'bluesky');
+  assert.equal(result.skipped[0].reason, 'duplicate_recent_post');
+});


### PR DESCRIPTION
**Summary**
- route thrown Zernio duplicate-post 409 responses through the nonfatal promo classifier
- keep real publish exceptions fatal
- add coverage for duplicate Zernio exceptions from Bluesky-style publisher calls

**Tests**
- node --test tests/publish-thumbgate-launch.test.js
- git diff --check
- pre-push package/link/regression guards