### PR TITLE
fix(gtm): treat duplicate Instagram posts as safe skips

### DIFF
--- a/.changeset/instagram-duplicate-safe-skip.md
+++ b/.changeset/instagram-duplicate-safe-skip.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Treat duplicate Instagram content blocks from Zernio as safe skipped outcomes instead of failing the Instagram Autopilot workflow.

--- a/scripts/social-analytics/instagram-thumbgate-post.js
+++ b/scripts/social-analytics/instagram-thumbgate-post.js
@@ -27,6 +27,18 @@ Works with Claude Code, Cursor, Codex, Gemini.
 
 #AIAgents #DeveloperTools #ClaudeCode #ThumbGate`;
 
+function getBlockedReasons(result) {
+  if (!result || !Array.isArray(result.reasons)) {
+    return [];
+  }
+
+  return result.reasons.map((reason) => reason.reason || reason.id || String(reason));
+}
+
+function isDuplicateContentBlock(result) {
+  return getBlockedReasons(result).includes('duplicate_content_all_platforms');
+}
+
 async function postThumbGateToInstagram(options = {}) {
   const caption = String(options.caption || THUMBGATE_CAPTION).trim();
   const imagePath = options.imagePath ? path.resolve(options.imagePath) : '';
@@ -73,9 +85,17 @@ async function postThumbGateToInstagram(options = {}) {
       result = await publishPost(caption, platforms, publishOptions);
     }
     if (result && result.blocked) {
-      const reasons = Array.isArray(result.reasons)
-        ? result.reasons.map((reason) => reason.reason || reason.id || String(reason)).join(', ')
-        : 'quality gate blocked the caption';
+      if (isDuplicateContentBlock(result)) {
+        console.log('✅ Instagram post skipped: duplicate content already published within the configured window.');
+        return {
+          ...result,
+          success: true,
+          skipped: true,
+          skipReason: 'duplicate_content_all_platforms',
+        };
+      }
+
+      const reasons = getBlockedReasons(result).join(', ') || 'quality gate blocked the caption';
       throw new Error(`Instagram post blocked: ${reasons}`);
     }
 
@@ -108,4 +128,9 @@ if (require.main === module) {
   })();
 }
 
-module.exports = { postThumbGateToInstagram, THUMBGATE_CAPTION };
+module.exports = {
+  postThumbGateToInstagram,
+  THUMBGATE_CAPTION,
+  getBlockedReasons,
+  isDuplicateContentBlock,
+};

--- a/scripts/social-analytics/publish-instagram-thumbgate.js
+++ b/scripts/social-analytics/publish-instagram-thumbgate.js
@@ -59,6 +59,8 @@ async function publishInstagramThumbGate(options = {}) {
       });
       if (schedule) {
         console.log(`[workflow] ✅ Post scheduled: ${postResult.id || postResult.data?.id}`);
+      } else if (postResult.skipped) {
+        console.log(`[workflow] ✅ Post skipped: ${postResult.skipReason}`);
       } else {
         console.log(`[workflow] ✅ Post published: ${postResult.id || postResult.data?.id}`);
       }
@@ -67,6 +69,8 @@ async function publishInstagramThumbGate(options = {}) {
         success: true,
         imagePath: postOnly ? undefined : imagePath,
         postId: postResult.id || postResult.data?.id,
+        skipped: Boolean(postResult.skipped),
+        skipReason: postResult.skipReason,
         scheduled: Boolean(schedule),
         scheduledFor: schedule || undefined,
       };

--- a/tests/publish-instagram-thumbgate.test.js
+++ b/tests/publish-instagram-thumbgate.test.js
@@ -9,12 +9,26 @@ const {
   publishInstagramThumbGate,
   IMAGE_PATH,
 } = require('../scripts/social-analytics/publish-instagram-thumbgate');
+const {
+  getBlockedReasons,
+  isDuplicateContentBlock,
+} = require('../scripts/social-analytics/instagram-thumbgate-post');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const TEST_IMAGE_PATH = path.join(REPO_ROOT, '.thumbgate', 'test-publish-instagram.png');
 
 let sharpAvailable = false;
 try { require('sharp'); sharpAvailable = true; } catch {}
+
+it('should classify Zernio duplicate-content blocks as safe skips', () => {
+  const result = {
+    blocked: true,
+    reasons: [{ reason: 'duplicate_content_all_platforms' }],
+  };
+
+  assert.deepEqual(getBlockedReasons(result), ['duplicate_content_all_platforms']);
+  assert.equal(isDuplicateContentBlock(result), true);
+});
 
 describe('Publish Instagram ThumbGate', { skip: !sharpAvailable ? 'sharp not installed' : false }, () => {
   let tmpDedupPath;
@@ -103,4 +117,5 @@ describe('Publish Instagram ThumbGate', { skip: !sharpAvailable ? 'sharp not ins
     console.log(`✅ Post-only mode succeeded`);
     console.log(`   Post ID: ${result.postId}`);
   });
+
 });


### PR DESCRIPTION
## Summary
- Treat Zernio duplicate-content Instagram blocks as successful skipped outcomes
- Preserve hard failures for other publisher quality-gate blocks
- Surface skipped metadata from the ThumbGate Instagram workflow

## Verification
- npm run test:publish-instagram-thumbgate
- git diff --check
- pre-commit guards passed
- pre-push guards passed