### PR TITLE
feat(gtm): enable bounded Bluesky reply publishing

### DIFF
--- a/.changeset/bluesky-safe-revenue-replies.md
+++ b/.changeset/bluesky-safe-revenue-replies.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a bounded Bluesky safe-reply publishing mode for manual revenue engagement runs.

--- a/.github/workflows/reply-monitor.yml
+++ b/.github/workflows/reply-monitor.yml
@@ -32,6 +32,15 @@ on:
         required: false
         type: boolean
         default: false
+      autonomous_bluesky_publish:
+        description: 'Auto-approve and publish a bounded set of safe Bluesky replies'
+        required: false
+        type: boolean
+        default: false
+      bluesky_publish_limit:
+        description: 'Maximum safe Bluesky replies to auto-publish'
+        required: false
+        default: '3'
 
 permissions:
   contents: read
@@ -90,12 +99,22 @@ jobs:
             ARGS="$ARGS --dry-run"
           fi
           if [ "${{ github.event.inputs.platform }}" = "bluesky" ]; then
-            node scripts/social-reply-monitor-bluesky.js $ARGS
+            if [ "${{ github.event.inputs.autonomous_bluesky_publish }}" = "true" ]; then
+              node scripts/social-reply-monitor-bluesky.js $ARGS --auto-approve-safe --limit="${{ github.event.inputs.bluesky_publish_limit }}"
+              node scripts/social-reply-monitor-bluesky.js --publish-approved --confirm-publish
+            else
+              node scripts/social-reply-monitor-bluesky.js $ARGS
+            fi
           else
             node scripts/social-reply-monitor.js $ARGS
             if [ -z "${{ github.event.inputs.platform }}" ]; then
               if [ -n "$BLUESKY_HANDLE" ] && [ -n "$BLUESKY_APP_PASSWORD" ]; then
-                node scripts/social-reply-monitor-bluesky.js $ARGS
+                if [ "${{ github.event.inputs.autonomous_bluesky_publish }}" = "true" ]; then
+                  node scripts/social-reply-monitor-bluesky.js $ARGS --auto-approve-safe --limit="${{ github.event.inputs.bluesky_publish_limit }}"
+                  node scripts/social-reply-monitor-bluesky.js --publish-approved --confirm-publish
+                else
+                  node scripts/social-reply-monitor-bluesky.js $ARGS
+                fi
               else
                 echo "Skipping Bluesky monitor: BLUESKY_HANDLE or BLUESKY_APP_PASSWORD is missing."
               fi

--- a/scripts/social-reply-monitor-bluesky.js
+++ b/scripts/social-reply-monitor-bluesky.js
@@ -42,6 +42,23 @@ const DRAFT_FILE = path.resolve(__dirname, '..', '.thumbgate', 'reply-drafts.jso
 
 const args = new Set(process.argv.slice(2));
 const DRY_RUN = args.has('--dry-run');
+const AUTO_APPROVE_SAFE = args.has('--auto-approve-safe');
+
+function parseLimitArg(argv = process.argv.slice(2), name = '--limit=') {
+  const raw = argv.find((arg) => arg.startsWith(name));
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw.slice(name.length), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function isSafeAutoReply(text) {
+  if (typeof text !== 'string') return false;
+  const trimmed = text.trim();
+  if (trimmed.length < 20 || trimmed.length > 260) return false;
+  if (/https?:\/\//i.test(trimmed)) return false;
+  if (/\b(buy|checkout|discount|dm me|hire me|sale|limited time)\b/i.test(trimmed)) return false;
+  return true;
+}
 
 function loadState() {
   try {
@@ -271,6 +288,8 @@ async function monitor({
   saveState: saveStateFn = saveState,
   loadState: loadStateFn = loadState,
   dryRun = DRY_RUN,
+  autoApproveSafe = false,
+  autoApproveLimit = 3,
 } = {}) {
   const session = await sessionFactory();
   const state = loadStateFn();
@@ -280,6 +299,7 @@ async function monitor({
   const actionable = notifications.filter((n) => ['reply', 'mention', 'quote'].includes(n.reason));
 
   let queued = 0;
+  let approved = 0;
   let skipped = 0;
 
   for (const n of actionable) {
@@ -312,6 +332,13 @@ async function monitor({
       },
       autoPost: false,
     };
+    if (autoApproveSafe && approved < autoApproveLimit && isSafeAutoReply(reply)) {
+      draft.approved = true;
+      draft.autoPost = true;
+      draft.approvedAt = draft.createdAt;
+      draft.approvalReason = 'safe_auto_reply';
+      approved += 1;
+    }
 
     if (dryRun) {
       console.log(
@@ -332,9 +359,9 @@ async function monitor({
   }
 
   console.log(
-    `[bluesky-monitor] notifications=${notifications.length} actionable=${actionable.length} queued=${queued} skipped=${skipped} dryRun=${dryRun}`,
+    `[bluesky-monitor] notifications=${notifications.length} actionable=${actionable.length} queued=${queued} approved=${approved} skipped=${skipped} dryRun=${dryRun}`,
   );
-  return { notifications: notifications.length, actionable: actionable.length, queued, skipped };
+  return { notifications: notifications.length, actionable: actionable.length, queued, approved, skipped };
 }
 
 const isMainModule =
@@ -344,9 +371,10 @@ const isMainModule =
 if (isMainModule) {
   const publishMode = args.has('--publish-approved');
   const confirmPublish = args.has('--confirm-publish');
+  const autoApproveLimit = parseLimitArg() || 3;
   const task = publishMode
     ? publishApprovedDrafts({ dryRun: DRY_RUN, confirmPublish })
-    : monitor();
+    : monitor({ autoApproveSafe: AUTO_APPROVE_SAFE, autoApproveLimit });
   task.catch((err) => {
     if (isTransientAtprotoError(err)) {
       console.warn(
@@ -371,4 +399,6 @@ module.exports = {
   assertPublishableDraft,
   publishApprovedDrafts,
   publishReply,
+  isSafeAutoReply,
+  parseLimitArg,
 };

--- a/scripts/social-reply-monitor-bluesky.js
+++ b/scripts/social-reply-monitor-bluesky.js
@@ -60,6 +60,15 @@ function isSafeAutoReply(text) {
   return true;
 }
 
+function normalizeAutoReplyKey(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
 function loadState() {
   try {
     if (fs.existsSync(STATE_FILE)) return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
@@ -301,6 +310,7 @@ async function monitor({
   let queued = 0;
   let approved = 0;
   let skipped = 0;
+  const approvedReplyKeys = new Set();
 
   for (const n of actionable) {
     if (state.repliedTo.bluesky[n.uri]) { skipped += 1; continue; }
@@ -332,11 +342,18 @@ async function monitor({
       },
       autoPost: false,
     };
-    if (autoApproveSafe && approved < autoApproveLimit && isSafeAutoReply(reply)) {
+    const replyKey = normalizeAutoReplyKey(reply);
+    if (
+      autoApproveSafe &&
+      approved < autoApproveLimit &&
+      isSafeAutoReply(reply) &&
+      !approvedReplyKeys.has(replyKey)
+    ) {
       draft.approved = true;
       draft.autoPost = true;
       draft.approvedAt = draft.createdAt;
       draft.approvalReason = 'safe_auto_reply';
+      approvedReplyKeys.add(replyKey);
       approved += 1;
     }
 
@@ -400,5 +417,6 @@ module.exports = {
   publishApprovedDrafts,
   publishReply,
   isSafeAutoReply,
+  normalizeAutoReplyKey,
   parseLimitArg,
 };

--- a/tests/social-reply-monitor-bluesky.test.js
+++ b/tests/social-reply-monitor-bluesky.test.js
@@ -8,6 +8,8 @@ const {
   buildReplyContext,
   monitor,
   assertPublishableDraft,
+  isSafeAutoReply,
+  parseLimitArg,
   publishApprovedDrafts,
   publishReply,
   reconcileDraftsWithState,
@@ -154,6 +156,50 @@ test('monitor writes draft + state on real run', async () => {
   assert.ok(savedState);
   assert.ok(savedState.repliedTo.bluesky['at://did:plc:other/app.bsky.feed.post/a']);
   assert.ok(savedState.lastCheck.bluesky);
+});
+
+test('monitor can auto-approve a bounded safe Bluesky reply for autonomous publishing', async () => {
+  const session = { did: 'did:plc:me', handle: 'me.test', pdsHost: 'pds.example', accessJwt: 'jwt' };
+  const notifications = [
+    {
+      uri: 'at://did:plc:other/app.bsky.feed.post/a',
+      cid: 'cidA',
+      reason: 'reply',
+      indexedAt: '2026-04-21T00:00:00Z',
+      author: { handle: 'someone.bsky.social', did: 'did:plc:someone' },
+      record: { text: 'hello' },
+    },
+  ];
+
+  let savedDraft = null;
+  const result = await monitor({
+    sessionFactory: async () => session,
+    listNotifications: async () => notifications,
+    generateReply: async () => 'Pre-action checks are useful because they stop the repeated bad move before another tool call spends money.',
+    saveDraft: (d) => { savedDraft = d; },
+    saveState: () => {},
+    loadState: () => ({ repliedTo: { bluesky: {} }, lastCheck: {} }),
+    dryRun: false,
+    autoApproveSafe: true,
+    autoApproveLimit: 1,
+  });
+
+  assert.equal(result.approved, 1);
+  assert.equal(savedDraft.approved, true);
+  assert.equal(savedDraft.autoPost, true);
+  assert.equal(savedDraft.approvalReason, 'safe_auto_reply');
+});
+
+test('safe auto-reply gate rejects promotional or link-bearing replies', () => {
+  assert.equal(isSafeAutoReply('This local check stops the repeated bad move before the next tool call.'), true);
+  assert.equal(isSafeAutoReply('Buy now at https://example.com'), false);
+  assert.equal(isSafeAutoReply('DM me for a limited time sale'), false);
+});
+
+test('parseLimitArg accepts positive integer limits only', () => {
+  assert.equal(parseLimitArg(['--limit=2']), 2);
+  assert.equal(parseLimitArg(['--limit=0']), null);
+  assert.equal(parseLimitArg(['--limit=nope']), null);
 });
 
 test('monitor skips notifications already recorded as replied', async () => {

--- a/tests/social-reply-monitor-bluesky.test.js
+++ b/tests/social-reply-monitor-bluesky.test.js
@@ -9,6 +9,7 @@ const {
   monitor,
   assertPublishableDraft,
   isSafeAutoReply,
+  normalizeAutoReplyKey,
   parseLimitArg,
   publishApprovedDrafts,
   publishReply,
@@ -194,6 +195,41 @@ test('safe auto-reply gate rejects promotional or link-bearing replies', () => {
   assert.equal(isSafeAutoReply('This local check stops the repeated bad move before the next tool call.'), true);
   assert.equal(isSafeAutoReply('Buy now at https://example.com'), false);
   assert.equal(isSafeAutoReply('DM me for a limited time sale'), false);
+});
+
+test('monitor does not auto-approve duplicate safe replies in one pass', async () => {
+  const session = { did: 'did:plc:me', handle: 'me.test', pdsHost: 'pds.example', accessJwt: 'jwt' };
+  const notifications = ['a', 'b', 'c'].map((id) => ({
+    uri: `at://did:plc:other/app.bsky.feed.post/${id}`,
+    cid: `cid${id}`,
+    reason: 'reply',
+    indexedAt: '2026-04-21T00:00:00Z',
+    author: { handle: `${id}.bsky.social`, did: `did:plc:${id}` },
+    record: { text: 'hello' },
+  }));
+  const savedDrafts = [];
+
+  const result = await monitor({
+    sessionFactory: async () => session,
+    listNotifications: async () => notifications,
+    generateReply: async () => 'Pre-action checks stop the repeated bad move before another tool call spends money.',
+    saveDraft: (d) => { savedDrafts.push(d); },
+    saveState: () => {},
+    loadState: () => ({ repliedTo: { bluesky: {} }, lastCheck: {} }),
+    dryRun: false,
+    autoApproveSafe: true,
+    autoApproveLimit: 3,
+  });
+
+  assert.equal(result.approved, 1);
+  assert.equal(savedDrafts.filter((draft) => draft.approved).length, 1);
+});
+
+test('normalizeAutoReplyKey collapses punctuation and spacing', () => {
+  assert.equal(
+    normalizeAutoReplyKey('Pre-action checks stop repeated mistakes.'),
+    normalizeAutoReplyKey('pre action   checks stop repeated mistakes'),
+  );
 });
 
 test('parseLimitArg accepts positive integer limits only', () => {


### PR DESCRIPTION
## Summary
- add a manual workflow switch for bounded Bluesky safe-reply publishing
- auto-approve only short non-promotional replies without links
- cover the guard and limit parsing in Bluesky reply monitor tests

## Tests
- npm run test:social-reply-monitor-bluesky
- git diff --check

## Revenue path
This lets the manual Social Reply Monitor use existing GitHub Bluesky secrets to publish a small number of safe, contextual replies, moving today from broad offer broadcasts into targeted buyer conversations.