### PR TITLE
fix(gtm): stop paid duplicate video autopilot

### DIFF
--- a/.changeset/zernio-video-autopilot-guard.md
+++ b/.changeset/zernio-video-autopilot-guard.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Guard Zernio video autopilot behind an explicit publish opt-in, slow TikTok and Instagram video cadence to one distinct experiment per day, and add a TikTok engagement creative that asks for concrete blocked-command examples instead of repeating generic product cards.

--- a/.github/workflows/video-autopilot.yml
+++ b/.github/workflows/video-autopilot.yml
@@ -1,14 +1,16 @@
 name: Video Autopilot
 
-# Fires every 4 hours. Generates a marketing slide video and posts to
-# TikTok, YouTube Shorts, and Instagram Reels via Zernio.
+# Fires every 4 hours, but scheduled runs are gated off by default. The
+# workflow can still generate dry-runs, but paid Zernio publishing requires an
+# explicit workflow input or repo variable because low-engagement duplicate
+# posts were burning attention without revenue.
 #
 # Content rotation: 6 templates picked by least-recently-used order in
 # the marketing DB — never double-posts the same template within 7 days.
 #
 # Per-platform cooldowns (enforced by marketing DB):
-#   TikTok:    4 h  (up to 6 videos/day)
-#   Instagram: 8 h  (up to 3 Reels/day)
+#   TikTok:    24 h (one distinct experiment/day)
+#   Instagram: 24 h (one Reel/day)
 #   YouTube:  12 h  (up to 2 Shorts/day)
 #
 # The CI run is a no-op (skips all platforms) if cooldowns haven't expired.
@@ -35,6 +37,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_enabled:
+        description: 'Allow paid Zernio publishing for this manual run'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -53,6 +60,7 @@ jobs:
       ZERNIO_TIKTOK_ACCOUNT_ID:   ${{ secrets.ZERNIO_TIKTOK_ACCOUNT_ID }}
       ZERNIO_YOUTUBE_ACCOUNT_ID:  ${{ secrets.ZERNIO_YOUTUBE_ACCOUNT_ID }}
       ZERNIO_INSTAGRAM_ACCOUNT_ID: ${{ secrets.ZERNIO_INSTAGRAM_ACCOUNT_ID }}
+      THUMBGATE_ENABLE_ZERNIO_VIDEO_AUTOPILOT: ${{ vars.THUMBGATE_ENABLE_ZERNIO_VIDEO_AUTOPILOT || '0' }}
       THUMBGATE_ANALYTICS_DB: .thumbgate/marketing-analytics.sqlite
 
     steps:
@@ -136,6 +144,7 @@ jobs:
           INPUT_OFFER: ${{ github.event.inputs.offer || 'default' }}
           INPUT_PLATFORMS: ${{ github.event.inputs.platforms || 'tiktok,youtube,instagram' }}
           INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+          INPUT_PUBLISH_ENABLED: ${{ github.event.inputs.publish_enabled }}
         run: |
           TEMPLATE="$INPUT_TEMPLATE"
           OFFER="$INPUT_OFFER"
@@ -143,6 +152,11 @@ jobs:
           DRY_RUN_FLAG=""
           if [ "$INPUT_DRY_RUN" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
+          fi
+          if [ "$INPUT_DRY_RUN" != "true" ] && [ "$INPUT_PUBLISH_ENABLED" != "true" ] && [ "$THUMBGATE_ENABLE_ZERNIO_VIDEO_AUTOPILOT" != "1" ]; then
+            echo "Zernio paid video publishing is disabled by default."
+            echo "Set workflow input publish_enabled=true for a manual run, or repo variable THUMBGATE_ENABLE_ZERNIO_VIDEO_AUTOPILOT=1 for scheduled publishing."
+            exit 0
           fi
           WEEK=$(date +%Y-W%V)
           node scripts/social-analytics/post-video.js \

--- a/scripts/social-analytics/generate-slides.js
+++ b/scripts/social-analytics/generate-slides.js
@@ -113,6 +113,17 @@ const TEMPLATES = {
     ],
   },
 
+  'tiktok-engagement': {
+    name: 'tiktok-engagement',
+    slides: [
+      { holdSeconds: 3, title: ['Your AI agent', 'just repeated', 'the same mistake.'], subtitle: 'Again.', lines: [], cta: null },
+      { holdSeconds: 4, title: ['Memory is not', 'enforcement.'], subtitle: null, lines: ['Memory: "remember not to do this"', 'Gate: blocks the tool call', 'That difference matters.'], cta: null },
+      { holdSeconds: 5, title: ['ThumbGate path:'], subtitle: null, lines: ['1. 👎 capture the bad action', '2. turn it into a prevention rule', '3. check before the tool runs', '4. block the repeat'], cta: null },
+      { holdSeconds: 5, title: ['Example gate:'], subtitle: null, lines: ['Agent: rm config/prod.json', 'Rule: protected production config', 'Decision: ✗ block before execution', 'Outcome: no rollback needed'], cta: null },
+      { holdSeconds: 5, title: ['Comment one', 'command you want', 'blocked.'], subtitle: 'I will turn the clearest one into a rule example.', lines: [], cta: null },
+    ],
+  },
+
 };
 
 // ---------------------------------------------------------------------------

--- a/scripts/social-analytics/post-video.js
+++ b/scripts/social-analytics/post-video.js
@@ -29,7 +29,7 @@ const { loadLocalEnv } = require('./load-env');
 
 loadLocalEnv();
 
-const { hashContent, isDuplicate, record } = require('./db/marketing-db');
+const { hashContent, isDuplicate, list, record } = require('./db/marketing-db');
 const zernioPublisher = require('./publishers/zernio');
 
 // ---------------------------------------------------------------------------
@@ -42,11 +42,18 @@ const ACCOUNTS = {
   instagram: process.env.ZERNIO_INSTAGRAM_ACCOUNT_ID || '69bed6ad6cb7b8cf4c8b0865',
 };
 
-// Per-platform cooldown in hours — prevents over-posting even when CI fires every 4h
+// Per-platform cooldown in hours — prevents over-posting even when CI fires every 4h.
+// TikTok/Instagram stay conservative until their engagement recovers; the
+// screenshots showed repeated-looking low-view posts, so volume is the bug.
 const PLATFORM_COOLDOWN_HOURS = {
-  tiktok:    4,   // up to 6 videos/day — TikTok rewards frequency
-  instagram: 8,   // up to 3 Reels/day
+  tiktok:    24,  // one genuinely distinct experiment/day
+  instagram: 24,  // one Reel/day; IG penalizes repeated-looking grids
   youtube:   12,  // 1-2 Shorts/day
+};
+
+const TIKTOK_ENGAGEMENT_FIRST_COMMENTS = {
+  default: 'What is the exact AI-agent command or edit you wish had been blocked before it ran?',
+  'operator-lab': 'Drop one repeated agent mistake. I will turn the clearest one into a prevention-rule example.',
 };
 
 const CAPTIONS = {
@@ -54,18 +61,18 @@ const CAPTIONS = {
   // ledger attributes views → installs → paid. GitHub is kept as secondary
   // proof ("open source") but no longer the primary click target, because
   // clicks on github.com never touch our funnel tracker.
-  tiktok: `Your AI agent deleted prod config because it "looked unused" 😬
+  tiktok: `POV: your coding agent says "small cleanup" and removes prod config.
 
-ThumbGate v1.4.1 intercepts BEFORE the action runs. Checks it against lessons from past failures. Blocks it permanently.
+The fix is not another reminder in CLAUDE.md.
+It is a pre-action gate:
 
-👎 feedback → lesson DB → prevention rule → physical gate
+bad action -> lesson -> prevention rule -> blocked before the tool call
 
-Not a prompt. A block.
+Comment the one command you want your agent blocked from repeating.
 
-See what it's blocked this week: https://thumbgate-production.up.railway.app/numbers
-Source (MIT): https://github.com/IgorGanapolsky/ThumbGate
+Live numbers: https://thumbgate-production.up.railway.app/numbers
 
-#ClaudeCode #AIAgents #DevTools #TechTok #Coding #SoftwareDev #AITools #Programming #DevTok`,
+#ClaudeCode #CursorAI #Codex #AIAgents #DevTools #TechTok #Coding`,
 
   youtube: `ThumbGate v1.4.1: How to stop AI coding agents from repeating mistakes
 
@@ -104,9 +111,11 @@ function buildOperatorLabUrl(platform) {
 }
 
 const OPERATOR_LAB_CAPTIONS = {
-  tiktok: `Stop fixing the same AI-agent mistake twice.
+  tiktok: `If your AI agent repeats the same mistake, do not write another reminder.
 
-ThumbGate Operator Lab is the free Skool path for turning one repeated failure into a prevention rule, wiring it into a PreToolUse gate, and proving it blocks before the action runs.
+Turn the repeat into a pre-action rule and prove the next bad tool call gets blocked.
+
+Comment the repeated failure you want turned into a gate.
 
 Join free: ${buildOperatorLabUrl('tiktok')}
 
@@ -156,6 +165,15 @@ function parseArgs(argv) {
   }
   if (opts.offer === 'operator-lab' && opts.template === 'auto') opts.template = 'operator-lab';
   if (opts.offer === 'operator-lab' && opts.campaign === 'default') opts.campaign = OPERATOR_LAB_CAMPAIGN;
+  if (
+    opts.offer === 'default' &&
+    opts.template === 'auto' &&
+    Array.isArray(opts.platforms) &&
+    opts.platforms.length === 1 &&
+    opts.platforms[0] === 'tiktok'
+  ) {
+    opts.template = 'tiktok-engagement';
+  }
   return opts;
 }
 
@@ -244,7 +262,10 @@ function buildPlatformPlan(platform, baseHash, offer = 'default') {
 
   const contentHash = hashContent(`${baseHash}::${platform}`);
   const cooldownHours = PLATFORM_COOLDOWN_HOURS[platform] || 4;
-  return { platform, caption, contentHash, cooldownDays: cooldownHours / 24, offer };
+  const firstComment = platform === 'tiktok'
+    ? TIKTOK_ENGAGEMENT_FIRST_COMMENTS[offer] || TIKTOK_ENGAGEMENT_FIRST_COMMENTS.default
+    : undefined;
+  return { platform, caption, contentHash, cooldownDays: cooldownHours / 24, offer, firstComment };
 }
 
 function duplicateResult(plan, isDuplicateFn = isDuplicate) {
@@ -254,13 +275,30 @@ function duplicateResult(plan, isDuplicateFn = isDuplicate) {
   return { platform: plan.platform, status: 'skipped', reason: 'duplicate', existing };
 }
 
+function platformCooldownResult(plan, listFn = list) {
+  const rows = listFn({
+    platform: plan.platform,
+    type: 'video',
+    days: Math.max(plan.cooldownDays, 1),
+    limit: 20,
+  });
+  const cutoffMs = Date.now() - plan.cooldownDays * 86_400_000;
+  const existing = rows.find(row => (
+    row.status === 'published' &&
+    Date.parse(row.published_at || '') >= cutoffMs
+  ));
+  if (!existing) return null;
+  console.log(`[post-video] SKIP ${plan.platform} — platform cooldown (${existing.published_at}): ${existing.post_url}`);
+  return { platform: plan.platform, status: 'skipped', reason: 'platform_cooldown', existing };
+}
+
 function recordPostOutcome({ plan, status, postUrl, error, campaign, mediaUrl, templateId, response, recordFn = record }) {
   const tags = [plan.offer || 'default', 'short', campaign].filter(Boolean);
   if (status === 'published') {
     console.log(`[post-video] ✓ ${plan.platform}: ${postUrl}`);
     recordFn({ type: 'video', platform: plan.platform, contentHash: plan.contentHash, postUrl, campaign,
       tags,
-      extra: { mediaUrl, templateId, zernioPostId: response.post?._id } });
+      extra: { mediaUrl, templateId, zernioPostId: response.post?._id, firstComment: plan.firstComment } });
     return;
   }
 
@@ -272,6 +310,8 @@ function recordPostOutcome({ plan, status, postUrl, error, campaign, mediaUrl, t
 async function processPlatform(plan, context) {
   const duplicate = duplicateResult(plan, context.isDuplicate);
   if (duplicate) return duplicate;
+  const platformCooldown = platformCooldownResult(plan, context.listPosts);
+  if (platformCooldown) return platformCooldown;
 
   if (context.dryRun) {
     console.log(`[post-video] DRY-RUN ${plan.platform} — would post video`);
@@ -299,7 +339,7 @@ async function processPlatform(plan, context) {
       mediaItems,
       title: YT_TITLES[plan.offer] || YT_TITLES.default,
       // YouTube Shorts use `title`; other platforms ignore it.
-      firstComment: undefined,
+      firstComment: plan.firstComment,
     });
 
     if (response && response.blocked) {
@@ -369,9 +409,11 @@ module.exports = {
   CAPTION_SETS,
   OPERATOR_LAB_CAPTIONS,
   PLATFORM_COOLDOWN_HOURS,
+  TIKTOK_ENGAGEMENT_FIRST_COMMENTS,
   buildPlatformPlan,
   buildOperatorLabUrl,
   duplicateResult,
+  platformCooldownResult,
   parseArgs,
   processPlatform,
   zernioUpload,

--- a/tests/post-video.test.js
+++ b/tests/post-video.test.js
@@ -57,6 +57,7 @@ function baseContext(extra = {}) {
     // Inject DB stubs so the real marketing-db (backed by better-sqlite3,
     // which isn't always installable in CI) is never touched.
     isDuplicate: () => null,
+    listPosts: () => [],
     record: () => {},
     ...extra,
   };
@@ -90,8 +91,8 @@ describe('post-video (Instagram presign fix)', () => {
 
   it('enforces the per-platform cooldown table', () => {
     const { PLATFORM_COOLDOWN_HOURS } = require('../scripts/social-analytics/post-video');
-    assert.ok(PLATFORM_COOLDOWN_HOURS.instagram >= 8, 'instagram cooldown respected');
-    assert.ok(PLATFORM_COOLDOWN_HOURS.tiktok <= 6, 'tiktok cooldown allows ≥ 4 posts/day');
+    assert.ok(PLATFORM_COOLDOWN_HOURS.instagram >= 24, 'instagram cooldown prevents duplicate-looking grids');
+    assert.ok(PLATFORM_COOLDOWN_HOURS.tiktok >= 24, 'tiktok cooldown prioritizes one strong daily experiment');
   });
 
   it('parseArgs parses --platforms and --dry-run', () => {
@@ -112,6 +113,14 @@ describe('post-video (Instagram presign fix)', () => {
     assert.deepEqual(opts.platforms, ['youtube']);
   });
 
+  it('parseArgs maps tiktok-only auto runs to the engagement template', () => {
+    const { parseArgs } = require('../scripts/social-analytics/post-video');
+    const opts = parseArgs(['--platforms=tiktok']);
+
+    assert.equal(opts.template, 'tiktok-engagement');
+    assert.deepEqual(opts.platforms, ['tiktok']);
+  });
+
   it('buildPlatformPlan returns null for unknown platforms', () => {
     const { buildPlatformPlan } = require('../scripts/social-analytics/post-video');
     assert.equal(buildPlatformPlan('unknown', 'base'), null);
@@ -121,7 +130,16 @@ describe('post-video (Instagram presign fix)', () => {
     const { buildPlatformPlan } = require('../scripts/social-analytics/post-video');
     const plan = buildPlatformPlan('instagram', 'base');
     assert.equal(plan.platform, 'instagram');
-    assert.ok(Math.abs(plan.cooldownDays - (8 / 24)) < 1e-9);
+    assert.ok(Math.abs(plan.cooldownDays - 1) < 1e-9);
+  });
+
+  it('buildPlatformPlan adds a TikTok first comment prompt only on TikTok', () => {
+    const { buildPlatformPlan } = require('../scripts/social-analytics/post-video');
+    const tiktok = buildPlatformPlan('tiktok', 'base');
+    const instagram = buildPlatformPlan('instagram', 'base');
+
+    assert.match(tiktok.firstComment, /exact AI-agent command/);
+    assert.equal(instagram.firstComment, undefined);
   });
 
   it('buildPlatformPlan uses operator-lab captions with tracked Skool links', () => {
@@ -161,6 +179,41 @@ describe('post-video (Instagram presign fix)', () => {
     assert.equal(result.platform, 'instagram');
     assert.equal(result.status, 'published');
     assert.ok(result.postUrl.includes('instagram.test'));
+  });
+
+  it('processPlatform sends TikTok first-comment bait to Zernio', async () => {
+    const { processPlatform, buildPlatformPlan } = require('../scripts/social-analytics/post-video');
+    const tr = buildTrackers();
+    const plan = buildPlatformPlan('tiktok', 'test-hash');
+    const context = baseContext({ ...tr });
+
+    await processPlatform(plan, context);
+
+    assert.equal(tr.publishes.length, 1);
+    assert.equal(tr.publishes[0].options.firstComment, plan.firstComment);
+  });
+
+  it('processPlatform skips recent platform videos even when content hash differs', async () => {
+    const { processPlatform, buildPlatformPlan } = require('../scripts/social-analytics/post-video');
+    const tr = buildTrackers();
+    const plan = buildPlatformPlan('instagram', 'new-hash');
+    const context = baseContext({
+      ...tr,
+      listPosts: () => [{
+        platform: 'instagram',
+        type: 'video',
+        status: 'published',
+        published_at: new Date().toISOString(),
+        post_url: 'https://instagram.test/p/existing',
+      }],
+    });
+
+    const result = await processPlatform(plan, context);
+
+    assert.equal(result.status, 'skipped');
+    assert.equal(result.reason, 'platform_cooldown');
+    assert.equal(tr.uploads.length, 0);
+    assert.equal(tr.publishes.length, 0);
   });
 
   it('processPlatform sends the operator-lab YouTube Shorts title', async () => {
@@ -260,5 +313,16 @@ describe('generate-slides operator-lab template', () => {
     assert.ok(TEMPLATES['operator-lab']);
     assert.match(TEMPLATES['operator-lab'].name, /operator-lab/);
     assert.ok(TEMPLATES['operator-lab'].slides.length >= 5);
+  });
+
+  it('exports a TikTok engagement template for comment-led tests', () => {
+    const { TEMPLATES, pickTemplate } = require('../scripts/social-analytics/generate-slides');
+
+    assert.equal(pickTemplate('tiktok-engagement'), 'tiktok-engagement');
+    assert.ok(TEMPLATES['tiktok-engagement']);
+    assert.match(TEMPLATES['tiktok-engagement'].name, /tiktok-engagement/);
+    assert.ok(TEMPLATES['tiktok-engagement'].slides.some(slide => (
+      Array.isArray(slide.title) && slide.title.join(' ').includes('Comment one')
+    )));
   });
 });


### PR DESCRIPTION
## Summary
- Disable paid Zernio video autopilot by default unless a manual run opts in or the repo variable explicitly re-enables scheduled publishing.
- Slow TikTok and Instagram videos to one distinct experiment per day, and add a platform-level cooldown so a different content hash cannot bypass recent-post protection.
- Add a TikTok-specific engagement template and first comment that asks for concrete repeated AI-agent failure examples instead of generic product-card spam.

## Why
Screenshots showed low-engagement, repeated-looking TikTok/Instagram posts, and the Zernio renewal failed. The safest revenue posture is to stop automatic paid-provider publishing until the creative earns engagement and the workflow is intentionally re-enabled.

## Verification
- node --test tests/post-video.test.js
- git diff --check origin/main..HEAD
- pre-push guards: npm pack dry-run, public HTML link validation, regression-guard tests