### PR TITLE
chore(gtm): gate remaining Zernio publish workflows

### DIFF
--- a/.changeset/zernio-cost-controls.md
+++ b/.changeset/zernio-cost-controls.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Make remaining Zernio publishing workflows opt-in by default so scheduled social, Instagram, weekly, and manual offer dispatches cannot spend paid-provider capacity or publish repeated content unless explicitly enabled.

--- a/.github/workflows/instagram-autopilot.yml
+++ b/.github/workflows/instagram-autopilot.yml
@@ -1,6 +1,8 @@
 name: Instagram Autopilot
 
-# Posts a ThumbGate Instagram static card once per day.
+# Generates a ThumbGate Instagram static card once per day, but scheduled
+# publishing is off by default. Screenshots showed repeated low-engagement
+# cards, so Zernio publishing must be explicitly re-enabled after proof.
 # Complements video-autopilot.yml (which posts Reels) by covering the
 # Instagram feed with image content as well.
 #
@@ -28,6 +30,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_enabled:
+        description: 'Allow paid Zernio publishing for this manual run'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -44,6 +51,7 @@ jobs:
     env:
       ZERNIO_API_KEY:              ${{ secrets.ZERNIO_API_KEY }}
       ZERNIO_INSTAGRAM_ACCOUNT_ID: ${{ secrets.ZERNIO_INSTAGRAM_ACCOUNT_ID }}
+      THUMBGATE_ENABLE_ZERNIO_INSTAGRAM_AUTOPILOT: ${{ vars.THUMBGATE_ENABLE_ZERNIO_INSTAGRAM_AUTOPILOT || '0' }}
       THUMBGATE_ANALYTICS_DB:      .thumbgate/marketing-analytics.sqlite
 
     steps:
@@ -103,12 +111,21 @@ jobs:
           " || true
 
       - name: Publish Instagram card
+        if: >-
+          github.event.inputs.image_only == 'true' ||
+          github.event.inputs.dry_run == 'true' ||
+          github.event.inputs.publish_enabled == 'true' ||
+          vars.THUMBGATE_ENABLE_ZERNIO_INSTAGRAM_AUTOPILOT == '1'
         env:
           INPUT_IMAGE_ONLY: ${{ github.event.inputs.image_only || github.event.inputs.dry_run }}
         run: |
           FLAGS=""
           if [ "$INPUT_IMAGE_ONLY" = "true" ]; then
             FLAGS="--image-only"
+          fi
+          if [ "$INPUT_IMAGE_ONLY" != "true" ] && [ "${{ github.event.inputs.publish_enabled }}" != "true" ] && [ "$THUMBGATE_ENABLE_ZERNIO_INSTAGRAM_AUTOPILOT" != "1" ]; then
+            echo "Instagram Zernio publishing disabled by default."
+            exit 0
           fi
           node scripts/social-analytics/publish-instagram-thumbgate.js $FLAGS
 

--- a/.github/workflows/social-engagement-hourly.yml
+++ b/.github/workflows/social-engagement-hourly.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_enabled:
+        description: 'Allow paid Zernio posting for this manual run'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -39,7 +44,7 @@ jobs:
   post-via-zernio:
     # Only post at 2pm UTC, not on reply-monitor runs
     if: >-
-      github.event.schedule == '0 14 * * *' ||
+      (github.event.schedule == '0 14 * * *' && vars.THUMBGATE_ENABLE_ZERNIO_DAILY_SOCIAL == '1') ||
       github.event.inputs.action == 'all' ||
       github.event.inputs.action == 'post'
     runs-on: ubuntu-latest
@@ -52,6 +57,7 @@ jobs:
       ZERNIO_REDDIT_ACCOUNT_ID: ${{ secrets.ZERNIO_REDDIT_ACCOUNT_ID }}
       ZERNIO_TIKTOK_ACCOUNT_ID: ${{ secrets.ZERNIO_TIKTOK_ACCOUNT_ID }}
       ZERNIO_YOUTUBE_ACCOUNT_ID: ${{ secrets.ZERNIO_YOUTUBE_ACCOUNT_ID }}
+      THUMBGATE_ENABLE_ZERNIO_DAILY_SOCIAL: ${{ vars.THUMBGATE_ENABLE_ZERNIO_DAILY_SOCIAL || '0' }}
       PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
     steps:
       - uses: actions/checkout@v6
@@ -67,6 +73,10 @@ jobs:
           DRY_RUN=""
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             DRY_RUN="--dry-run"
+          fi
+          if [ "$DRY_RUN" != "--dry-run" ] && [ "${{ github.event.inputs.publish_enabled }}" != "true" ] && [ "$THUMBGATE_ENABLE_ZERNIO_DAILY_SOCIAL" != "1" ]; then
+            echo "Daily Zernio posting disabled by default."
+            exit 0
           fi
           node scripts/social-post-hourly.js $DRY_RUN
 

--- a/.github/workflows/weekly-social-post.yml
+++ b/.github/workflows/weekly-social-post.yml
@@ -1,8 +1,8 @@
 name: Weekly Social Post
 
 # Runs the build-in-public weekly stats post every Monday at 14:00 UTC (9am ET).
-# Uses Zernio as the primary publisher (LinkedIn, Instagram, YouTube, Threads,
-# Bluesky). X/Twitter was dropped from distribution 2026-04-20.
+# Scheduled runs are dry-run by default while Zernio ROI is unproven; paid
+# publishing requires workflow opt-in or THUMBGATE_ENABLE_ZERNIO_WEEKLY_SOCIAL=1.
 
 on:
   schedule:
@@ -18,6 +18,11 @@ on:
         description: 'Number of days to include in stats window'
         required: false
         default: '7'
+      publish_enabled:
+        description: 'Allow paid Zernio publishing for this manual run'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # needed to commit state file changes back to repo
@@ -39,6 +44,7 @@ jobs:
       ZERNIO_LINKEDIN_ACCOUNT_ID: ${{ secrets.ZERNIO_LINKEDIN_ACCOUNT_ID }}
       ZERNIO_YOUTUBE_ACCOUNT_ID: ${{ secrets.ZERNIO_YOUTUBE_ACCOUNT_ID }}
       ZERNIO_PROFILE_ID: ${{ secrets.ZERNIO_PROFILE_ID }}
+      THUMBGATE_ENABLE_ZERNIO_WEEKLY_SOCIAL: ${{ vars.THUMBGATE_ENABLE_ZERNIO_WEEKLY_SOCIAL || '0' }}
       # X/Twitter fallback publisher was retired 2026-04-20. Zernio is the
       # sole publisher; if it fails, the job surfaces the error and exits.
       # Dev.to — article publishing
@@ -82,11 +88,21 @@ jobs:
           fi
           PERIOD_DAYS="${{ github.event.inputs.period_days }}"
           PERIOD_DAYS="${PERIOD_DAYS:-7}"
+          SHOULD_PUBLISH=false
+          if [ "${{ github.event.inputs.publish_enabled }}" = "true" ] || [ "$THUMBGATE_ENABLE_ZERNIO_WEEKLY_SOCIAL" = "1" ]; then
+            SHOULD_PUBLISH=true
+          fi
+          if [ "$DRY_RUN_FLAG" = "--dry-run" ] || [ "$SHOULD_PUBLISH" != "true" ]; then
+            EFFECTIVE_DRY_RUN=true
+            echo "Weekly Zernio publishing disabled; generating dry-run output only."
+          else
+            EFFECTIVE_DRY_RUN=false
+          fi
           node -e "
             const { runWeeklyPost } = require('./scripts/weekly-auto-post');
             runWeeklyPost({
               periodDays: parseInt('$PERIOD_DAYS'),
-              dryRun: '$DRY_RUN_FLAG' === '--dry-run',
+              dryRun: '$EFFECTIVE_DRY_RUN' === 'true',
             })
             .then(r => {
               console.log(JSON.stringify(r, null, 2));
@@ -104,6 +120,10 @@ jobs:
           sudo apt-get install -y ffmpeg --quiet
 
       - name: Generate and post marketing video (TikTok + YouTube + Instagram Reels)
+        if: >-
+          github.event.inputs.dry_run == 'true' ||
+          github.event.inputs.publish_enabled == 'true' ||
+          vars.THUMBGATE_ENABLE_ZERNIO_WEEKLY_SOCIAL == '1'
         env:
           ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
           ZERNIO_TIKTOK_ACCOUNT_ID: ${{ secrets.ZERNIO_TIKTOK_ACCOUNT_ID }}
@@ -113,6 +133,10 @@ jobs:
           DRY_RUN_FLAG=""
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
+          fi
+          if [ "$DRY_RUN_FLAG" != "--dry-run" ] && [ "${{ github.event.inputs.publish_enabled }}" != "true" ] && [ "$THUMBGATE_ENABLE_ZERNIO_WEEKLY_SOCIAL" != "1" ]; then
+            echo "Weekly Zernio video publishing disabled by default."
+            exit 0
           fi
           # post-video.js: generates slides → stitches with ffmpeg → uploads → posts to all video platforms
           # Marketing DB dedup prevents double-posting within 7 days

--- a/.github/workflows/zernio-offer-dispatch.yml
+++ b/.github/workflows/zernio-offer-dispatch.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_enabled:
+        description: 'Required to publish through paid Zernio provider'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -93,7 +98,7 @@ jobs:
           NODE
 
       - name: Publish offer via Zernio
-        if: github.event.inputs.dry_run != 'true'
+        if: github.event.inputs.dry_run != 'true' && github.event.inputs.publish_enabled == 'true'
         env:
           OFFER_TEXT: ${{ github.event.inputs.text }}
           OFFER_PLATFORMS: ${{ github.event.inputs.platforms }}


### PR DESCRIPTION
## Summary
- Make scheduled Instagram card, daily social, and weekly social Zernio publishing opt-in by default.
- Require publish_enabled=true for manual Zernio offer dispatches, so validation can run without accidentally publishing through the paid provider.
- Keep dry-run/image generation paths available while blocking spend-producing publish calls unless explicitly enabled by workflow input or repo variable.

## Why
Zernio billing is currently failed/paused and the visible TikTok/Instagram output had repeated low-engagement posts. We should not keep scheduled paid-provider publishing active until ROI is proven.

## Verification
- node --test tests/post-video.test.js tests/post-everywhere-zernio-default.test.js
- ruby YAML parse for instagram-autopilot.yml, weekly-social-post.yml, social-engagement-hourly.yml, zernio-offer-dispatch.yml
- git diff --check
- pre-push guards: npm pack dry-run, public HTML link validation, regression-guard tests

Note: node --test tests/social-post-hourly.test.js was not run in this clean worktree because dependencies are not installed locally; it failed before test execution on missing module dotenv.