### PR TITLE
Add QSR consultant Dev.to dispatch

### DIFF
--- a/.github/workflows/qsr-devto-consultant-dispatch.yml
+++ b/.github/workflows/qsr-devto-consultant-dispatch.yml
@@ -1,0 +1,90 @@
+name: QSR Dev.to Consultant Dispatch
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Publish QSR consultant article
+        run: |
+          node - <<'NODE'
+          const devto = require('./scripts/social-analytics/publishers/devto');
+
+          const body = [
+            'A lot of AI automation consultants are still selling generic demos.',
+            '',
+            'Restaurants are a better wedge because the workflows are visible, repetitive, and painful:',
+            '',
+            '- missed order details',
+            '- low inventory before rush periods',
+            '- waste logs nobody reads',
+            '- review replies that sit for days',
+            '- shift handoff notes scattered across texts and spreadsheets',
+            '',
+            'The first offer does not need to be a giant autonomous restaurant agent. It can be a narrow operations workflow with human review.',
+            '',
+            '## A practical demo angle',
+            '',
+            'Pick one store workflow and build a 15-minute demo around it.',
+            '',
+            'Example:',
+            '',
+            '1. Pull yesterday inventory or waste data into n8n.',
+            '2. Summarize risk in a controlled AI step.',
+            '3. Flag missing items, unusual waste, and rush-period risks.',
+            '4. Send the manager a short action brief.',
+            '5. Log the output so the owner can inspect what happened.',
+            '',
+            'That demo is easier to sell than a vague chatbot because the buyer can see the operational problem immediately.',
+            '',
+            '## Where the money is',
+            '',
+            'The sale is not "AI".',
+            '',
+            'The sale is fewer avoidable mistakes before lunch rush, faster handoffs, cleaner inventory review, and a manager who does not need to inspect five systems manually.',
+            '',
+            '## A starter kit I put together',
+            '',
+            'I made a small QSR AI Ops Pack for builders who want a ready starting point:',
+            '',
+            '- 6 importable n8n workflow JSON templates',
+            '- OpenClaw-ready agent specs',
+            '- prompt libraries',
+            '- test payloads',
+            '- quickstart docs',
+            '',
+            'The launch pack is $29:',
+            'https://iganapolsky.gumroad.com/l/qsr-ai-ops-pack',
+            '',
+            'For operators or consultants who want one workflow mapped before building, there is also a $499 diagnostic:',
+            'https://iganapolsky.gumroad.com/l/qsr-ai-automation-diagnostic',
+            '',
+            'The useful pattern is simple: triage, draft, escalate, log. That is usually enough to ship a first restaurant AI workflow without creating avoidable risk.',
+          ].join('\n');
+
+          devto.publishArticle({
+            title: 'A restaurant AI demo an automation consultant can sell this week',
+            body_markdown: body,
+            tags: ['ai', 'automation', 'n8n', 'business'],
+            published: true,
+          }).then((article) => {
+            console.log(`QSR_CONSULTANT_DEVTO_URL=${article.url}`);
+          }).catch((error) => {
+            console.error(error.message);
+            process.exit(1);
+          });
+          NODE


### PR DESCRIPTION
Adds a one-shot workflow_dispatch publisher for a second QSR AI Ops Pack Dev.to article targeting automation consultants. This creates another public buyer-facing surface with the live Gumroad links.