### PR TITLE
Surface quick-read checkout on Pro page

### DIFF
--- a/.changeset/pro-page-quick-read-checkout.md
+++ b/.changeset/pro-page-quick-read-checkout.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Route high-intent Pro page visitors to the direct quick-read checkout while keeping the Pro dashboard checkout available.

--- a/public/pro.html
+++ b/public/pro.html
@@ -718,7 +718,7 @@ __GA_BOOTSTRAP__
       <a href="#pricing">Pricing</a>
       <a href="#faq">FAQ</a>
       <a href="/dashboard">Demo</a>
-      <a class="nav-cta btn-pro-checkout" href="/checkout/pro?utm_source=website&utm_medium=pro_page_nav&utm_campaign=pro_pack&cta_id=pro_page_nav&cta_placement=nav&plan_id=pro&landing_path=%2Fpro">Start Pro Now</a>
+      <a class="nav-cta" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_nav_quick_read_checkout',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read</a>
     </div>
   </div>
 </nav>
@@ -729,8 +729,8 @@ __GA_BOOTSTRAP__
       <div class="eyebrow">Paid lane for individual operators</div>
       <h1>Buy the operator loop that proves your AI agent stopped repeating the mistake.</h1>
       <p style="font-size:13px;opacity:0.8;margin-bottom:0.5rem;">Updated: <time datetime="2026-04-20">2026-04-20</time> · by <a href="https://github.com/IgorGanapolsky" style="color:inherit;">Igor Ganapolsky</a></p>
-      <p>ThumbGate Pro is the fastest paid path for one operator who already hit a repeated AI-agent failure and now needs proof: what was blocked, why it was blocked, and what changed before the next risky run.</p>
-      <p>Start with the local-first Pro dashboard and DPO export. Move to Team only when one correction needs to protect multiple developers, agents, or shared repos.</p>
+      <p>ThumbGate Pro is for one operator who already hit a repeated AI-agent failure and now needs proof: what was blocked, why it was blocked, and what changed before the next risky run.</p>
+      <p>If you need help today, start with the $19 quick read: send one failed tool call or workflow snippet and get the likely rule shape plus proof check. Use Pro when you want the local dashboard and DPO export.</p>
       <div class="hero-proof">
         <div class="proof-pill">Personal local dashboard</div>
         <div class="proof-pill">DPO export from real corrections</div>
@@ -738,7 +738,8 @@ __GA_BOOTSTRAP__
         <div class="proof-pill">Founder support on risky flows</div>
       </div>
       <div class="hero-actions">
-        <a class="btn-primary btn-pro-checkout" href="/checkout/pro?utm_source=website&utm_medium=pro_page_hero&utm_campaign=pro_pack&cta_id=pro_page_primary&cta_placement=hero&plan_id=pro&landing_path=%2Fpro">Start Pro Now</a>
+        <a class="btn-primary" data-quick-read-link href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'pro_page_hero_quick_read_checkout',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'quick_read',item_name:'AI Agent Failure Quick Read'}]});">Pay $19 quick read</a>
+        <a class="btn-secondary btn-pro-checkout" href="/checkout/pro?utm_source=website&utm_medium=pro_page_hero&utm_campaign=pro_pack&cta_id=pro_page_primary&cta_placement=hero&plan_id=pro&landing_path=%2Fpro">Start Pro dashboard</a>
         <a class="btn-secondary btn-demo" href="/dashboard?utm_source=website&utm_medium=pro_page&utm_campaign=pro_pack">Open dashboard demo</a>
         <a class="btn-ghost btn-free-path" href="/guide?utm_source=website&utm_medium=pro_page&utm_campaign=free_install">Stay on Free and install locally</a>
       </div>

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -30,6 +30,9 @@ test('pro landing page uses checkout routes for monthly and annual conversions',
   const proPage = readProPage();
 
   assert.match(proPage, /Start Pro Now/i);
+  assert.match(proPage, /Pay \$19 quick read/i);
+  assert.match(proPage, /pro_page_hero_quick_read_checkout/);
+  assert.match(proPage, /pro_page_nav_quick_read_checkout/);
   assert.match(proPage, /\/checkout\/pro\?/);
   assert.match(proPage, /pricing_pro/);
   assert.match(proPage, /billing_cycle=annual/);


### PR DESCRIPTION
## Summary
- Make the Pro page nav and hero route high-intent visitors directly to the live  quick-read Stripe checkout.
- Keep the Pro dashboard checkout as a secondary path for buyers who want self-serve Pro.
- Add regression coverage for the new nav/hero quick-read CTA ids.

## Verification
- node --test tests/pro-landing.test.js
- node --test tests/public-landing.test.js
- npm run test:checkout-bot-guard
- git diff --check
