### PR TITLE
Add Zernio custom post dispatch

### DIFF
--- a/.github/workflows/zernio-custom-post-dispatch.yml
+++ b/.github/workflows/zernio-custom-post-dispatch.yml
@@ -1,0 +1,45 @@
+name: Zernio Custom Post Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      text:
+        description: 'Post body to publish via Zernio'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zernio-custom-post-dispatch
+  cancel-in-progress: false
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - name: Publish via Zernio
+        env:
+          POST_TEXT: ${{ github.event.inputs.text }}
+        run: |
+          if [ -z "${ZERNIO_API_KEY:-}" ]; then
+            echo "ZERNIO_API_KEY is not configured." >&2
+            exit 1
+          fi
+
+          node scripts/social-analytics/publishers/zernio.js --text="$POST_TEXT"


### PR DESCRIPTION
Adds a manual workflow for publishing a custom text post through the existing Zernio publisher using repository secrets. This is needed for time-sensitive revenue posts without exposing credentials locally.