### PR TITLE
Fix misleading ThumbGate numbers page claims

### DIFF
--- a/.changeset/truthful-numbers-page.md
+++ b/.changeset/truthful-numbers-page.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Clarify the public numbers page so configured checks are labeled as inventory, recorded block/warn counts are treated as the usage evidence, zero-occurrence blocker claims are suppressed, and scorer calibration is reported as n/a until the feedback sample has both safe and harmful outcomes.

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -6,9 +6,9 @@
 <meta name="generator" content="ThumbGate">
 <meta name="author" content="Igor Ganapolsky">
 <title>ThumbGate — The Numbers | First-Party Data Snapshot</title>
-<meta name="description" content="ThumbGate's generated first-party operational snapshot: active pre-action checks, AI agent actions blocked, estimated LLM tokens and dollars saved, and the Bayes error rate of the intervention scorer.">
+<meta name="description" content="ThumbGate's generated first-party operational snapshot: configured pre-action checks, recorded block/warn events, estimated LLM token savings when events exist, and scorer calibration when the sample supports it.">
 <meta property="og:title" content="ThumbGate — The Numbers">
-<meta property="og:description" content="Generated first-party operational metrics: gates, blocks, token savings, and scorer calibration.">
+<meta property="og:description" content="Generated first-party operational snapshot: configured gates, recorded interventions, and explicit zero-evidence caveats.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://thumbgate-production.up.railway.app/numbers">
 <meta name="twitter:card" content="summary_large_image">
@@ -27,7 +27,7 @@
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
   "softwareVersion": "1.16.21",
   "url": "https://thumbgate-production.up.railway.app/numbers",
-  "dateModified": "2026-05-06",
+  "dateModified": "2026-05-07",
   "creator": {
     "@type": "Person",
     "name": "Igor Ganapolsky",
@@ -44,8 +44,8 @@
 {
   "@context": "https://schema.org",
   "@type": "Dataset",
-  "name": "ThumbGate Live Operational Metrics",
-  "description": "First-party operational metrics from the ThumbGate pre-action check runtime: active checks, blocked AI agent actions, estimated token savings, and Bayes error rate of the intervention scorer.",
+  "name": "ThumbGate Operational Snapshot",
+  "description": "First-party operational snapshot from the ThumbGate pre-action check runtime: configured checks, recorded block/warn events, estimated token savings from recorded blocks, and Bayes error rate when the sample supports it.",
   "url": "https://thumbgate-production.up.railway.app/numbers",
   "license": "https://opensource.org/licenses/MIT",
   "creator": {
@@ -57,8 +57,8 @@
       "https://www.linkedin.com/in/igorganapolsky"
     ]
   },
-  "dateModified": "2026-05-06",
-  "datePublished": "2026-05-06",
+  "dateModified": "2026-05-07",
+  "datePublished": "2026-05-07",
   "keywords": [
     "AI agent gates",
     "LLM token savings",
@@ -69,7 +69,7 @@
   "variableMeasured": [
     {
       "@type": "PropertyValue",
-      "name": "active_gates",
+      "name": "configured_gates",
       "value": 36
     },
     {
@@ -119,6 +119,8 @@
     --cyan: #22d3ee;
     --green: #34d399;
     --amber: #fbbf24;
+    --amber-soft: rgba(251, 191, 36, 0.1);
+    --amber-line: rgba(251, 191, 36, 0.34);
   }
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
   nav { padding: 1rem 2rem; border-bottom: 1px solid var(--border); display: flex; gap: 1.5rem; align-items: center; }
@@ -140,6 +142,16 @@
     font-weight: 600;
     margin-bottom: 2.5rem;
   }
+  .truth-note {
+    background: var(--amber-soft);
+    border: 1px solid var(--amber-line);
+    border-radius: 12px;
+    color: #fde68a;
+    padding: 16px 18px;
+    margin: 0 0 2.5rem;
+    font-size: 0.95rem;
+  }
+  .truth-note strong { color: #fff3bd; }
   .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 18px; margin: 1.5rem 0; }
   .stat-card {
     background: var(--bg-card);
@@ -189,33 +201,34 @@
 
 <main class="container">
   <h1>The Numbers</h1>
-  <p class="subtitle">Generated first-party operational data from the ThumbGate runtime. No surveys or projections — this page is a release-time snapshot produced by the same local scripts that power the CLI and dashboard.</p>
-  <div class="freshness">Updated: 2026-05-06 · Version 1.16.21</div>
+  <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.16.21</div>
+  <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>
   <div class="stats-grid">
     <div class="stat-card">
-      <div class="stat-label">Active gates</div>
+      <div class="stat-label">Configured checks</div>
       <div class="stat-value">36</div>
-      <div class="stat-sub">36 manual · 0 auto-promoted</div>
+      <div class="stat-sub">36 shipped defaults · 0 auto-promoted; inventory, not usage</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Actions blocked</div>
       <div class="stat-value">0</div>
-      <div class="stat-sub">repeat AI mistakes prevented at the gate</div>
+      <div class="stat-sub">no recorded hard-block events in this snapshot</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Actions warned</div>
       <div class="stat-value">0</div>
-      <div class="stat-sub">soft interventions; not blocks</div>
+      <div class="stat-sub">no recorded soft-warning events in this snapshot</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
-      <div class="stat-label">Top blocked gate</div>
-      <div class="stat-value" style="font-size:1.1rem;">local-only-git-writes (0 blocks)</div>
-      <div class="stat-sub">highest-occurrence prevention rule</div>
+      <div class="stat-label">Top recorded blocker</div>
+      <div class="stat-value" style="font-size:1.1rem;">No recorded blocker yet</div>
+      <div class="stat-sub">top blocker appears only after at least one recorded block</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
   </div>
@@ -225,25 +238,25 @@
     <div class="stat-card">
       <div class="stat-label">Estimated hours saved</div>
       <div class="stat-value">0.0</div>
-      <div class="stat-sub">~15 min per blocked mistake × blocks+warns</div>
+      <div class="stat-sub">0 because no block/warn events are recorded</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Estimated LLM dollars saved</div>
       <div class="stat-value">$0.00</div>
-      <div class="stat-sub">blended Sonnet/Opus/Haiku 80/15/5 mix</div>
+      <div class="stat-sub">0 because no recorded block events feed this estimate</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/token-savings.js">source: token-savings.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Tokens not spent</div>
       <div class="stat-value">0</div>
-      <div class="stat-sub">2,000 input + 600 output per block, conservative</div>
+      <div class="stat-sub">0 because no recorded block events feed this estimate</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/token-savings.js">source: token-savings.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Scorer Bayes error</div>
-      <div class="stat-value">n/a (no feedback sequences recorded yet)</div>
-      <div class="stat-sub">irreducible error given current feature set</div>
+      <div class="stat-value">n/a</div>
+      <div class="stat-sub">needs both safe and harmful feedback sequences</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/bayes-optimal-gate.js">source: bayes-optimal-gate.js</a>
     </div>
   </div>
@@ -252,11 +265,11 @@
   <div class="method">
     <p><strong>Where the numbers come from.</strong> This page is regenerated from local scripts — no survey data, no hand-edited figures, no third-party attribution. Every number on this page is produced by code in the public <a href="https://github.com/IgorGanapolsky/ThumbGate">ThumbGate repo</a>.</p>
     <ul>
-      <li><strong>Active checks</strong> — union of shipped default rules and the auto-promotion ledger (auto).</li>
-      <li><strong>Actions blocked/warned</strong> — sum of <code>occurrences</code> across gates with the corresponding action.</li>
-      <li><strong>Hours saved</strong> — conservative 15-minute/incident estimate for debugging a repeated AI mistake × (blocks + warns).</li>
-      <li><strong>Dollars saved</strong> — blended per-call token estimate (2k input + 600 output) × blocks × 2026-04-15 Anthropic + OpenAI list prices. See <code>scripts/token-savings.js</code> for the full price snapshot.</li>
-      <li><strong>Bayes error rate</strong> — irreducible classifier error of the current risk scorer given its feature set. High values mean "add features, don't tune thresholds."</li>
+      <li><strong>Configured checks</strong> — union of shipped default rules and the auto-promotion ledger. This is inventory, not proof that the check fired.</li>
+      <li><strong>Actions blocked/warned</strong> — recorded intervention counts from gate occurrence data. These are the evidence counters.</li>
+      <li><strong>Hours saved</strong> — conservative 15-minute/incident estimate, shown only as a function of recorded block/warn counts.</li>
+      <li><strong>Dollars saved</strong> — blended per-call token estimate (2k input + 600 output) × recorded blocks × 2026-04-15 Anthropic + OpenAI list prices. See <code>scripts/token-savings.js</code> for the full price snapshot.</li>
+      <li><strong>Bayes error rate</strong> — shown only when the feedback sample contains both safe and harmful outcomes. One-class samples are reported as n/a.</li>
     </ul>
     <p style="margin-top:12px;">Last auto-promotion: none. Regenerated on every release via <code>npm run numbers:generate</code> and on a weekly cadence.</p>
   </div>
@@ -264,7 +277,7 @@
   <div class="cta">
     <a href="https://www.npmjs.com/package/thumbgate">Install ThumbGate — npx thumbgate init</a>
     <div class="footer-note">Prefer the raw feed? See <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a> or run <code>npm run gate:stats</code> locally.</div>
-    <div class="footer-note">Generated at 2026-05-06T21:53:14.685Z UTC.</div>
+    <div class="footer-note">Generated at 2026-05-07T12:49:54.256Z UTC.</div>
   </div>
 </main>
 </body>

--- a/scripts/gate-stats.js
+++ b/scripts/gate-stats.js
@@ -43,10 +43,12 @@ function calculateStats() {
     .filter((g) => g.action === 'warn')
     .reduce((sum, g) => sum + (g.occurrences || 0), 0);
 
-  // Top blocked gate
+  // Top blocked gate. A configured block rule with zero occurrences is not a
+  // "top blocker"; only recorded block events should appear here.
   const topBlocked = [...allGates]
+    .filter((g) => g.action === 'block' && Number(g.occurrences || 0) > 0)
     .sort((a, b) => (b.occurrences || 0) - (a.occurrences || 0))
-    .find((g) => g.action === 'block') || null;
+    .at(0) || null;
 
   // Last promotion event
   const lastPromotion = promotionLog.length > 0
@@ -58,11 +60,9 @@ function calculateStats() {
   const estimatedHoursSaved = (estimatedMinutesSaved / 60).toFixed(1);
 
   // Bayes error rate: irreducible error floor of the current scorer given its
-  // feature set (tag signatures). If this is near zero, the scorer is already
-  // close to optimal — threshold tuning won't help, and new features are the
-  // only lever. If this is high, the feature set can't discriminate the signal
-  // and we should add features (file path, recency, commit context) rather
-  // than tune thresholds. Null when no feedback sequences have been recorded.
+  // feature set (tag signatures). It is only meaningful when the local sample
+  // contains both harmful and safe outcomes; an all-negative or all-positive
+  // sample can produce a misleading 0.0% floor.
   const bayesErrorRate = tryComputeBayesErrorRate();
 
   return {
@@ -90,10 +90,31 @@ function tryComputeBayesErrorRate() {
       .filter(Boolean)
       .map((line) => { try { return JSON.parse(line); } catch { return null; } })
       .filter(Boolean);
+    if (!hasMixedOutcomeClasses(rows)) return null;
     return computeBayesErrorRate(rows);
   } catch {
     return null;
   }
+}
+
+function hasMixedOutcomeClasses(rows) {
+  if (!Array.isArray(rows) || rows.length < 2) return false;
+  let harmful = 0;
+  let safe = 0;
+  for (const row of rows) {
+    if (sequenceIsHarmful(row)) harmful += 1;
+    else safe += 1;
+    if (harmful > 0 && safe > 0) return true;
+  }
+  return false;
+}
+
+function sequenceIsHarmful(row) {
+  if (!row || typeof row !== 'object') return false;
+  if (typeof row.targetRisk === 'number') return row.targetRisk > 0;
+  if (typeof row.accepted === 'boolean' && row.accepted === false) return true;
+  const label = String(row.label || row.signal || '').toLowerCase();
+  return label === 'negative';
 }
 
 function formatLastPromotion(promo) {
@@ -125,7 +146,7 @@ function formatStats(stats) {
 }
 
 function formatBayesErrorRate(rate) {
-  if (rate === null || rate === undefined) return 'n/a (no feedback sequences yet)';
+  if (rate === null || rate === undefined) return 'n/a (need both safe and harmful feedback sequences)';
   const pct = (rate * 100).toFixed(1);
   if (rate < 0.02) return `${pct}% — scorer is near-optimal; add features, don't tune thresholds`;
   if (rate < 0.10) return `${pct}% — scorer has modest headroom`;

--- a/scripts/generate-numbers-page.js
+++ b/scripts/generate-numbers-page.js
@@ -7,8 +7,10 @@
  * Why this exists (SEO 2026 rationale):
  *   Search engines — and the AI retrievers that sit on top of them — rank
  *   first-party, freshly-dated, extractable content higher than synthesized
- *   summaries. ThumbGate has unique operational data (gate counts, blocked
- *   actions, token savings, Bayes error rate) that competitors cannot fake.
+ *   summaries. ThumbGate has operational data (configured gate counts,
+ *   recorded block/warn events, token savings estimates, Bayes error rate)
+ *   that should be published only with explicit caveats about what was
+ *   observed versus what was merely configured.
  *   Publishing those numbers as a structured, machine-liftable page with a
  *   visible "Updated:" stamp hits three ranking signals at once:
  *     1. First-party data (proprietary, not synthesized)
@@ -16,8 +18,8 @@
  *     3. Extractability (JSON-LD Dataset + SoftwareApplication + Person)
  *
  * Data sources (all local, no network calls):
- *   - scripts/gate-stats.js       → gate counts, blocks, warns, Bayes error
- *   - scripts/token-savings.js    → blended $/token savings estimate
+ *   - scripts/gate-stats.js       → configured gate inventory, recorded block/warn counts, Bayes error
+ *   - scripts/token-savings.js    → blended $/token savings estimate from recorded block counts
  *   - package.json                → current version
  *
  * Output:
@@ -109,9 +111,9 @@ function renderNumbersPage(input) {
   const datasetLd = {
     '@context': 'https://schema.org',
     '@type': 'Dataset',
-    name: 'ThumbGate Live Operational Metrics',
+    name: 'ThumbGate Operational Snapshot',
     description:
-      'First-party operational metrics from the ThumbGate pre-action check runtime: active checks, blocked AI agent actions, estimated token savings, and Bayes error rate of the intervention scorer.',
+      'First-party operational snapshot from the ThumbGate pre-action check runtime: configured checks, recorded block/warn events, estimated token savings from recorded blocks, and Bayes error rate when the sample supports it.',
     url: 'https://thumbgate-production.up.railway.app/numbers',
     license: 'https://opensource.org/licenses/MIT',
     creator: softwareLd.creator,
@@ -125,7 +127,7 @@ function renderNumbersPage(input) {
       'self-improving agents',
     ],
     variableMeasured: [
-      { '@type': 'PropertyValue', name: 'active_gates', value: gate.totalGates },
+      { '@type': 'PropertyValue', name: 'configured_gates', value: gate.totalGates },
       { '@type': 'PropertyValue', name: 'actions_blocked', value: gate.totalBlocked },
       { '@type': 'PropertyValue', name: 'actions_warned', value: gate.totalWarned },
       {
@@ -152,13 +154,36 @@ function renderNumbersPage(input) {
     ],
   };
 
-  const topBlockedLine = gate.topBlocked
+  const hasRecordedBlocks = Number(gate.totalBlocked || 0) > 0;
+  const hasRecordedWarnings = Number(gate.totalWarned || 0) > 0;
+  const topBlockedLine = hasRecordedBlocks && gate.topBlocked
     ? `${escapeHtml(gate.topBlocked.id)} (${formatNumber(gate.topBlocked.occurrences || 0)} blocks)`
-    : 'none yet';
+    : 'No recorded blocker yet';
+  const topBlockedSub = hasRecordedBlocks
+    ? 'highest recorded block count'
+    : 'top blocker appears only after at least one recorded block';
+  const blockedSub = hasRecordedBlocks
+    ? 'recorded hard blocks in the local gate ledger'
+    : 'no recorded hard-block events in this snapshot';
+  const warnedSub = hasRecordedWarnings
+    ? 'recorded soft interventions; not hard blocks'
+    : 'no recorded soft-warning events in this snapshot';
+  const hoursSub = hasRecordedBlocks || hasRecordedWarnings
+    ? '~15 min per recorded block/warn event'
+    : '0 because no block/warn events are recorded';
+  const dollarsSub = hasRecordedBlocks
+    ? 'blended Sonnet/Opus/Haiku 80/15/5 mix from recorded blocks'
+    : '0 because no recorded block events feed this estimate';
+  const tokensSub = hasRecordedBlocks
+    ? '2,000 input + 600 output per recorded block, conservative'
+    : '0 because no recorded block events feed this estimate';
 
   const bayesLine = gate.bayesErrorRate === null || gate.bayesErrorRate === undefined
-    ? 'n/a (no feedback sequences recorded yet)'
+    ? 'n/a'
     : `${(gate.bayesErrorRate * 100).toFixed(1)}%`;
+  const bayesSub = gate.bayesErrorRate === null || gate.bayesErrorRate === undefined
+    ? 'needs both safe and harmful feedback sequences'
+    : 'irreducible error given current feature set';
 
   const lastPromotionLine = (() => {
     if (!gate.lastPromotion) return 'none';
@@ -177,9 +202,9 @@ function renderNumbersPage(input) {
 <meta name="generator" content="ThumbGate">
 <meta name="author" content="Igor Ganapolsky">
 <title>ThumbGate — The Numbers | First-Party Data Snapshot</title>
-<meta name="description" content="ThumbGate's generated first-party operational snapshot: active pre-action checks, AI agent actions blocked, estimated LLM tokens and dollars saved, and the Bayes error rate of the intervention scorer.">
+<meta name="description" content="ThumbGate's generated first-party operational snapshot: configured pre-action checks, recorded block/warn events, estimated LLM token savings when events exist, and scorer calibration when the sample supports it.">
 <meta property="og:title" content="ThumbGate — The Numbers">
-<meta property="og:description" content="Generated first-party operational metrics: gates, blocks, token savings, and scorer calibration.">
+<meta property="og:description" content="Generated first-party operational snapshot: configured gates, recorded interventions, and explicit zero-evidence caveats.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://thumbgate-production.up.railway.app/numbers">
 <meta name="twitter:card" content="summary_large_image">
@@ -208,6 +233,8 @@ ${JSON.stringify(datasetLd, null, 2)}
     --cyan: #22d3ee;
     --green: #34d399;
     --amber: #fbbf24;
+    --amber-soft: rgba(251, 191, 36, 0.1);
+    --amber-line: rgba(251, 191, 36, 0.34);
   }
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
   nav { padding: 1rem 2rem; border-bottom: 1px solid var(--border); display: flex; gap: 1.5rem; align-items: center; }
@@ -229,6 +256,16 @@ ${JSON.stringify(datasetLd, null, 2)}
     font-weight: 600;
     margin-bottom: 2.5rem;
   }
+  .truth-note {
+    background: var(--amber-soft);
+    border: 1px solid var(--amber-line);
+    border-radius: 12px;
+    color: #fde68a;
+    padding: 16px 18px;
+    margin: 0 0 2.5rem;
+    font-size: 0.95rem;
+  }
+  .truth-note strong { color: #fff3bd; }
   .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 18px; margin: 1.5rem 0; }
   .stat-card {
     background: var(--bg-card);
@@ -278,33 +315,34 @@ ${JSON.stringify(datasetLd, null, 2)}
 
 <main class="container">
   <h1>The Numbers</h1>
-  <p class="subtitle">Generated first-party operational data from the ThumbGate runtime. No surveys or projections — this page is a release-time snapshot produced by the same local scripts that power the CLI and dashboard.</p>
+  <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
   <div class="freshness">Updated: ${escapeHtml(nowDate)} · Version ${escapeHtml(version)}</div>
+  <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports ${formatNumber(gate.totalBlocked)} recorded hard-block event(s) and ${formatNumber(gate.totalWarned)} recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>
   <div class="stats-grid">
     <div class="stat-card">
-      <div class="stat-label">Active gates</div>
+      <div class="stat-label">Configured checks</div>
       <div class="stat-value">${formatNumber(gate.totalGates)}</div>
-      <div class="stat-sub">${formatNumber(gate.manualGates)} manual · ${formatNumber(gate.autoPromotedGates)} auto-promoted</div>
+      <div class="stat-sub">${formatNumber(gate.manualGates)} shipped defaults · ${formatNumber(gate.autoPromotedGates)} auto-promoted; inventory, not usage</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Actions blocked</div>
       <div class="stat-value">${formatNumber(gate.totalBlocked)}</div>
-      <div class="stat-sub">repeat AI mistakes prevented at the gate</div>
+      <div class="stat-sub">${blockedSub}</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Actions warned</div>
       <div class="stat-value">${formatNumber(gate.totalWarned)}</div>
-      <div class="stat-sub">soft interventions; not blocks</div>
+      <div class="stat-sub">${warnedSub}</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
-      <div class="stat-label">Top blocked gate</div>
+      <div class="stat-label">Top recorded blocker</div>
       <div class="stat-value" style="font-size:1.1rem;">${topBlockedLine}</div>
-      <div class="stat-sub">highest-occurrence prevention rule</div>
+      <div class="stat-sub">${topBlockedSub}</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
   </div>
@@ -314,25 +352,25 @@ ${JSON.stringify(datasetLd, null, 2)}
     <div class="stat-card">
       <div class="stat-label">Estimated hours saved</div>
       <div class="stat-value">${escapeHtml(String(gate.estimatedHoursSaved))}</div>
-      <div class="stat-sub">~15 min per blocked mistake × blocks+warns</div>
+      <div class="stat-sub">${hoursSub}</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/gate-stats.js">source: gate-stats.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Estimated LLM dollars saved</div>
       <div class="stat-value">${escapeHtml(savings.dollarsSavedDisplay)}</div>
-      <div class="stat-sub">blended Sonnet/Opus/Haiku 80/15/5 mix</div>
+      <div class="stat-sub">${dollarsSub}</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/token-savings.js">source: token-savings.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Tokens not spent</div>
       <div class="stat-value">${escapeHtml(savings.tokensSavedDisplay)}</div>
-      <div class="stat-sub">2,000 input + 600 output per block, conservative</div>
+      <div class="stat-sub">${tokensSub}</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/token-savings.js">source: token-savings.js</a>
     </div>
     <div class="stat-card">
       <div class="stat-label">Scorer Bayes error</div>
       <div class="stat-value">${escapeHtml(bayesLine)}</div>
-      <div class="stat-sub">irreducible error given current feature set</div>
+      <div class="stat-sub">${bayesSub}</div>
       <a class="stat-source" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/scripts/bayes-optimal-gate.js">source: bayes-optimal-gate.js</a>
     </div>
   </div>
@@ -341,11 +379,11 @@ ${JSON.stringify(datasetLd, null, 2)}
   <div class="method">
     <p><strong>Where the numbers come from.</strong> This page is regenerated from local scripts — no survey data, no hand-edited figures, no third-party attribution. Every number on this page is produced by code in the public <a href="https://github.com/IgorGanapolsky/ThumbGate">ThumbGate repo</a>.</p>
     <ul>
-      <li><strong>Active checks</strong> — union of shipped default rules and the auto-promotion ledger (auto).</li>
-      <li><strong>Actions blocked/warned</strong> — sum of <code>occurrences</code> across gates with the corresponding action.</li>
-      <li><strong>Hours saved</strong> — conservative 15-minute/incident estimate for debugging a repeated AI mistake × (blocks + warns).</li>
-      <li><strong>Dollars saved</strong> — blended per-call token estimate (2k input + 600 output) × blocks × 2026-04-15 Anthropic + OpenAI list prices. See <code>scripts/token-savings.js</code> for the full price snapshot.</li>
-      <li><strong>Bayes error rate</strong> — irreducible classifier error of the current risk scorer given its feature set. High values mean "add features, don't tune thresholds."</li>
+      <li><strong>Configured checks</strong> — union of shipped default rules and the auto-promotion ledger. This is inventory, not proof that the check fired.</li>
+      <li><strong>Actions blocked/warned</strong> — recorded intervention counts from gate occurrence data. These are the evidence counters.</li>
+      <li><strong>Hours saved</strong> — conservative 15-minute/incident estimate, shown only as a function of recorded block/warn counts.</li>
+      <li><strong>Dollars saved</strong> — blended per-call token estimate (2k input + 600 output) × recorded blocks × 2026-04-15 Anthropic + OpenAI list prices. See <code>scripts/token-savings.js</code> for the full price snapshot.</li>
+      <li><strong>Bayes error rate</strong> — shown only when the feedback sample contains both safe and harmful outcomes. One-class samples are reported as n/a.</li>
     </ul>
     <p style="margin-top:12px;">Last auto-promotion: ${lastPromotionLine}. Regenerated on every release via <code>npm run numbers:generate</code> and on a weekly cadence.</p>
   </div>

--- a/tests/gate-stats.test.js
+++ b/tests/gate-stats.test.js
@@ -132,11 +132,31 @@ test('formatStats: handles no top blocked gate', () => {
   assert.ok(output.includes('Last promotion: none'));
 });
 
+test('formatStats: does not invent a top blocked gate for zero-occurrence block rules', () => {
+  const stats = {
+    totalGates: 1,
+    manualGates: 1,
+    autoPromotedGates: 0,
+    blockGates: 1,
+    warnGates: 0,
+    totalBlocked: 0,
+    totalWarned: 0,
+    topBlocked: null,
+    lastPromotion: null,
+    estimatedHoursSaved: '0.0',
+    gates: [{ id: 'local-only-git-writes', action: 'block', occurrences: 0 }],
+  };
+  const output = formatStats(stats);
+  assert.ok(output.includes('Top blocked gate: none'));
+  assert.ok(!output.includes('local-only-git-writes (0 blocks)'));
+});
+
 // -- formatBayesErrorRate --
 
 test('formatBayesErrorRate: returns n/a for null or undefined', () => {
   assert.ok(formatBayesErrorRate(null).includes('n/a'));
   assert.ok(formatBayesErrorRate(undefined).includes('n/a'));
+  assert.ok(formatBayesErrorRate(null).includes('safe and harmful'));
 });
 
 test('formatBayesErrorRate: labels near-zero error as near-optimal', () => {

--- a/tests/numbers-page.test.js
+++ b/tests/numbers-page.test.js
@@ -76,8 +76,8 @@ describe('generate-numbers-page renderer', () => {
       'expected Dataset JSON-LD type',
     );
     assert.ok(
-      html.includes('"name": "active_gates"'),
-      'expected active_gates property in Dataset',
+      html.includes('"name": "configured_gates"'),
+      'expected configured_gates property in Dataset',
     );
     assert.ok(
       html.includes('"name": "actions_blocked"'),
@@ -125,6 +125,41 @@ describe('generate-numbers-page renderer', () => {
       html.includes('never-force-push-main'),
       'expected top blocked gate id',
     );
+  });
+
+  it('renders zero recorded intervention counts as zero evidence, not traction', () => {
+    const zero = renderNumbersPage({
+      version: '1.12.2',
+      nowIso: '2026-04-20T10:00:00.000Z',
+      nowDate: '2026-04-20',
+      gate: {
+        ...FIXTURE_STATS,
+        totalBlocked: 0,
+        totalWarned: 0,
+        topBlocked: null,
+        estimatedHoursSaved: '0.0',
+        bayesErrorRate: null,
+      },
+      savings: {
+        ...FIXTURE_SAVINGS,
+        blockedCalls: 0,
+        tokensSavedInput: 0,
+        tokensSavedOutput: 0,
+        tokensSavedTotal: 0,
+        dollarsSaved: 0,
+        dollarsSavedDisplay: '$0.00',
+        tokensSavedDisplay: '0',
+      },
+    });
+
+    assert.match(zero, /configured checks are inventory/i);
+    assert.match(zero, /0 recorded hard-block event\(s\)/);
+    assert.match(zero, /no recorded hard-block events in this snapshot/i);
+    assert.match(zero, /No recorded blocker yet/);
+    assert.match(zero, /n\/a/);
+    assert.doesNotMatch(zero, /repeat AI mistakes prevented at the gate/);
+    assert.doesNotMatch(zero, /highest-occurrence prevention rule/);
+    assert.doesNotMatch(zero, /local-only-git-writes \(0 blocks\)/);
   });
 
   it('links each stat back to its source script so numbers are auditable', () => {


### PR DESCRIPTION
## Summary
- Reword /numbers so configured checks are clearly inventory, not usage evidence
- Suppress zero-occurrence top blocker claims and show no recorded blocker until a block event exists
- Report Bayes error as n/a unless the feedback sample has both safe and harmful outcomes
- Regenerate public/numbers.html with the corrected zero-evidence wording

## Tests
- node --test tests/numbers-page.test.js tests/gate-stats.test.js
- node scripts/changeset-check.js --since=origin/main
- git diff --check
