### PR TITLE
Fix Pro upgrade bundle packaging

### DIFF
--- a/.changeset/fix-pro-upgrade-bundle.md
+++ b/.changeset/fix-pro-upgrade-bundle.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix `thumbgate pro --upgrade` in the public npm package by shipping the local Pro upgrade bundle from `config/pro` and adding a clear missing-bundle error instead of referencing an unpublished top-level `pro/` subtree.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1112,7 +1112,6 @@ function pro() {
   }
 
   if (args.upgrade) {
-    const proDir = path.join(PKG_ROOT, 'pro');
     const thumbgateDir = path.join(CWD, '.thumbgate');
     if (!fs.existsSync(thumbgateDir)) fs.mkdirSync(thumbgateDir, { recursive: true });
 
@@ -1122,6 +1121,21 @@ function pro() {
       ['thompson-presets.json', '4 sampling presets'],
       ['reminders-pro.json', '8 reminder templates'],
     ];
+
+    const candidateDirs = [
+      path.join(PKG_ROOT, 'config', 'pro'),
+      path.join(PKG_ROOT, 'pro'),
+    ];
+    const proDir = candidateDirs.find((dir) =>
+      files.every(([file]) => fs.existsSync(path.join(dir, file)))
+    );
+
+    if (!proDir) {
+      console.error('Pro upgrade bundle is missing from this ThumbGate install.');
+      console.error(`Expected files under: ${path.join(PKG_ROOT, 'config', 'pro')}`);
+      console.error('Please upgrade to the latest thumbgate package and retry: npm install -g thumbgate@latest');
+      process.exit(1);
+    }
 
     for (const [file] of files) {
       fs.copyFileSync(path.join(proDir, file), path.join(thumbgateDir, file));

--- a/config/pro/constraints-pro.json
+++ b/config/pro/constraints-pro.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "name": "ThumbGate Pro Constraints",
+  "description": "Public Pro upgrade bundle installed by `thumbgate pro --upgrade` for local workflow hardening.",
+  "constraints": [
+    {
+      "id": "evidence-before-completion",
+      "severity": "critical",
+      "rule": "Do not claim done, fixed, shipped, published, or paid until the relevant command, URL, PR, workflow, or billing record has been checked."
+    },
+    {
+      "id": "read-before-write",
+      "severity": "high",
+      "rule": "Before editing existing code, read the surrounding implementation and tests so the patch follows local contracts."
+    },
+    {
+      "id": "no-destructive-git-without-intent",
+      "severity": "critical",
+      "rule": "Block destructive git operations such as reset --hard, checkout --, clean -fd, and force-push unless the operator explicitly requested that exact operation."
+    },
+    {
+      "id": "production-data-write-gate",
+      "severity": "critical",
+      "rule": "Block production database writes, deletes, migrations, and irreversible data operations unless a backup, target environment, and rollback plan are present."
+    },
+    {
+      "id": "secrets-redaction",
+      "severity": "critical",
+      "rule": "Never print, commit, paste, or persist secrets. Use only sanitized status output when verifying credentials."
+    },
+    {
+      "id": "test-before-merge",
+      "severity": "high",
+      "rule": "Before saying a code change is ready, run the narrow relevant tests or explain exactly why verification could not run."
+    },
+    {
+      "id": "no-synthetic-traction",
+      "severity": "critical",
+      "rule": "Do not describe views, clicks, stars, configured gates, or generated artifacts as revenue, customers, or proven interventions."
+    },
+    {
+      "id": "paid-path-health",
+      "severity": "high",
+      "rule": "Before promoting a paid offer, verify the landing page and checkout route return HTTP 200 and point to the intended Stripe path."
+    },
+    {
+      "id": "single-source-commercial-truth",
+      "severity": "high",
+      "rule": "Commercial claims must match docs/COMMERCIAL_TRUTH.md for pricing, traction, tier limits, and proof language."
+    },
+    {
+      "id": "bounded-agent-run",
+      "severity": "high",
+      "rule": "Long-running agent work must have a bounded objective, progress evidence, and a stop condition instead of open-ended activity."
+    }
+  ]
+}

--- a/config/pro/prevention-rules-pro.md
+++ b/config/pro/prevention-rules-pro.md
@@ -1,0 +1,27 @@
+# ThumbGate Pro Prevention Rules
+
+These public Pro rules are installed by `thumbgate pro --upgrade` into `.thumbgate/`.
+They are starting points for local operator hardening, not proof that any gate has fired.
+
+## Evidence Claims
+
+- Require a fresh command, API response, workflow status, URL check, or billing record before completion claims.
+- Treat configured checks as inventory and recorded blocks or warnings as usage evidence.
+- Treat Stripe-reconciled charges as revenue proof; treat traffic and clicks as funnel evidence only.
+
+## Code Changes
+
+- Read the existing file and nearby tests before editing.
+- Keep edits scoped to the requested behavior.
+- Run narrow tests for the touched behavior before reporting success.
+
+## Risky Actions
+
+- Block destructive git commands unless the operator explicitly asked for the exact action.
+- Block production data changes unless the target, backup, and rollback plan are explicit.
+- Block checkout, publish, deploy, or customer-write claims until the live path is verified.
+
+## Agent Workflow
+
+- If an agent repeats a known failure, capture the failed action, expected behavior, and enforcement rule in one concise lesson.
+- Prefer one workflow owner, one repeated failure, and one proof review before expanding a Team rollout.

--- a/config/pro/reminders-pro.json
+++ b/config/pro/reminders-pro.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "name": "ThumbGate Pro Reminder Templates",
+  "reminders": [
+    {
+      "id": "verify-before-claim",
+      "text": "Verify with a tool before claiming this is done."
+    },
+    {
+      "id": "read-local-contract",
+      "text": "Read the local implementation and tests before editing."
+    },
+    {
+      "id": "protect-user-work",
+      "text": "Do not revert user changes or unrelated dirty worktree state."
+    },
+    {
+      "id": "billing-truth",
+      "text": "Do not claim revenue unless Stripe or billing evidence proves it."
+    },
+    {
+      "id": "configured-is-not-fired",
+      "text": "Configured checks are inventory; recorded blocks and warnings are usage evidence."
+    },
+    {
+      "id": "checkout-health",
+      "text": "Verify the paid landing page and checkout route before sending traffic."
+    },
+    {
+      "id": "narrow-tests",
+      "text": "Run the smallest relevant test set for this change."
+    },
+    {
+      "id": "bounded-workflow",
+      "text": "Name the workflow owner, repeated failure, proof artifact, and stop condition."
+    }
+  ]
+}

--- a/config/pro/thompson-presets.json
+++ b/config/pro/thompson-presets.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "name": "ThumbGate Pro Thompson Sampling Presets",
+  "presets": [
+    {
+      "id": "conservative",
+      "description": "Prefer warn before block until repeated harmful evidence accumulates.",
+      "alpha": 1,
+      "beta": 3,
+      "blockThreshold": 0.82,
+      "warnThreshold": 0.55
+    },
+    {
+      "id": "balanced",
+      "description": "Default local hardening profile for repeated workflow failures.",
+      "alpha": 2,
+      "beta": 2,
+      "blockThreshold": 0.72,
+      "warnThreshold": 0.48
+    },
+    {
+      "id": "strict",
+      "description": "Use for high-blast-radius workflows such as production data, deploys, billing, and destructive git.",
+      "alpha": 3,
+      "beta": 1,
+      "blockThreshold": 0.62,
+      "warnThreshold": 0.38
+    },
+    {
+      "id": "evidence-first",
+      "description": "Bias toward interventions when the agent lacks proof for claims or risky writes.",
+      "alpha": 4,
+      "beta": 2,
+      "blockThreshold": 0.66,
+      "warnThreshold": 0.42
+    }
+  ]
+}

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -797,6 +797,44 @@ describe('bin/cli.js', () => {
     assert.doesNotMatch(result.stdout, /\$10\/mo|38 spots remaining|first 50 users|Founding Member/i);
   });
 
+  test('pro --upgrade installs the shipped public Pro config bundle', () => {
+    const homeDir = makeTmpDir();
+    const projectDir = makeTmpDir();
+
+    const result = runCliSync(['pro', '--upgrade'], {
+      cwd: projectDir,
+      env: unlicensedProEnv(homeDir, {
+        THUMBGATE_NO_NUDGE: '1',
+      }),
+    });
+
+    assert.equal(result.status, 0, `pro --upgrade failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.match(result.stdout, /Pro configs installed to \.thumbgate/);
+    assert.doesNotMatch(result.stderr, /ENOENT|constraints-pro\.json/);
+
+    const thumbgateDir = path.join(projectDir, '.thumbgate');
+    for (const fileName of [
+      'constraints-pro.json',
+      'prevention-rules-pro.md',
+      'thompson-presets.json',
+      'reminders-pro.json',
+    ]) {
+      assert.ok(
+        fs.existsSync(path.join(thumbgateDir, fileName)),
+        `${fileName} should be installed into the project .thumbgate directory`,
+      );
+    }
+
+    const constraints = JSON.parse(fs.readFileSync(path.join(thumbgateDir, 'constraints-pro.json'), 'utf8'));
+    assert.ok(
+      constraints.constraints.length >= 10,
+      'Pro constraints bundle should include the advertised 10 local constraints',
+    );
+
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
   test('pro command launches local dashboard when a license is already saved', async () => {
     const homeDir = makeTmpDir();
     const licenseDir = path.join(homeDir, '.thumbgate');

--- a/tests/license.test.js
+++ b/tests/license.test.js
@@ -57,6 +57,40 @@ test('activateLicense rejects invalid prefixes but accepts legacy Stripe keys', 
   }
 });
 
+test('activateLicense persists a Pro key that verifyLicense reads from the local license path', () => {
+  const { moduleExports: license, homeDir, restore } = loadWithIsolatedLicenseEnv(LICENSE_MODULE_ID);
+  try {
+    const key = 'tg_pro_localtiercoverage1234567890';
+    const activation = license.activateLicense(key, { homeDir });
+
+    assert.equal(activation.success, true);
+    assert.equal(activation.path, license.getLicensePath(homeDir));
+
+    const verified = license.verifyLicense({ homeDir });
+    assert.equal(verified.valid, true);
+    assert.equal(verified.source, 'file');
+    assert.equal(verified.key, key);
+    assert.equal(verified.path, activation.path);
+  } finally {
+    restore();
+  }
+});
+
+test('verifyLicense prefers a valid Pro env key over the local license file', () => {
+  const { moduleExports: license, homeDir, restore } = loadWithIsolatedLicenseEnv(LICENSE_MODULE_ID);
+  try {
+    license.activateLicense('tg_pro_filetiercoverage1234567890', { homeDir });
+    process.env.THUMBGATE_PRO_KEY = 'tg_pro_envtiercoverage1234567890';
+
+    const verified = license.verifyLicense({ homeDir });
+    assert.equal(verified.valid, true);
+    assert.equal(verified.source, 'env');
+    assert.equal(verified.key, 'tg_pro_envtiercoverage1234567890');
+  } finally {
+    restore();
+  }
+});
+
 test('Pro feature gate blocks without license', () => {
   const { moduleExports: proFeatures, restore } = loadWithIsolatedLicenseEnv(
     PRO_FEATURES_MODULE_ID,

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -121,6 +121,10 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     'scripts/statusline-meta.js',
     'scripts/tool-registry.js',
     'skills/thumbgate/SKILL.md',
+    'config/pro/constraints-pro.json',
+    'config/pro/prevention-rules-pro.md',
+    'config/pro/thompson-presets.json',
+    'config/pro/reminders-pro.json',
     '.claude-plugin/plugin.json',
     'README.md',
     'LICENSE',
@@ -211,9 +215,12 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 242 → 245 (2026-05-06) to ship ThumbGate Bench from the npm
   // package: scripts/thumbgate-bench.js plus the default and ProgramBench-style
   // bench fixtures. The CLI now exposes `thumbgate bench --programbench-smoke`.
+  // Bumped 245 → 249 (2026-05-07) to ship the four public Pro upgrade bundle
+  // files under config/pro so `thumbgate pro --upgrade` works from npm without
+  // reintroducing the private top-level pro/ subtree.
   assert.ok(
-    manifest.fileCount <= 245,
-    `npm package should stay <= 245 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 249,
+    `npm package should stay <= 249 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing
@@ -274,9 +281,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 3.45 MB → 3.50 MB (2026-05-06) for the packaged bench runner,
   // default ThumbGate Bench fixture, ProgramBench-style smoke fixture, and
   // landing-page governance setup intake copy. Observed package is ~3.479 MB.
+  // Bumped 3.50 MB -> 3.52 MB (2026-05-07) for the four public Pro upgrade
+  // bundle files under config/pro. Observed package is ~3.505 MB.
   assert.ok(
-    manifest.unpackedSize <= 3_500_000,
-    `npm package should stay <= 3.50 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 3_520_000,
+    `npm package should stay <= 3.52 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/public-package-parity.test.js
+++ b/tests/public-package-parity.test.js
@@ -53,6 +53,30 @@ describe('public/ package parity', () => {
     );
   });
 
+  test('public Pro upgrade bundle lives under config/pro and ships with the npm config whitelist', () => {
+    assert.ok(
+      pkg.files.includes('config/'),
+      'package.json files must include config/ so the public Pro upgrade bundle ships',
+    );
+    assert.equal(
+      fs.existsSync(path.join(ROOT, 'pro')),
+      false,
+      'public package must not rely on an unpublished top-level pro/ subtree',
+    );
+
+    for (const rel of [
+      'config/pro/constraints-pro.json',
+      'config/pro/prevention-rules-pro.md',
+      'config/pro/thompson-presets.json',
+      'config/pro/reminders-pro.json',
+    ]) {
+      assert.ok(
+        fs.existsSync(path.join(ROOT, rel)),
+        `${rel} must exist so thumbgate pro --upgrade works from npm`,
+      );
+    }
+  });
+
   test('critical shipped HTML files have correct pricing', () => {
     // Guard against $99/seat Team pricing leaking back into any shipped HTML
     const shipped = pkg.files


### PR DESCRIPTION
## Summary
- ship the public Pro upgrade bundle from config/pro so npm installs can run thumbgate pro --upgrade
- make the CLI prefer config/pro with a legacy fallback and a clear missing-bundle error
- add CLI, license, package-boundary, and public package parity tests for all tiers/package surfaces

## Verification
- node --test tests/license.test.js tests/cli.test.js tests/public-package-parity.test.js tests/package-boundary.test.js tests/public-package-boundary.test.js tests/pro-landing.test.js tests/public-landing.test.js tests/billing.test.js tests/stripe-live-status.test.js tests/checkout-bot-guard.test.js (200 pass, 0 fail)
- npm pack --dry-run --json confirmed config/pro/{constraints-pro.json,prevention-rules-pro.md,thompson-presets.json,reminders-pro.json} are shipped
- git diff --check