### PR TITLE
Version packages for thumbgate@1.16.22

### DIFF
--- a/.changeset/agent-governance-runtime-gates.md
+++ b/.changeset/agent-governance-runtime-gates.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add high-ROI agent governance runtime checks for hybrid RAG scale, inference economics, model-harness fit, solver-backed workflows, and org-wide agent registry governance.

--- a/.changeset/aiventyx-revenue-email-dispatch.md
+++ b/.changeset/aiventyx-revenue-email-dispatch.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a guarded Resend-backed Aiventyx partner email dispatch workflow for same-day marketplace revenue follow-up.

--- a/.changeset/bluesky-safe-revenue-replies.md
+++ b/.changeset/bluesky-safe-revenue-replies.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a bounded Bluesky safe-reply publishing mode for manual revenue engagement runs.

--- a/.changeset/browser-checkout-skip-intent.md
+++ b/.changeset/browser-checkout-skip-intent.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Send real browser checkout traffic directly to the Stripe email gate while keeping bot-safe checkout interstitials.

--- a/.changeset/checkout-cancel-first-dollar-recovery.md
+++ b/.changeset/checkout-cancel-first-dollar-recovery.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add first-dollar and quick-read recovery links to the checkout cancellation page so abandoned buyers can restart with a lower-friction paid path.

--- a/.changeset/checkout-recovery-downsells.md
+++ b/.changeset/checkout-recovery-downsells.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add low-friction checkout recovery offers to the checkout intent and cancel paths.

--- a/.changeset/community-course-platform-launch-kit.md
+++ b/.changeset/community-course-platform-launch-kit.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Track the community course platform launch kit in the test suite so Skool and course-platform promotion guardrails stay covered.

--- a/.changeset/direct-confirmed-pro-checkout.md
+++ b/.changeset/direct-confirmed-pro-checkout.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Send hydrated Pro buyer CTAs directly to confirmed Stripe checkout while preserving attribution and bot-safe fallback routes.

--- a/.changeset/direct-paid-sprint-links.md
+++ b/.changeset/direct-paid-sprint-links.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Route the paid workflow-hardening sprint campaign through direct Stripe checkout links with paid-sprint attribution.

--- a/.changeset/first-dollar-owned-cta.md
+++ b/.changeset/first-dollar-owned-cta.md
@@ -1,5 +1,0 @@
----
-thumbgate: patch
----
-
-Add a first-dollar failure-rule checkout CTA to the homepage and Pro buyer paths.

--- a/.changeset/fix-pro-upgrade-bundle.md
+++ b/.changeset/fix-pro-upgrade-bundle.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Fix `thumbgate pro --upgrade` in the public npm package by shipping the local Pro upgrade bundle from `config/pro` and adding a clear missing-bundle error instead of referencing an unpublished top-level `pro/` subtree.

--- a/.changeset/fix-zernio-text-offer-instagram.md
+++ b/.changeset/fix-zernio-text-offer-instagram.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Skip Instagram in text-only Zernio offer dispatches unless media is attached, keeping LinkedIn, Threads, and Bluesky publishes from failing after a successful post.

--- a/.changeset/guarded-reddit-warm-dm.md
+++ b/.changeset/guarded-reddit-warm-dm.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a guarded GitHub Actions dispatch path for warm Reddit diagnostic DMs.

--- a/.changeset/guide-direct-paid-ctas.md
+++ b/.changeset/guide-direct-paid-ctas.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add direct paid Pro and workflow sprint calls to action near the setup guide install path.

--- a/.changeset/instagram-duplicate-safe-skip.md
+++ b/.changeset/instagram-duplicate-safe-skip.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Treat duplicate Instagram content blocks from Zernio as safe skipped outcomes instead of failing the Instagram Autopilot workflow.

--- a/.changeset/linkedin-auth-soft-fail.md
+++ b/.changeset/linkedin-auth-soft-fail.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Warn instead of failing the LinkedIn post-dispatch workflow when LinkedIn credentials are missing or revoked.

--- a/.changeset/marketing-autopilot-post-file.md
+++ b/.changeset/marketing-autopilot-post-file.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Fix marketing autopilot text publishing by generating a paid-offer post file before invoking post-everywhere, limiting the text step to text/image-capable channels, and preserving campaign UTM attribution.

--- a/.changeset/money-marketplace-distribution-pack.md
+++ b/.changeset/money-marketplace-distribution-pack.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a guarded money marketplace distribution pack for Lindy, Gumroad, and GoHighLevel revenue motions.

--- a/.changeset/openclaw-governance-kits.md
+++ b/.changeset/openclaw-governance-kits.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add checkout-ready ThumbGate + OpenClaw digital kit assets, live Stripe links, Zernio promotion copy, and a landing-page CTA for the first self-serve governance kit.

--- a/.changeset/paid-sprint-zernio-offer.md
+++ b/.changeset/paid-sprint-zernio-offer.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a paid workflow-sprint Zernio campaign option for direct diagnostic and implementation-sprint revenue posts.

--- a/.changeset/pro-page-quick-read-checkout.md
+++ b/.changeset/pro-page-quick-read-checkout.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Route high-intent Pro page visitors to the direct quick-read checkout while keeping the Pro dashboard checkout available.

--- a/.changeset/pro-paid-recovery.md
+++ b/.changeset/pro-paid-recovery.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a high-intent paid diagnostic and sprint recovery path to the Pro page.

--- a/.changeset/programbench-smoke-bench.md
+++ b/.changeset/programbench-smoke-bench.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a ProgramBench-style cleanroom smoke proof lane to ThumbGate Bench, publish the benchmark fixtures with the npm package, and expose the high-ticket Reliable AI Agent Governance Setup intake path on the landing page.

--- a/.changeset/promo-publisher-duplicate-exceptions.md
+++ b/.changeset/promo-publisher-duplicate-exceptions.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Treat thrown Zernio duplicate-post responses as skipped promo outcomes so idempotent paid-offer reruns stay green.

--- a/.changeset/promo-publisher-idempotent-skips.md
+++ b/.changeset/promo-publisher-idempotent-skips.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Treat recent duplicate social publishes and Reddit text-post restrictions as skipped promo outcomes instead of fatal ThumbGate Creator Platform Promo failures.

--- a/.changeset/proof-led-checkout-priority.md
+++ b/.changeset/proof-led-checkout-priority.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Prioritize Workflow Hardening Diagnostic and Sprint checkout paths above lower-price Pro and intake recovery paths for high-intent visitors.

--- a/.changeset/quick-read-checkout-cta.md
+++ b/.changeset/quick-read-checkout-cta.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add $19 AI Agent Failure Quick Read checkout calls to action on the homepage and Pro paid recovery path.

--- a/.changeset/remove-archived-diagnostic-cta.md
+++ b/.changeset/remove-archived-diagnostic-cta.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Remove the archived $99 hero diagnostic CTA and focus the paid homepage path on the current $499 diagnostic and $1500 workflow sprint offers.

--- a/.changeset/remove-paid-trial-copy-checkout-friction.md
+++ b/.changeset/remove-paid-trial-copy-checkout-friction.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Remove remaining Pro trial copy and keep real browser checkout routed directly to Stripe-collected email/payment.

--- a/.changeset/revenue-engagement-reporting.md
+++ b/.changeset/revenue-engagement-reporting.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Keep Ralph Mode revenue engagement reporting honest by counting LinkedIn posts only after the platform returns a real published post id, and let Ralph Loop use the stronger GitHub token for traffic analytics when configured.

--- a/.changeset/revenue-loop-sales-pipeline-sync.md
+++ b/.changeset/revenue-loop-sales-pipeline-sync.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Automatically sync evidence-backed GTM revenue-loop targets into the local sales pipeline so operator follow-up starts from tracked leads instead of a separate manual import step.

--- a/.changeset/revenue-status-operator-config.md
+++ b/.changeset/revenue-status-operator-config.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Let revenue status audits use the local ThumbGate operator config when environment keys are not set.

--- a/.changeset/same-day-teardown-site.md
+++ b/.changeset/same-day-teardown-site.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add the same-day teardown checkout to the homepage paid path.

--- a/.changeset/skool-headless-reader.md
+++ b/.changeset/skool-headless-reader.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a headless Skool community reader and read-only MCP connector for revenue research without taking over the user's browser.

--- a/.changeset/social-dedupe-cleanup.md
+++ b/.changeset/social-dedupe-cleanup.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a manual Zernio duplicate cleanup workflow for TikTok and Instagram posts.

--- a/.changeset/stripe-checkout-recovery.md
+++ b/.changeset/stripe-checkout-recovery.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Enable Stripe Checkout recovery URLs and promotion-code entry for paid sessions so abandoned buyers can resume checkout.

--- a/.changeset/stripe-collects-checkout-email.md
+++ b/.changeset/stripe-collects-checkout-email.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Remove the extra hosted email gate for real-browser Pro checkout starts so Stripe collects the buyer email directly while bot traffic still lands on the safe intent interstitial.

--- a/.changeset/truthful-numbers-page.md
+++ b/.changeset/truthful-numbers-page.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Clarify the public numbers page so configured checks are labeled as inventory, recorded block/warn counts are treated as the usage evidence, zero-occurrence blocker claims are suppressed, and scorer calibration is reported as n/a until the feedback sample has both safe and harmful outcomes.

--- a/.changeset/voice-agent-diagnostic-offer.md
+++ b/.changeset/voice-agent-diagnostic-offer.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a paid voice-agent reliability diagnostic offer to the Zernio promo publisher.

--- a/.changeset/zernio-cost-controls.md
+++ b/.changeset/zernio-cost-controls.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Make remaining Zernio publishing workflows opt-in by default so scheduled social, Instagram, weekly, and manual offer dispatches cannot spend paid-provider capacity or publish repeated content unless explicitly enabled.

--- a/.changeset/zernio-offer-dispatch.md
+++ b/.changeset/zernio-offer-dispatch.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a guarded Zernio offer dispatch workflow with campaign tracking for manual paid-offer pushes.

--- a/.changeset/zernio-video-autopilot-guard.md
+++ b/.changeset/zernio-video-autopilot-guard.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Guard Zernio video autopilot behind an explicit publish opt-in, slow TikTok and Instagram video cadence to one distinct experiment per day, and add a TikTok engagement creative that asks for concrete blocked-command examples instead of repeating generic product cards.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -13,7 +13,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.16.21",
+      "version": "1.16.22",
       "author": {
         "name": "Igor Ganapolsky"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action checks, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.16.21"
+    "version": "1.16.22"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,93 @@
 # Changelog
 
+## 1.16.22
+
+### Patch Changes
+
+- [#1777](https://github.com/IgorGanapolsky/ThumbGate/pull/1777) [`990b10b`](https://github.com/IgorGanapolsky/ThumbGate/commit/990b10b6618ea07c4ba20e405ef01b21dcbbdf4e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add high-ROI agent governance runtime checks for hybrid RAG scale, inference economics, model-harness fit, solver-backed workflows, and org-wide agent registry governance.
+
+- [#1755](https://github.com/IgorGanapolsky/ThumbGate/pull/1755) [`108f8ea`](https://github.com/IgorGanapolsky/ThumbGate/commit/108f8ea572e883fefe7b4f1d246a68957abeee61) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a guarded Resend-backed Aiventyx partner email dispatch workflow for same-day marketplace revenue follow-up.
+
+- [#1769](https://github.com/IgorGanapolsky/ThumbGate/pull/1769) [`6c97652`](https://github.com/IgorGanapolsky/ThumbGate/commit/6c97652710cbe561d9f5943029a47ce031cc4c4e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a bounded Bluesky safe-reply publishing mode for manual revenue engagement runs.
+
+- [#1719](https://github.com/IgorGanapolsky/ThumbGate/pull/1719) [`6793790`](https://github.com/IgorGanapolsky/ThumbGate/commit/6793790cddb8d5d093496b131ec252ec27bf0b88) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Send real browser checkout traffic directly to the Stripe email gate while keeping bot-safe checkout interstitials.
+
+- [#1758](https://github.com/IgorGanapolsky/ThumbGate/pull/1758) [`b85f9eb`](https://github.com/IgorGanapolsky/ThumbGate/commit/b85f9ebc03386d1071ed3b0b132741899de8c906) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add first-dollar and quick-read recovery links to the checkout cancellation page so abandoned buyers can restart with a lower-friction paid path.
+
+- [#1773](https://github.com/IgorGanapolsky/ThumbGate/pull/1773) [`4432906`](https://github.com/IgorGanapolsky/ThumbGate/commit/4432906163b554d27a77d4cefb6aed60b9d6f2cd) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add low-friction checkout recovery offers to the checkout intent and cancel paths.
+
+- [#1728](https://github.com/IgorGanapolsky/ThumbGate/pull/1728) [`68f9ba2`](https://github.com/IgorGanapolsky/ThumbGate/commit/68f9ba2abeb5d44d1129cf2b572369a5a89ca792) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Track the community course platform launch kit in the test suite so Skool and course-platform promotion guardrails stay covered.
+
+- [#1747](https://github.com/IgorGanapolsky/ThumbGate/pull/1747) [`b724bb8`](https://github.com/IgorGanapolsky/ThumbGate/commit/b724bb8ea459475a07db2f67a5ca637877b03818) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Send hydrated Pro buyer CTAs directly to confirmed Stripe checkout while preserving attribution and bot-safe fallback routes.
+
+- [#1743](https://github.com/IgorGanapolsky/ThumbGate/pull/1743) [`4ad2387`](https://github.com/IgorGanapolsky/ThumbGate/commit/4ad2387af95f9568fb65af6c4a6c0f5bb9399925) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Route the paid workflow-hardening sprint campaign through direct Stripe checkout links with paid-sprint attribution.
+
+- [#1756](https://github.com/IgorGanapolsky/ThumbGate/pull/1756) [`0d527b1`](https://github.com/IgorGanapolsky/ThumbGate/commit/0d527b18b2d85cfb1fbcbb676b4fcb61105386d6) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a first-dollar failure-rule checkout CTA to the homepage and Pro buyer paths.
+
+- [#1801](https://github.com/IgorGanapolsky/ThumbGate/pull/1801) [`86277a8`](https://github.com/IgorGanapolsky/ThumbGate/commit/86277a86a2cedef4394c93a2ddec41c1e5b7d206) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Fix `thumbgate pro --upgrade` in the public npm package by shipping the local Pro upgrade bundle from `config/pro` and adding a clear missing-bundle error instead of referencing an unpublished top-level `pro/` subtree.
+
+- [#1754](https://github.com/IgorGanapolsky/ThumbGate/pull/1754) [`752a588`](https://github.com/IgorGanapolsky/ThumbGate/commit/752a588d5bc947366ba796a6870e8e3b9fbaa23a) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Skip Instagram in text-only Zernio offer dispatches unless media is attached, keeping LinkedIn, Threads, and Bluesky publishes from failing after a successful post.
+
+- [#1749](https://github.com/IgorGanapolsky/ThumbGate/pull/1749) [`4d70bb7`](https://github.com/IgorGanapolsky/ThumbGate/commit/4d70bb7c9969014f7de9485dfefbd91db89ed4c7) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a guarded GitHub Actions dispatch path for warm Reddit diagnostic DMs.
+
+- [#1735](https://github.com/IgorGanapolsky/ThumbGate/pull/1735) [`01adcb9`](https://github.com/IgorGanapolsky/ThumbGate/commit/01adcb9b19a7ef0ca86c52170a7ed711e81156f2) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add direct paid Pro and workflow sprint calls to action near the setup guide install path.
+
+- [#1768](https://github.com/IgorGanapolsky/ThumbGate/pull/1768) [`64d1f8d`](https://github.com/IgorGanapolsky/ThumbGate/commit/64d1f8d29b368773318003f56278fc933f743ba3) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Treat duplicate Instagram content blocks from Zernio as safe skipped outcomes instead of failing the Instagram Autopilot workflow.
+
+- [#1745](https://github.com/IgorGanapolsky/ThumbGate/pull/1745) [`0ce9a65`](https://github.com/IgorGanapolsky/ThumbGate/commit/0ce9a655407098e2ea3f352e5f86ea30a99eab8d) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Warn instead of failing the LinkedIn post-dispatch workflow when LinkedIn credentials are missing or revoked.
+
+- [#1741](https://github.com/IgorGanapolsky/ThumbGate/pull/1741) [`e6b9409`](https://github.com/IgorGanapolsky/ThumbGate/commit/e6b9409a3315d1e71a873d3706909a727dc742ac) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Fix marketing autopilot text publishing by generating a paid-offer post file before invoking post-everywhere, limiting the text step to text/image-capable channels, and preserving campaign UTM attribution.
+
+- [#1727](https://github.com/IgorGanapolsky/ThumbGate/pull/1727) [`532c072`](https://github.com/IgorGanapolsky/ThumbGate/commit/532c0729ebe629f79abdf033a659ba5c3f2740ff) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a guarded money marketplace distribution pack for Lindy, Gumroad, and GoHighLevel revenue motions.
+
+- [#1777](https://github.com/IgorGanapolsky/ThumbGate/pull/1777) [`990b10b`](https://github.com/IgorGanapolsky/ThumbGate/commit/990b10b6618ea07c4ba20e405ef01b21dcbbdf4e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add checkout-ready ThumbGate + OpenClaw digital kit assets, live Stripe links, Zernio promotion copy, and a landing-page CTA for the first self-serve governance kit.
+
+- [#1738](https://github.com/IgorGanapolsky/ThumbGate/pull/1738) [`50a4f8d`](https://github.com/IgorGanapolsky/ThumbGate/commit/50a4f8dffbec6180bd5ffd79968ba93801a7fe9e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a paid workflow-sprint Zernio campaign option for direct diagnostic and implementation-sprint revenue posts.
+
+- [#1792](https://github.com/IgorGanapolsky/ThumbGate/pull/1792) [`0b415b5`](https://github.com/IgorGanapolsky/ThumbGate/commit/0b415b5e20d8b2b959fda2576b4efaf86dac3e03) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Route high-intent Pro page visitors to the direct quick-read checkout while keeping the Pro dashboard checkout available.
+
+- [#1723](https://github.com/IgorGanapolsky/ThumbGate/pull/1723) [`a9588ab`](https://github.com/IgorGanapolsky/ThumbGate/commit/a9588abad5695fb497e0178d63c9cbd1197fbed3) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a high-intent paid diagnostic and sprint recovery path to the Pro page.
+
+- [#1777](https://github.com/IgorGanapolsky/ThumbGate/pull/1777) [`990b10b`](https://github.com/IgorGanapolsky/ThumbGate/commit/990b10b6618ea07c4ba20e405ef01b21dcbbdf4e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a ProgramBench-style cleanroom smoke proof lane to ThumbGate Bench, publish the benchmark fixtures with the npm package, and expose the high-ticket Reliable AI Agent Governance Setup intake path on the landing page.
+
+- [#1760](https://github.com/IgorGanapolsky/ThumbGate/pull/1760) [`d5bc51c`](https://github.com/IgorGanapolsky/ThumbGate/commit/d5bc51ce4392533be359cda45c4b1d5849953cea) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Treat thrown Zernio duplicate-post responses as skipped promo outcomes so idempotent paid-offer reruns stay green.
+
+- [#1759](https://github.com/IgorGanapolsky/ThumbGate/pull/1759) [`fb942ce`](https://github.com/IgorGanapolsky/ThumbGate/commit/fb942ce2459ff71122ef4b86987c2937aa277ded) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Treat recent duplicate social publishes and Reddit text-post restrictions as skipped promo outcomes instead of fatal ThumbGate Creator Platform Promo failures.
+
+- [#1787](https://github.com/IgorGanapolsky/ThumbGate/pull/1787) [`b2b9a28`](https://github.com/IgorGanapolsky/ThumbGate/commit/b2b9a2808fdfb97dd0dcf7a59d309cecf4b051b0) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Prioritize Workflow Hardening Diagnostic and Sprint checkout paths above lower-price Pro and intake recovery paths for high-intent visitors.
+
+- [#1753](https://github.com/IgorGanapolsky/ThumbGate/pull/1753) [`4a77d5d`](https://github.com/IgorGanapolsky/ThumbGate/commit/4a77d5d80c5527934a554a1b601fa23559e3538c) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add $19 AI Agent Failure Quick Read checkout calls to action on the homepage and Pro paid recovery path.
+
+- [#1748](https://github.com/IgorGanapolsky/ThumbGate/pull/1748) [`e83ce3c`](https://github.com/IgorGanapolsky/ThumbGate/commit/e83ce3c45338dfa8b3740cb8be22311ba8ed8626) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Remove the archived $99 hero diagnostic CTA and focus the paid homepage path on the current $499 diagnostic and $1500 workflow sprint offers.
+
+- [#1734](https://github.com/IgorGanapolsky/ThumbGate/pull/1734) [`a7a95d4`](https://github.com/IgorGanapolsky/ThumbGate/commit/a7a95d4cbb71933e60c46bf4c0fec305d98d715e) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Remove remaining Pro trial copy and keep real browser checkout routed directly to Stripe-collected email/payment.
+
+- [#1720](https://github.com/IgorGanapolsky/ThumbGate/pull/1720) [`a78a7eb`](https://github.com/IgorGanapolsky/ThumbGate/commit/a78a7eb3b51880fe62b4fe2296e41c89741d8d94) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Keep Ralph Mode revenue engagement reporting honest by counting LinkedIn posts only after the platform returns a real published post id, and let Ralph Loop use the stronger GitHub token for traffic analytics when configured.
+
+- [#1679](https://github.com/IgorGanapolsky/ThumbGate/pull/1679) [`a0b7fac`](https://github.com/IgorGanapolsky/ThumbGate/commit/a0b7fac6512b0f76d942b1e4992651bd8a8d8e3b) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Automatically sync evidence-backed GTM revenue-loop targets into the local sales pipeline so operator follow-up starts from tracked leads instead of a separate manual import step.
+
+- [#1721](https://github.com/IgorGanapolsky/ThumbGate/pull/1721) [`4d8ba82`](https://github.com/IgorGanapolsky/ThumbGate/commit/4d8ba82ac26749162108a0c95a00101be78f2604) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Let revenue status audits use the local ThumbGate operator config when environment keys are not set.
+
+- [#1750](https://github.com/IgorGanapolsky/ThumbGate/pull/1750) [`d59d637`](https://github.com/IgorGanapolsky/ThumbGate/commit/d59d6374cad325bdafffc3289f18f141c3d0edd5) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add the same-day teardown checkout to the homepage paid path.
+
+- [#1736](https://github.com/IgorGanapolsky/ThumbGate/pull/1736) [`0c3373b`](https://github.com/IgorGanapolsky/ThumbGate/commit/0c3373baeca216da3ae78e4433107f32ee83f07d) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a headless Skool community reader and read-only MCP connector for revenue research without taking over the user's browser.
+
+- [#1781](https://github.com/IgorGanapolsky/ThumbGate/pull/1781) [`28dc90d`](https://github.com/IgorGanapolsky/ThumbGate/commit/28dc90d635ffad1ecbf7600e3287d4aa12ec0860) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a manual Zernio duplicate cleanup workflow for TikTok and Instagram posts.
+
+- [#1737](https://github.com/IgorGanapolsky/ThumbGate/pull/1737) [`aceb673`](https://github.com/IgorGanapolsky/ThumbGate/commit/aceb673d7ca9b12e0d23850606217d00673ee5c2) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Enable Stripe Checkout recovery URLs and promotion-code entry for paid sessions so abandoned buyers can resume checkout.
+
+- [#1755](https://github.com/IgorGanapolsky/ThumbGate/pull/1755) [`108f8ea`](https://github.com/IgorGanapolsky/ThumbGate/commit/108f8ea572e883fefe7b4f1d246a68957abeee61) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Remove the extra hosted email gate for real-browser Pro checkout starts so Stripe collects the buyer email directly while bot traffic still lands on the safe intent interstitial.
+
+- [#1800](https://github.com/IgorGanapolsky/ThumbGate/pull/1800) [`3fc5b0b`](https://github.com/IgorGanapolsky/ThumbGate/commit/3fc5b0bf569a296b8479983d9e1b6609ae374621) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Clarify the public numbers page so configured checks are labeled as inventory, recorded block/warn counts are treated as the usage evidence, zero-occurrence blocker claims are suppressed, and scorer calibration is reported as n/a until the feedback sample has both safe and harmful outcomes.
+
+- [#1746](https://github.com/IgorGanapolsky/ThumbGate/pull/1746) [`2377002`](https://github.com/IgorGanapolsky/ThumbGate/commit/2377002c459cef974896eaaf25da82472ce7777c) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a paid voice-agent reliability diagnostic offer to the Zernio promo publisher.
+
+- [#1778](https://github.com/IgorGanapolsky/ThumbGate/pull/1778) [`4dbc0a9`](https://github.com/IgorGanapolsky/ThumbGate/commit/4dbc0a99e1edf67bafd9d9fa7761592a523dcacb) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Make remaining Zernio publishing workflows opt-in by default so scheduled social, Instagram, weekly, and manual offer dispatches cannot spend paid-provider capacity or publish repeated content unless explicitly enabled.
+
+- [#1744](https://github.com/IgorGanapolsky/ThumbGate/pull/1744) [`d1d6504`](https://github.com/IgorGanapolsky/ThumbGate/commit/d1d65040232c7bf178e931cb3394b701e60e2985) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add a guarded Zernio offer dispatch workflow with campaign tracking for manual paid-offer pushes.
+
+- [#1775](https://github.com/IgorGanapolsky/ThumbGate/pull/1775) [`294bb52`](https://github.com/IgorGanapolsky/ThumbGate/commit/294bb521f671157cd4993712491857f0ba54026b) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Guard Zernio video autopilot behind an explicit publish opt-in, slow TikTok and Instagram video cadence to one distinct experiment per day, and add a TikTok engagement creative that asks for concrete blocked-command examples instead of repeating generic product cards.
+
 ## 1.16.21
 
 ### Patch Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -3,7 +3,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.16.21 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.16.22 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.16.21", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.16.22", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.16.21", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.16.22", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -216,7 +216,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.16.21' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.16.22' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.16.21",
+        "thumbgate@1.16.22",
         "thumbgate",
         "serve"
       ],

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.16.21 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.16.22 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.16.21 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.16.22 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1562,7 +1562,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.16.21 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.16.22 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2779,7 +2779,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.16.21 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.16.22 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.16.21`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.16.22`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/marketing/codex-marketplace-revenue-pack.json
+++ b/docs/marketing/codex-marketplace-revenue-pack.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-06T21:52:10.010Z",
+  "generatedAt": "2026-05-07T14:51:39.523Z",
   "channel": "Codex",
   "objective": "Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and qualified workflow sprint conversations.",
   "canonicalIdentity": {
@@ -29,7 +29,7 @@
       "key": "standalone_bundle",
       "name": "Standalone bundle download",
       "url": "https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip",
-      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.21/thumbgate-codex-plugin-v1.16.21.zip",
+      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.22/thumbgate-codex-plugin-v1.16.22.zip",
       "supportUrl": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/README.md",
       "evidenceSource": "plugins/codex-profile/README.md",
       "operatorUse": "Portable plugin path for buyers who want a direct asset instead of a repo checkout.",

--- a/docs/marketing/codex-marketplace-revenue-pack.md
+++ b/docs/marketing/codex-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Operator Revenue Pack
 
-Updated: 2026-05-06T21:52:10.010Z
+Updated: 2026-05-07T14:51:39.523Z
 
 This is a sales operator artifact. It is not proof of installs, revenue, or marketplace approval by itself.
 
@@ -26,7 +26,7 @@ Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and 
 
 ### Standalone bundle download
 - URL: https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip
-- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.21/thumbgate-codex-plugin-v1.16.21.zip
+- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.16.22/thumbgate-codex-plugin-v1.16.22.zip
 - Operator use: Portable plugin path for buyers who want a direct asset instead of a repo checkout.
 - Buyer signal: Warm buyers ready to install now if the runtime, update policy, and proof links are explicit.
 - Evidence source: plugins/codex-profile/README.md

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.16.21 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.16.22 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.16.21", "serve"],
+      "args": ["-y", "thumbgate@1.16.22", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.16.21", "serve"],
+      "args": ["-y", "thumbgate@1.16.22", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.16.21 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.16.22 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.16.21
+1.16.22
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.16.21"
+version: "1.16.22"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.16.21",
+      "version": "1.16.22",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 33 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.16.21",
+        "thumbgate@1.16.22",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.16.21",
+  "version": "1.16.22",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.16.21", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.16.22", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -1298,7 +1298,7 @@ __GA_BOOTSTRAP__
 <!-- HOW IT WORKS -->
 <section class="how-it-works" id="how-it-works">
   <div class="container">
-    <div class="section-label">New in v1.16.21</div>
+    <div class="section-label">New in v1.16.22</div>
     <h2 class="section-title">Three steps to stop repeated AI failures</h2>
     <div class="steps">
       <div class="step">
@@ -1717,7 +1717,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.16.21</span>
+    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · v1.16.22</span>
   </div>
 </footer>
 

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.16.21",
+  "softwareVersion": "1.16.22",
   "url": "https://thumbgate-production.up.railway.app/numbers",
   "dateModified": "2026-05-07",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-05-07 · Version 1.16.21</div>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.16.22</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>
@@ -277,7 +277,7 @@
   <div class="cta">
     <a href="https://www.npmjs.com/package/thumbgate">Install ThumbGate — npx thumbgate init</a>
     <div class="footer-note">Prefer the raw feed? See <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a> or run <code>npm run gate:stats</code> locally.</div>
-    <div class="footer-note">Generated at 2026-05-07T12:49:54.256Z UTC.</div>
+    <div class="footer-note">Generated at 2026-05-07T14:59:51.816Z UTC.</div>
   </div>
 </main>
 </body>

--- a/scripts/codex-marketplace-revenue-pack.js
+++ b/scripts/codex-marketplace-revenue-pack.js
@@ -25,6 +25,7 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const CODEX_SOURCE = 'codex';
 const CODEX_SURFACE = 'codex_plugin';
 const CODEX_MEDIUM = 'plugin_page';
+const CODEX_PUBLIC_APP_ORIGIN = 'https://thumbgate.ai';
 const CANONICAL_SHORT_DESCRIPTION = 'Auto-updating ThumbGate plugin for Codex. Capture thumbs-up/down feedback, turn repeated failures into Pre-Action Checks, and keep proof close to the install path.';
 const CANONICAL_HEADLINE = 'Stop Codex from repeating the same tool mistake.';
 const CANONICAL_SUBHEAD = 'ThumbGate gives Codex an auto-updating MCP runtime, local-first feedback memory, and hard pre-action gates before risky commands, edits, or publishes run again.';
@@ -32,6 +33,16 @@ const INSTALL_DOC_URL = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/p
 const PROFILE_README_URL = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/README.md';
 const BRIDGE_README_URL = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/claude-codex-bridge/README.md';
 const PROOF_LINKS = [COMMERCIAL_TRUTH_LINK, VERIFICATION_EVIDENCE_LINK];
+
+function buildCodexRevenueLinks(baseLinks = buildRevenueLinks()) {
+  return {
+    ...baseLinks,
+    appOrigin: CODEX_PUBLIC_APP_ORIGIN,
+    guideLink: `${CODEX_PUBLIC_APP_ORIGIN}/guide`,
+    proCheckoutLink: `${CODEX_PUBLIC_APP_ORIGIN}/checkout/pro`,
+    sprintLink: `${CODEX_PUBLIC_APP_ORIGIN}/#workflow-sprint-intake`,
+  };
+}
 
 function buildTrackedCodexLink(baseUrl, tracking = {}) {
   const url = new URL(buildUTMLink(baseUrl, {
@@ -59,7 +70,7 @@ function buildTrackedCodexLink(baseUrl, tracking = {}) {
   return url.toString();
 }
 
-function buildEvidenceSurfaces(links = buildRevenueLinks(), about = readGitHubAbout(), repoRoot = REPO_ROOT) {
+function buildEvidenceSurfaces(links = buildCodexRevenueLinks(), about = readGitHubAbout(), repoRoot = REPO_ROOT) {
   const surfaces = [
     {
       key: 'install_page',
@@ -115,7 +126,7 @@ function buildEvidenceSurfaces(links = buildRevenueLinks(), about = readGitHubAb
   }));
 }
 
-function buildListingCopy(links = buildRevenueLinks()) {
+function buildListingCopy(links = buildCodexRevenueLinks()) {
   const followOnOffers = [
     {
       key: 'pro',
@@ -175,7 +186,7 @@ function buildListingCopy(links = buildRevenueLinks()) {
   };
 }
 
-function buildOperatorQueue(links = buildRevenueLinks()) {
+function buildOperatorQueue(links = buildCodexRevenueLinks()) {
   const queue = [
     {
       key: 'solo_repeat_mistake',
@@ -238,7 +249,7 @@ function buildOperatorQueue(links = buildRevenueLinks()) {
   }));
 }
 
-function buildOutreachDrafts(links = buildRevenueLinks()) {
+function buildOutreachDrafts(links = buildCodexRevenueLinks()) {
   const installLink = buildTrackedCodexLink(`${links.appOrigin}/codex-plugin`, {
     utmCampaign: 'codex_outreach_install',
     utmContent: 'plugin_page',
@@ -299,7 +310,7 @@ function buildMeasurementPlan() {
   };
 }
 
-function buildCodexMarketplaceRevenuePack(links = buildRevenueLinks(), about = readGitHubAbout(), repoRoot = REPO_ROOT) {
+function buildCodexMarketplaceRevenuePack(links = buildCodexRevenueLinks(), about = readGitHubAbout(), repoRoot = REPO_ROOT) {
   return {
     generatedAt: new Date().toISOString(),
     channel: 'Codex',
@@ -462,7 +473,9 @@ if (isCliInvocation()) {
 module.exports = {
   CANONICAL_HEADLINE,
   CANONICAL_SHORT_DESCRIPTION,
+  CODEX_PUBLIC_APP_ORIGIN,
   buildCodexMarketplaceRevenuePack,
+  buildCodexRevenueLinks,
   buildEvidenceSurfaces,
   buildListingCopy,
   buildMeasurementPlan,

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -55,7 +55,7 @@ function syncJsonField(target, field, expectedValue, drifted, checkOnly) {
 
 function syncVersion(opts) {
   const options = opts || {};
-  const checkOnly = options.check || false;
+  const checkOnly = options.check || options.checkOnly || false;
   const pkg = readJson('package.json');
   const version = pkg.version;
   const homepageUrl = pkg.homepage;
@@ -417,7 +417,44 @@ function syncVersion(opts) {
     targets.push(publicIndexPath);
   }
 
-  // 14. adapters/mcp/server-stdio.js — MCP server metadata
+  // 14. public/numbers.html — generated proof snapshot version markers
+  const publicNumbersPath = 'public/numbers.html';
+  if (fs.existsSync(path.join(PROJECT_ROOT, publicNumbersPath))) {
+    const publicNumbersFile = path.join(PROJECT_ROOT, publicNumbersPath);
+    let numbersContent = fs.readFileSync(publicNumbersFile, 'utf-8');
+    let numbersContentChanged = false;
+
+    const softwareVersionMatch = numbersContent.match(new RegExp(`"softwareVersion":\\s*"(${VERSION_PATTERN})"`));
+    if (softwareVersionMatch && softwareVersionMatch[1] !== version) {
+      drifted.push({ file: publicNumbersPath, field: 'softwareVersion', current: softwareVersionMatch[1] });
+      if (!checkOnly) {
+        numbersContent = numbersContent.replace(
+          new RegExp(`"softwareVersion":\\s*"${VERSION_PATTERN}"`),
+          `"softwareVersion": "${version}"`
+        );
+        numbersContentChanged = true;
+      }
+    }
+
+    const freshnessVersionMatch = numbersContent.match(new RegExp(`Updated:\\s*\\d{4}-\\d{2}-\\d{2}\\s*·\\s*Version\\s+(${VERSION_PATTERN})`));
+    if (freshnessVersionMatch && freshnessVersionMatch[1] !== version) {
+      drifted.push({ file: publicNumbersPath, field: 'freshness-version', current: freshnessVersionMatch[1] });
+      if (!checkOnly) {
+        numbersContent = numbersContent.replace(
+          new RegExp(`(Updated:\\s*\\d{4}-\\d{2}-\\d{2}\\s*·\\s*Version\\s+)${VERSION_PATTERN}`),
+          `$1${version}`
+        );
+        numbersContentChanged = true;
+      }
+    }
+
+    if (numbersContentChanged) {
+      fs.writeFileSync(publicNumbersFile, numbersContent);
+    }
+    targets.push(publicNumbersPath);
+  }
+
+  // 15. adapters/mcp/server-stdio.js — MCP server metadata
   const serverStdioPath = 'adapters/mcp/server-stdio.js';
   const serverStdioFile = path.join(PROJECT_ROOT, serverStdioPath);
   if (fs.existsSync(serverStdioFile)) {
@@ -435,7 +472,7 @@ function syncVersion(opts) {
     targets.push(serverStdioPath);
   }
 
-  // 15. mcpize.yaml
+  // 16. mcpize.yaml
   const mcpizePath = 'mcpize.yaml';
   const mcpizeFile = path.join(PROJECT_ROOT, mcpizePath);
   if (fs.existsSync(mcpizeFile)) {

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.16.21",
+  "version": "1.16.22",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.16.21",
+      "version": "1.16.22",
       "transport": {
         "type": "stdio"
       }

--- a/tests/codex-marketplace-revenue-pack.test.js
+++ b/tests/codex-marketplace-revenue-pack.test.js
@@ -9,7 +9,9 @@ const path = require('node:path');
 const {
   CANONICAL_HEADLINE,
   CANONICAL_SHORT_DESCRIPTION,
+  CODEX_PUBLIC_APP_ORIGIN,
   buildCodexMarketplaceRevenuePack,
+  buildCodexRevenueLinks,
   buildEvidenceSurfaces,
   buildListingCopy,
   buildMeasurementPlan,
@@ -69,6 +71,22 @@ test('tracked Codex links keep attribution machine-readable', () => {
   assert.equal(installUrl.searchParams.get('utm_medium'), 'plugin_page');
   assert.equal(installUrl.searchParams.get('utm_campaign'), 'codex_plugin_page');
   assert.equal(installUrl.searchParams.get('surface'), 'codex_plugin');
+});
+
+test('default Codex revenue links stay on the branded public domain', () => {
+  const links = buildCodexRevenueLinks({
+    appOrigin: 'https://thumbgate-production.up.railway.app',
+    guideLink: 'https://thumbgate-production.up.railway.app/guide',
+    proCheckoutLink: 'https://thumbgate-production.up.railway.app/checkout/pro',
+    sprintLink: 'https://thumbgate-production.up.railway.app/#workflow-sprint-intake',
+    proPriceLabel: '$19/mo or $149/yr',
+  });
+  const pack = buildCodexMarketplaceRevenuePack(undefined, ABOUT_FIXTURE, path.join(__dirname, '..'));
+
+  assert.equal(links.appOrigin, CODEX_PUBLIC_APP_ORIGIN);
+  assert.equal(links.proCheckoutLink, `${CODEX_PUBLIC_APP_ORIGIN}/checkout/pro`);
+  assert.equal(pack.canonicalIdentity.installPageUrl, `${CODEX_PUBLIC_APP_ORIGIN}/codex-plugin`);
+  assert.match(pack.listingCopy.followOnOffers[0].cta, /thumbgate\.ai\/checkout\/pro/);
 });
 
 test('listing copy keeps proof and follow-on motions explicit', () => {

--- a/tests/sync-version.test.js
+++ b/tests/sync-version.test.js
@@ -74,6 +74,15 @@ test('sync-version covers public MCP discovery manifests', serial, () => {
   );
 });
 
+test('sync-version covers the generated numbers page version markers', serial, () => {
+  const { syncVersion } = require('../scripts/sync-version');
+  const result = syncVersion({ checkOnly: true });
+  assert.ok(
+    result.targets.includes('public/numbers.html'),
+    'public/numbers.html should be a sync target'
+  );
+});
+
 test('sync-version no longer tracks an embedded pro package manifest', serial, () => {
   const { syncVersion } = require('../scripts/sync-version');
   const result = syncVersion({ checkOnly: true });
@@ -164,5 +173,34 @@ test('sync-version updates multiple public landing markers in one pass', serial,
     assert.ok(synced.includes(`MIT License · v${version}`), 'footer marker should be synced');
   } finally {
     fs.writeFileSync(publicIndexPath, original);
+  }
+});
+
+test('sync-version detects and repairs public numbers page version drift', serial, () => {
+  const { syncVersion } = require('../scripts/sync-version');
+  const { version } = require('../package.json');
+  const numbersPath = path.join(ROOT, 'public', 'numbers.html');
+  const original = fs.readFileSync(numbersPath, 'utf8');
+  const drifted = original
+    .replace(/"softwareVersion": "\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?"/, '"softwareVersion": "0.0.1"')
+    .replace(/Updated:\s*\d{4}-\d{2}-\d{2}\s*·\s*Version\s+\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/, 'Updated: 2026-05-07 · Version 0.0.1');
+
+  try {
+    fs.writeFileSync(numbersPath, drifted);
+    const result = syncVersion({ checkOnly: false });
+    assert.ok(
+      result.drifted.some((entry) => entry.file === 'public/numbers.html' && entry.field === 'softwareVersion'),
+      `expected softwareVersion drift, found: ${JSON.stringify(result.drifted)}`
+    );
+    assert.ok(
+      result.drifted.some((entry) => entry.file === 'public/numbers.html' && entry.field === 'freshness-version'),
+      `expected freshness version drift, found: ${JSON.stringify(result.drifted)}`
+    );
+
+    const synced = fs.readFileSync(numbersPath, 'utf8');
+    assert.ok(synced.includes(`"softwareVersion": "${version}"`), 'softwareVersion should be synced');
+    assert.match(synced, new RegExp(`Updated:\\s*\\d{4}-\\d{2}-\\d{2}\\s*·\\s*Version\\s+${version.replaceAll('.', '\\.')}`));
+  } finally {
+    fs.writeFileSync(numbersPath, original);
   }
 });


### PR DESCRIPTION
## Summary
- version ThumbGate to 1.16.22 so the merged Pro upgrade bundle fix can publish through the audited npm lane
- consume pending changesets into CHANGELOG.md and synced package/plugin metadata
- keep the Pro bundle pack boundary verified for the public npm tarball

## Verification
- node scripts/sync-version.js --check
- npm run test:deployment (106 pass, 0 fail)
- npm run test:postinstall (4 pass, 0 fail)
- npm run prove:runtime (7 pass, 0 fail)
- npm pack --dry-run --json confirmed thumbgate@1.16.22 includes config/pro/{constraints-pro.json,prevention-rules-pro.md,thompson-presets.json,reminders-pro.json}
- git diff --check