### PR TITLE
Enable always-on safe Bluesky reply publishing

### DIFF
--- a/.changeset/always-on-safe-bluesky-replies.md
+++ b/.changeset/always-on-safe-bluesky-replies.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Enable Ralph Loop to auto-publish a bounded set of safe Bluesky replies during scheduled engagement runs while leaving risky replies in the review draft queue.

--- a/.github/workflows/ralph-loop.yml
+++ b/.github/workflows/ralph-loop.yml
@@ -4,6 +4,8 @@ name: Ralph Loop Audience Engagement
 # - hourly audience sensing and reply monitoring
 # - cache-backed state so CI does not forget handled replies
 # - Reddit remains draft-only; LinkedIn replies pass the social quality gate
+# - Bluesky can auto-publish a bounded set of safe replies: no URLs, no sales
+#   terms, and capped length. Risky drafts still require review.
 # - outbound campaign posts stay in the separate Ralph Mode workflow
 # - X/Twitter was retired from distribution 2026-04-20.
 
@@ -28,6 +30,15 @@ on:
         required: false
         type: boolean
         default: false
+      autonomous_bluesky_publish:
+        description: 'Auto-publish bounded safe Bluesky replies'
+        required: false
+        type: boolean
+        default: true
+      bluesky_publish_limit:
+        description: 'Maximum safe Bluesky replies to publish per run'
+        required: false
+        default: '3'
 
 permissions:
   contents: read
@@ -61,10 +72,12 @@ jobs:
       THUMBGATE_REDDIT_TRACKED_THREADS: https://www.reddit.com/r/ClaudeCode/comments/1szi5qp/
       LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
       LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
-      # Bluesky reply monitor (scripts/social-reply-monitor-bluesky.js, AT Protocol direct). Drafts are queued to
-      # .thumbgate/reply-drafts.jsonl for human review — never auto-posts.
+      # Bluesky reply monitor (scripts/social-reply-monitor-bluesky.js, AT Protocol direct).
+      # Safe replies may auto-publish; risky drafts are queued for review.
       BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
       BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+      THUMBGATE_AUTONOMOUS_BLUESKY_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.autonomous_bluesky_publish) || vars.THUMBGATE_AUTONOMOUS_BLUESKY_PUBLISH || '1' }}
+      THUMBGATE_BLUESKY_PUBLISH_LIMIT: ${{ github.event_name == 'workflow_dispatch' && inputs.bluesky_publish_limit || vars.THUMBGATE_BLUESKY_PUBLISH_LIMIT || '3' }}
       PLAUSIBLE_API_KEY: ${{ secrets.PLAUSIBLE_API_KEY }}
       PLAUSIBLE_SITE_ID: ${{ secrets.PLAUSIBLE_SITE_ID }}
 

--- a/scripts/ralph-loop.js
+++ b/scripts/ralph-loop.js
@@ -101,6 +101,15 @@ function hasAllEnv(env, keys = []) {
   return keys.every((key) => Boolean(env[key]));
 }
 
+function envFlagEnabled(value) {
+  return /^(1|true|yes|on)$/i.test(String(value || '').trim());
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value || '').trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function makeNodeStep(id, scriptPath, args = [], extra = {}) {
   return {
     id,
@@ -135,6 +144,11 @@ function wants(mode, names) {
 function buildRalphSteps(options = {}, env = process.env) {
   const mode = normalizeMode(options.mode || 'all');
   const dryRun = Boolean(options.dryRun);
+  const autonomousBlueskyPublish = !dryRun && envFlagEnabled(env.THUMBGATE_AUTONOMOUS_BLUESKY_PUBLISH);
+  const blueskyPublishLimit = parsePositiveInteger(
+    env.THUMBGATE_BLUESKY_PUBLISH_LIMIT || options.blueskyPublishLimit,
+    3,
+  );
   const steps = [];
 
   if (wants(mode, ['poll'])) {
@@ -165,9 +179,13 @@ function buildRalphSteps(options = {}, env = process.env) {
     if (dryRun) {
       replyArgs.push('--dry-run');
     }
+    const blueskyReplyArgs = [...replyArgs];
+    if (autonomousBlueskyPublish) {
+      blueskyReplyArgs.push('--auto-approve-safe', `--limit=${blueskyPublishLimit}`);
+    }
     // Bluesky reply monitor: Zernio has no inbound/comments API, so we poll AT
-    // Protocol directly. This only queues drafts to .thumbgate/reply-drafts.jsonl
-    // — never auto-posts. Human review required before send.
+    // Protocol directly. Scheduled mode may auto-publish only bounded safe
+    // replies: no URLs, no sales terms, and max 260 chars.
     steps.push(
       makeNodeStep(
         'reply-monitor',
@@ -181,13 +199,25 @@ function buildRalphSteps(options = {}, env = process.env) {
       makeNodeStep(
         'reply-monitor-bluesky',
         'scripts/social-reply-monitor-bluesky.js',
-        replyArgs,
+        blueskyReplyArgs,
         {
           stage: 'engage',
-          description: 'Polls Bluesky notifications via AT Protocol and queues draft replies for human review (never auto-posts).',
+          description: autonomousBlueskyPublish
+            ? 'Polls Bluesky notifications, auto-approves bounded safe replies, and leaves risky drafts for review.'
+            : 'Polls Bluesky notifications via AT Protocol and queues draft replies for human review.',
           requiredEnvAll: ['BLUESKY_HANDLE', 'BLUESKY_APP_PASSWORD'],
         }
       ),
+      ...(autonomousBlueskyPublish ? [makeNodeStep(
+        'publish-approved-bluesky',
+        'scripts/social-reply-monitor-bluesky.js',
+        ['--publish-approved', '--confirm-publish'],
+        {
+          stage: 'engage',
+          description: 'Publishes only Bluesky drafts that passed the safe auto-approval gate in this run.',
+          requiredEnvAll: ['BLUESKY_HANDLE', 'BLUESKY_APP_PASSWORD'],
+        }
+      )] : []),
       makeNodeStep(
         'prospect-bluesky',
         'scripts/social-bluesky-prospecting.js',

--- a/tests/ralph-loop.test.js
+++ b/tests/ralph-loop.test.js
@@ -62,7 +62,7 @@ test('buildRalphSteps keeps hourly all mode focused on sensing, replying, and au
   assert.match(steps.find((step) => step.id === 'sync-launch-assets').skipReason, /ZERNIO_API_KEY/);
   assert.deepEqual(steps.find((step) => step.id === 'reply-monitor').args.slice(-1), ['--dry-run']);
   // Bluesky reply monitor uses direct AT Protocol (Zernio has no inbound API as
-  // of 2026-04-21). Gated on BLUESKY_HANDLE + BLUESKY_APP_PASSWORD; drafts-only.
+  // of 2026-04-21). Gated on BLUESKY_HANDLE + BLUESKY_APP_PASSWORD.
   const bluesky = steps.find((step) => step.id === 'reply-monitor-bluesky');
   assert.deepEqual(bluesky.args.slice(-1), ['--dry-run']);
   assert.match(bluesky.skipReason, /BLUESKY_HANDLE|BLUESKY_APP_PASSWORD/);
@@ -71,6 +71,31 @@ test('buildRalphSteps keeps hourly all mode focused on sensing, replying, and au
   assert.match(prospecting.description, /relevant agent-reliability pain/);
   assert.match(prospecting.skipReason, /BLUESKY_HANDLE|BLUESKY_APP_PASSWORD/);
   assert.equal(ids.includes('daily-social-post'), false);
+});
+
+test('buildRalphSteps can publish bounded safe Bluesky replies on the scheduled loop', () => {
+  const steps = buildRalphSteps({ mode: 'engage', dryRun: false }, {
+    BLUESKY_HANDLE: 'igor.example.bsky.social',
+    BLUESKY_APP_PASSWORD: 'app-password',
+    THUMBGATE_AUTONOMOUS_BLUESKY_PUBLISH: '1',
+    THUMBGATE_BLUESKY_PUBLISH_LIMIT: '2',
+  });
+  const ids = steps.map((step) => step.id);
+  const bluesky = steps.find((step) => step.id === 'reply-monitor-bluesky');
+  const publish = steps.find((step) => step.id === 'publish-approved-bluesky');
+
+  assert.deepEqual(ids.slice(0, 5), [
+    'sync-launch-assets',
+    'reply-monitor',
+    'reply-monitor-bluesky',
+    'publish-approved-bluesky',
+    'prospect-bluesky',
+  ]);
+  assert.deepEqual(bluesky.args.slice(-2), ['--auto-approve-safe', '--limit=2']);
+  assert.equal(bluesky.skipReason, undefined);
+  assert.deepEqual(publish.args.slice(-2), ['--publish-approved', '--confirm-publish']);
+  assert.equal(publish.skipReason, undefined);
+  assert.match(publish.description, /safe auto-approval/);
 });
 
 test('buildRalphSteps supports manual post mode with skip evidence', () => {
@@ -220,6 +245,8 @@ test('Ralph workflows are scheduled, stateful, and split outbound from reply eng
   assert.match(ralph, /\.thumbgate\/reply-drafts\.jsonl/);
   assert.match(ralph, /\.thumbgate\/social-launch-assets\.json/);
   assert.match(ralph, /BLUESKY_HANDLE/);
+  assert.match(ralph, /THUMBGATE_AUTONOMOUS_BLUESKY_PUBLISH/);
+  assert.match(ralph, /THUMBGATE_BLUESKY_PUBLISH_LIMIT/);
   assert.match(ralph, /scripts\/social-reply-monitor-bluesky\.js/);
   assert.match(ralphMode, /name: Ralph Mode - 24\/7 Engagement Loop/);
   assert.match(ralphMode, /cron: '0 \*\/2 \* \* \*'/);


### PR DESCRIPTION
## Summary
- Wire Ralph Loop scheduled engagement into the existing safe Bluesky auto-approval path.
- Publish only approved safe Bluesky drafts after the monitor step; risky replies remain drafts.
- Add workflow controls and regression coverage for the scheduled publish lane.

## Verification
- node --test tests/ralph-loop.test.js tests/social-reply-monitor-bluesky.test.js
- pre-push guards passed