### PR TITLE
fix(billing): resolve plan amounts for funnel-derived github_marketplace events

### DIFF
--- a/.changeset/resolve-funnel-derived-marketplace-amounts.md
+++ b/.changeset/resolve-funnel-derived-marketplace-amounts.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Resolve plan amounts for funnel-derived github_marketplace paid events so `cfo --today` no longer reports `$0.00` when orders only exist in the funnel ledger. The read-time deriver now runs entries through the same plan-pricing resolver the on-disk revenue ledger already uses.

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -1149,7 +1149,8 @@ function loadResolvedRevenueEvents(options = {}) {
     const derived = deriveRevenueEventFromPaidProviderEvent(entry);
     if (!derived) continue;
     if (hasRevenueEventMatch(resolved, derived)) continue;
-    resolved.push(derived);
+    const priced = resolveGithubMarketplaceRevenueEntry(derived, { annotate: false }).entry;
+    resolved.push(priced);
   }
 
   return mergeRevenueEvents(resolved, extraRevenueEvents);

--- a/tests/github-billing.test.js
+++ b/tests/github-billing.test.js
@@ -273,6 +273,46 @@ describe('billing.js — GitHub Marketplace Webhooks', () => {
     const revenueEvents = readRevenueEvents().filter((entry) => entry.orderId === '4444');
     assert.equal(revenueEvents.length, 1);
   });
+
+  test('loadResolvedRevenueEvents — funnel-derived paid events resolve plan amounts', () => {
+    process.env.THUMBGATE_GITHUB_MARKETPLACE_PLAN_PRICES_JSON = JSON.stringify({
+      77: { amountCents: 1900, currency: 'USD', recurringInterval: 'month' },
+    });
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
+
+    const funnelLedgerPath = process.env._TEST_FUNNEL_LEDGER_PATH;
+    const funnelOnlyOrderId = 'gh_marketplace_funnel_only_5555';
+    const funnelEntry = {
+      timestamp: new Date().toISOString(),
+      stage: 'paid',
+      event: 'github_marketplace_purchased',
+      evidence: funnelOnlyOrderId,
+      metadata: {
+        provider: 'github_marketplace',
+        customerId: 'github_user_5555',
+        source: 'github_marketplace',
+        marketplaceOrderId: funnelOnlyOrderId,
+        planId: 77,
+        billingCycle: 'monthly',
+        monthly_price_in_cents: 1900,
+        priceModel: 'flat-rate',
+      },
+    };
+    fs.appendFileSync(funnelLedgerPath, `${JSON.stringify(funnelEntry)}\n`, 'utf-8');
+
+    const resolved = billing.loadResolvedRevenueEvents();
+    const match = resolved.find((entry) => entry && entry.orderId === funnelOnlyOrderId);
+    assert.ok(match, 'funnel-derived paid event should surface in resolved revenue events');
+    assert.equal(match.amountKnown, true);
+    assert.equal(match.amountCents, 1900);
+    assert.equal(match.currency, 'USD');
+    assert.equal(match.recurringInterval, 'month');
+
+    delete process.env.THUMBGATE_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
+  });
 });
 
 describe('API server — GitHub Webhook Route', () => {


### PR DESCRIPTION
## Summary

- `cfo --today` reports github_marketplace paid events with $0 booked when orders only exist in the funnel ledger
- `deriveRevenueEventFromPaidProviderEvent` (scripts/billing.js:1087) hard-codes `amountCents:null, amountKnown:false`, bypassing `resolveGithubMarketplaceRevenueEntry` which the on-disk revenue-ledger path already runs
- This PR runs derived events through the same resolver so amounts populate from `THUMBGATE_GITHUB_MARKETPLACE_PLAN_PRICES_JSON` or webhook plan metadata that's already on the funnel record

## Why this matters

Per `primer.md`, 6 GitHub Marketplace paid events surfaced today with `$0.00` booked because all 6 had unknown amounts. This is the read-time fix; a follow-up should extend `repairGithubMarketplaceRevenueLedger` to persist resolved amounts from funnel-derived rows back to `revenue-events.jsonl`.

## Test plan

- [x] `node --test tests/github-billing.test.js` — 11 pass including new regression
- [x] `node --test tests/billing.test.js tests/funnel-analytics.test.js tests/funnel-invariants.test.js tests/billing-webhook-email.test.js` — 60 pass, 0 fail
- [ ] After merge + Railway rebuild, run `node bin/cli.js cfo --today --timezone=America/New_York` locally and confirm booked revenue is no longer \$0 for funnel-only orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)