### PR TITLE
copy(landing): cut hero CTA overload + concrete-pain headline

### DIFF
--- a/.changeset/landing-hero-conversion-cleanup.md
+++ b/.changeset/landing-hero-conversion-cleanup.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Cut hero CTA overload (six paid-service buttons removed from above the fold) and replace jargon-heavy hero copy with a concrete-pain paragraph. Lead with Pro $19/mo as the primary self-serve path, since all booked customers have purchased Pro; demote diagnostic / sprint / governance kit links to a single "See paid services →" line.

--- a/public/index.html
+++ b/public/index.html
@@ -674,28 +674,13 @@ __GA_BOOTSTRAP__
 <section class="hero">
   <div class="container">
     <div class="hero-thumbs">👍👎</div>
-    <div class="hero-badge">● Machine-speed pre-action defense for coding agents</div>
+    <div class="hero-badge">● Block repeated mistakes before the next tool call fires</div>
     <h1>Stop paying $ for the same AI mistake.</h1>
-    <p style="font-size:18px;color:var(--text-muted);max-width:720px;margin:0 auto 20px;line-height:1.6;">Every retry loop, every hallucinated import, every "let me try a different approach" — those are billable tokens on every LLM vendor's bill. ThumbGate is machine-speed pre-action defense: thumbs-down once, block that exact mistake on every future call, surface the next highest-ROI remediation, and show which agent surfaces are actually active before rollout. Across Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — any MCP-compatible agent, forever, including fast-moving vibe coding workflows.</p>
-    <p style="font-size:15px;color:var(--text-dim);max-width:760px;margin:0 auto 24px;line-height:1.6;">As desktop agents move into parallel sessions, terminals, and production workflows, ThumbGate checks the thing benchmarks miss: is this next action a known workflow, an open-ended agent, a costly fan-out, or a blind tool call with no way to verify it worked?</p>
+    <p style="font-size:18px;color:var(--text-muted);max-width:720px;margin:0 auto 20px;line-height:1.6;">Your agent force-pushed to main. Or skipped tests. Or hallucinated the same import you've corrected six times. ThumbGate captures one thumbs-down and blocks that exact pattern on every future tool call — across Claude Code, Cursor, Codex, Gemini, and any MCP-compatible agent. Local-first, no training required, including fast-moving vibe coding workflows.</p>
 
-    <div class="hero-paid-path" aria-label="Paid AI agent governance sprint checkout options">
-      <div>
-        <strong>Need buyer-ready proof today?</strong>
-        <span>For one repeated workflow failure, book the $499 diagnostic or $1500 sprint first. Same-day Workflow Teardown and smaller paid reads remain available when you need clear rules, examples, and pre-action checks before a larger scope.</span>
-      </div>
-      <div class="hero-paid-actions">
-        <a class="diagnostic" href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars});">Pay $499 diagnostic &rarr;</a>
-        <a class="sprint" href="__WORKFLOW_SPRINT_CHECKOUT_URL__" onclick="sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',price:workflowSprintPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:workflowSprintPriceDollars});">Pay $1500 sprint &rarr;</a>
-        <a class="starter" title="First AI Agent Failure Rule" href="https://buy.stripe.com/4gM6oHgH2bTw4lH6i73sI0z" onclick="sendFirstPartyTelemetry('first_failure_rule_checkout_started',{ctaId:'hero_first_failure_rule_checkout',price:1});sendGa4Event('begin_checkout',{currency:'USD',value:1,items:[{item_id:'first_failure_rule',item_name:'First AI Agent Failure Rule'}]});">Pay $1 first rule &rarr;</a>
-        <a class="starter" title="AI Agent Failure Quick Read" href="https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w" onclick="sendFirstPartyTelemetry('quick_read_checkout_started',{ctaId:'hero_quick_read_checkout',price:19});">Pay $19 quick read &rarr;</a>
-        <a class="starter" href="https://buy.stripe.com/7sYfZhgH29LodWhdKz3sI0v" onclick="sendFirstPartyTelemetry('workflow_teardown_checkout_started',{ctaId:'hero_workflow_teardown_checkout'})">Pay $99 teardown</a>
-        <a class="intake" href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'hero_workflow_sprint_recovery_intake'});sendGa4Event('generate_lead',{method:'workflow_sprint_recovery_intake'});">Send workflow first &rarr;</a>
-        <a class="starter" href="/guides/ai-agent-governance-sprint">See sprint scope &rarr;</a>
-      </div>
-    </div>
+    <p style="font-size:13px;color:var(--text-dim);max-width:560px;margin:0 auto 24px;line-height:1.6;">Need a paid diagnostic, workflow sprint, or governance kit instead? <a href="/guides/ai-agent-governance-sprint" style="color:var(--cyan);text-decoration:none;">See paid services →</a></p>
 
-    <!-- HERO PRICING CARD — secondary path after the proof-led paid offers -->
+    <!-- HERO PRICING CARD — primary self-serve path -->
     <div id="pro-pitch" style="max-width:820px;margin:0 auto 32px;padding:24px 28px;background:linear-gradient(180deg,rgba(17,17,19,0.94) 0%,rgba(22,22,24,0.94) 100%);border:1px solid rgba(34,211,238,0.32);border-radius:20px;box-shadow:0 0 0 1px rgba(34,211,238,0.18),0 24px 64px rgba(0,0,0,0.35);text-align:left;">
       <div style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:16px;">
         <div>

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -105,33 +105,24 @@ test('public landing page includes pricing section with Free, Pro, and Team tier
 test('public landing page exposes env-driven paid sprint checkout path', () => {
   const landingPage = readLandingPage();
 
+  // Hero CTAs were demoted to a single "See paid services →" link in
+  // copy/landing-conversion-cleanup; the multi-button hero-paid-path block
+  // (Pay $499 / Pay $1500 / Pay $1 first rule / Pay $19 quick read /
+  // Pay $99 teardown) was removed because all 4 booked customers bought
+  // Pro $19, not the high-ticket services. The diagnostic/sprint CTAs now
+  // live in the team-paid-path section and the JS constants stay so server
+  // injection still works.
   assert.match(landingPage, /const sprintDiagnosticCheckoutUrl = '__SPRINT_DIAGNOSTIC_CHECKOUT_URL__';/);
   assert.match(landingPage, /const workflowSprintCheckoutUrl = '__WORKFLOW_SPRINT_CHECKOUT_URL__';/);
   assert.match(landingPage, /data-sprint-paid-path/);
   assert.match(landingPage, /Workflow Hardening Diagnostic/);
-  assert.match(landingPage, /AI Agent Failure Quick Read/);
-  assert.match(landingPage, /Same-day Workflow Teardown/);
-  assert.match(landingPage, /Need buyer-ready proof today\?/);
-  assert.match(landingPage, /Pay \$19 quick read/);
-  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
-  assert.match(landingPage, /quick_read_checkout_started/);
-  assert.match(landingPage, /href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__"/);
-  assert.match(landingPage, /href="__WORKFLOW_SPRINT_CHECKOUT_URL__"/);
+  assert.match(landingPage, /See paid services/i);
+  assert.match(landingPage, /\/guides\/ai-agent-governance-sprint/);
   assert.doesNotMatch(landingPage, /founder_workflow_diagnostic_checkout_started/);
   assert.doesNotMatch(landingPage, /Pay \$99 diagnostic/);
   assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/7sY4gzgH24r49G17mb3sI0g/);
-  assert.match(landingPage, /First AI Agent Failure Rule/);
-  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/4gM6oHgH2bTw4lH6i73sI0z/);
-  assert.match(landingPage, /Pay \$1 first rule/);
-  assert.match(landingPage, /first_failure_rule_checkout_started/);
-  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/7sYfZhgH29LodWhdKz3sI0v/);
-  assert.match(landingPage, /Pay \$99 teardown/);
-  assert.match(landingPage, /AI Agent Failure Quick Read/);
-  assert.match(landingPage, /Pay \$19 quick read/);
-  assert.match(landingPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
-  assert.match(landingPage, /quick_read_checkout_started/);
-  assert.match(landingPage, /Pay \$499 diagnostic/);
-  assert.match(landingPage, /Pay \$1500 sprint/);
+
+  // Team-paid-path section assertions (still present, lower on the page)
   assert.match(landingPage, /Reliable AI Agent Governance Setup/);
   assert.match(landingPage, /\$3,997/);
   assert.match(landingPage, /\$297\/mo/);
@@ -144,19 +135,8 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.match(landingPage, /Send workflow first/);
   assert.match(landingPage, /Pay for diagnostic/);
   assert.match(landingPage, /Pay for sprint/);
-  assert.match(landingPage, /workflow_teardown_checkout_started/);
-  assert.match(landingPage, /hero_workflow_sprint_diagnostic_checkout/);
-  assert.match(landingPage, /hero_workflow_sprint_checkout/);
-  assert.match(landingPage, /hero_workflow_sprint_recovery_intake/);
   assert.match(landingPage, /workflow_sprint_diagnostic_checkout_started/);
-  assert.match(landingPage, /workflow_sprint_checkout_started/);
   assert.match(landingPage, /workflow_sprint_recovery_intake_clicked/);
-  assert.match(landingPage, /workflow_sprint_recovery_intake/);
-  assert.match(landingPage, /ctaId:'hero_first_failure_rule_checkout'/);
-  assert.match(landingPage, /ctaId:'hero_workflow_teardown_checkout'/);
-  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_diagnostic_checkout'/);
-  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_checkout'/);
-  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_recovery_intake'/);
 });
 
 test('public landing page includes Plausible analytics and search engine proof bar', () => {
@@ -492,7 +472,6 @@ test('public landing page internally links to comparison and guide pages without
   assert.match(landingPage, /Code Knowledge Graph Guardrails/);
   assert.match(landingPage, /Developer Machine Supply Chain Guardrails/);
   assert.match(landingPage, /Prompt Tricks Are Not Enough/);
-  assert.match(landingPage, /clear rules, examples, and pre-action checks/);
   assert.match(landingPage, /Proxy-Pointer RAG Guardrails/);
   assert.match(landingPage, /RAG Precision Tuning Guardrails/);
   assert.match(landingPage, /SEO Agent Skills Guardrails/);


### PR DESCRIPTION
## Summary

Acts on the landing-page audit (independent assessment + internal evaluation). Three reversible copy changes; pricing/policy items deferred to CEO.

**Shipped here:**
1. **Removed 6-CTA hero-paid-path block** — \$499 diagnostic, \$1500 sprint, \$1 first rule, \$19 quick read, \$99 teardown, intake, sprint scope. Replaced with a single "See paid services →" link to `/guides/ai-agent-governance-sprint`. The Pro \$19/mo card remains the primary path. All 4 booked customers ([docs/COMMERCIAL_TRUTH.md](docs/COMMERCIAL_TRUTH.md)) bought Pro — leading with Pro matches actual buyer behavior; the hero ladder was Hick's-Law drag.
2. **Replaced jargon paragraphs** with concrete pain: "Your agent force-pushed to main. Or skipped tests. Or hallucinated the same import you've corrected six times. ThumbGate captures one thumbs-down and blocks that exact pattern on every future tool call — across Claude Code, Cursor, Codex, Gemini, and any MCP-compatible agent."
3. **Simplified hero badge** from "Machine-speed pre-action defense for coding agents" to "Block repeated mistakes before the next tool call fires."

**Not touched (need CEO call):**
- Free tier 3-capture limit (revenue policy, churn/upsell math)
- Hero video/GIF asset (need a real .mp4 or .gif)
- "14 GitHub Stars" trust bar display (judgment: transparency vs theater)
- Pro feature-list ordering inside the pricing section

## Test plan

- [x] `node --test tests/landing-page-claims.test.js tests/competitive-positioning-marketing.test.js tests/numbers-page.test.js` — 48 pass, 0 fail
- [x] Pre-commit `check-congruence` (SEO terms, claims-vs-code) green
- [x] Pre-push internal-links + regression guards green
- [ ] CEO eyeball in preview / on Railway after merge
- [ ] After Railway rebuild, validate hero shows two primary CTAs and the simplified copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)