### PR TITLE
fix(post-everywhere): clear error for tiktok instead of TypeError

### DIFF
--- a/.changeset/tiktok-publisher-clear-error.md
+++ b/.changeset/tiktok-publisher-clear-error.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+`scripts/post-everywhere.js` now surfaces a clear error when TikTok routing is requested, instead of crashing with `TypeError: tiktok.publishPost is not a function`. TikTok has no text-only Direct Post endpoint; the working paths are `scripts/social-pipeline.js` with a recorded MP4 or direct `publishTikTokVideo({ videoUrl, title })` invocation.

--- a/scripts/post-everywhere.js
+++ b/scripts/post-everywhere.js
@@ -217,7 +217,17 @@ async function postToTikTok(parsed, dryRun) {
   }
 
   const tiktok = getPublisher('tiktok');
-  return tiktok.publishPost({ text });
+  // TikTok's Direct Post API only accepts video uploads; there is no text-only
+  // endpoint. publishTikTokVideo(...) requires { videoUrl, title, token } and
+  // is not exposed through this dispatcher's text-first post pipeline. Surface
+  // a clear error instead of throwing TypeError on an undefined publishPost.
+  if (typeof tiktok.publishTikTokVideo !== 'function') {
+    throw new Error('TikTok publisher missing publishTikTokVideo entrypoint');
+  }
+  throw new Error(
+    'TikTok publishing via post-everywhere is not supported: TikTok requires a video upload, not text. ' +
+    'Use scripts/social-pipeline.js with a recorded MP4, or call publishTikTokVideo({ videoUrl, title }) directly.'
+  );
 }
 
 async function postToYouTube(parsed, dryRun) {


### PR DESCRIPTION
## Summary

\`scripts/post-everywhere.js:220\` called \`tiktok.publishPost({ text })\` but the publisher module exports only \`publishTikTokVideo({ videoUrl, title, token })\` — TikTok has no text-only Direct Post endpoint. Any caller invoking the tiktok platform via this dispatcher would crash with \`TypeError: tiktok.publishPost is not a function\` and no actionable message.

Replace the bad call with a clear runtime \`Error\` explaining (a) the API shape mismatch, (b) the working alternatives (\`scripts/social-pipeline.js\` with a recorded MP4, or direct \`publishTikTokVideo\` invocation), and (c) a guard against the publisher contract drifting again.

## Why this matters

Per primer.md, TikTok automation is reporting 0 successful posts. The latent crash hides the real auth/profile diagnosis: the Chrome \`Default\` profile isn't signed into tiktok.com (separate, manual fix from CEO). Surfacing the dispatcher mismatch lets the next runner show the *actual* failure mode instead of a generic TypeError.

## Test plan

- [x] \`node --test tests/post-everywhere-channels.test.js tests/post-everywhere-instagram.test.js tests/post-everywhere-zernio-default.test.js\` — 37 pass
- [x] Pre-commit + pre-push regression-guard green
- [ ] Optionally add a regression test asserting \`postToTikTok\` throws an actionable Error

🤖 Generated with [Claude Code](https://claude.com/claude-code)