### PR TITLE
copy(landing): collapse 35-card buyer-guides SEO grid into <details>

### DIFF
--- a/.changeset/landing-collapse-buyer-guides-grid.md
+++ b/.changeset/landing-collapse-buyer-guides-grid.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Collapse the 35-card "Popular Buyer Questions" SEO grid into a `<details>` disclosure on the homepage. All cards remain in the DOM (still indexable for SEO and assertions still pass), but the homepage no longer leads with a 217-line content-farm wall — visitors reach pricing, workflow sprint intake, and the FAQ first.

--- a/public/index.html
+++ b/public/index.html
@@ -1050,6 +1050,12 @@ __GA_BOOTSTRAP__
 
 <section class="seo-pages" id="compare-guides">
   <div class="container">
+    <details style="border:1px solid var(--border);border-radius:12px;padding:0;background:rgba(17,17,19,0.4);">
+      <summary style="padding:18px 24px;cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;font-size:14px;color:var(--text-muted);">
+        <span><strong style="color:var(--text);">Buyer guides &amp; comparisons (35+)</strong> · ThumbGate vs Mem0, ThumbGate vs SpecLock, pre-action checks explained, platform-team rollouts, regulated workflows…</span>
+        <span style="font-size:18px;color:var(--text-muted);">▾</span>
+      </summary>
+      <div style="padding:0 24px 24px;">
     <div class="section-label">Popular Buyer Questions</div>
     <h2 class="section-title">How buyers discover ThumbGate in search and AI answers</h2>
     <div class="seo-grid">
@@ -1264,6 +1270,8 @@ __GA_BOOTSTRAP__
         <div class="card-arrow">Read the Autoresearch guide →</div>
       </a>
     </div>
+      </div>
+    </details>
   </div>
 </section>
 

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -340,9 +340,13 @@ test('public landing page includes an explicit Team rollout lane with shared wor
   assert.match(landingPage, /checkout_abandon/);
   assert.match(landingPage, /workflow_sprint_intake_started/);
   assert.match(landingPage, /workflow_sprint_intake_submit_attempted/);
+  // Team intake form must not be wrapped in a <details> disclosure (would require a click).
+  // Tighten the regex to match only an <details> that has NOT been closed before the form,
+  // so unrelated <details> wrappers elsewhere on the page (e.g. the buyer-guides SEO grid)
+  // do not falsely trip this assertion.
   assert.doesNotMatch(
     landingPage,
-    /<details[^>]*>[\s\S]*?<form[^>]+action="\/v1\/intake\/workflow-sprint"/,
+    /<details[^>]*>(?:(?!<\/details>)[\s\S])*?<form[^>]+action="\/v1\/intake\/workflow-sprint"/,
     'Team intake must be visible without a disclosure click'
   );
 });


### PR DESCRIPTION
## Summary

The "Popular Buyer Questions" SEO grid had 35 cards (ThumbGate vs Mem0, RAG Precision Tuning Guardrails, Reasoning Compression Guardrails, Semantic Programmatic SEO Guardrails, etc.) consuming ~217 lines of homepage real estate above the FAQ and pricing. Audit flagged this as a top-3 conversion liability — reads as AI-content-farm signaling to first-time visitors.

**Change:** wrap the entire grid in a single \`<details>\` disclosure with a one-line summary. All 35 cards remain in the DOM — Google still indexes them, \`public-landing.test.js\` href assertions still pass — but they collapse below the fold by default. Visitors reach pricing, workflow-sprint intake, and the FAQ without scrolling past a content-farm.

## Why \`<details>\` over deletion or move

- Deletion: would break SEO and the \`public-landing.test.js\` assertions on specific guide URLs.
- Move to \`/guides/index.html\`: requires creating that page and migrating links — separate PR.
- Collapse: zero link loss, zero new pages, fixes the visual-dominance issue today. Best ROI per line of change.

## Test fix

\`tests/public-landing.test.js:343-347\` had a too-broad regex that matched ANY \`<details>\` on the page followed by the workflow-sprint form anywhere later. Tightened to require no \`</details>\` between the opening tag and the form, so unrelated disclosures don't false-positive.

## Test plan

- [x] \`node --test tests/public-landing.test.js tests/landing-page-claims.test.js\` — 68 pass
- [x] \`node scripts/check-congruence.js\` — green
- [ ] CEO eyeball in preview / Railway after merge — confirm grid collapses by default and click expands cleanly
- [ ] Optional follow-up: migrate the grid to a real \`/guides/index.html\` and link a single "All buyer guides →" footer instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)