### PR TITLE
Fix landing page link audit and claims hygiene

### DIFF
--- a/.changeset/landing-link-claims-audit.md
+++ b/.changeset/landing-link-claims-audit.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix public landing and marketing link hygiene by adding route aliases for legacy public URLs, preventing empty revenue links, and removing unsupported pricing, traction, and guarantee claims from public copy.

--- a/public/blog.html
+++ b/public/blog.html
@@ -293,15 +293,17 @@
         <h2>The Claude Code Leak Proves Why Pre-Action Checks Matter</h2>
 
         <p>
-          Anthropic accidentally shipped 512,000 lines of Claude Code source
-          inside an npm package. A missing <code>.npmignore</code> exposed the
-          full agent architecture: tool-call loops, permission models, retry
-          logic, 44 unreleased feature flags.
+          A public Claude Code packaging incident showed why local agent
+          guardrails need to be evaluated as runtime behavior, not only as
+          documentation. When implementation details move quickly, teams need a
+          way to verify what their agents are allowed to do before the next tool
+          call runs.
         </p>
 
         <p>
-          Within 24 hours, a clean rewrite called Claw-code hit 100K GitHub
-          stars — the fastest-growing repo in GitHub history.
+          The lesson for agent builders is practical: permissions, hooks, retry
+          loops, and local memory are product surfaces. Treat them as governed
+          workflow boundaries, not as invisible plumbing.
         </p>
 
         <h3>What the leak revealed about agent security</h3>
@@ -343,9 +345,9 @@
         </p>
 
         <p>
-          The leak proves agents are powerful but fallible software. Memory
-          without enforcement is a suggestion.
-          <strong>ThumbGate is a guarantee.</strong>
+          Agents are powerful but fallible software. Memory without enforcement
+          is a suggestion. ThumbGate adds a pre-action check layer so repeated
+          mistakes can be caught before execution.
         </p>
 
         <a class="cta" href="https://www.npmjs.com/package/thumbgate"
@@ -367,12 +369,10 @@
 
         <h3>The problem we didn't see</h3>
         <p>
-          ~1,700 developers install ThumbGate via npm every month.
-          <strong>Zero of them ever saw a checkout button.</strong> They find
-          the GitHub README, run <code>npx thumbgate init</code>, use
-          it for free, and never visit the landing page. The checkout flow
-          nobody reaches is irrelevant. We were optimizing a storefront in a
-          building with no door.
+          The problem we missed was structural: users can arrive through npm or
+          the GitHub README, run <code>npx thumbgate init</code>, use the free
+          local install, and never visit the landing page. A checkout flow that
+          only exists on the website is easy for CLI-first users to miss.
         </p>
 
         <h3>Gate reasoning chains</h3>
@@ -429,8 +429,7 @@
 
         <h3>The funnel fix</h3>
         <p>
-          Four touchpoints now put the checkout URL where 100% of npm users
-          actually are:
+          Four touchpoints now put the checkout URL closer to the CLI workflow:
         </p>
         <ul>
           <li>

--- a/public/index.html
+++ b/public/index.html
@@ -833,7 +833,7 @@ __GA_BOOTSTRAP__
       </div>
       <div style="display:flex;gap:12px;flex-wrap:wrap;">
         <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('claude_section_extension_click',{cta:'install_claude_extension'})" style="background:#d97706;color:#fff;">Download Claude Extension (.mcpb)</a>
-        <a href="/guide.html" class="btn-free" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">Claude Desktop setup guide</a>
+        <a href="/guide" class="btn-free" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">Claude Desktop setup guide</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/.claude-plugin/README.md" class="btn-free" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;padding:12px 20px;border-radius:8px;">Claude plugin docs</a>
       </div>
       <p class="gpt-note"><strong>Claude Code Skill:</strong> Type <code>/thumbgate</code> in any Claude Code session. Auto-triggers on “check”, “feedback”, “block mistake”. Free skill on top of the same local gateway.</p>
@@ -879,15 +879,15 @@ __GA_BOOTSTRAP__
     <div class="compatibility-grid">
       <a class="compat-card" href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" onclick="if(typeof posthog!=='undefined')posthog.capture('compat_claude_desktop_click',{cta:'download_claude_desktop'})" style="border-color:rgba(217,119,6,0.3);background:linear-gradient(135deg, rgba(217,119,6,0.06) 0%, var(--bg-card) 100%);">
         <h3>🧩 Claude Desktop Extension</h3>
-        <p>Install the published Claude Desktop plugin <code>.mcpb</code> bundle today. Claude Code users can add the repo marketplace immediately with <code>/plugin marketplace add</code>. No waiting for directory approval. <a href="/guide.html" style="color:var(--text-muted);text-decoration:underline;" onclick="event.stopPropagation();">60-second setup guide →</a></p>
+        <p>Install the published Claude Desktop plugin <code>.mcpb</code> bundle today. Claude Code users can add the repo marketplace immediately with <code>/plugin marketplace add</code>. No waiting for directory approval. <a href="/guide" style="color:var(--text-muted);text-decoration:underline;" onclick="event.stopPropagation();">60-second setup guide →</a></p>
         <div class="card-arrow" style="color:#d97706;">Download .mcpb bundle →</div>
       </a>
-      <a class="compat-card seo-card" href="/guides/claude-code-prevent-repeated-mistakes.html" rel="noopener">
+      <a class="compat-card seo-card" href="/guides/claude-code-prevent-repeated-mistakes" rel="noopener">
         <h3>⚡ Claude Code Skill</h3>
         <p>Type <code>/thumbgate</code> in any Claude Code session. Auto-triggers on "check", "feedback", "block mistake". Free skill on top of the same local gateway teams later harden into a shared workflow.</p>
         <div class="card-arrow">Read the Claude Code guide →</div>
       </a>
-      <a class="compat-card" href="/guide.html" rel="noopener">
+      <a class="compat-card" href="/guide" rel="noopener">
         <h3>🤖 AI CLIs</h3>
         <p>Claude Code, Codex, Gemini CLI, Amp, and OpenCode all use the same gateway and memory model. Any MCP-compatible agent gets pre-action checks, feedback memory, and enforcement out of the box.</p>
         <div class="card-arrow">Open the setup guide →</div>
@@ -902,12 +902,12 @@ __GA_BOOTSTRAP__
         <p>Codex gets a standalone ThumbGate plugin bundle, a repo-local plugin profile, and the same auto-updating MCP launcher. The runtime resolves <code>thumbgate@latest</code> when Codex starts, so npm fixes reach active installs. The install page includes the zip, MCP config, and verification path in one place.</p>
         <div class="card-arrow">Open the Codex install page →</div>
       </a>
-      <a class="compat-card" href="/guides/cursor-prevent-repeated-mistakes.html" rel="noopener">
+      <a class="compat-card" href="/guides/cursor-prevent-repeated-mistakes" rel="noopener">
         <h3>🎯 Cursor plugin</h3>
         <p>Drop the ThumbGate MCP config into <code>.cursor/mcp.json</code> and Cursor gets the same pre-action checks as Claude Code and Codex. Ships with bundled rules, commands, hooks, and agents.</p>
         <div class="card-arrow">Read the Cursor guide →</div>
       </a>
-      <a class="compat-card" href="/guide.html" rel="noopener">
+      <a class="compat-card" href="/guide" rel="noopener">
         <h3>✏️ Editor workflows</h3>
         <p>VS Code works when you run an MCP-compatible agent inside it (Continue, Cline, etc.). Any editor that speaks MCP stdio gets the same gateway.</p>
         <div class="card-arrow">Open the setup guide →</div>
@@ -996,7 +996,7 @@ __GA_BOOTSTRAP__
     <div style="max-width:900px;margin:26px auto 0;border:1px solid rgba(34,211,238,0.14);border-radius:8px;background:rgba(17,17,19,0.55);padding:14px 16px;">
       <div style="color:var(--cyan);font-weight:700;">Compare ThumbGate with other agent-safety approaches</div>
       <div style="display:flex;flex-wrap:wrap;gap:10px;margin-top:14px;font-size:13px;line-height:1.4;">
-        <a href="/guides">Browse the guide library</a>
+        <a href="/learn">Browse the guide library</a>
         <a href="/compare/speclock">SpecLock</a>
         <a href="/compare/mem0">Mem0</a>
         <a href="/compare/fallow">Fallow</a>
@@ -1261,7 +1261,7 @@ __GA_BOOTSTRAP__
         <p style="font-size:11px;color:var(--text-muted);margin-top:8px;text-align:center;">No self-serve trial. Team is $49/seat/mo with a 3-seat minimum and starts with the Workflow Hardening Sprint intake, not a self-serve trial.</p>
       </div>
     </div>
-    <p style="text-align:center;color:var(--text-muted);font-size:13px;margin:40px 0;">Need a custom diagnostic, sprint, or setup? <a href="/services" style="color:var(--cyan);text-decoration:none;">See services →</a></p>
+    <p style="text-align:center;color:var(--text-muted);font-size:13px;margin:40px 0;">Need a custom diagnostic, sprint, or setup? <a href="#workflow-sprint-intake" style="color:var(--cyan);text-decoration:none;">Send workflow first →</a></p>
   </div>
 </section>
 
@@ -1402,7 +1402,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What does Pro cost?</div>
-        <div class="faq-a">Pro is $19/mo or $149/yr for individual operators and bills immediately through Stripe so the self-serve path can create revenue today. Team is $49/seat/mo and includes a 7-day money-back guarantee.</div>
+        <div class="faq-a">Pro is $19/mo or $149/yr for individual operators and bills immediately through Stripe. Team is $49/seat/mo with a 3-seat minimum and starts through the workflow intake so scope, shared rules, and rollout proof are explicit before a team rollout.</div>
       </div>
     </div>
   </div>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -16,6 +16,8 @@ const POSTHOG_STATIC_PATH_PREFIX = '/static/';
 const FIRST_FAILURE_RULE_CHECKOUT_URL = 'https://buy.stripe.com/4gM6oHgH2bTw4lH6i73sI0z';
 const QUICK_READ_CHECKOUT_URL = 'https://buy.stripe.com/aFa8wPgH29Lo4lH35V3sI0w';
 const WORKFLOW_TEARDOWN_CHECKOUT_URL = 'https://buy.stripe.com/7sYfZhgH29LodWhdKz3sI0v';
+const SPRINT_DIAGNOSTIC_CHECKOUT_URL = 'https://buy.stripe.com/3cI7sLgH25v8dWh5e33sI0o';
+const WORKFLOW_SPRINT_CHECKOUT_URL = 'https://buy.stripe.com/8x25kDcqMaPs9G15e33sI0p';
 
 function getPosthogProxyPath(pathname) {
   return pathname.slice('/ingest'.length) || '/';
@@ -210,6 +212,7 @@ const NUMBERS_PAGE_PATH = path.resolve(__dirname, '../../public/numbers.html');
 const LEARN_DIR = path.resolve(__dirname, '../../public/learn');
 const GUIDES_DIR = path.resolve(__dirname, '../../public/guides');
 const COMPARE_DIR = path.resolve(__dirname, '../../public/compare');
+const USE_CASES_DIR = path.resolve(__dirname, '../../public/use-cases');
 const PUBLIC_DIR = path.resolve(__dirname, '../../public');
 const PUBLIC_ASSETS_DIR = path.resolve(__dirname, '../../public/assets');
 const BUYER_INTENT_SCRIPT_PATH = path.resolve(__dirname, '../../public/js/buyer-intent.js');
@@ -1587,6 +1590,12 @@ function normalizeTrackedLinkSlug(value) {
   return String(value || '').trim().toLowerCase().replace(/[^a-z0-9-]/g, '');
 }
 
+function normalizePublicPageSlug(value) {
+  return String(value || '')
+    .replace(/\.html$/i, '')
+    .replace(/[^a-z0-9-]/g, '');
+}
+
 function getTrackedLinkTarget(slug) {
   const normalizedSlug = normalizeTrackedLinkSlug(slug);
   return TRACKED_LINK_TARGETS[normalizedSlug]
@@ -1939,8 +1948,8 @@ function loadPublicMarketingTemplateHtml(templatePath, runtimeConfig, pageContex
     '__CHECKOUT_FALLBACK_URL__': runtimeConfig.checkoutFallbackUrl,
     '__PRO_PRICE_DOLLARS__': runtimeConfig.proPriceDollars,
     '__PRO_PRICE_LABEL__': runtimeConfig.proPriceLabel,
-    '__SPRINT_DIAGNOSTIC_CHECKOUT_URL__': runtimeConfig.sprintDiagnosticCheckoutUrl || '',
-    '__WORKFLOW_SPRINT_CHECKOUT_URL__': runtimeConfig.workflowSprintCheckoutUrl || '',
+    '__SPRINT_DIAGNOSTIC_CHECKOUT_URL__': runtimeConfig.sprintDiagnosticCheckoutUrl || SPRINT_DIAGNOSTIC_CHECKOUT_URL,
+    '__WORKFLOW_SPRINT_CHECKOUT_URL__': runtimeConfig.workflowSprintCheckoutUrl || WORKFLOW_SPRINT_CHECKOUT_URL,
     '__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__': runtimeConfig.sprintDiagnosticPriceDollars || 499,
     '__WORKFLOW_SPRINT_PRICE_DOLLARS__': runtimeConfig.workflowSprintPriceDollars || 1500,
     '__GA_MEASUREMENT_ID__': runtimeConfig.gaMeasurementId || '',
@@ -4193,6 +4202,15 @@ async function addContext(){
       return;
     }
 
+    if (isGetLikeRequest && pathname === '/lessons/') {
+      res.writeHead(302, {
+        Location: '/lessons',
+        'Cache-Control': 'no-store',
+      });
+      res.end();
+      return;
+    }
+
     if (isGetLikeRequest && pathname === '/lessons') {
       try {
         const html = loadLessonsPageHtml(req, expectedApiKey);
@@ -4245,7 +4263,7 @@ async function addContext(){
       return;
     }
 
-    if (isGetLikeRequest && pathname === '/guide') {
+    if (isGetLikeRequest && (pathname === '/guide' || pathname === '/guide.html')) {
       try {
         const html = fs.readFileSync(GUIDE_PAGE_PATH, 'utf-8');
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
@@ -4255,7 +4273,7 @@ async function addContext(){
       return;
     }
 
-    if (isGetLikeRequest && pathname === '/codex-plugin') {
+    if (isGetLikeRequest && (pathname === '/codex-plugin' || pathname === '/codex-plugin.html')) {
       try {
         const html = fs.readFileSync(CODEX_PLUGIN_PAGE_PATH, 'utf-8');
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
@@ -4265,7 +4283,7 @@ async function addContext(){
       return;
     }
 
-    if (isGetLikeRequest && pathname === '/compare') {
+    if (isGetLikeRequest && (pathname === '/compare' || pathname === '/compare.html')) {
       try {
         const html = fs.readFileSync(COMPARE_PAGE_PATH, 'utf-8');
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
@@ -4275,7 +4293,7 @@ async function addContext(){
       return;
     }
 
-    if (isGetLikeRequest && pathname === '/blog') {
+    if (isGetLikeRequest && (pathname === '/blog' || pathname === '/blog.html')) {
       try {
         const blogPath = path.resolve(__dirname, '../../public/blog.html');
         const html = fs.readFileSync(blogPath, 'utf-8');
@@ -4286,13 +4304,31 @@ async function addContext(){
       return;
     }
 
-    if (isGetLikeRequest && pathname === '/learn') {
+    if (isGetLikeRequest && (pathname === '/learn' || pathname === '/learn.html')) {
       try {
         const html = fs.readFileSync(LEARN_PAGE_PATH, 'utf-8');
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
       } catch {
         sendJson(res, 404, { error: 'Learn page not found' });
       }
+      return;
+    }
+
+    if (isGetLikeRequest && (pathname === '/guides' || pathname === '/guides/' || pathname === '/guides.html')) {
+      res.writeHead(302, {
+        Location: '/learn',
+        'Cache-Control': 'no-store',
+      });
+      res.end();
+      return;
+    }
+
+    if (isGetLikeRequest && (pathname === '/services' || pathname === '/services.html')) {
+      res.writeHead(302, {
+        Location: '/#workflow-sprint-intake',
+        'Cache-Control': 'no-store',
+      });
+      res.end();
       return;
     }
 
@@ -4331,7 +4367,7 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname.startsWith('/learn/')) {
       try {
-        const slug = pathname.replace('/learn/', '').replace(/[^a-z0-9-]/g, '');
+        const slug = normalizePublicPageSlug(pathname.replace('/learn/', ''));
         const articlePath = path.join(LEARN_DIR, `${slug}.html`);
         if (!articlePath.startsWith(LEARN_DIR)) {
           sendJson(res, 403, { error: 'Forbidden' });
@@ -4347,7 +4383,7 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname.startsWith('/guides/')) {
       try {
-        const slug = pathname.replace('/guides/', '').replace(/[^a-z0-9-]/g, '');
+        const slug = normalizePublicPageSlug(pathname.replace('/guides/', ''));
         const guidePath = path.join(GUIDES_DIR, `${slug}.html`);
         if (!guidePath.startsWith(GUIDES_DIR)) { sendJson(res, 403, { error: 'Forbidden' }); return; }
         const html = fs.readFileSync(guidePath, 'utf-8');
@@ -4358,12 +4394,23 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname.startsWith('/compare/') && pathname !== '/compare') {
       try {
-        const slug = pathname.replace('/compare/', '').replace(/[^a-z0-9-]/g, '');
+        const slug = normalizePublicPageSlug(pathname.replace('/compare/', ''));
         const comparePath = path.join(COMPARE_DIR, `${slug}.html`);
         if (!comparePath.startsWith(COMPARE_DIR)) { sendJson(res, 403, { error: 'Forbidden' }); return; }
         const html = fs.readFileSync(comparePath, 'utf-8');
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
       } catch { sendJson(res, 404, { error: 'Comparison not found' }); }
+      return;
+    }
+
+    if (isGetLikeRequest && pathname.startsWith('/use-cases/')) {
+      try {
+        const slug = normalizePublicPageSlug(pathname.replace('/use-cases/', ''));
+        const useCasePath = path.join(USE_CASES_DIR, `${slug}.html`);
+        if (!useCasePath.startsWith(USE_CASES_DIR)) { sendJson(res, 403, { error: 'Forbidden' }); return; }
+        const html = fs.readFileSync(useCasePath, 'utf-8');
+        sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
+      } catch { sendJson(res, 404, { error: 'Use case not found' }); }
       return;
     }
 
@@ -4500,24 +4547,28 @@ async function addContext(){
           ctaPlacement: 'checkout_interstitial',
           planId: 'workflow_teardown',
         });
-        const diagnosticCheckoutHref = hostedConfig.sprintDiagnosticCheckoutUrl
-          ? buildCheckoutIntentHref(hostedConfig.sprintDiagnosticCheckoutUrl, analyticsMetadata, {
+        const diagnosticCheckoutHref = buildCheckoutIntentHref(
+          hostedConfig.sprintDiagnosticCheckoutUrl || SPRINT_DIAGNOSTIC_CHECKOUT_URL,
+          analyticsMetadata,
+          {
             utmMedium: 'checkout_interstitial_paid_path',
             utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_diagnostic',
             ctaId: 'checkout_interstitial_sprint_diagnostic_checkout',
             ctaPlacement: 'checkout_interstitial',
             planId: 'sprint_diagnostic',
-          })
-          : '';
-        const sprintCheckoutHref = hostedConfig.workflowSprintCheckoutUrl
-          ? buildCheckoutIntentHref(hostedConfig.workflowSprintCheckoutUrl, analyticsMetadata, {
+          }
+        );
+        const sprintCheckoutHref = buildCheckoutIntentHref(
+          hostedConfig.workflowSprintCheckoutUrl || WORKFLOW_SPRINT_CHECKOUT_URL,
+          analyticsMetadata,
+          {
             utmMedium: 'checkout_interstitial_paid_path',
             utmCampaign: analyticsMetadata.utmCampaign || 'checkout_interstitial_workflow_sprint',
             ctaId: 'checkout_interstitial_workflow_sprint_checkout',
             ctaPlacement: 'checkout_interstitial',
             planId: 'workflow_sprint',
-          })
-          : '';
+          }
+        );
         const html = renderCheckoutIntentPage({
           confirmHref: buildCheckoutConfirmHref(parsed),
           firstRuleCheckoutHref,

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -126,6 +126,31 @@ describe('/checkout/pro bot guard', () => {
     assert.match(body, /cta_id=checkout_interstitial_workflow_sprint_checkout/);
   });
 
+  it('falls back to verified default checkout URLs when paid path env vars are missing', async () => {
+    const diagnosticCheckoutUrl = process.env.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL;
+    const workflowSprintCheckoutUrl = process.env.THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL;
+    delete process.env.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL;
+    delete process.env.THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL;
+
+    try {
+      const res = await fetch(`${origin}/checkout/pro`, {
+        redirect: 'manual',
+        headers: {
+          'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+          accept: 'text/html,*/*',
+        },
+      });
+      assert.equal(res.status, 200);
+      const body = await res.text();
+      assert.match(body, /https:\/\/buy\.stripe\.com\/3cI7sLgH25v8dWh5e33sI0o/);
+      assert.match(body, /https:\/\/buy\.stripe\.com\/8x25kDcqMaPs9G15e33sI0p/);
+      assert.doesNotMatch(body, /href=""/);
+    } finally {
+      process.env.THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL = diagnosticCheckoutUrl;
+      process.env.THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL = workflowSprintCheckoutUrl;
+    }
+  });
+
   it('returns HTML interstitial for curl (missing browser headers)', async () => {
     const res = await fetch(`${origin}/checkout/pro`, {
       redirect: 'manual',

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -231,7 +231,7 @@ describe('Pro tier bullets: code-backed claims', () => {
 
   test('compat cards that do NOT promise a download must link to a guide or real directory — never to a GitHub source browser', () => {
     // Rule: if the card does NOT promise a download, the outer href must be
-    //   (a) a local /guide.html, /guides/*.html, or dedicated install page, or
+    //   (a) a local /guide, /guide.html, /guides/*, or dedicated install page, or
     //   (b) a real external directory/listing (mcp.so, chatgpt.com, npmjs.com,
     //       pulsemcp.com, smithery.ai, cursor.directory), or
     //   (c) an internal redirect like /go/gpt.
@@ -258,7 +258,8 @@ describe('Pro tier bullets: code-backed claims', () => {
         /^\s*(Download|Get the) .* (plugin|bundle|extension)/i.test(cardArrow);
       if (promisesDownload) continue;
 
-      const isLocalGuide = /^\/guide(s)?(\.html|\/)/.test(outerHref);
+      const isLocalGuide = /^\/guide(?:\.html)?(?:[?#]|$)/.test(outerHref) ||
+        /^\/guides(?:\.html|\/)/.test(outerHref);
       const isLocalInstallPage = /^\/codex-plugin(?:[?#]|$)/.test(outerHref);
       const isInternalRedirect = /^\/go\//.test(outerHref);
       const isAllowedDirectory = allowedExternalDirectories.some((d) =>
@@ -267,7 +268,7 @@ describe('Pro tier bullets: code-backed claims', () => {
 
       assert.ok(
         isLocalGuide || isLocalInstallPage || isInternalRedirect || isAllowedDirectory,
-        `Non-download card (arrow: "${cardArrow.trim()}") has href "${outerHref}" — must link to /guide.html, /guides/*, /codex-plugin, /go/*, or a real external directory (mcp.so, chatgpt.com, npmjs.com, etc.), NOT a GitHub source browser`,
+        `Non-download card (arrow: "${cardArrow.trim()}") has href "${outerHref}" — must link to /guide, /guide.html, /guides/*, /codex-plugin, /go/*, or a real external directory (mcp.so, chatgpt.com, npmjs.com, etc.), NOT a GitHub source browser`,
       );
 
       assert.doesNotMatch(

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -448,7 +448,7 @@ test('public landing page internally links to comparison and guide pages without
 
   assert.match(landingPage, /id="compare-guides"/);
   assert.match(landingPage, /Browse the guide library/i);
-  assert.match(landingPage, /href="\/guides"/);
+  assert.match(landingPage, /href="\/learn"/);
   // No internal marketing jargon visible to customers
   assert.doesNotMatch(landingPage, /GSD Pages/);
   assert.doesNotMatch(landingPage, /Bottom of funnel/i);

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -11,6 +11,7 @@ process.env._TEST_API_KEYS_PATH = path.join(tmp, 'api-keys.json');
 
 const { startServer } = require('../src/api/server');
 const root = path.join(__dirname, '..');
+const publicDir = path.join(root, 'public');
 
 let handle;
 let origin = '';
@@ -87,4 +88,112 @@ test('packaged well-known MCP server card is valid JSON', () => {
   const payload = JSON.parse(fs.readFileSync(path.join(root, '.well-known/mcp/server-card.json'), 'utf8'));
   assert.equal(payload.name, 'thumbgate');
   assert.equal(typeof payload.version, 'string');
+});
+
+test('landing page does not render empty revenue links', async () => {
+  const res = await fetch(`${origin}/`);
+  assert.equal(res.status, 200);
+  const html = await res.text();
+
+  assert.doesNotMatch(html, /href=""/, 'rendered landing page must not contain empty href links');
+  assert.doesNotMatch(html, /__SPRINT_DIAGNOSTIC_CHECKOUT_URL__|__WORKFLOW_SPRINT_CHECKOUT_URL__/);
+  assert.match(html, /https:\/\/buy\.stripe\.com\/3cI7sLgH25v8dWh5e33sI0o/);
+  assert.match(html, /https:\/\/buy\.stripe\.com\/8x25kDcqMaPs9G15e33sI0p/);
+});
+
+test('landing page internal links resolve without auth or broken .html aliases', async () => {
+  const res = await fetch(`${origin}/`);
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  const hrefs = Array.from(html.matchAll(/<a\b[^>]*href="([^"]*)"/gi), (match) => match[1])
+    .filter((href) => href && href.startsWith('/'))
+    .map((href) => href.split('#')[0])
+    .filter(Boolean);
+  const uniquePaths = Array.from(new Set(hrefs));
+  const failures = [];
+
+  for (const pathname of uniquePaths) {
+    const target = `${origin}${pathname}`;
+    const linkRes = await fetch(target, {
+      method: 'HEAD',
+      redirect: 'manual',
+      headers: {
+        'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+        accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+    });
+    if (![200, 204, 301, 302, 303, 307, 308].includes(linkRes.status)) {
+      failures.push(`${pathname} -> ${linkRes.status}`);
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});
+
+test('public marketing .html aliases remain live for existing indexed links', async () => {
+  const paths = [
+    '/guide.html',
+    '/codex-plugin.html',
+    '/compare.html',
+    '/learn.html',
+    '/guides/claude-desktop.html',
+    '/guides/claude-code-prevent-repeated-mistakes.html',
+    '/guides/cursor-prevent-repeated-mistakes.html',
+    '/compare/mem0.html',
+    '/learn/agent-harness-pattern.html',
+  ];
+
+  for (const pathname of paths) {
+    const res = await fetch(`${origin}${pathname}`, { method: 'HEAD' });
+    assert.equal(res.status, 200, `${pathname} should resolve`);
+    assert.match(res.headers.get('content-type') || '', /text\/html/);
+  }
+});
+
+test('public marketing directory aliases redirect to canonical pages', async () => {
+  const cases = [
+    ['/lessons/', '/lessons'],
+    ['/guides', '/learn'],
+    ['/guides/', '/learn'],
+    ['/guides.html', '/learn'],
+    ['/services', '/#workflow-sprint-intake'],
+    ['/services.html', '/#workflow-sprint-intake'],
+  ];
+
+  for (const [pathname, expectedLocation] of cases) {
+    const res = await fetch(`${origin}${pathname}`, {
+      method: 'HEAD',
+      redirect: 'manual',
+    });
+    assert.equal(res.status, 302, `${pathname} should redirect`);
+    assert.equal(res.headers.get('location'), expectedLocation);
+  }
+});
+
+test('public sales copy avoids unsupported pricing, traction, and guarantee claims', async () => {
+  const files = [
+    'index.html',
+    'pro.html',
+    'blog.html',
+    'guides/claude-code-prevent-repeated-mistakes.html',
+    'guides/cursor-prevent-repeated-mistakes.html',
+  ];
+  const bannedClaims = [
+    /money-back guarantee/i,
+    /\b(?:money-back|revenue|income|results?) guarantee\b/i,
+    /fastest-growing repo/i,
+    /100K GitHub stars/i,
+    /~?1,700 developers install/i,
+    /Zero of them ever saw a checkout button/i,
+    /100% of npm users/i,
+    /income guarantees?/i,
+    /revenue guarantees?/i,
+  ];
+
+  for (const file of files) {
+    const html = fs.readFileSync(path.join(publicDir, file), 'utf-8');
+    for (const claimPattern of bannedClaims) {
+      assert.doesNotMatch(html, claimPattern, `${file} contains unsupported claim ${claimPattern}`);
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- fix broken public route aliases and trailing-slash paths used by landing/blog/docs links
- remove unsupported public sales claims: install-volume, 100% npm-user, fastest-growing repo, and money-back guarantee language
- add regression coverage for empty revenue links, public internal links, legacy .html aliases, and unsupported sales claims

## Evidence
- node --test tests/landing-page-claims.test.js tests/public-static-assets.test.js tests/checkout-bot-guard.test.js tests/public-landing.test.js => 90 passed, 0 failed
- local crawl checked 60 internal public links => all internal links resolve
- node scripts/sync-version.js --check => all 31 targets in sync at v1.16.22
- pre-commit passed: package parity, version sync, congruence, landing-page claims
- pre-push passed: npm pack dry-run, public internal-link validation, regression guards

## Why
The live page had trust-breaking route/link issues and some public copy overstated proof we could not verify. This PR treats the public site as a claims ledger: every visible claim must resolve to working code, a live route, a real checkout path, or be removed.