### PR TITLE
fix(billing): persist funnel-derived github_marketplace orders to ledger (v2)

### DIFF
--- a/.changeset/repair-github-marketplace-funnel-derived-rows.md
+++ b/.changeset/repair-github-marketplace-funnel-derived-rows.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+`repairGithubMarketplaceRevenueLedger` now also walks the funnel ledger and persists resolved amounts for `paid` `github_marketplace` orders that never landed in `revenue-events.jsonl`. PR #1810 fixed read-time resolution; this fix completes the loop by writing recovered rows to disk so audits and downstream exports see them too. Idempotent — only persists when plan pricing produces a known amount, and skips rows already in the ledger.

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -1162,6 +1162,9 @@ function repairGithubMarketplaceRevenueLedger(options = {}) {
   const rows = loadJsonlFile(ledgerPath);
   const resolvedAt = new Date().toISOString();
   const repairs = [];
+
+  // Pass 1: in-place repair of rows already in revenue-events.jsonl that have
+  // unknown amounts but resolvable plan metadata.
   const updatedRows = rows.map((entry) => {
     const result = resolveGithubMarketplaceRevenueEntry(entry, {
       annotate: true,
@@ -1179,21 +1182,76 @@ function repairGithubMarketplaceRevenueLedger(options = {}) {
       currency: normalizeCurrency(result.entry.currency),
       recurringInterval: normalizeText(result.entry.recurringInterval),
       pricingSource: normalizeText(metadata.githubMarketplaceAmountSource),
+      source: 'in_place',
     });
     return result.entry;
   });
 
+  // Pass 2: append rows for funnel-derived paid github_marketplace events that
+  // never landed in the revenue ledger. The webhook handler at handleGithubWebhook
+  // skips appendRevenueEvent when hasRevenueEventMatch is true, so duplicates from
+  // a re-run are already prevented; the only way an order gets here is if the
+  // revenue write was skipped at webhook time (e.g. funnel pre-existed, planPricing
+  // had unknown amount at the time, or the row was created via a different path).
+  const funnelRecords = loadFunnelLedger().filter(
+    (e) =>
+      e &&
+      e.stage === 'paid' &&
+      normalizeText((e.metadata && e.metadata.provider) || e.provider) === 'github_marketplace'
+  );
+
+  for (const funnelEntry of funnelRecords) {
+    const derived = deriveRevenueEventFromPaidProviderEvent(funnelEntry);
+    if (!derived) continue;
+    if (hasRevenueEventMatch(updatedRows, derived)) continue;
+
+    const resolved = resolveGithubMarketplaceRevenueEntry(derived, {
+      annotate: true,
+      resolvedAt,
+    });
+    // Skip funnel-derived rows that still have unknown amounts after resolving —
+    // we don't want to permanently bake amountKnown:false rows when there's no
+    // pricing data to attach. Better to leave them off-disk and keep the
+    // read-time merge in loadResolvedRevenueEvents covering them.
+    if (!resolved.changed || !resolved.entry.amountKnown) continue;
+
+    const persisted = {
+      ...resolved.entry,
+      metadata: {
+        ...sanitizeMetadata(resolved.entry.metadata),
+        recoveredFromFunnelLedger: true,
+        funnelRecordedAt: normalizeText(funnelEntry.timestamp) || null,
+      },
+    };
+    updatedRows.push(persisted);
+
+    const metadata = sanitizeMetadata(persisted.metadata);
+    repairs.push({
+      orderId: normalizeText(persisted.orderId),
+      customerId: normalizeText(persisted.customerId),
+      planId: normalizeText(metadata.planId ?? persisted.planId),
+      amountCents: normalizeInteger(persisted.amountCents),
+      currency: normalizeCurrency(persisted.currency),
+      recurringInterval: normalizeText(persisted.recurringInterval),
+      pricingSource: normalizeText(metadata.githubMarketplaceAmountSource),
+      source: 'funnel_derived',
+    });
+  }
+
   const writeResult = write && repairs.length > 0
     ? writeJsonlRecords(ledgerPath, updatedRows)
-    : { written: false, rowCount: rows.length };
+    : { written: false, rowCount: updatedRows.length };
 
   return {
     ledgerPath,
     write,
     wrote: Boolean(writeResult.written),
     scanned: rows.length,
+    funnelScanned: funnelRecords.length,
     repaired: repairs.length,
-    unchanged: rows.length - repairs.length,
+    repairedInPlace: repairs.filter((r) => r.source === 'in_place').length,
+    repairedFromFunnel: repairs.filter((r) => r.source === 'funnel_derived').length,
+    unchanged: rows.length - repairs.filter((r) => r.source === 'in_place').length,
     repairs,
     writeResult,
   };

--- a/tests/github-billing.test.js
+++ b/tests/github-billing.test.js
@@ -313,6 +313,71 @@ describe('billing.js — GitHub Marketplace Webhooks', () => {
     delete require.cache[require.resolve('../scripts/billing')];
     billing = require('../scripts/billing');
   });
+
+  test('repairGithubMarketplaceRevenueLedger — persists funnel-derived paid orders to disk', () => {
+    process.env.THUMBGATE_GITHUB_MARKETPLACE_PLAN_PRICES_JSON = JSON.stringify({
+      88: { amountCents: 4900, currency: 'USD', recurringInterval: 'month' },
+    });
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
+
+    const funnelLedgerPath = process.env._TEST_FUNNEL_LEDGER_PATH;
+    const orderId = 'gh_marketplace_repair_funnel_8888';
+    fs.appendFileSync(
+      funnelLedgerPath,
+      `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        stage: 'paid',
+        event: 'github_marketplace_purchased',
+        evidence: orderId,
+        metadata: {
+          provider: 'github_marketplace',
+          customerId: 'github_user_8888',
+          source: 'github_marketplace',
+          marketplaceOrderId: orderId,
+          planId: 88,
+          billingCycle: 'monthly',
+        },
+      })}\n`,
+      'utf-8'
+    );
+
+    // Dry run first — must report the repair without writing.
+    const dry = billing.repairGithubMarketplaceRevenueLedger({ write: false });
+    const dryThis = dry.repairs.filter((r) => r.orderId === orderId && r.source === 'funnel_derived');
+    assert.equal(dryThis.length, 1, 'this funnel-derived row should be detected');
+    assert.equal(dry.wrote, false, 'dry run must not write');
+    assert.equal(
+      readRevenueEvents().filter((r) => r.orderId === orderId).length,
+      0,
+      'dry run must not append to ledger'
+    );
+
+    // Real run — must persist the resolved row to disk.
+    const written = billing.repairGithubMarketplaceRevenueLedger({ write: true });
+    const writtenThis = written.repairs.filter((r) => r.orderId === orderId && r.source === 'funnel_derived');
+    assert.equal(writtenThis.length, 1);
+    assert.equal(written.wrote, true);
+    const persisted = readRevenueEvents().filter((r) => r.orderId === orderId);
+    assert.equal(persisted.length, 1, 'funnel-derived row must be persisted exactly once');
+    assert.equal(persisted[0].amountKnown, true);
+    assert.equal(persisted[0].amountCents, 4900);
+    assert.equal(persisted[0].metadata.recoveredFromFunnelLedger, true);
+
+    // Idempotency — second run for THIS row must not double-write.
+    const second = billing.repairGithubMarketplaceRevenueLedger({ write: true });
+    const secondThis = second.repairs.filter((r) => r.orderId === orderId && r.source === 'funnel_derived');
+    assert.equal(secondThis.length, 0, 'second pass must skip this already-persisted row');
+    assert.equal(
+      readRevenueEvents().filter((r) => r.orderId === orderId).length,
+      1,
+      'no duplicate after re-run'
+    );
+
+    delete process.env.THUMBGATE_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
+  });
 });
 
 describe('API server — GitHub Webhook Route', () => {


### PR DESCRIPTION
## Summary

Recreated from main (closes #1819 which had drifted into reverting unrelated work).

PR #1810 fixed amount resolution at READ time for funnel-derived paid github_marketplace events. This PR completes the loop by walking the funnel ledger and persisting resolved amounts to \`revenue-events.jsonl\` for orders that landed only in the funnel ledger — so downstream readers (audits, exports) see them too.

- Idempotent: skips rows already in revenue ledger; only writes when \`amountKnown=true\`.
- Audit trail: persisted rows stamped \`recoveredFromFunnelLedger:true\` + \`funnelRecordedAt\`.
- New report counters: \`repairedInPlace\`, \`repairedFromFunnel\`, \`funnelScanned\`.

## Test plan

- [x] \`node --test tests/github-billing.test.js\` — 12 pass including new regression
- [x] Pre-push regression-guard green (after wiring \`test:cli-test-block\`)

## Closes

- #1819 (drifted version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)