### PR TITLE
fix(landing): broken header CTAs + Install button UX

### DIFF
--- a/.changeset/landing-broken-links-fix.md
+++ b/.changeset/landing-broken-links-fix.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix three broken navigation paths on the homepage: the ThumbGate logo link (`href="#"` → `/`), the header "Install Free" button (was pointing at the ChatGPT GPT redirect; now points at the actual install flow), and the hero + final "Install Free CLI" buttons (now copy `npx thumbgate init` to clipboard inline with visible "Copied ✓" feedback, instead of redirecting to `/guide` where buyers perceive "nothing happened").

--- a/public/index.html
+++ b/public/index.html
@@ -669,7 +669,7 @@ __GA_BOOTSTRAP__
 <!-- NAV -->
 <nav>
   <div class="container">
-    <a href="#" class="nav-logo"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+    <a href="/" class="nav-logo"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
     <div class="nav-links">
       <a href="#how-it-works">How It Works</a>
       <a href="#pricing">Pricing</a>
@@ -685,7 +685,7 @@ __GA_BOOTSTRAP__
       <a href="#claude-code-section" class="nav-claude" onclick="posthog.capture('nav_claude_click')" style="display:none;">Claude</a>
       <a href="#workflow-sprint-intake" onclick="posthog.capture('workflow_sprint')" style="display:none;">Start Sprint</a>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" onclick="posthog.capture('nav_claude_extension_click',{cta:'install_claude_extension'})" class="nav-cta" style="background:#d97706;display:none;">Claude Extension</a>
-      <a href="/go/gpt?utm_source=website&utm_medium=nav&utm_campaign=chatgpt_gpt&cta_id=nav_open_gpt&cta_placement=nav" target="_blank" rel="noopener" onclick="posthog.capture('nav_cta_click',{cta:'open_gpt'})" class="nav-cta">Install Free</a>
+      <a href="/go/install?utm_source=website&utm_medium=nav&utm_campaign=install_free&cta_id=nav_install_free&cta_placement=nav" onclick="posthog.capture('nav_cta_click',{cta:'install_free'})" class="nav-cta">Install Free</a>
     </div>
   </div>
 </nav>
@@ -709,7 +709,7 @@ __GA_BOOTSTRAP__
         <span class="cmd">npx thumbgate init</span>
         <span class="copy-hint">click to copy</span>
       </div>
-      <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="posthog.capture('hero_install_click',{cta:'install_cli'})" class="btn-gpt-page btn-install-hero">Install Free CLI</a>
+      <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-gpt-page btn-install-hero" title="Click to copy: npx thumbgate init">Install Free CLI</a>
       <a href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" class="btn-pro-page hero-diagnostic" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars});">Pay $499 diagnostic</a>
     </div>
 
@@ -1442,7 +1442,7 @@ __GA_BOOTSTRAP__
         <span class="cmd">npx thumbgate init</span>
         <span class="copy-hint">click to copy</span>
       </div>
-      <a href="/go/install?utm_source=website&utm_medium=homepage_final&utm_campaign=install_free&cta_id=final_install_cli&cta_placement=final_cta" onclick="posthog.capture('final_install_click',{cta:'install_cli'})" class="btn-pro btn-install-link" style="padding:14px 36px;font-size:16px;">Install Free CLI</a>
+      <a href="/go/install?utm_source=website&utm_medium=homepage_final&utm_campaign=install_free&cta_id=final_install_cli&cta_placement=final_cta" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('final_install_click',{cta:'install_cli'})}catch(_){}" class="btn-pro btn-install-link" style="padding:14px 36px;font-size:16px;" title="Click to copy: npx thumbgate init">Install Free CLI</a>
     </div>
     <div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;align-items:center;margin-top:12px;opacity:0.7;">
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" class="btn-gpt-page" target="_blank" rel="noopener" onclick="posthog.capture('final_claude_extension_click',{cta:'install_claude_extension'})" style="padding:8px 16px;font-size:12px;background:#d97706;color:#fff;">Install Claude Extension</a>


### PR DESCRIPTION
## Summary

CEO reported "clicking Install Free CLI just goes to the homepage" — audit found 3 real link bugs on \`public/index.html\`:

| Line | Element | Before | After |
|---|---|---|---|
| 672 | Logo link | \`href="#"\` | \`href="/"\` |
| 688 | Header "Install Free" button | \`/go/gpt\` (ChatGPT GPT redirect — zero install affordance) | \`/go/install\` with correct UTM (\`nav_install_free\`) |
| 712 | Hero "Install Free CLI" button | \`href="/go/install"\` → 302 → \`/guide\` (visually similar to homepage; buyer perceives "nothing happened") | Inline copy-to-clipboard: click → copies \`npx thumbgate init\` → button text flips to "Copied ✓ — paste in your repo" for 2s. \`href\` preserved as no-JS fallback. |
| 1445 | Final CTA "Install Free CLI" button | Same problem as 712 | Same fix |

## Why the inline copy is right

The page already has a copy-to-clipboard \`hero-install\` element right next to the button (`$ npx thumbgate init` with "click to copy"). The button next to it doing something completely different — navigating away — broke buyer expectation. The fix mirrors the existing UX: click → copy → confirmation. No friction.

Telemetry call is wrapped in try/catch so a PostHog load failure never breaks the copy.

## Test plan

- [x] \`node --test tests/public-landing.test.js tests/landing-page-claims.test.js\` — 68 pass, 0 fail
- [x] \`node scripts/check-congruence.js\` — green
- [x] \`grep -c 'href="#"' public/index.html\` → 0 remaining
- [ ] After merge + Railway rebuild: click each fixed CTA on prod, verify the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)