### PR TITLE
feat: free-tier unlimited+5 rules + persist funnel-derived github_marketplace orders

### DIFF
--- a/.changeset/free-tier-unlimited-captures-five-rules.md
+++ b/.changeset/free-tier-unlimited-captures-five-rules.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Free tier now grants unlimited feedback captures and up to 5 active auto-promoted prevention rules (previously 3 lifetime captures + 1 rule). The hard 3-capture wall blocked habit formation; this opens the daily-use lane while keeping the dashboard, recall, lesson search, unlimited rules, and DPO export gated to Pro.

--- a/.changeset/repair-github-marketplace-funnel-derived-rows.md
+++ b/.changeset/repair-github-marketplace-funnel-derived-rows.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+`repairGithubMarketplaceRevenueLedger` now also walks the funnel ledger and persists resolved amounts for `paid` `github_marketplace` orders that never landed in `revenue-events.jsonl`. PR #1810 fixed read-time resolution; this fix completes the loop by writing recovered rows to disk so audits and downstream exports see them too. Idempotent — only persists when plan pricing produces a known amount, and skips rows already in the ledger.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -40,7 +40,7 @@ npx thumbgate init --agent claude-code
 ## Pricing
 
 - Free GPT: advice, checkpointing, and setup help in ChatGPT
-- Free local CLI: 3 feedback captures/day, 5 lesson searches/day, recall, and local Pre-Action Checks after install
+- Free local CLI: unlimited feedback captures, up to 5 active prevention rules, and local Pre-Action Checks after install (recall and lesson search are Pro-only)
 - Pro: $19/mo or $149/yr — personal enforcement proof, local dashboard, check debugger, DPO export, and review-ready exports
 - Team: $49/seat/mo, 3-seat minimum after intake — shared lessons, org visibility, approval boundaries, and rollout proof
 

--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ npx thumbgate bench --programbench-smoke  # include cleanroom whole-repo proof l
 | Org-wide dashboard | — | — | ✅ |
 | Approval + audit proof | — | — | ✅ |
 
-The free tier gives you 3 lifetime feedback captures and 1 auto-promoted prevention rule — enough to prove the enforcement loop works. MCP integrations for all agents (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode) ship free.
+The free tier gives you unlimited feedback captures and up to 5 active auto-promoted prevention rules — generous enough to make ThumbGate part of your daily flow. MCP integrations for all agents (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode) ship free.
 
-Pro ($19/mo or $149/yr) lifts those caps and adds history-aware lesson recall, lesson search, DPO export, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement across the org. Pro and Team include `open_feedback_session`, `append_feedback_context`, and `finalize_feedback_session` for structured multi-turn feedback capture.
+Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recall, lesson search, DPO export, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement across the org. Pro and Team include `open_feedback_session`, `append_feedback_context`, and `finalize_feedback_session` for structured multi-turn feedback capture.
 
 **Best first paid motion for teams:** the **Workflow Hardening Sprint** — qualify one repeated failure before committing to a full rollout. **[Start intake →](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=team_rollout#workflow-sprint-intake)**
 
@@ -354,7 +354,7 @@ curl -X POST http://localhost:3456/v1/dpo/export \
 | Layer | Technology |
 |-------|-----------|
 | **Storage** | SQLite + FTS5, LanceDB vectors, JSONL logs |
-| **Capture** | 3 feedback captures lifetime (free), unlimited (Pro) |
+| **Capture** | Unlimited feedback captures (free + Pro) |
 | **Intelligence** | MemAlign dual recall, Thompson Sampling |
 | **Enforcement** | PreToolUse hook engine, Checks config |
 | **Interfaces** | MCP stdio, HTTP API, CLI (Node.js >=18) |
@@ -415,9 +415,9 @@ Those are suggestions the agent can ignore. ThumbGate checks are enforced — th
 If it supports MCP or pre-action hooks, yes. Claude Code, Claude Desktop, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode all work out of the box.
 
 **Is it free?**
-The free tier gives you 3 lifetime feedback captures and 1 auto-promoted prevention rule — enough to prove the enforcement loop works. MCP integrations ship free for every agent.
+The free tier gives you unlimited feedback captures and up to 5 active auto-promoted prevention rules — generous enough for solo devs to use daily. MCP integrations ship free for every agent.
 
-Pro ($19/mo or $149/yr) lifts those caps and adds history-aware lesson recall, lesson search, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement.
+Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recall, lesson search, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement.
 
 ---
 

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -23,8 +23,8 @@ This document is the source of truth for product, pricing, traction, and proof c
 
 ### Free (local, `npx thumbgate serve`)
 
-- 3 lifetime feedback captures
-- 1 auto-promoted prevention rule
+- Unlimited feedback captures
+- Up to 5 active auto-promoted prevention rules
 - No recall or lesson search
 - No exports (DPO, Databricks, HuggingFace)
 - 5 built-in checks plus local PreToolUse hook blocking

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -1135,8 +1135,8 @@
             <p style='margin:0 0 8px;font-size:15px;color:var(--muted);font-style:italic;'>CLI-first local enforcement for a solo developer proving the need.</p>
             <div class='price'>$0 <small>/ forever</small></div>
             <ul>
-              <li>3 feedback captures total</li>
-              <li>1 auto-promoted prevention rule</li>
+              <li>Unlimited feedback captures</li>
+              <li>Up to 5 active auto-promoted prevention rules</li>
               <li>5 built-in checks</li>
               <li>No recall or lesson search</li>
               <li>No DPO/KTO export</li>

--- a/docs/marketing/email-nurture-sequence.md
+++ b/docs/marketing/email-nurture-sequence.md
@@ -166,7 +166,7 @@ If ThumbGate has saved you from a repeated mistake, we'd genuinely love to hear 
 
 You've been using ThumbGate for two weeks. By now you likely know whether the local loop is catching real mistakes.
 
-Free tier gives you 3 feedback captures total and keeps recall plus lesson search behind Pro. If you've hit that wall, ThumbGate already proved the enforcement loop matters on your workflow.
+Free tier gives you unlimited feedback captures and 5 active prevention rules, but keeps recall, lesson search, the dashboard, and DPO exports behind Pro. If you've leaned on ThumbGate for two weeks, the next step is the dashboard and unlimited rules.
 
 ThumbGate Pro removes the limit and adds:
 

--- a/docs/marketing/pricing-comparison.md
+++ b/docs/marketing/pricing-comparison.md
@@ -2,13 +2,13 @@
 
 | Feature | Free | Pro ($19/mo or $149/yr) |
 |---------|------|--------------|
-| Feedback capture | 3 total | Unlimited |
+| Feedback capture | Unlimited | Unlimited |
 | Recall + lesson search | No | Yes |
-| Prevention rules | 1 auto-promoted rule | Unlimited |
+| Prevention rules | Up to 5 active | Unlimited |
 | 5 built-in checks | Yes | Yes |
 | PreToolUse hook blocking | Yes | Yes |
 | DPO/KTO export | No | Yes |
-| Auto-gate promotion | 1 rule | Yes |
+| Auto-gate promotion | Up to 5 rules | Unlimited |
 | Unlimited custom checks | No | Yes |
 | Multi-repo sync | No | Yes |
 | CI webhook auto-ingest | No | Yes |

--- a/docs/marketing/product-hunt-launch-kit.md
+++ b/docs/marketing/product-hunt-launch-kit.md
@@ -60,7 +60,7 @@ I'm here all day — ask me anything.
 
 Happy launch day! A few things to know before you try it:
 
-The free tier gives you the local loop: 3 feedback captures total, 1 auto-promoted prevention rule, and local enforcement via PreToolUse hooks. No cloud account, no credit card.
+The free tier gives you the local loop: unlimited feedback captures, up to 5 active auto-promoted prevention rules, and local enforcement via PreToolUse hooks. No cloud account, no credit card.
 
 Pro ($19/mo) adds the personal local dashboard, DPO export pairs for downstream fine-tuning, and a check debugger to trace exactly why a rule fired.
 

--- a/docs/marketing/show-hn.md
+++ b/docs/marketing/show-hn.md
@@ -54,8 +54,8 @@ It speaks MCP stdio, so it plugs into Claude Code, Claude Desktop,
 Cursor, Codex CLI, Gemini CLI, Amp, OpenCode — anything that speaks the
 protocol. One correction in Claude Code also protects your Cursor session.
 
-Free tier: 3 captures total, 1 auto-promoted rule. Enough to prove one blocked
-repeat on a real workflow. Pro is $19/mo or $149/yr for unlimited captures + a
+Free tier: unlimited captures, 5 active auto-promoted rules. Enough to make
+ThumbGate part of your daily flow. Pro is $19/mo or $149/yr for unlimited rules + a
 local dashboard showing tokens-saved since install (Sonnet-blended
 estimate, conservative). Team is $49/seat/mo for a shared hosted
 lesson DB.

--- a/public/compare.html
+++ b/public/compare.html
@@ -62,7 +62,7 @@
       "name": "Is ThumbGate free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate has a free tier that includes local enforcement with 3 feedback captures total, 1 auto-promoted prevention rule, and pre-action check blocking. Pro ($19/mo or $149/yr) adds a personal local dashboard, recall, lesson search, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard."
+        "text": "ThumbGate has a free tier that includes local enforcement with unlimited feedback captures, up to 5 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds a personal local dashboard, recall, lesson search, unlimited rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard."
       }
     },
     {
@@ -299,7 +299,7 @@
 
 <div class="card">
   <h3>Is ThumbGate free?</h3>
-  <p>ThumbGate has a free tier that includes local enforcement with 3 feedback captures total, 1 auto-promoted prevention rule, and pre-action check blocking. Pro ($19/mo or $149/yr) adds a personal local dashboard, recall, lesson search, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard.</p>
+  <p>ThumbGate has a free tier that includes local enforcement with unlimited feedback captures, up to 5 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds a personal local dashboard, recall, lesson search, unlimited rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard.</p>
 </div>
 
 <div class="card">

--- a/public/guide.html
+++ b/public/guide.html
@@ -356,7 +356,7 @@ npx thumbgate init --agent gemini</code></pre>
 <a href="https://buy.stripe.com/00w14neyUcXA5pL5e33sI0e" class="cta cta-secondary">Pay $499 diagnostic</a>
 <a href="https://buy.stripe.com/fZu9AT76saPsg4pbCr3sI0f" class="cta cta-secondary">Pay $1500 sprint</a>
 <a href="https://thumbgate.ai/#workflow-sprint-intake" class="cta cta-secondary">Send workflow first</a>
-<p style="color:var(--muted); font-size:0.85rem;">Free: 3 feedback captures, 1 prevention rule, hook blocking. Pro: dashboard, recall, lesson search, DPO export. Team: intake first, then $49/seat/mo with a 3-seat minimum.</p>
+<p style="color:var(--muted); font-size:0.85rem;">Free: unlimited captures, 5 active prevention rules, hook blocking. Pro: dashboard, recall, lesson search, unlimited rules, DPO export. Team: intake first, then $49/seat/mo with a 3-seat minimum.</p>
 
 </div>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -1211,11 +1211,11 @@ __GA_BOOTSTRAP__
       <div class="price-card free-highlight" style="border-color:var(--cyan);box-shadow:0 0 40px var(--cyan-dim), inset 0 1px 0 rgba(34,211,238,0.15);position:relative;">
         <div class="tier" style="color:var(--cyan);">Free</div>
         <div class="price">$0</div>
-        <div class="price-sub">See how it works. Hit the wall. Then decide.</div>
-        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">3 captures total, 1 rule. Enough to prove the enforcement loop works. When you need more, you will know.</p>
+        <div class="price-sub">Block repeated mistakes daily. Forever free for solo devs.</div>
+        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">Unlimited captures, 5 active rules. Enough to make ThumbGate part of your daily flow. Upgrade when you want the dashboard, exports, or unlimited rules.</p>
         <ul>
-          <li><strong>3 feedback captures total</strong> (not per day)</li>
-          <li>1 auto-promoted prevention rule</li>
+          <li><strong>Unlimited feedback captures</strong> — every thumbs-down, every session</li>
+          <li>Up to 5 active auto-promoted prevention rules</li>
           <li>No recall or lesson search</li>
           <li>No exports (DPO, Databricks, HuggingFace)</li>
           <li>All MCP integrations (Claude Code, Cursor, Codex, Gemini, Amp, any MCP agent)</li>
@@ -1399,7 +1399,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">Do I need a cloud account?</div>
-        <div class="faq-a">No. Free keeps local enforcement on your machine with 3 feedback captures total, 1 auto-promoted prevention rule, built-in safety checks, and hook blocking. Recall, lesson search, and exports open up on Pro. No cloud account is required. The business starts when a team wants shared rules, approval boundaries, hosted review views, org dashboard visibility, and proof that survives handoffs. Pro is the optional solo side lane for a personal dashboard, DPO export, and team lesson export/import — share lessons across projects so one team's mistakes become every team's prevention rules.</div>
+        <div class="faq-a">No. Free keeps local enforcement on your machine with unlimited feedback captures, up to 5 active auto-promoted prevention rules, built-in safety checks, and hook blocking. Recall, lesson search, unlimited rules, and exports open up on Pro. No cloud account is required. The business starts when a team wants shared rules, approval boundaries, hosted review views, org dashboard visibility, and proof that survives handoffs. Pro is the optional solo side lane for a personal dashboard, DPO export, and team lesson export/import — share lessons across projects so one team's mistakes become every team's prevention rules.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What if my thumbs-down is vague?</div>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -127,7 +127,7 @@ This alignment means ThumbGate is not an experimental tool — it implements the
 ## Pricing
 
 - **Free GPT**: Advice, checkpointing, setup help, and typed thumbs-up/down memory capture inside ChatGPT.
-- **Free local CLI**: Local enforcement for individual developers after install. Includes 3 feedback captures total, 1 auto-promoted prevention rule, and PreToolUse hook blocking. Recall, lesson search, and exports are Pro-only.
+- **Free local CLI**: Local enforcement for individual developers after install. Includes unlimited feedback captures, up to 5 active auto-promoted prevention rules, and PreToolUse hook blocking. Recall, lesson search, and exports are Pro-only.
 - **Workflow Hardening Sprint / Team**: Team pricing anchors at $49/seat/mo with a 3-seat minimum after qualification. The first paid step is an intake-led sprint around one workflow, one repeated blocker, and one proof review.
 - **Pro**: $19/mo or $149/yr. Adds personal enforcement proof, a local dashboard, DPO export for fine-tuning, a check debugger, and advanced data exports for solo operators who want a self-serve side lane.
 

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -1162,6 +1162,9 @@ function repairGithubMarketplaceRevenueLedger(options = {}) {
   const rows = loadJsonlFile(ledgerPath);
   const resolvedAt = new Date().toISOString();
   const repairs = [];
+
+  // Pass 1: in-place repair of rows already in revenue-events.jsonl that have
+  // unknown amounts but resolvable plan metadata.
   const updatedRows = rows.map((entry) => {
     const result = resolveGithubMarketplaceRevenueEntry(entry, {
       annotate: true,
@@ -1179,21 +1182,76 @@ function repairGithubMarketplaceRevenueLedger(options = {}) {
       currency: normalizeCurrency(result.entry.currency),
       recurringInterval: normalizeText(result.entry.recurringInterval),
       pricingSource: normalizeText(metadata.githubMarketplaceAmountSource),
+      source: 'in_place',
     });
     return result.entry;
   });
 
+  // Pass 2: append rows for funnel-derived paid github_marketplace events that
+  // never landed in the revenue ledger. The webhook handler at handleGithubWebhook
+  // skips appendRevenueEvent when hasRevenueEventMatch is true, so duplicates from
+  // a re-run are already prevented; the only way an order gets here is if the
+  // revenue write was skipped at webhook time (e.g. funnel pre-existed, planPricing
+  // had unknown amount at the time, or the row was created via a different path).
+  const funnelRecords = loadFunnelLedger().filter(
+    (e) =>
+      e &&
+      e.stage === 'paid' &&
+      normalizeText((e.metadata && e.metadata.provider) || e.provider) === 'github_marketplace'
+  );
+
+  for (const funnelEntry of funnelRecords) {
+    const derived = deriveRevenueEventFromPaidProviderEvent(funnelEntry);
+    if (!derived) continue;
+    if (hasRevenueEventMatch(updatedRows, derived)) continue;
+
+    const resolved = resolveGithubMarketplaceRevenueEntry(derived, {
+      annotate: true,
+      resolvedAt,
+    });
+    // Skip funnel-derived rows that still have unknown amounts after resolving —
+    // we don't want to permanently bake amountKnown:false rows when there's no
+    // pricing data to attach. Better to leave them off-disk and keep the
+    // read-time merge in loadResolvedRevenueEvents covering them.
+    if (!resolved.changed || !resolved.entry.amountKnown) continue;
+
+    const persisted = {
+      ...resolved.entry,
+      metadata: {
+        ...sanitizeMetadata(resolved.entry.metadata),
+        recoveredFromFunnelLedger: true,
+        funnelRecordedAt: normalizeText(funnelEntry.timestamp) || null,
+      },
+    };
+    updatedRows.push(persisted);
+
+    const metadata = sanitizeMetadata(persisted.metadata);
+    repairs.push({
+      orderId: normalizeText(persisted.orderId),
+      customerId: normalizeText(persisted.customerId),
+      planId: normalizeText(metadata.planId ?? persisted.planId),
+      amountCents: normalizeInteger(persisted.amountCents),
+      currency: normalizeCurrency(persisted.currency),
+      recurringInterval: normalizeText(persisted.recurringInterval),
+      pricingSource: normalizeText(metadata.githubMarketplaceAmountSource),
+      source: 'funnel_derived',
+    });
+  }
+
   const writeResult = write && repairs.length > 0
     ? writeJsonlRecords(ledgerPath, updatedRows)
-    : { written: false, rowCount: rows.length };
+    : { written: false, rowCount: updatedRows.length };
 
   return {
     ledgerPath,
     write,
     wrote: Boolean(writeResult.written),
     scanned: rows.length,
+    funnelScanned: funnelRecords.length,
     repaired: repairs.length,
-    unchanged: rows.length - repairs.length,
+    repairedInPlace: repairs.filter((r) => r.source === 'in_place').length,
+    repairedFromFunnel: repairs.filter((r) => r.source === 'funnel_derived').length,
+    unchanged: rows.length - repairs.filter((r) => r.source === 'in_place').length,
     repairs,
     writeResult,
   };

--- a/scripts/check-congruence.js
+++ b/scripts/check-congruence.js
@@ -336,12 +336,12 @@ async function main() {
     'public/index.html must mention the linked feedback session flow'
   );
   check(
-    /3 feedback captures total/i.test(landingHtml) || /3 captures/i.test(landingHtml),
-    'public/index.html must advertise the truthful free-tier capture limits'
+    /unlimited (feedback )?captures/i.test(landingHtml),
+    'public/index.html must advertise the truthful free-tier capture limits (unlimited)'
   );
   check(
-    /1 rule/i.test(landingHtml) || /1 prevention rule/i.test(landingHtml),
-    'public/index.html must advertise the truthful free-tier rule limit'
+    /5 (active )?(auto-promoted )?prevention rules/i.test(landingHtml),
+    'public/index.html must advertise the truthful free-tier rule limit (5 active rules)'
   );
   check(
     landingHtml.includes(PRODUCTHUNT_URL),

--- a/scripts/rate-limiter.js
+++ b/scripts/rate-limiter.js
@@ -12,28 +12,28 @@ const {
 const USAGE_FILE = path.join(process.env.HOME || '/tmp', '.thumbgate', 'usage-limits.json');
 
 // ──────────────────────────────────────────────────────────
-// NEW: Lifetime caps on free tier — users hit the wall fast
-// and must upgrade to keep using core features.
+// Free tier: generous on captures (habit formation) and rules
+// (5 active gates), gated on Pro-only features (recall, search,
+// exports). Dashboard, exports, and unlimited rules drive Pro.
 // ──────────────────────────────────────────────────────────
 const FREE_TIER_LIMITS = {
-  capture_feedback:   { daily: Infinity, lifetime: 3,  label: 'feedback captures' },
-  prevention_rules:   { daily: Infinity, lifetime: 1,  label: 'prevention rules generated' },
-  recall:             { daily: 0,        lifetime: 0,  label: 'recall queries (Pro only)' },
-  search_lessons:     { daily: 0,        lifetime: 0,  label: 'lesson searches (Pro only)' },
-  search_thumbgate:   { daily: 0,        lifetime: 0,  label: 'ThumbGate searches (Pro only)' },
-  commerce_recall:    { daily: 0,        lifetime: 0,  label: 'commerce recalls (Pro only)' },
-  export_dpo:         { daily: 0,        lifetime: 0,  label: 'DPO exports (Pro only)' },
-  export_databricks:  { daily: 0,        lifetime: 0,  label: 'Databricks exports (Pro only)' },
-  construct_context_pack: { daily: Infinity, lifetime: 3, label: 'context packs' },
+  capture_feedback:   { daily: Infinity, lifetime: Infinity, label: 'feedback captures' },
+  prevention_rules:   { daily: Infinity, lifetime: Infinity, label: 'prevention rules generated' },
+  recall:             { daily: 0,        lifetime: 0,        label: 'recall queries (Pro only)' },
+  search_lessons:     { daily: 0,        lifetime: 0,        label: 'lesson searches (Pro only)' },
+  search_thumbgate:   { daily: 0,        lifetime: 0,        label: 'ThumbGate searches (Pro only)' },
+  commerce_recall:    { daily: 0,        lifetime: 0,        label: 'commerce recalls (Pro only)' },
+  export_dpo:         { daily: 0,        lifetime: 0,        label: 'DPO exports (Pro only)' },
+  export_databricks:  { daily: 0,        lifetime: 0,        label: 'Databricks exports (Pro only)' },
+  construct_context_pack: { daily: Infinity, lifetime: Infinity, label: 'context packs' },
 };
 
-const FREE_TIER_MAX_GATES = 1; // Down from 5 — one auto-promoted gate, then paywall
+const FREE_TIER_MAX_GATES = 5; // 5 active prevention rules on free; Pro is unlimited
 
-const UPGRADE_MESSAGE = `Pro: ${PRO_PRICE_LABEL} — unlimited captures, recall, prevention rules, and dashboard: ${PRO_MONTHLY_PAYMENT_LINK}\n  Team: ${TEAM_PRICE_LABEL} after workflow qualification.`;
+const UPGRADE_MESSAGE = `Pro: ${PRO_PRICE_LABEL} — unlimited rules, recall, lesson search, dashboard, and exports: ${PRO_MONTHLY_PAYMENT_LINK}\n  Team: ${TEAM_PRICE_LABEL} after workflow qualification.`;
 
 const PAYWALL_MESSAGES = {
-  capture_feedback: 'You\'ve used all 3 free feedback captures. Your agent is still making mistakes — upgrade to Pro to capture every one and build real prevention rules.',
-  prevention_rules: 'Free tier includes 1 prevention rule. Your agents need more protection — upgrade to Pro for unlimited rules.',
+  prevention_rules: 'Free tier includes 5 active prevention rules. Promote more or unlock unlimited rules with Pro.',
   recall: 'Recall is a Pro feature. Your past feedback is stored locally — upgrade to search and reuse it.',
   search_lessons: 'Lesson search is a Pro feature. Upgrade to find patterns in your agent\'s mistakes.',
   default: 'This feature requires Pro. Start Pro — card required; billed today.',

--- a/tests/check-congruence.test.js
+++ b/tests/check-congruence.test.js
@@ -54,7 +54,11 @@ test('README commercial copy stays aligned with current Pro and Team packaging',
   assert.match(readme, /org dashboard/i);
   assert.match(readme, /history-aware/i);
   assert.match(readme, /feedback session|open_feedback_session|append_feedback_context|finalize_feedback_session/i);
-  assert.match(readme, /3.*feedback capture/i);
+  // Free tier moved from "3 feedback captures" to "unlimited feedback captures
+  // and up to 5 active auto-promoted prevention rules" on 2026-05-07
+  // (feat/free-tier-unlimited-captures-5-rules) to enable habit formation.
+  assert.match(readme, /unlimited feedback captures/i);
+  assert.match(readme, /5 active auto-promoted prevention rules/i);
   assert.match(readme, /lesson/i);
   assert.doesNotMatch(readme, /\$12\/seat\/mo/i);
   assert.doesNotMatch(readme, /shared team DB/i);

--- a/tests/docs-claim-hygiene.test.js
+++ b/tests/docs-claim-hygiene.test.js
@@ -89,7 +89,9 @@ test('active commercial surfaces avoid stale free-tier limit claims', () => {
 test('pricing comparison keeps free-tier pro features out of the free column', () => {
   const pricing = fs.readFileSync(path.join(projectRoot, 'docs/marketing/pricing-comparison.md'), 'utf8');
 
-  assert.match(pricing, /\|\s*Feedback capture\s*\|\s*3 total\s*\|\s*Unlimited\s*\|/i);
+  // Free tier moved from "3 total" captures to unlimited captures + 5 active
+  // rules on 2026-05-07 (feat/free-tier-unlimited-captures-5-rules).
+  assert.match(pricing, /\|\s*Feedback capture\s*\|\s*Unlimited\s*\|\s*Unlimited\s*\|/i);
   assert.match(pricing, /\|\s*Recall \+ lesson search\s*\|\s*No\s*\|\s*Yes\s*\|/i);
   assert.match(pricing, /\|\s*DPO\/KTO export\s*\|\s*No\s*\|\s*Yes\s*\|/i);
 });

--- a/tests/github-billing.test.js
+++ b/tests/github-billing.test.js
@@ -313,6 +313,71 @@ describe('billing.js — GitHub Marketplace Webhooks', () => {
     delete require.cache[require.resolve('../scripts/billing')];
     billing = require('../scripts/billing');
   });
+
+  test('repairGithubMarketplaceRevenueLedger — persists funnel-derived paid orders to disk', () => {
+    process.env.THUMBGATE_GITHUB_MARKETPLACE_PLAN_PRICES_JSON = JSON.stringify({
+      88: { amountCents: 4900, currency: 'USD', recurringInterval: 'month' },
+    });
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
+
+    const funnelLedgerPath = process.env._TEST_FUNNEL_LEDGER_PATH;
+    const orderId = 'gh_marketplace_repair_funnel_8888';
+    fs.appendFileSync(
+      funnelLedgerPath,
+      `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        stage: 'paid',
+        event: 'github_marketplace_purchased',
+        evidence: orderId,
+        metadata: {
+          provider: 'github_marketplace',
+          customerId: 'github_user_8888',
+          source: 'github_marketplace',
+          marketplaceOrderId: orderId,
+          planId: 88,
+          billingCycle: 'monthly',
+        },
+      })}\n`,
+      'utf-8'
+    );
+
+    // Dry run first — must report the repair without writing.
+    const dry = billing.repairGithubMarketplaceRevenueLedger({ write: false });
+    const dryThis = dry.repairs.filter((r) => r.orderId === orderId && r.source === 'funnel_derived');
+    assert.equal(dryThis.length, 1, 'this funnel-derived row should be detected');
+    assert.equal(dry.wrote, false, 'dry run must not write');
+    assert.equal(
+      readRevenueEvents().filter((r) => r.orderId === orderId).length,
+      0,
+      'dry run must not append to ledger'
+    );
+
+    // Real run — must persist the resolved row to disk.
+    const written = billing.repairGithubMarketplaceRevenueLedger({ write: true });
+    const writtenThis = written.repairs.filter((r) => r.orderId === orderId && r.source === 'funnel_derived');
+    assert.equal(writtenThis.length, 1);
+    assert.equal(written.wrote, true);
+    const persisted = readRevenueEvents().filter((r) => r.orderId === orderId);
+    assert.equal(persisted.length, 1, 'funnel-derived row must be persisted exactly once');
+    assert.equal(persisted[0].amountKnown, true);
+    assert.equal(persisted[0].amountCents, 4900);
+    assert.equal(persisted[0].metadata.recoveredFromFunnelLedger, true);
+
+    // Idempotency — second run for THIS row must not double-write.
+    const second = billing.repairGithubMarketplaceRevenueLedger({ write: true });
+    const secondThis = second.repairs.filter((r) => r.orderId === orderId && r.source === 'funnel_derived');
+    assert.equal(secondThis.length, 0, 'second pass must skip this already-persisted row');
+    assert.equal(
+      readRevenueEvents().filter((r) => r.orderId === orderId).length,
+      1,
+      'no duplicate after re-run'
+    );
+
+    delete process.env.THUMBGATE_GITHUB_MARKETPLACE_PLAN_PRICES_JSON;
+    delete require.cache[require.resolve('../scripts/billing')];
+    billing = require('../scripts/billing');
+  });
 });
 
 describe('API server — GitHub Webhook Route', () => {

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -53,23 +53,23 @@ describe('Free tier bullets: extraction', () => {
 });
 
 describe('Free tier bullets: code-backed claims', () => {
-  test('"3 feedback captures total" matches FREE_TIER_LIMITS.capture_feedback.lifetime', () => {
+  test('"Unlimited feedback captures" matches FREE_TIER_LIMITS.capture_feedback.lifetime', () => {
     const { FREE_TIER_LIMITS } = require(path.join(ROOT, 'scripts', 'rate-limiter.js'));
-    assert.equal(FREE_TIER_LIMITS.capture_feedback.lifetime, 3,
-      'rate-limiter says free gets N captures; landing page says 3 — must match');
+    assert.equal(FREE_TIER_LIMITS.capture_feedback.lifetime, Infinity,
+      'free tier captures must be unlimited to back habit-formation flow');
     assert.ok(
-      FREE_BULLETS.some((b) => /3 feedback captures/i.test(b)),
-      'Landing page must claim "3 feedback captures"',
+      FREE_BULLETS.some((b) => /unlimited (feedback )?captures/i.test(b)),
+      'Landing page must claim "unlimited captures"',
     );
   });
 
-  test('"1 prevention rule" matches FREE_TIER_MAX_GATES + prevention_rules.lifetime', () => {
+  test('"5 prevention rules" matches FREE_TIER_MAX_GATES', () => {
     const { FREE_TIER_LIMITS, FREE_TIER_MAX_GATES } = require(path.join(ROOT, 'scripts', 'rate-limiter.js'));
-    assert.equal(FREE_TIER_MAX_GATES, 1, 'FREE_TIER_MAX_GATES must be 1 to back "1 rule" claim');
-    assert.equal(FREE_TIER_LIMITS.prevention_rules.lifetime, 1, 'prevention_rules.lifetime must be 1');
+    assert.equal(FREE_TIER_MAX_GATES, 5, 'FREE_TIER_MAX_GATES must be 5 to back "5 active prevention rules" claim');
+    assert.equal(FREE_TIER_LIMITS.prevention_rules.lifetime, Infinity, 'prevention_rules.lifetime must be Infinity (cap is via FREE_TIER_MAX_GATES)');
     assert.ok(
-      FREE_BULLETS.some((b) => /1 (auto-promoted )?prevention rule/i.test(b)),
-      'Landing page must claim exactly 1 prevention rule',
+      FREE_BULLETS.some((b) => /5 (active )?(auto-promoted )?prevention rules/i.test(b)),
+      'Landing page must claim 5 active prevention rules',
     );
   });
 

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -91,7 +91,9 @@ test('public landing page includes pricing section with Free, Pro, and Team tier
   assert.match(landingPage, /\/mo/);
   assert.match(landingPage, /\$49/);
   assert.match(landingPage, /\/seat\/mo/);
-  assert.match(landingPage, /See how it works/);
+  // Free tier price-sub copy moved from "See how it works..." to
+  // "Block repeated mistakes daily..." in feat/free-tier-unlimited-captures.
+  assert.match(landingPage, /Block repeated mistakes daily|See how it works/);
   assert.match(landingPage, /3 captures total.*1 rule/i);
   assert.doesNotMatch(landingPage, /3 captures.*1 rule.*1 agent/i);
   assert.match(landingPage, /solo side lane/i);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -91,11 +91,13 @@ test('public landing page includes pricing section with Free, Pro, and Team tier
   assert.match(landingPage, /\/mo/);
   assert.match(landingPage, /\$49/);
   assert.match(landingPage, /\/seat\/mo/);
-  // Free tier price-sub copy moved from "See how it works..." to
-  // "Block repeated mistakes daily..." in feat/free-tier-unlimited-captures.
-  assert.match(landingPage, /Block repeated mistakes daily|See how it works/);
-  assert.match(landingPage, /3 captures total.*1 rule/i);
+  // Free tier moved from "3 captures total, 1 rule" to "Unlimited captures,
+  // 5 active rules" in feat/free-tier-unlimited-captures-5-rules. Price-sub
+  // copy moved from "See how it works..." to "Block repeated mistakes daily..."
+  assert.match(landingPage, /Block repeated mistakes daily/);
+  assert.match(landingPage, /Unlimited captures.*5 (active )?rules/i);
   assert.doesNotMatch(landingPage, /3 captures.*1 rule.*1 agent/i);
+  assert.doesNotMatch(landingPage, /3 captures total/i);
   assert.match(landingPage, /solo side lane/i);
   assert.match(landingPage, /Shared enforcement/i);
   assert.match(landingPage, /Install Free/);

--- a/tests/rate-limiter.test.js
+++ b/tests/rate-limiter.test.js
@@ -51,14 +51,11 @@ describe('rate-limiter', () => {
     if (fs.existsSync(TEMP_USAGE_FILE)) fs.unlinkSync(TEMP_USAGE_FILE);
   });
 
-  it('allows 3 capture_feedback on free tier then blocks', () => {
-    for (let i = 0; i < 3; i++) {
+  it('allows unlimited capture_feedback on free tier (habit-building lane)', () => {
+    for (let i = 0; i < 50; i++) {
       const result = rateLimiter.checkLimit('capture_feedback');
       assert.equal(result.allowed, true, `call ${i + 1} should be allowed`);
     }
-    const blocked = rateLimiter.checkLimit('capture_feedback');
-    assert.equal(blocked.allowed, false, 'call 4 should be blocked');
-    assert.ok(blocked.message.includes('3 free feedback captures') || blocked.message.includes('Upgrade') || blocked.message.includes('Pro'), 'blocked message should mention limit or upgrade');
   });
 
   it('blocks recall on free tier (Pro-only)', () => {


### PR DESCRIPTION
## Summary

Consolidates two PRs (#1859 + #1858) into one merge cycle to break the serial Trunk-queue gridlock. Each set of changes is orthogonal — different files, different surfaces, no overlap.

## A. Free-tier: unlimited captures + 5 active rules (was #1859)

Replaces "3 captures total, 1 rule" with "unlimited feedback captures, up to 5 active auto-promoted prevention rules." The 3-capture wall blocked habit formation. Generous-by-default is the right model for a dev tool — wall off the dashboard, recall, lesson search, unlimited rules, and DPO export to Pro instead.

- \`scripts/rate-limiter.js\`: \`capture_feedback.lifetime: 3 → Infinity\`, \`prevention_rules.lifetime: 1 → Infinity\`, \`FREE_TIER_MAX_GATES: 1 → 5\`; paywall messages + UPGRADE_MESSAGE updated.
- \`scripts/check-congruence.js\`: regex now requires "unlimited captures" + "5 active prevention rules".
- Copy updates: \`public/index.html\` (Free card + FAQ), \`public/compare.html\`, \`public/guide.html\`, \`public/llm-context.md\`, \`docs/COMMERCIAL_TRUTH.md\`, \`docs/landing-page.html\`, \`docs/marketing/*\` (4 files), \`README.md\`, \`.well-known/llms.txt\`.

## B. Repair script persists funnel-derived github_marketplace orders (was #1858)

PR #1810 fixed amount resolution at READ time for funnel-derived paid github_marketplace events. This completes the loop: \`repairGithubMarketplaceRevenueLedger\` now also walks the funnel ledger and persists resolved amounts to \`revenue-events.jsonl\` for orders that landed only in the funnel ledger — so audits, exports, and downstream readers see them too.

- Idempotent: skips rows already in revenue ledger; only writes when \`amountKnown=true\`.
- Audit trail: persisted rows stamped \`recoveredFromFunnelLedger:true\` + \`funnelRecordedAt\`.
- New report counters: \`repairedInPlace\`, \`repairedFromFunnel\`, \`funnelScanned\`.

## Why consolidate

Serial Trunk processing was costing 60-90 min wall-clock for two unrelated PRs. Consolidating drops it to ~20 min for one Trunk cycle. Zero conflict risk — A touches rate-limiter + landing copy + tests; B touches scripts/billing.js + github-billing tests. No file overlap.

## Test plan

- [x] \`node --test tests/rate-limiter.test.js tests/landing-page-claims.test.js tests/check-congruence.test.js tests/docs-claim-hygiene.test.js tests/public-landing.test.js tests/github-billing.test.js\` — **107/107 pass**
- [x] \`node scripts/check-congruence.js\` — green
- [x] Content verified: \`Block repeated mistakes daily\` = 1, \`Unlimited captures\` = 1, \`3 captures total\` = 0
- [ ] After merge: Railway verify, then close #1858 + #1859 as superseded
- [ ] After merge: run \`npx thumbgate repair-github-marketplace --write\` on Railway to actually recover historical orders

## Closes

- Will close #1858 and #1859 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)