### PR TITLE
copy(landing): drop "Max Smith KDP LLC" from footer — reads as KDP/Kindle

### DIFF
--- a/.changeset/landing-drop-kdp-footer.md
+++ b/.changeset/landing-drop-kdp-footer.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Drop "Max Smith KDP LLC" from public landing + blog footers and Schema.org publisher metadata. "KDP" reads as Kindle Direct Publishing to enterprise buyers evaluating an agent governance tool, and the trust hit is quiet but consistent. Now reads "© 2026 ThumbGate · MIT License".

--- a/public/blog.html
+++ b/public/blog.html
@@ -32,7 +32,7 @@
         "@type": "Blog",
         "name": "ThumbGate Blog",
         "url": "https://thumbgate-production.up.railway.app/blog",
-        "publisher": { "@type": "Organization", "name": "Max Smith KDP LLC" },
+        "publisher": { "@type": "Organization", "name": "ThumbGate" },
         "blogPost": [
           {
             "@type": "BlogPosting",
@@ -466,7 +466,7 @@
         <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a> ·
         <a href="https://x.com/IgorGanapolsky">X</a> ·
         <a href="https://www.linkedin.com/in/igorganapolsky">LinkedIn</a>
-        <br /><br />© 2026 Max Smith KDP LLC · MIT License
+        <br /><br />© 2026 ThumbGate · MIT License
       </div>
     </footer>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -1463,7 +1463,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 Max Smith KDP LLC · MIT License · npm v1.16.22</span>
+    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.16.22</span>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

External audit flagged the footer:

> \`© 2026 Max Smith KDP LLC · MIT License · npm v1.16.22\`

"KDP" reads as Kindle Direct Publishing (the unrelated passive-income business) to anyone evaluating an agent governance tool. The trust hit is quiet but consistent — every enterprise buyer who scans the footer of a security-adjacent product sees "publishing LLC" and downgrades trust.

Five-minute fix; non-trivial conversion cost left running.

## Changes

- \`public/index.html\` footer-copy → \`© 2026 ThumbGate · MIT License · npm v1.16.22\`
- \`public/blog.html\` footer + Schema.org \`Organization\` publisher name → \`ThumbGate\`

## Legal note

Copyright protection applies regardless of named entity. MIT License attribution is preserved. If a formal copyright holder needs to appear later (SOC 2 audit, DPA), it can be re-introduced as "ThumbGate, a product of \<entity\>" without losing the trust improvement.

## Test plan

- [x] \`node --test tests/public-landing.test.js tests/landing-page-claims.test.js\` — 68 pass, 0 fail
- [x] \`node scripts/check-congruence.js\` — green
- [x] \`grep -c "Max Smith KDP" public/index.html public/blog.html\` → 0/0
- [ ] After merge + Railway rebuild: \`curl -s https://thumbgate.ai/ | grep -c "Max Smith KDP"\` should be 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)