### PR TITLE
feat(landing): live npm badge + hero Pro $19/mo CTA swap

### DIFF
--- a/.changeset/landing-hero-pro-cta.md
+++ b/.changeset/landing-hero-pro-cta.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Swap landing hero secondary CTA from "Pay $499 diagnostic" to "Get Pro — $19/mo". Cold-visitor conversion: the natural hero pair is Install Free + the $19/mo self-serve path. The $499 diagnostic still ships via the Workflow Hardening Sprint intake panel below the hero, so high-ticket service buyers still have a clear path.

--- a/.changeset/landing-npm-downloads-badge.md
+++ b/.changeset/landing-npm-downloads-badge.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add live npm weekly-downloads badge to the landing hero trust bar. Real momentum (verifiable via shields.io against `npm/dw/thumbgate`) replaces a vague "MIT open source" pill as the leading trust signal. Auto-updates as installs grow — no manual copy edits required.

--- a/public/index.html
+++ b/public/index.html
@@ -714,6 +714,7 @@ __GA_BOOTSTRAP__
     </div>
 
     <div class="hero-trust-bar">
+      <span><a href="https://www.npmjs.com/package/thumbgate" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;"><img src="https://img.shields.io/npm/dw/thumbgate?label=npm&amp;color=22d3ee" alt="weekly npm installs of thumbgate" loading="lazy" style="vertical-align:middle;"></a></span>
       <span>MIT open source</span>
       <span>Local-first</span>
       <span>Works with MCP-compatible agents</span>

--- a/public/index.html
+++ b/public/index.html
@@ -710,7 +710,7 @@ __GA_BOOTSTRAP__
         <span class="copy-hint">click to copy</span>
       </div>
       <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-gpt-page btn-install-hero" title="Click to copy: npx thumbgate init">Install Free CLI</a>
-      <a href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" class="btn-pro-page hero-diagnostic" onclick="sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',price:sprintDiagnosticPriceDollars});sendGa4Event('begin_checkout',{currency:'USD',value:sprintDiagnosticPriceDollars});">Pay $499 diagnostic</a>
+      <a href="/go/pro?utm_source=website&amp;utm_medium=hero_cta&amp;utm_campaign=pro_upgrade&amp;cta_id=hero_go_pro&amp;cta_placement=hero&amp;plan_id=pro&amp;landing_path=%2F" onclick="try{posthog.capture('hero_pro_click',{cta:'go_pro'})}catch(_){};sendFirstPartyTelemetry('hero_pro_checkout_started',{ctaId:'hero_go_pro',ctaPlacement:'hero',planId:'pro',price:19});sendGa4Event('begin_checkout',{currency:'USD',value:19,items:[{item_id:'pro',item_name:'ThumbGate Pro'}]});" class="btn-pro-page hero-pro">Get Pro — $19/mo</a>
     </div>
 
     <div class="hero-trust-bar">

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -130,7 +130,11 @@ test('public landing page exposes env-driven paid sprint checkout path', () => {
   assert.doesNotMatch(landingPage, /Pay \$19 quick read/);
   assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
   assert.doesNotMatch(landingPage, /quick_read_checkout_started/);
-  assert.match(landingPage, /Pay \$499 diagnostic/);
+  // Hero CTA pair is intentionally Free + Pro $19/mo for cold-visitor conversion.
+  // The $499 diagnostic still ships via the workflow-sprint-intake paid path below ("Pay for diagnostic" card).
+  assert.doesNotMatch(landingPage, /Pay \$499 diagnostic/);
+  assert.match(landingPage, /Get Pro — \$19\/mo/);
+  assert.match(landingPage, /Pay for diagnostic/);
   assert.doesNotMatch(landingPage, /Pay \$1500 sprint/);
   assert.match(landingPage, /Reliable AI Agent Governance Setup/);
   assert.match(landingPage, /\$3,997/);


### PR DESCRIPTION
## What

Two cold-visitor conversion improvements to the landing hero, bundled (both edit `public/index.html` and ship together):

1. **Live npm weekly-downloads badge** in trust bar — `shields.io/npm/dw/thumbgate`, currently **810/wk** (verified against npmjs.org API). Auto-updates as installs grow.
2. **Hero secondary CTA swap**: `Pay $499 diagnostic` → `Get Pro — $19/mo`. The natural cold-visitor pair is Install Free + the self-serve $19/mo path; the $499 diagnostic was scaring off the very buyer it sits next to. Diagnostic still reachable via the Workflow Hardening Sprint intake panel below.

## Why

External conversion audit flagged both as the highest-leverage items still unaddressed after #1855/#1866/#1869 cleanup. Two of the other audit items (free-tier 3/1 wall, ctaId leak) were already shipped — verified on prod.

Demoted to non-autonomous (CEO action required):
- Testimonials (need real outreach, can't fabricate)
- GIF screen-cap of blocked `git push --force` (needs offline screen recording)

## Test plan
- [x] `node --test tests/public-landing.test.js` → 45 pass
- [x] congruence ✓, version sync ✓, internal links ✓, claims ✓
- [ ] Trunk merge queue
- [ ] Verify on prod: npm badge renders, hero CTA reads "Get Pro — \$19/mo"

🤖 Generated with [Claude Code](https://claude.com/claude-code)