### PR TITLE
fix(activation): single 👎 now promotes a working gate (WARN_THRESHOLD 2→1)

### DIFF
--- a/.changeset/single-thumb-down-activation.md
+++ b/.changeset/single-thumb-down-activation.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Fix the activation loop: a single 👎 now auto-promotes a working gate. Lowered `WARN_THRESHOLD` in `scripts/auto-promote-gates.js` from `2 → 1`. Block escalation (`BLOCK_THRESHOLD = 3`) is unchanged, so noise doesn't auto-hard-block. Also expands `HIGH_RISK_TAGS` in `scripts/feedback-to-rules.js` to match the tag vocabulary `inferSemanticTags()` actually emits (`destructive`, `force-push`, `delete`, `drop`, `production`, `database`, `payment`, `credentials`, `secrets`, `data-loss`, etc.) so the high-risk-tag fast-path also triggers on first capture for matching destructive patterns. Cold-buyer experience was: install → give 1 👎 → "No domain has reached the threshold (2) yet" → bail. After this fix: install → give 1 👎 → gate `auto-*` with `action: warn` is live, visible in `npx thumbgate gate-stats`. Updates `tests/auto-promote-gates.test.js` to pin the new 1/3 contract.

--- a/scripts/auto-promote-gates.js
+++ b/scripts/auto-promote-gates.js
@@ -6,7 +6,10 @@ const path = require('path');
 const { resolveFeedbackDir } = require('./feedback-paths');
 
 const MAX_AUTO_GATES = 10;
-const WARN_THRESHOLD = 2; // 2+ repeated failures surface a warning gate
+// 1+ failure auto-promotes to a warning gate. Cold buyers expect "one 👎 → blocked next time"
+// — a 2-capture threshold made first-capture invisible and broke the activation loop. Block
+// escalation still requires 3 captures (BLOCK_THRESHOLD) so noise doesn't auto-hard-block.
+const WARN_THRESHOLD = 1;
 const BLOCK_THRESHOLD = 3; // 3+ repeated failures hard-block the action
 const WINDOW_DAYS = 30;
 

--- a/scripts/feedback-to-rules.js
+++ b/scripts/feedback-to-rules.js
@@ -32,7 +32,17 @@ function normalize(ctx) {
   return (ctx || '').replace(/\/Users\/[^\s/]+/g, '~').replace(/:[0-9]+/g, '').toLowerCase().trim();
 }
 
-const HIGH_RISK_TAGS = new Set(['git-workflow', 'scope-control', 'trust-breach', 'execution-gap', 'regression', 'security']);
+// HIGH_RISK_TAGS triggers single-capture promotion (count >= 1 && hasHighRisk).
+// Tags here MUST overlap with what inferSemanticTags() actually emits (see scripts/feedback-loop.js)
+// — otherwise cold buyers' first 👎 stays a lesson and never becomes a gate.
+const HIGH_RISK_TAGS = new Set([
+  // Original semantic-category labels
+  'git-workflow', 'scope-control', 'trust-breach', 'execution-gap', 'regression', 'security',
+  // Tags inferSemanticTags() emits for destructive / irreversible operations
+  'destructive', 'force-push', 'delete', 'drop', 'force-overwrite',
+  'production', 'database', 'payment', 'credentials', 'secrets',
+  'rm-rf', 'reset-hard', 'truncate', 'data-loss',
+]);
 function analyze(entries) {
   let positiveCount = 0, negativeCount = 0;
   const categories = {};

--- a/tests/auto-promote-gates.test.js
+++ b/tests/auto-promote-gates.test.js
@@ -93,8 +93,10 @@ test('getAutoGatesPath: resolves inside the active feedback directory', () => {
   }
 });
 
-test('threshold constants preserve the 2 warn / 3 block contract', () => {
-  assert.strictEqual(WARN_THRESHOLD, 2);
+test('threshold constants: 1 warn (first-capture activation) / 3 block (escalation)', () => {
+  // WARN_THRESHOLD was 2; lowered to 1 so cold buyers see a working gate after their
+  // first 👎 (activation-loop fix). Hard block still requires 3 captures to avoid noise.
+  assert.strictEqual(WARN_THRESHOLD, 1);
   assert.strictEqual(BLOCK_THRESHOLD, 3);
 });
 


### PR DESCRIPTION
## Why this matters for revenue

Cold-buyer expected flow:
```
npx thumbgate init
# agent does something bad
npx thumbgate capture --feedback=down --context='git push --force'
# expects: "blocked next time"
```

Actual flow before this PR:
```
$ npx thumbgate gate-stats
  Active gates: 36 (36 manual, 0 auto-promoted)
  Last promotion: none
$ npx thumbgate rules
  No domain has reached the threshold (2) yet.
```

The cold buyer's first 👎 silently disappeared. They needed to give 2 👎 of the same pattern before ThumbGate showed any sign of life — which they have no way to know. **First-time activation broken.**

This is exactly the failure mode that came up while building the rapid-response kit for the buyer-leads outreach (PR #1878). When `mstHex` or `calebthecm` shares a repro and I send back proof, the proof needs to show "you give one 👎 and it works" — not "give 2 👎 and try again."

## The fix

### `scripts/auto-promote-gates.js`: `WARN_THRESHOLD` 2 → 1

```js
// 1+ failure auto-promotes to a warning gate. Cold buyers expect "one 👎 → blocked next time"
const WARN_THRESHOLD = 1;
```

Block escalation (`BLOCK_THRESHOLD = 3`) is unchanged, so a single 👎 doesn't auto-hard-block — it just makes the gate visible and active as `warn`. Persistent failure (3+) still auto-upgrades to `block`.

### `scripts/feedback-to-rules.js`: expand `HIGH_RISK_TAGS`

```js
const HIGH_RISK_TAGS = new Set([
  // Original semantic-category labels
  'git-workflow', 'scope-control', 'trust-breach', 'execution-gap', 'regression', 'security',
  // Tags inferSemanticTags() emits for destructive / irreversible operations
  'destructive', 'force-push', 'delete', 'drop', 'force-overwrite',
  'production', 'database', 'payment', 'credentials', 'secrets',
  'rm-rf', 'reset-hard', 'truncate', 'data-loss',
]);
```

The existing single-capture high-risk fast path (`count >= 1 && hasHighRisk`) never fired because `HIGH_RISK_TAGS` strings didn't overlap with what `inferSemanticTags()` actually emits. Now they do.

## End-to-end verification

Fresh `mkdir test && npx thumbgate init && npx thumbgate capture --feedback=down ...` produces:

```
Active gates: 37 (36 manual, 1 auto-promoted)
Actions warned: 1
Last promotion: auto-destructive-force-push-git (today)
```

```json
{
  "id": "auto-destructive-force-push-git",
  "action": "warn",
  "message": "Auto-promoted repeated pattern: \"Agent ran git push --force on main\" (1 occurrences in 30 days)",
  "occurrences": 1,
  "promotedAt": "2026-05-11T21:35:30Z"
}
```

## Test plan
- [x] `node --test tests/auto-promote-gates.test.js` → 21 pass (threshold contract test updated)
- [x] `node --test tests/feedback-to-rules.test.js` → all pass
- [x] `node --test tests/recent-corrective-actions-context.test.js` → all pass
- [x] End-to-end clean-repo install + single-👎 → auto-promoted gate verified
- [ ] Trunk merge
- [ ] Verify in next published npm version

🤖 Generated with [Claude Code](https://claude.com/claude-code)