### PR TITLE
Fail revenue email dispatch on rejected sends

### DIFF
--- a/.changeset/resend-rejected-revenue-email.md
+++ b/.changeset/resend-rejected-revenue-email.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fail confirmed revenue email dispatches when Resend rejects the send. This prevents revenue workflows from recording a successful run when the provider returns an API error such as an unverified sender domain.

--- a/scripts/revenue-email-dispatch.js
+++ b/scripts/revenue-email-dispatch.js
@@ -80,13 +80,18 @@ async function main(argv = process.argv.slice(2), deps = {}) {
     from: process.env.RESEND_FROM_EMAIL || DEFAULT_FROM,
     replyTo: process.env.THUMBGATE_TRIAL_EMAIL_REPLY_TO || DEFAULT_REPLY_TO,
   });
-  console.log(JSON.stringify({
+  const summary = {
     campaign: options.campaign,
     leadId: message.pipelineLeadId,
     sent: Boolean(result.sent),
     providerId: result?.id || result?.providerId || null,
     reason: result?.reason || null,
-  }, null, 2));
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  if (!result.sent) {
+    const reason = result?.reason ? `: ${result.reason}` : '';
+    throw new Error(`Revenue email was not sent${reason}`);
+  }
   return result;
 }
 

--- a/tests/revenue-email-dispatch.test.js
+++ b/tests/revenue-email-dispatch.test.js
@@ -42,6 +42,15 @@ test('revenue email dispatch sends through injected transport when confirmed', a
   assert.equal(calls[0].to, 'qaisermehdi3@gmail.com');
 });
 
+test('revenue email dispatch fails confirmed runs when Resend rejects the send', async () => {
+  await assert.rejects(
+    () => main(['--campaign=aiventyx_marketplace_followup', '--confirm-send'], {
+      sendEmail: async () => ({ sent: false, reason: 'api_error' }),
+    }),
+    /Revenue email was not sent: api_error/,
+  );
+});
+
 test('parseArgs captures campaign and guards', () => {
   assert.deepEqual(parseArgs(['--campaign=aiventyx_marketplace_followup', '--dry-run', '--confirm-send']), {
     campaign: 'aiventyx_marketplace_followup',


### PR DESCRIPTION
## Summary
- fail confirmed revenue-email dispatch runs when Resend rejects the send
- keep the structured dispatch summary in logs before failing
- add coverage for rejected confirmed sends

## Test
- node --test tests/revenue-email-dispatch.test.js

## Revenue note
The latest live Revenue Email Dispatch run returned Resend 403 testing-mode/domain-verification rejection but still concluded success. This patch prevents false contacted/sent attribution until the Resend sender domain is verified.