### PR TITLE
feat(rag): cache sync reranker retrieval

### DIFF
--- a/.changeset/reranker-cache-latency.md
+++ b/.changeset/reranker-cache-latency.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Cache synchronous cross-encoder lesson retrieval inside the caller feedback directory to reduce PreToolUse latency while preserving existing reranking behavior.

--- a/scripts/cross-encoder-reranker.js
+++ b/scripts/cross-encoder-reranker.js
@@ -19,6 +19,7 @@
  */
 
 const { retrieveRelevantLessons, scoreRelevance, buildActionSignature } = require('./lesson-retrieval');
+const { getCachedRetrieval, setCachedRetrieval } = require('./retrieval-cache');
 
 /**
  * Heuristic cross-encoder: scores a (query, document) pair jointly.
@@ -176,7 +177,13 @@ function retrieveWithRerankingSync(toolName, actionContext, options = {}) {
     candidateCount = 20,
     maxResults = 5,
     feedbackDir,
+    enableCache = true,
   } = options;
+
+  if (enableCache) {
+    const cached = getCachedRetrieval(toolName, actionContext, { candidateCount, maxResults, feedbackDir });
+    if (cached) return cached;
+  }
 
   const candidates = retrieveRelevantLessons(toolName, actionContext, {
     maxResults: candidateCount,
@@ -184,7 +191,12 @@ function retrieveWithRerankingSync(toolName, actionContext, options = {}) {
   });
 
   if (candidates.length === 0) return [];
-  if (candidates.length <= maxResults) return candidates;
+  if (candidates.length <= maxResults) {
+    if (enableCache) {
+      setCachedRetrieval(toolName, actionContext, candidates, { candidateCount, maxResults, feedbackDir });
+    }
+    return candidates;
+  }
 
   const query = `${toolName || ''} ${actionContext || ''}`.trim();
 
@@ -196,12 +208,18 @@ function retrieveWithRerankingSync(toolName, actionContext, options = {}) {
   const reranked = candidates.map((c, i) => ({
     ...c,
     crossEncoderScore: rerankedScores[i],
-    combinedScore: c.relevanceScore * 0.4 + rerankedScores[i] * 0.6,
+    combinedScore: (c.relevanceScore || 0) * 0.4 + rerankedScores[i] * 0.6,
   }));
 
-  return reranked
+  const results = reranked
     .sort((a, b) => b.combinedScore - a.combinedScore)
     .slice(0, maxResults);
+
+  if (enableCache) {
+    setCachedRetrieval(toolName, actionContext, results, { candidateCount, maxResults, feedbackDir });
+  }
+
+  return results;
 }
 
 // --- Utility functions ---

--- a/scripts/retrieval-cache.js
+++ b/scripts/retrieval-cache.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { resolveFeedbackDir } = require('./feedback-paths');
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 500;
+
+function getCachePath(options = {}) {
+  const feedbackDir = options.feedbackDir || resolveFeedbackDir();
+  return path.join(feedbackDir, 'retrieval-cache.json');
+}
+
+function computeCacheKey(toolName, actionContext, options = {}) {
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify({
+      toolName: toolName || '',
+      actionContext: actionContext || '',
+      candidateCount: options.candidateCount || 20,
+      maxResults: options.maxResults || 5,
+    }))
+    .digest('hex');
+}
+
+function readCache(options = {}) {
+  try {
+    const cachePath = getCachePath(options);
+    if (!fs.existsSync(cachePath)) return {};
+    const parsed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function pruneCache(cache, options = {}) {
+  const now = options.now || Date.now();
+  return Object.fromEntries(
+    Object.entries(cache)
+      .filter(([, entry]) => entry && now - Number(entry.timestamp || 0) < CACHE_TTL_MS)
+      .sort((a, b) => Number(b[1].timestamp || 0) - Number(a[1].timestamp || 0))
+      .slice(0, MAX_CACHE_ENTRIES),
+  );
+}
+
+function getCachedRetrieval(toolName, actionContext, options = {}) {
+  const key = computeCacheKey(toolName, actionContext, options);
+  const cache = pruneCache(readCache(options), options);
+  const entry = cache[key];
+  return entry && Array.isArray(entry.results) ? entry.results : null;
+}
+
+function setCachedRetrieval(toolName, actionContext, results, options = {}) {
+  if (!Array.isArray(results)) return false;
+
+  try {
+    const cachePath = getCachePath(options);
+    const cache = pruneCache(readCache(options), options);
+    cache[computeCacheKey(toolName, actionContext, options)] = {
+      timestamp: options.now || Date.now(),
+      results,
+    };
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  CACHE_TTL_MS,
+  MAX_CACHE_ENTRIES,
+  computeCacheKey,
+  getCachePath,
+  getCachedRetrieval,
+  setCachedRetrieval,
+};

--- a/tests/cross-encoder-reranker.test.js
+++ b/tests/cross-encoder-reranker.test.js
@@ -17,6 +17,10 @@ const {
 } = require('../scripts/cross-encoder-reranker');
 
 const llmClientPath = require.resolve('../scripts/llm-client');
+const {
+  computeCacheKey,
+  getCachePath,
+} = require('../scripts/retrieval-cache');
 
 async function withMockedLlmClient(mock, fn) {
   const previous = require.cache[llmClientPath];
@@ -185,6 +189,37 @@ describe('retrieveWithRerankingSync', () => {
     if (results.length > 0) {
       assert.equal(results[0].id, 'target', `Cross-encoder should rank force-push lesson first, got: ${results[0].id} (${results[0].title})`);
     }
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('caches sync reranking results in the caller feedback directory', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-rerank-cache-'));
+    const lessons = [
+      { id: 'target', title: 'MISTAKE: force push wiped history', content: 'Never use git push --force on protected branches.', tags: ['negative'], metadata: { toolsUsed: ['Bash'] }, timestamp: new Date().toISOString() },
+      { id: 'decoy', title: 'SUCCESS: normal push', content: 'A normal feature branch push was safe.', tags: ['positive'], metadata: { toolsUsed: ['Bash'] }, timestamp: new Date().toISOString() },
+    ];
+    fs.writeFileSync(
+      path.join(tmpDir, 'memory-log.jsonl'),
+      lessons.map((l) => JSON.stringify(l)).join('\n') + '\n',
+    );
+
+    const options = {
+      feedbackDir: tmpDir,
+      candidateCount: 10,
+      maxResults: 1,
+    };
+    const first = retrieveWithRerankingSync('Bash', 'git push --force', options);
+    assert.equal(first[0].id, 'target');
+
+    fs.writeFileSync(path.join(tmpDir, 'memory-log.jsonl'), '');
+    const second = retrieveWithRerankingSync('Bash', 'git push --force', options);
+    assert.deepEqual(second, first);
+
+    const cache = JSON.parse(fs.readFileSync(getCachePath({ feedbackDir: tmpDir }), 'utf8'));
+    const cacheKey = computeCacheKey('Bash', 'git push --force', options);
+    assert.ok(cache[cacheKey]);
+    assert.equal(cache[cacheKey].results[0].id, 'target');
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- add a bounded feedback-dir-scoped cache for sync cross-encoder reranking
- cache PreToolUse retrieval results under the caller feedback directory
- add regression coverage proving cached results are reused without re-reading memory

## Verification
- node --test tests/cross-encoder-reranker.test.js tests/lesson-retrieval.test.js tests/pretooluse-lesson-injection.test.js
- node --check scripts/retrieval-cache.js
- node --check scripts/cross-encoder-reranker.js
- git diff --check

## ROI
Reduces synchronous PreToolUse retrieval/reranking latency without changing enforcement behavior.