### PR TITLE
fix(ci): grant Claude review OIDC permission

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,9 +30,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-20250514
           trigger_phrase: "@claude"
-          direct_prompt: |
+          prompt: |
             Review this PR for:
             1. Security vulnerabilities
             2. Test coverage gaps


### PR DESCRIPTION
## Summary
- grant id-token: write to the Claude Code Review job so anthropics/claude-code-action@v1 can exchange OIDC tokens
- replace unsupported direct_prompt input with prompt and remove unsupported model input

## Verification
- node workflow smoke: id-token present, unsupported inputs absent
- git diff --check

## Note
This PR fixes the Claude review workflow itself. Until this workflow content exists on the default branch, the Claude action may fail its own app-token workflow-identity validation.