### PR TITLE
fix(redirector): add /go/teams → Team checkout (CLEAN re-spin of #1910)

### DIFF
--- a/.changeset/go-teams-redirector.md
+++ b/.changeset/go-teams-redirector.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Add `/go/teams` to the tracked-link redirector — was returning HTTP 404 + "Tracked link not found" since the slug wasn't registered in `TRACKED_LINK_TARGETS`. Real impact: Aiventyx marketplace's Teams listing (5 clicks on 8 views ≈ 62% CTR — our strongest-performing external listing) had every click landing on a 404 page after our integrator swapped to the canonical `https://thumbgate.ai/go/teams?utm_source=aiventyx&...` URL. Now redirects to `/checkout/pro` with `plan_id=team&seat_count=3&billing_cycle=monthly` defaults — the 3-seat ($147/mo) self-serve Stripe Team checkout path. UTM params from caller flow through (Aiventyx-attributed clicks remain traceable end-to-end into Stripe). Two regression tests added pinning the redirect contract.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -403,6 +403,27 @@ const TRACKED_LINK_TARGETS = Object.freeze({
     },
     allowCustomerEmail: true,
   },
+  // 2026-05-12: Aiventyx marketplace listing routes its Teams clicks through
+  // /go/teams (best-performing listing at ~62% CTR). Without this slug the
+  // server returned 404 + "Tracked link not found". Every Aiventyx Teams
+  // click between the URL swap and this deploy landed on that error page.
+  // Destination: 3-seat Team self-serve Stripe checkout (the path I shipped
+  // in PR #1877 — plan_id=team + seat_count=3 = $147/mo entry).
+  teams: {
+    path: '/checkout/pro',
+    ctaId: 'go_teams',
+    ctaPlacement: 'link_router',
+    eventType: 'cta_click',
+    defaults: {
+      utm_source: 'website',
+      utm_medium: 'link_router',
+      utm_campaign: 'team_self_serve',
+      plan_id: 'team',
+      seat_count: '3',
+      billing_cycle: 'monthly',
+    },
+    allowCustomerEmail: true,
+  },
   install: {
     path: '/guide',
     ctaId: 'go_install',

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -544,6 +544,35 @@ test('/go/pro 302 redirects to /checkout/pro with caller-provided UTM params pre
   assert.equal(url.searchParams.get('cta_id'), 'go_pro');
 });
 
+test('/go/teams 302 redirects to /checkout/pro with plan_id=team + seat_count=3 (3-seat self-serve)', async () => {
+  // 2026-05-12: Aiventyx marketplace listing best-performer at ~62% CTR routes
+  // its Teams clicks through /go/teams. Pin the contract: redirect to
+  // /checkout/pro with plan_id=team + seat_count=3 so the canonical Aiventyx
+  // URL keeps landing on the 3-seat $147/mo self-serve Stripe checkout.
+  const res = await fetch(apiUrl('/go/teams?utm_source=aiventyx&utm_medium=marketplace&utm_campaign=aiventyx_teams_listing&cta_id=aiventyx_teams_listing&cta_placement=marketplace_listing'), { redirect: 'manual' });
+  assert.equal(res.status, 302);
+  assert.equal(res.headers.get('x-thumbgate-link-slug'), 'teams');
+  const url = new URL(res.headers.get('location'));
+  assert.equal(url.pathname, '/checkout/pro');
+  assert.equal(url.searchParams.get('plan_id'), 'team');
+  assert.equal(url.searchParams.get('seat_count'), '3');
+  assert.equal(url.searchParams.get('billing_cycle'), 'monthly');
+  assert.equal(url.searchParams.get('utm_source'), 'aiventyx');
+  assert.equal(url.searchParams.get('utm_medium'), 'marketplace');
+  assert.equal(url.searchParams.get('cta_id'), 'aiventyx_teams_listing');
+});
+
+test('/go/teams falls back to default UTM attribution when no params are supplied', async () => {
+  const res = await fetch(apiUrl('/go/teams'), { redirect: 'manual' });
+  assert.equal(res.status, 302);
+  const url = new URL(res.headers.get('location'));
+  assert.equal(url.pathname, '/checkout/pro');
+  assert.equal(url.searchParams.get('plan_id'), 'team');
+  assert.equal(url.searchParams.get('seat_count'), '3');
+  assert.equal(url.searchParams.get('utm_campaign'), 'team_self_serve');
+  assert.equal(url.searchParams.get('cta_id'), 'go_teams');
+});
+
 test('/go/pro falls back to default UTM attribution when no params are supplied', async () => {
   const res = await fetch(apiUrl('/go/pro'), { redirect: 'manual' });
   assert.equal(res.status, 302);


### PR DESCRIPTION
## Summary

Adds `/go/teams` to the tracked-link redirector. Currently returns HTTP 404 + "Tracked link not found" because the slug isn't in `TRACKED_LINK_TARGETS`. **Aiventyx marketplace's Teams listing (~62% CTR, our strongest external surface) has had every click landing on this 404 page** since their integrator swapped to the canonical `https://thumbgate.ai/go/teams?...` URL.

After this merges: 302 redirect to `/checkout/pro` with `plan_id=team&seat_count=3&billing_cycle=monthly` defaults — the 3-seat ($147/mo) self-serve Stripe Team checkout path. UTM params from caller flow through.

## Why this is a CLEAN re-spin

The original #1910 collected ~14 unrelated bot-authored commits over the day (Python feedback eval, X poster changes, GTM revenue loop, etc.) that dragged SonarCloud's "≥80% coverage on new code" gate below threshold for hours. This PR cherry-picks **only** the actual `/go/teams` fix onto a fresh branch from `main`.

## What's in this PR

- `src/api/server.js` (+21) — `teams` entry in `TRACKED_LINK_TARGETS`
- `tests/api-server.test.js` (+29) — 2 regression tests pinning the redirect contract + UTM passthrough
- `.changeset/go-teams-redirector.md` (+5)

Total: **3 files, 55 lines, 1 commit, properly authored.**

## Test plan

- [x] 2 regression tests pass locally
- [ ] CI green
- [ ] After merge + Railway redeploy: `curl https://thumbgate.ai/go/teams` returns 302

🤖 Generated with [Claude Code](https://claude.com/claude-code)