### PR TITLE
fix(ci): trigger Verify changeset on merge_group events

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -3,6 +3,14 @@ name: Changeset Check
 on:
   pull_request:
     branches: [main]
+  # Required-check name "Verify changeset" is in the main branch protection
+  # contexts (8 of 8). Without merge_group support, Trunk's synthetic merge
+  # SHA never gets a "Verify changeset" status report, GitHub fails the
+  # "8 of 8 required status checks are expected" gate, and Trunk drops the
+  # PR from the queue — observed on #1846, #1902, #1943 (Aiventyx Teams).
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

**Root-cause fix** for the bug that's been blocking every revenue PR from merging today.

Main branch protection requires 8 status checks. When Trunk creates the synthetic merge SHA for the merge queue, GitHub fires a `merge_group` event and waits for **all 8 named checks** to report. Every workflow except this one subscribed to `merge_group`; `changeset-check.yml` only listened to `pull_request`.

So:
- PR CI completes → all 8 checks SUCCESS on the PR SHA ✓
- Trunk queues → creates synthetic merge SHA → fires merge_group event
- 7 of 8 checks fire & succeed on the synthetic SHA
- "Verify changeset" never runs (no merge_group trigger)
- GitHub reports: `8 of 8 required status checks are expected`
- Trunk drops the PR from the queue

**Observed casualties today:**
- #1846 (`@anthropic-ai/sdk` bump) — Trunk Merge Queue FAILURE
- #1902 (rate-limit security) — Trunk Merge Queue FAILURE
- **#1943 (`/go/teams` redirector)** — has been blocking Aiventyx's highest-CTR Teams listing, every click currently lands on a JSON 404. THE revenue blocker.

## Change

Add `merge_group` trigger (mirroring the same shape used in `sonarcloud.yml`, `ci.yml`, `codeql.yml`). 2 lines of YAML, no logic change.

## Test plan

- [x] No code changes — workflow trigger only
- [x] pre-commit guards passed
- [ ] CI green on this PR
- [ ] Once merged: re-submit #1943 to Trunk queue → expect SUCCESS this time