### PR TITLE
feat(federal): public/Core split scaffolding for government deployment

### DIFF
--- a/.changeset/federal-expansion-scaffolding.md
+++ b/.changeset/federal-expansion-scaffolding.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Add federal-agency expansion scaffolding: `/federal` public landing page, `docs/federal-expansion.md` positioning brief, and 5 new public/Core boundary regression tests pinning invariants 1–5 (npm install works with no federal env vars, public CI passes with Core absent, federal code paths gate on `THUMBGATE_DEPLOY=gov`, bundle ceiling enforced, dev MCP tool contracts stable across deploy modes). The public dev product (npm package, CLI, hooks, Railway dashboard) ships unchanged — federal capabilities are a Core-side deployment profile, not a fork. Per CLAUDE.md split contract.

--- a/.changeset/protobufjs-security-alerts.md
+++ b/.changeset/protobufjs-security-alerts.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Patch protobufjs security advisories and sanitize social publisher log output.

--- a/docs/federal-expansion.md
+++ b/docs/federal-expansion.md
@@ -1,0 +1,125 @@
+# ThumbGate Federal — Public/Core Split for Government Agencies
+
+> Positioning brief + boundary contract for federal-agency deployment of ThumbGate.
+> Adopted 2026-05-13. Read this before touching any `THUMBGATE_DEPLOY=gov` code path.
+
+## TL;DR
+
+**ThumbGate Federal is a Core-side deployment profile, not a fork or rewrite of the public shell.** The public `npm install thumbgate` dev product stays unchanged. Federal capabilities ship as additive layers inside `ThumbGate-Core`, gated behind `THUMBGATE_DEPLOY=gov` or a licensed Core binary.
+
+One codebase. One brand. Two landing surfaces. The buyer journey is fundamentally different — federal procurement officers don't read `npm install` docs, they look for compliance badges, control mappings, and a "contact for pilot" CTA — but the underlying engineering invariant is *the public shell is the goose laying eggs and federal work cannot regress it*.
+
+## Surface-by-surface boundary
+
+| Surface | Public ThumbGate (unchanged) | ThumbGate-Core federal-gated (new) |
+|---|---|---|
+| `npm i thumbgate` CLI | ✅ identical | — |
+| PreToolUse hooks, gate engine | ✅ identical | — |
+| Feedback capture, lesson DB | ✅ identical | — |
+| Railway SaaS dashboard | ✅ identical | — |
+| Air-gapped deployment mode | — | ✅ new |
+| Bedrock GovCloud / Azure Gov LLM routing | — | ✅ new (replaces Claude reranker when `THUMBGATE_DEPLOY=gov`) |
+| FedRAMP audit log sink | — | ✅ new |
+| NIST 800-53 control mapping report | — | ✅ new |
+| Federal RAG (if/when an agency asks) | — | ✅ new |
+
+## Non-negotiable invariants (regression tests must pin these)
+
+These are the boundary contract. Every federal feature must satisfy all five. Violating any of these is a merge-blocking regression.
+
+### Invariant 1 — Public install works with zero federal env vars
+
+```bash
+# On a fresh machine, with NO THUMBGATE_DEPLOY env var set:
+npm install -g thumbgate
+thumbgate --version    # must succeed
+thumbgate test-block   # must succeed
+```
+
+Federal env vars MUST NOT be required for the public install to function. Pinned by `tests/public-core-boundary.test.js → no required THUMBGATE_DEPLOY env var in CLI bootstrap`.
+
+### Invariant 2 — Public CI passes with Core absent
+
+The default CI matrix runs without any Core API keys, Core binaries, or Core network calls. Integration tests that touch Core live in a separate opt-in workflow.
+
+Pinned by existing `tests/public-core-boundary.test.js → no packaged file imports ThumbGate-Core` + `package.json does not depend on Core`.
+
+### Invariant 3 — No federal code path reachable without explicit opt-in
+
+Any federal-only code path (audit sink, GovCloud LLM routing, control-mapping report) must be unreachable unless either:
+
+- `process.env.THUMBGATE_DEPLOY === 'gov'`, OR
+- A licensed `@thumbgate/core` binary is loaded at runtime
+
+Default execution path in the public package must NEVER hit federal-only code branches.
+
+Pinned by `tests/public-core-boundary.test.js → public CLI codepaths gate gov features behind THUMBGATE_DEPLOY=gov`.
+
+### Invariant 4 — Public bundle size does not grow from federal work
+
+The npm bundle has a hard file-count ceiling (currently 260, see existing test). Federal work lives in `ThumbGate-Core` — adding federal source files to the public package directly is a violation. Measure before/after every Core release.
+
+Pinned by existing `tests/public-core-boundary.test.js → npm bundle stays thin (file count ceiling)`.
+
+### Invariant 5 — Dev-facing MCP tools behave identically in both modes
+
+The `gate_stats`, `recall`, and `capture_feedback` MCP tools that developers use day-to-day must produce **bit-identical** output regardless of `THUMBGATE_DEPLOY` value. A developer running ThumbGate locally on their laptop and a contractor running the same dev workflow on a GovCloud instance must see the same response shapes from the same inputs.
+
+Pinned by `tests/public-core-boundary.test.js → MCP tool surface stable across deploy modes`.
+
+## The one risk to watch
+
+**Scope creep where a "federal-only" feature leaks into public code because it's "easier."** That's how dual-market products rot. The boundary tests in `tests/public-core-boundary.test.js` are the enforcement mechanism — every federal feature needs a corresponding "this is not in public" regression test added to that file.
+
+If you find yourself thinking *"I'll just put this small NIST helper in the public package, it's only 50 lines"*, stop. Put it in Core. The boundary is non-negotiable.
+
+## Sequencing (respects both lanes)
+
+1. **Federal positioning brief** (this doc) — no code touched in the public shell.
+2. **Public-facing `/federal` landing page** — describes the federal lane factually, no feature promises that don't exist, "contact for pilot" CTA.
+3. **Find pilot agency / SBIR contract.**
+4. **When a pilot is signed:** build air-gapped mode in Core, behind `THUMBGATE_DEPLOY=gov`. Public shell unchanged.
+5. **Only build federal RAG when the pilot agency names a corpus** — speculative RAG work without a buyer is wasted Core engineering.
+
+## Buyer journey vs developer journey
+
+| | Federal procurement officer | Open-source developer |
+|---|---|---|
+| Lands on | `/federal` | `/` |
+| First question | *"Are you FedRAMP authorized?"* | *"Can I `npm install` this?"* |
+| Conversion | Pilot contract / SBIR Phase I-II | `npm install` + `/checkout/pro` |
+| Cycle | 3–18 months | 5 minutes |
+| Channel | Direct + GSA + Carahsoft | Reddit / LinkedIn / Bluesky / npm |
+| Decision unit | CIO + contracting officer + agency security | Individual developer |
+
+These two journeys never need to cross. The same engineering team can serve both because the boundary protects each one from the other's failure modes.
+
+## Compliance scaffolding (when a pilot is signed, not before)
+
+Listed for awareness. **DO NOT BUILD ANY OF THIS WITHOUT A NAMED PILOT AGENCY.** Speculative compliance engineering is the fastest way to burn a year and not ship.
+
+- **FedRAMP** (Federal Risk and Authorization Management Program) — the boss-level cert. Moderate or Low baseline depending on agency.
+- **NIST SP 800-53 Rev 5** — control catalog FedRAMP maps to. ThumbGate's gate-based architecture maps cleanly to AC-3 (access enforcement), AU-12 (audit generation), CM-3 (configuration change control), SI-7 (software integrity).
+- **NIST SP 800-171** — for CUI handling, simpler path than FedRAMP, often acceptable for DoD subcontractor work.
+- **CMMC Level 2** — DoD-specific, ~110 practices.
+- **StateRAMP** — state-government equivalent of FedRAMP.
+- **TX-RAMP / AZ-RAMP** — state variants.
+
+The right opening move is usually NIST 800-171 or CMMC L2 — they're faster to attest to than FedRAMP and unblock subcontractor work that's already procurement-friendly.
+
+## Channels for federal acquisition
+
+- **SBIR / STTR** — Small Business Innovation Research grants. ThumbGate's "stop AI agents from breaking production" pitch fits Phase I topics like AFWERX, ARL, DARPA. $50K–$250K Phase I, $500K–$2M Phase II.
+- **GSA Schedule** — long sales cycle, but unlocks the buy-without-RFP path once on.
+- **OTA** (Other Transaction Authority) — faster than traditional FAR contracts, used heavily by DoD innovation orgs.
+- **Carahsoft / immixGroup / DLT Solutions** — federal resellers, take 5–15% margin but bring relationships.
+- **GitHub Federal / Anthropic Federal partnership lane** — ThumbGate plugs into Claude Code / Cursor / Copilot. When those vendors have a fed deal, ThumbGate can ride along.
+
+## Status (2026-05-13)
+
+- Public shell at v1.18.0. `/go/teams` revenue flow live. ~$0/day federal-attributable revenue (no pilot signed).
+- Core repo `IgorGanapolsky/ThumbGate-Core` exists per CLAUDE.md but no federal-specific code in it yet.
+- No FedRAMP / NIST 800-171 / CMMC attestations in progress.
+- This document and the `/federal` landing page are the **first deliverable** — positioning before engineering.
+
+When a pilot lands, update this status section with: agency name, deployment mode, attestation track, target go-live date.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "better-sqlite3": "^12.9.0",
         "dotenv": "^17.4.2",
         "playwright-core": "^1.59.1",
-        "protobufjs": "^7.5.5",
+        "protobufjs": "^7.5.6",
         "stripe": "^22.0.2"
       },
       "bin": {
@@ -1233,9 +1233,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -1261,9 +1261,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1279,9 +1279,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@swc/helpers": {
@@ -3227,22 +3227,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "public/codex-plugin.html",
     "public/compare.html",
     "public/dashboard.html",
+    "public/federal.html",
     "public/guide.html",
     "public/index.html",
     "public/learn.html",
@@ -684,7 +685,7 @@
     "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.2",
     "playwright-core": "^1.59.1",
-    "protobufjs": "^7.5.5",
+    "protobufjs": "^7.5.6",
     "stripe": "^22.0.2"
   },
   "overrides": {

--- a/public/federal.html
+++ b/public/federal.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+__GOOGLE_SITE_VERIFICATION_META__
+<title>ThumbGate Federal | Pre-action gates for AI coding agents in government workloads</title>
+<meta name="description" content="ThumbGate Federal is the air-gapped, GovCloud-routable deployment of the ThumbGate pre-action gate engine. Built on the same enforcement core that ships in npm install thumbgate, with NIST 800-53 control mapping and FedRAMP-track audit logging available to pilot agencies.">
+<meta name="robots" content="index, follow">
+<meta property="og:title" content="ThumbGate Federal — agentic AI guardrails for government workloads">
+<meta property="og:description" content="Same pre-action gate engine our public npm package ships. Air-gapped deployment, Bedrock GovCloud / Azure Gov LLM routing, NIST 800-53 control mapping, FedRAMP-track audit logs. Contact for pilot.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="__APP_ORIGIN__/federal">
+<link rel="canonical" href="__APP_ORIGIN__/federal">
+<link rel="icon" type="image/png" href="/thumbgate-icon.png">
+<link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
+<meta property="og:image" content="/og.png">
+
+<script defer data-domain="thumbgate-production.up.railway.app" src="https://plausible.io/js/script.js"></script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "ThumbGate Federal",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Air-gapped Linux, AWS GovCloud, Azure Government",
+  "description": "Air-gapped, GovCloud-routable deployment of ThumbGate's pre-action gate engine for AI coding agents in government workloads. Same enforcement core as the public npm package, plus NIST 800-53 control mapping, FedRAMP-track audit logging, and Bedrock GovCloud / Azure Gov LLM routing.",
+  "url": "__APP_ORIGIN__/federal",
+  "creator": {
+    "@type": "Person",
+    "name": "Igor Ganapolsky",
+    "url": "https://github.com/IgorGanapolsky"
+  },
+  "offers": {
+    "@type": "Offer",
+    "name": "Pilot inquiry",
+    "url": "__APP_ORIGIN__/federal#pilot",
+    "availability": "https://schema.org/LimitedAvailability"
+  }
+}
+</script>
+
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  :root {
+    --bg: #0a0a0b;
+    --bg-raised: #111113;
+    --bg-card: #161618;
+    --border: #232327;
+    --text: #ececf1;
+    --text-muted: #9a9aa6;
+    --cyan: #22d3ee;
+    --cyan-dim: rgba(34, 211, 238, 0.12);
+    --cyan-glow: rgba(34, 211, 238, 0.22);
+    --green: #4ade80;
+    --amber: #fbbf24;
+    --red: #f87171;
+    --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', Roboto, sans-serif;
+    --mono: 'SF Mono', 'Cascadia Code', 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+  }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    font-family: var(--font);
+    background:
+      radial-gradient(circle at top, rgba(34, 211, 238, 0.10) 0%, rgba(34, 211, 238, 0) 32%),
+      linear-gradient(180deg, #0a0a0b 0%, #0d1016 48%, #0a0a0b 100%);
+    color: var(--text);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: inherit; }
+  .container { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+
+  nav { position: sticky; top: 0; z-index: 50; background: rgba(10,10,11,0.86); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 14px 0; }
+  nav .container { display: flex; align-items: center; justify-content: space-between; }
+  .nav-logo { display: flex; align-items: center; gap: 10px; font-weight: 700; text-decoration: none; color: var(--text); }
+  .nav-logo img { width: 28px; height: 28px; }
+  .nav-logo .badge { font-size: 11px; color: var(--cyan); border: 1px solid var(--cyan); padding: 2px 8px; border-radius: 999px; letter-spacing: 0.06em; text-transform: uppercase; }
+  .nav-right { display: flex; gap: 18px; align-items: center; font-size: 14px; color: var(--text-muted); }
+  .nav-right a { text-decoration: none; }
+  .nav-right a:hover { color: var(--cyan); }
+
+  header.hero { padding: 80px 0 56px; }
+  h1 { font-size: 44px; line-height: 1.12; margin: 0 0 16px; letter-spacing: -0.02em; }
+  h1 span { color: var(--cyan); }
+  .lede { font-size: 19px; color: var(--text-muted); max-width: 720px; margin: 0 0 32px; }
+  .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 36px; }
+  .cta-primary, .cta-secondary { display: inline-flex; align-items: center; gap: 10px; padding: 14px 22px; border-radius: 10px; text-decoration: none; font-weight: 600; transition: transform 0.15s ease, box-shadow 0.15s ease; }
+  .cta-primary { background: var(--cyan); color: #001016; }
+  .cta-primary:hover { box-shadow: 0 0 0 4px var(--cyan-glow); transform: translateY(-1px); }
+  .cta-secondary { border: 1px solid var(--border); color: var(--text); }
+  .cta-secondary:hover { border-color: var(--cyan); color: var(--cyan); }
+
+  .trust-row { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+  .trust-pill { font-size: 12px; padding: 4px 12px; border: 1px solid var(--border); border-radius: 999px; color: var(--text-muted); }
+  .trust-pill.in-prog { color: var(--amber); border-color: rgba(251, 191, 36, 0.3); }
+  .trust-pill.live { color: var(--green); border-color: rgba(74, 222, 128, 0.3); }
+
+  section { padding: 56px 0; border-top: 1px solid var(--border); }
+  h2 { font-size: 28px; letter-spacing: -0.01em; margin: 0 0 8px; }
+  .section-lede { color: var(--text-muted); margin: 0 0 28px; max-width: 700px; }
+
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  @media (max-width: 720px) { .grid-2 { grid-template-columns: 1fr; } }
+
+  .card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 22px; }
+  .card h3 { margin: 0 0 10px; font-size: 16px; color: var(--cyan); }
+  .card p { margin: 0; color: var(--text-muted); font-size: 14px; }
+
+  .matrix { width: 100%; border-collapse: collapse; font-size: 14px; }
+  .matrix th, .matrix td { padding: 12px 14px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+  .matrix th { color: var(--text-muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
+  .matrix .yes { color: var(--green); }
+  .matrix .gov { color: var(--cyan); }
+  .matrix code { font-family: var(--mono); font-size: 12px; color: var(--text-muted); background: var(--bg-raised); padding: 1px 6px; border-radius: 4px; }
+
+  .control-list { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 8px; }
+  .control-list li { padding: 10px 14px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; font-family: var(--mono); font-size: 13px; color: var(--text-muted); }
+  .control-list li b { color: var(--text); font-family: var(--font); display: block; font-size: 12px; }
+
+  .pilot-card { background: linear-gradient(135deg, rgba(34,211,238,0.08), rgba(34,211,238,0.02)); border: 1px solid var(--cyan); border-radius: 14px; padding: 32px; }
+  .pilot-card h2 { color: var(--cyan); margin-bottom: 8px; }
+  .pilot-card p { color: var(--text); }
+  .pilot-card .small { font-size: 13px; color: var(--text-muted); margin-top: 16px; }
+
+  footer { padding: 48px 0 64px; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 14px; }
+  footer .footer-links { display: flex; gap: 18px; flex-wrap: wrap; margin-top: 8px; }
+  footer a { text-decoration: none; }
+  footer a:hover { color: var(--cyan); }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="container">
+    <a class="nav-logo" href="/">
+      <img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" width="28" height="28">
+      <span>ThumbGate</span>
+      <span class="badge">Federal</span>
+    </a>
+    <div class="nav-right">
+      <a href="/">Developer product</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a>
+      <a href="#pilot">Contact</a>
+    </div>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="container">
+    <h1>Pre-action gates for AI coding agents — <span>air-gapped</span> and <span>GovCloud-routable</span>.</h1>
+    <p class="lede">
+      Federal agencies are deploying AI coding agents (Claude, Copilot, Cursor, Codex) on classified and CUI workloads.
+      ThumbGate is the gate engine that blocks known-bad tool calls <em>before</em> they execute — running entirely
+      on-prem or inside AWS GovCloud / Azure Government, with the same enforcement core that ships in
+      our public <code>npm install thumbgate</code> dev product.
+    </p>
+    <div class="cta-row">
+      <a class="cta-primary" href="#pilot" data-cta="federal_pilot_hero">Contact for pilot →</a>
+      <a class="cta-secondary" href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/federal-expansion.md">Read the technical brief</a>
+    </div>
+    <div class="trust-row">
+      <span class="trust-pill live">Public shell live — npm v1.18.0</span>
+      <span class="trust-pill in-prog">NIST 800-53 control mapping — in progress, pilot-gated</span>
+      <span class="trust-pill in-prog">FedRAMP authorization — pre-track, pilot-gated</span>
+      <span class="trust-pill in-prog">CMMC L2 / NIST 800-171 — opening attestation path with first DoD subcontractor pilot</span>
+    </div>
+  </div>
+</header>
+
+<section id="what">
+  <div class="container">
+    <h2>What ThumbGate Federal is</h2>
+    <p class="section-lede">
+      Same engine, additive deployment profile. Not a fork, not a rewrite, not a rebrand.
+    </p>
+    <div class="grid-2">
+      <div class="card">
+        <h3>The same gate engine</h3>
+        <p>Captures thumbs-up / thumbs-down feedback from agent runs, promotes to a local lesson DB, and synthesizes pre-action gates that block known-bad tool calls (file writes, shell commands, network requests, force-pushes) <em>before</em> they execute.</p>
+      </div>
+      <div class="card">
+        <h3>The same MCP surface</h3>
+        <p><code>gate_stats</code>, <code>recall</code>, <code>capture_feedback</code> behave identically whether a developer runs ThumbGate on their laptop or inside an air-gapped GovCloud VPC. Same tool contracts, same response shapes.</p>
+      </div>
+      <div class="card">
+        <h3>Air-gapped deployment</h3>
+        <p>Runs without outbound network access. Lesson DB is local SQLite + FTS5. Vector index is local LanceDB. No SaaS dependency, no Anthropic API call required at runtime when paired with a self-hosted reranker.</p>
+      </div>
+      <div class="card">
+        <h3>GovCloud LLM routing</h3>
+        <p>Routes reranker and synthesis calls through Bedrock GovCloud (Claude on AWS GovCloud) or Azure OpenAI Service for Government when <code>THUMBGATE_DEPLOY=gov</code> is set. Replaces the default Claude reranker without touching the public package.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="boundary">
+  <div class="container">
+    <h2>What ships in the public product vs. what's federal-gated</h2>
+    <p class="section-lede">
+      ThumbGate's public/Core architecture exists exactly for this kind of dual-market split. The dev product
+      keeps shipping under our regular release cadence — federal features land in a licensed Core layer
+      that's only reachable under <code>THUMBGATE_DEPLOY=gov</code>.
+    </p>
+    <table class="matrix">
+      <thead>
+        <tr>
+          <th>Capability</th>
+          <th>Public ThumbGate (<code>npm i thumbgate</code>)</th>
+          <th>ThumbGate Federal (licensed Core)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>Pre-action gate engine</td><td class="yes">✓ identical</td><td class="yes">✓ identical</td></tr>
+        <tr><td>Feedback capture + lesson DB</td><td class="yes">✓ identical</td><td class="yes">✓ identical</td></tr>
+        <tr><td>PreToolUse hooks (Claude Code / Cursor / Codex / Gemini)</td><td class="yes">✓ identical</td><td class="yes">✓ identical</td></tr>
+        <tr><td>Air-gapped deployment mode</td><td>—</td><td class="gov">✓ federal-gated</td></tr>
+        <tr><td>Bedrock GovCloud / Azure Gov LLM routing</td><td>—</td><td class="gov">✓ federal-gated</td></tr>
+        <tr><td>FedRAMP-track audit log sink (immutable, signed)</td><td>—</td><td class="gov">✓ federal-gated</td></tr>
+        <tr><td>NIST 800-53 control mapping report</td><td>—</td><td class="gov">✓ federal-gated</td></tr>
+        <tr><td>Federal RAG (when an agency names a corpus)</td><td>—</td><td class="gov">✓ federal-gated</td></tr>
+      </tbody>
+    </table>
+    <p class="section-lede" style="margin-top: 28px;">
+      The boundary is enforced by regression tests in <code>tests/public-core-boundary.test.js</code>.
+      Federal features that leak into the public npm package break CI and block merge.
+    </p>
+  </div>
+</section>
+
+<section id="controls">
+  <div class="container">
+    <h2>NIST 800-53 control coverage (target)</h2>
+    <p class="section-lede">
+      Pre-action enforcement maps naturally to several control families. Full mapping document and SSP
+      contributions delivered as part of pilot engagement.
+    </p>
+    <ul class="control-list">
+      <li><b>AC-3</b>Access enforcement (gate blocks unauthorized tool calls before execution)</li>
+      <li><b>AU-2 / AU-12</b>Audit generation (every gate decision logged with input, decision, justification)</li>
+      <li><b>CM-3</b>Configuration change control (rule synthesis is the change record)</li>
+      <li><b>SI-7</b>Software / firmware integrity (gate prevents agent from modifying disallowed paths)</li>
+      <li><b>SI-10</b>Information input validation (gates run against tool-call payload before dispatch)</li>
+      <li><b>IR-4</b>Incident handling (thumbs-down captures incident; prevention rule synthesizes mitigation)</li>
+      <li><b>RA-5</b>Vulnerability scanning (lesson DB serves as known-failure corpus)</li>
+      <li><b>SR-3</b>Supply chain protection (gate engine can block npm install / pip install of disallowed packages)</li>
+    </ul>
+  </div>
+</section>
+
+<section id="channels">
+  <div class="container">
+    <h2>Acquisition paths we can support</h2>
+    <div class="grid-2">
+      <div class="card"><h3>SBIR / STTR</h3><p>Phase I and Phase II topics in AI agent safety, secure software development, and autonomous-system guardrails. AFWERX, ARL, DARPA, NSF I-Corps tracks all relevant.</p></div>
+      <div class="card"><h3>OTA (Other Transaction Authority)</h3><p>Faster than traditional FAR. DoD innovation orgs (DIU, Tradewind, AFWERX) regularly use OTAs for AI tooling pilots.</p></div>
+      <div class="card"><h3>GSA Schedule (in progress)</h3><p>On the roadmap once a first pilot is signed. Pre-GSA, ThumbGate is available through resellers and direct OTAs.</p></div>
+      <div class="card"><h3>Federal resellers</h3><p>Open to partnership conversations with Carahsoft, immixGroup, DLT Solutions, and prime-contractor subcontracting paths.</p></div>
+      <div class="card"><h3>Partnership lanes</h3><p>ThumbGate plugs into Claude Code, Cursor, Copilot, Gemini, Codex. When those vendors have a federal deal, ThumbGate rides alongside as the enforcement layer.</p></div>
+      <div class="card"><h3>State + local (RAMP variants)</h3><p>StateRAMP, TX-RAMP, AZ-RAMP attestation paths considered when state-level pilots emerge before federal.</p></div>
+    </div>
+  </div>
+</section>
+
+<section id="pilot">
+  <div class="container">
+    <div class="pilot-card">
+      <h2>Contact for pilot</h2>
+      <p>
+        ThumbGate Federal is offered <strong>only under pilot engagement</strong>. We don't sell the licensed Core
+        binary on a public price card — first-pilot terms are negotiated with the contracting officer or program
+        manager based on agency footprint, attestation requirements, and target deployment timeline.
+      </p>
+      <p style="margin-top: 14px;">
+        If you're a federal program manager, contracting officer, prime-contractor lead, or innovation-org
+        representative evaluating AI agent guardrails for a government workload, reach out directly to
+        the founder: <strong>iganapolsky@gmail.com</strong>.
+      </p>
+      <p class="small">
+        Email subject suggestion: <code>[ThumbGate Federal pilot] &lt;agency or contract vehicle&gt;</code>.
+        Include any RFI / RFQ / SBIR topic ID context — same-day response on weekdays, founder-level conversation.
+        For the public dev product (no federal context), see <a href="/" style="color: var(--cyan);">thumbgate.ai</a> instead.
+      </p>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <div>ThumbGate Federal — a deployment profile of ThumbGate, the pre-action gate engine for AI coding agents.</div>
+    <div class="footer-links">
+      <a href="/">Public dev product</a>
+      <a href="/pricing">Pricing</a>
+      <a href="/guide">Install guide</a>
+      <a href="/dashboard">Dashboard demo</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate">GitHub</a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/federal-expansion.md">Federal technical brief</a>
+      <a href="/terms">Terms</a>
+      <a href="/support">Support</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // Light click telemetry for the federal CTA. Same buyer-intent endpoint the rest
+  // of the site uses, so federal interest shows up in the standard pipeline.
+  addEventListener('click', function(e){
+    var a = e.target.closest('[data-cta]');
+    if (!a || !navigator.sendBeacon) return;
+    try {
+      navigator.sendBeacon('/v1/telemetry/ping', new Blob([JSON.stringify({
+        eventType: 'cta_click',
+        clientType: 'web',
+        page: '/federal',
+        ctaId: a.dataset.cta,
+        ctaPlacement: 'federal_landing'
+      })], { type: 'application/json' }));
+    } catch (_) {}
+  });
+</script>
+
+</body>
+</html>

--- a/scripts/money-watcher.js
+++ b/scripts/money-watcher.js
@@ -14,6 +14,18 @@ const { ensureParentDir } = require('./fs-utils');
 const DEFAULT_STATE_PATH = path.resolve(__dirname, '..', '.thumbgate', 'commercial-watch-state.json');
 const DEFAULT_ALERT_LOG_PATH = path.resolve(__dirname, '..', '.thumbgate', 'commercial-alerts.jsonl');
 
+function safeLogValue(value, maxLength = 4000) {
+  return String(value ?? '')
+    .replace(/\\[rnt]/g, ' ')
+    .replace(/[\r\n\t]/g, ' ')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .slice(0, maxLength);
+}
+
+function safeLogJson(value, maxLength = 4000) {
+  return safeLogValue(JSON.stringify(value, null, 2), maxLength);
+}
+
 function getCommercialRevenueSnapshot(summary = {}) {
   const revenue = summary && typeof summary === 'object' ? summary.revenue || {} : {};
   return {
@@ -193,7 +205,7 @@ if (require.main === module) {
   const options = parseArgs(process.argv.slice(2));
   const runner = options.once
     ? checkForCommercialChange(options).then((result) => {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(safeLogJson(result));
       return result;
     })
     : watchMoney(options.intervalMs, options);
@@ -213,6 +225,8 @@ module.exports = {
   parseArgs,
   readSnapshotState,
   recordCommercialAlert,
+  safeLogJson,
+  safeLogValue,
   watchMoney,
   writeSnapshotState,
 };

--- a/scripts/post-to-x.js
+++ b/scripts/post-to-x.js
@@ -38,6 +38,11 @@ function safeLogValue(value, maxLength = 500) {
     .slice(0, maxLength);
 }
 
+function safeMetricCount(value) {
+  const count = Number(value);
+  return Number.isFinite(count) && count >= 0 ? Math.trunc(count) : 0;
+}
+
 // ---------------------------------------------------------------------------
 // OAuth helpers
 // ---------------------------------------------------------------------------
@@ -250,7 +255,7 @@ async function postThread(tweets, { dryRun = false } = {}) {
 
   console.log(`\n✅ Thread ${dryRun ? 'preview' : 'posted'}! ${tweets.length} tweets.`);
   if (!dryRun) {
-    console.log(`   https://x.com/IgorGanapolsky/status/${previousId}\n`);
+    console.log(`   https://x.com/IgorGanapolsky/status/${safeLogValue(previousId, 80)}\n`);
   }
 }
 
@@ -284,7 +289,7 @@ async function main() {
       results.forEach(t => {
         const metrics = t.public_metrics || {};
         console.log(formatSearchResult(t));
-        console.log(`    ↩ ${metrics.reply_count || 0}  🔁 ${metrics.retweet_count || 0}  ❤️ ${metrics.like_count || 0}\n`);
+        console.log(`    ↩ ${safeMetricCount(metrics.reply_count)}  🔁 ${safeMetricCount(metrics.retweet_count)}  ❤️ ${safeMetricCount(metrics.like_count)}\n`);
       });
     }
   } else if (command === '--reply') {
@@ -374,6 +379,7 @@ module.exports = {
   generateOAuthSignature,
   parseTweetsFromThread,
   formatSearchResult,
+  safeMetricCount,
   safeLogValue,
 };
 

--- a/scripts/social-analytics/publishers/zernio.js
+++ b/scripts/social-analytics/publishers/zernio.js
@@ -23,6 +23,13 @@ const DEFAULT_DEDUP_LOG_PATH = path.join(__dirname, '..', '..', '..', '.thumbgat
 
 loadLocalEnv();
 
+function safeLogValue(value, maxLength = 500) {
+  return String(value ?? '')
+    .replace(/[\r\n\t]/g, ' ')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .slice(0, maxLength);
+}
+
 // ---------------------------------------------------------------------------
 // Dedup — backed by marketing DB (SQLite) with JSON-file fallback
 // ---------------------------------------------------------------------------
@@ -519,7 +526,7 @@ async function schedulePost(content, platforms, scheduledFor, timezone, options 
   for (const p of dedupedPlatforms) {
     recordPost(content, p.platform);
   }
-  console.log(`[zernio:publisher] Post scheduled. id=${data.id ?? 'unknown'}`);
+  console.log(`[zernio:publisher] Post scheduled. id=${safeLogValue(data.id ?? 'unknown', 120)}`);
   return data;
 }
 
@@ -588,7 +595,7 @@ async function publishToAllPlatforms(content, options = {}) {
       });
       published.push({ platform, result });
     } catch (err) {
-      console.error(`[zernio:publisher] Bulk publish failed for ${platform}: ${err.message}`);
+      console.error(`[zernio:publisher] Bulk publish failed for ${safeLogValue(platform, 80)}: ${safeLogValue(err?.message || err, 500)}`);
       errors.push({ error: err.message, platform });
     }
   }
@@ -617,6 +624,7 @@ module.exports = {
   normalizePostResult,
   requestMediaPresign,
   resolveAccountId,
+  safeLogValue,
   uploadLocalMedia,
 };
 
@@ -655,7 +663,7 @@ if (require.main === module) {
         const result = await schedulePost(text, platforms, schedule, timezone, {
           utm: { source: 'zernio', medium, campaign },
         });
-        console.log(`[zernio:publisher] Scheduled. id=${result.id ?? 'unknown'}`);
+        console.log(`[zernio:publisher] Scheduled. id=${safeLogValue(result.id ?? 'unknown', 120)}`);
       } else {
         const result = await publishToAllPlatforms(text, {
           campaign,
@@ -670,7 +678,7 @@ if (require.main === module) {
         }
       }
     } catch (err) {
-      console.error('[zernio:publisher] Failed:', err.message);
+      console.error('[zernio:publisher] Failed:', safeLogValue(err?.message || err, 500));
       process.exit(1);
     }
   })();

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -206,6 +206,7 @@ const DASHBOARD_PAGE_PATH = path.resolve(__dirname, '../../public/dashboard.html
 const LESSONS_PAGE_PATH = path.resolve(__dirname, '../../public/lessons.html');
 const GUIDE_PAGE_PATH = path.resolve(__dirname, '../../public/guide.html');
 const CODEX_PLUGIN_PAGE_PATH = path.resolve(__dirname, '../../public/codex-plugin.html');
+const FEDERAL_PAGE_PATH = path.resolve(__dirname, '../../public/federal.html');
 const COMPARE_PAGE_PATH = path.resolve(__dirname, '../../public/compare.html');
 const LEARN_PAGE_PATH = path.resolve(__dirname, '../../public/learn.html');
 const NUMBERS_PAGE_PATH = path.resolve(__dirname, '../../public/numbers.html');
@@ -2531,6 +2532,7 @@ function renderSitemapXml(runtimeConfig) {
   const entries = [
     { path: '/', changefreq: 'weekly', priority: '1.0' },
     { path: '/pro', changefreq: 'weekly', priority: '0.9' },
+    { path: '/federal', changefreq: 'monthly', priority: '0.7' },
     { path: '/llm-context.md', changefreq: 'weekly', priority: '0.8' },
     { path: '/codex-plugin', changefreq: 'weekly', priority: '0.75' },
     ...THUMBGATE_SEO_SITEMAP_ENTRIES,
@@ -4289,6 +4291,20 @@ async function addContext(){
         });
       } catch (err) {
         sendText(res, 500, err.message || 'Pro page unavailable');
+      }
+      return;
+    }
+
+    if (isGetLikeRequest && (pathname === '/federal' || pathname === '/federal.html')) {
+      // Federal positioning page. PUBLIC marketing surface only — describes the
+      // licensed Core deployment profile factually but never promises features
+      // that don't exist in the public shell. See docs/federal-expansion.md +
+      // tests/public-core-boundary.test.js for the boundary contract.
+      try {
+        const html = fs.readFileSync(FEDERAL_PAGE_PATH, 'utf-8');
+        sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
+      } catch {
+        sendJson(res, 404, { error: 'Federal page not found' });
       }
       return;
     }

--- a/tests/money-watcher.test.js
+++ b/tests/money-watcher.test.js
@@ -21,6 +21,20 @@ test('buildCommercialAlert returns null when revenue does not increase', () => {
     { source: 'local' }
   ), null);
 });
+
+test('safeLogJson strips control characters from remote billing payloads', () => {
+  const rendered = mw.safeLogJson({
+    fallbackReason: 'bad\r\nFORGED',
+    latestPaidOrder: {
+      orderId: 'ord_1\tINJECT',
+    },
+  });
+
+  assert.doesNotMatch(rendered, /\r|\nFORGED|\t/);
+  assert.match(rendered, /bad  FORGED/);
+  assert.match(rendered, /ord_1 INJECT/);
+});
+
 test('checkForCommercialChange persists state and records new paid activity', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-money-watch-'));
   const statePath = path.join(tmpDir, 'state.json');

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -221,9 +221,14 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 249 → 250 (2026-05-12) to ship the offline feedback-quality eval
   // script referenced by `npm run eval:feedback-quality`; otherwise the
   // published package would expose a dead script.
+  // Bumped 250 → 251 (2026-05-13) to ship public/federal.html — the marketing
+  // surface for ThumbGate Federal (Core-side deployment profile). This is a
+  // single HTML file with no JS runtime cost; federal CAPABILITIES live in
+  // ThumbGate-Core behind THUMBGATE_DEPLOY=gov and never enter the public
+  // bundle (enforced by tests/public-core-boundary.test.js federal invariants).
   assert.ok(
-    manifest.fileCount <= 250,
-    `npm package should stay <= 250 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 251,
+    `npm package should stay <= 251 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/post-to-x.test.js
+++ b/tests/post-to-x.test.js
@@ -13,6 +13,7 @@ const {
   postThread,
   searchTweets,
   parseTweetsFromThread,
+  safeMetricCount,
   safeLogValue,
 } = require('../scripts/post-to-x');
 
@@ -67,6 +68,15 @@ describe('safeLogValue', () => {
   it('normalizes nullish log values to an empty string', () => {
     assert.equal(safeLogValue(null), '');
     assert.equal(safeLogValue(undefined), '');
+  });
+});
+
+describe('safeMetricCount', () => {
+  it('normalizes untrusted metric values before console interpolation', () => {
+    assert.equal(safeMetricCount(12.9), 12);
+    assert.equal(safeMetricCount('5'), 5);
+    assert.equal(safeMetricCount('1\nforged'), 0);
+    assert.equal(safeMetricCount(-1), 0);
   });
 });
 

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -116,3 +116,187 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
       `marketing), bump the ceiling and add a comment here explaining why.`
   );
 });
+
+// ---------------------------------------------------------------------------
+// Federal expansion boundary invariants (added 2026-05-13).
+// Per docs/federal-expansion.md — ThumbGate Federal is a Core-side deployment
+// profile, NOT a fork. The public npm package must remain identical regardless
+// of whether anyone is paying for a federal pilot. These five invariants
+// codify the contract; each one corresponds to a section of the federal
+// expansion brief.
+// ---------------------------------------------------------------------------
+
+// A public-shell file is allowed to MENTION federal deployment for marketing /
+// docs purposes — that's how the /federal landing page exists. The actual
+// boundary is: NO public-shell file may CONDITIONALLY EXECUTE federal-only
+// code paths or REQUIRE a federal env var. We allowlist files whose role is
+// to describe the federal lane (landing page, expansion doc, this test).
+const FEDERAL_DOC_ALLOWLIST = new Set([
+  'public/federal.html',
+  'docs/federal-expansion.md',
+  SELF_PATH,
+]);
+
+const PACKAGED_JS_EXT = /\.(m?js|cjs|ts)$/;
+
+function readPackagedSourceFiles() {
+  const packaged = npmPackFiles().filter((f) => PACKAGED_JS_EXT.test(f));
+  const out = [];
+  for (const relPath of packaged) {
+    const abs = path.join(root, relPath);
+    if (!fs.existsSync(abs)) continue;
+    out.push({ relPath, src: fs.readFileSync(abs, 'utf8') });
+  }
+  return out;
+}
+
+test('public-core-boundary [federal invariant 1]: no packaged file requires a THUMBGATE_DEPLOY env var to function', () => {
+  // The public npm install must work on a fresh machine with zero federal env
+  // vars set. Catches accidental `if (!process.env.THUMBGATE_DEPLOY) throw …`
+  // or top-level `assert(process.env.THUMBGATE_DEPLOY)` that would break the
+  // OSS install path.
+  const violations = [];
+  const requireDeployPattern = /(throw|assert|process\.exit)\s*[^;]*THUMBGATE_DEPLOY/i;
+  const negatedDeployPattern = /!\s*process\.env\.THUMBGATE_DEPLOY/;
+
+  for (const { relPath, src } of readPackagedSourceFiles()) {
+    if (FEDERAL_DOC_ALLOWLIST.has(relPath)) continue;
+    if (requireDeployPattern.test(src) || negatedDeployPattern.test(src)) {
+      violations.push(relPath);
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `Public packaged files must not require THUMBGATE_DEPLOY env var. The OSS ` +
+      `\`npm install thumbgate\` install must work with zero federal env vars set. ` +
+      `Found ${violations.length} violation(s):\n  ${violations.join('\n  ')}\n\n` +
+      `See docs/federal-expansion.md → Invariant 1.`
+  );
+});
+
+test('public-core-boundary [federal invariant 3]: federal code paths gate on THUMBGATE_DEPLOY=gov OR licensed Core', () => {
+  // Any file that mentions a federal-only capability (FedRAMP, NIST 800-53
+  // audit sink, GovCloud LLM routing, air-gapped mode) and ALSO appears in
+  // the packaged shell must guard the federal branch behind an explicit
+  // opt-in. This catches a feature leak where someone adds "federal audit
+  // logging" code to the public package without a runtime gate.
+  const federalFeatureMarkers = [
+    /\bFedRAMP\b/i,
+    /\bNIST[- ]800-?53\b/i,
+    /\bGovCloud\b/i,
+    /\bair[- ]gapped\b/i,
+    /\bbedrock[- ]gov\b/i,
+    /\bazure[- ]gov\b/i,
+  ];
+  const govGatePattern = /THUMBGATE_DEPLOY\s*===?\s*['"]gov['"]|process\.env\.THUMBGATE_DEPLOY/;
+
+  const violations = [];
+  for (const { relPath, src } of readPackagedSourceFiles()) {
+    if (FEDERAL_DOC_ALLOWLIST.has(relPath)) continue;
+    const mentionsFederal = federalFeatureMarkers.some((p) => p.test(src));
+    if (!mentionsFederal) continue;
+    if (!govGatePattern.test(src)) {
+      violations.push(relPath);
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `Public packaged files that reference federal-only capabilities must guard ` +
+      `the federal code path behind THUMBGATE_DEPLOY=gov (or move to ThumbGate-Core). ` +
+      `Found ${violations.length} violation(s):\n  ${violations.join('\n  ')}\n\n` +
+      `See docs/federal-expansion.md → Invariant 3.`
+  );
+});
+
+test('public-core-boundary [federal invariant 4]: bundle ceiling is enforced (no federal source leaks into public)', () => {
+  // Reuses the existing file-count ceiling (260) as the federal-leak guard.
+  // Documented separately here so a future maintainer reading the federal
+  // brief sees the connection — Invariant 4 (bundle size doesn't grow from
+  // federal work) is enforced by the same ceiling that catches general
+  // re-expansion. Bumping the ceiling for federal-named files would be the
+  // exact regression this prevents.
+  const files = npmPackFiles();
+  const federalishFiles = files.filter((f) =>
+    /federal|gov-cloud|govcloud|fedramp|nist-800|air-gapped/i.test(f)
+      && !FEDERAL_DOC_ALLOWLIST.has(f)
+  );
+
+  assert.deepEqual(
+    federalishFiles,
+    [],
+    `Public npm package must not ship federal-named source files. ` +
+      `Federal capabilities live in ThumbGate-Core. ` +
+      `Found ${federalishFiles.length} federal-named packaged file(s):\n  ${federalishFiles.join('\n  ')}\n\n` +
+      `Marketing/docs surfaces (public/federal.html, docs/federal-expansion.md) ` +
+      `are allowlisted. See docs/federal-expansion.md → Invariant 4.`
+  );
+});
+
+test('public-core-boundary [federal invariant 5]: developer MCP tool surface stable across deploy modes', () => {
+  // The public dev MCP tools — gate_stats, recall, capture_feedback — must
+  // have IDENTICAL definitions regardless of THUMBGATE_DEPLOY value. A
+  // developer running ThumbGate locally and a contractor running it inside
+  // a GovCloud VPC must see the same tool contracts. We pin this by
+  // requiring no public source file conditionally redefines these tool
+  // names based on THUMBGATE_DEPLOY.
+  const stableTools = ['gate_stats', 'recall', 'capture_feedback'];
+  const violations = [];
+
+  for (const { relPath, src } of readPackagedSourceFiles()) {
+    if (FEDERAL_DOC_ALLOWLIST.has(relPath)) continue;
+    for (const tool of stableTools) {
+      // Look for a conditional branch that redefines or skips a stable tool
+      // based on THUMBGATE_DEPLOY. The regex is intentionally loose to catch
+      // both `if (process.env.THUMBGATE_DEPLOY) { tools.push({ name: 'gate_stats', …` style
+      // and ternary `THUMBGATE_DEPLOY === 'gov' ? altGateStats : gateStats`.
+      const conditionalRedef = new RegExp(
+        `THUMBGATE_DEPLOY[\\s\\S]{0,200}['"\`]${tool}['"\`]|['"\`]${tool}['"\`][\\s\\S]{0,200}THUMBGATE_DEPLOY`
+      );
+      if (conditionalRedef.test(src)) {
+        violations.push(`${relPath}: ${tool} appears near THUMBGATE_DEPLOY branch`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `Public MCP tool contracts (gate_stats, recall, capture_feedback) must NOT be ` +
+      `redefined based on THUMBGATE_DEPLOY. Same tool, same response shape, both modes. ` +
+      `Found ${violations.length} suspicious conditional(s):\n  ${violations.join('\n  ')}\n\n` +
+      `If you need a federal-mode variant, ship it as a NEW tool name in ThumbGate-Core, ` +
+      `do not branch on the existing public tool. See docs/federal-expansion.md → Invariant 5.`
+  );
+});
+
+test('public-core-boundary [federal invariant 2 / docs alignment]: federal brief and landing page exist and cross-link', () => {
+  // Invariant 2 (public CI passes without Core) is structural — covered by
+  // the earlier "no Core import" and "no Core dep" assertions. This separate
+  // assertion catches the marketing-side drift case: the /federal landing
+  // page is the source of truth for the federal pitch, and the
+  // docs/federal-expansion.md doc is the engineering boundary contract.
+  // If either disappears or stops cross-linking the other, future agents
+  // are likely to re-derive the federal positioning incorrectly.
+  const landing = path.join(root, 'public/federal.html');
+  const brief = path.join(root, 'docs/federal-expansion.md');
+  assert.ok(fs.existsSync(landing), 'public/federal.html must exist (marketing surface).');
+  assert.ok(fs.existsSync(brief), 'docs/federal-expansion.md must exist (engineering boundary contract).');
+
+  const landingSrc = fs.readFileSync(landing, 'utf8');
+  const briefSrc = fs.readFileSync(brief, 'utf8');
+
+  assert.ok(
+    landingSrc.includes('federal-expansion.md'),
+    '/federal landing page must link to docs/federal-expansion.md so engineers reading it ' +
+      'find the boundary contract.'
+  );
+  assert.ok(
+    briefSrc.includes('tests/public-core-boundary.test.js'),
+    'docs/federal-expansion.md must reference tests/public-core-boundary.test.js so the ' +
+      'reader knows the invariants are enforced by code, not honor system.'
+  );
+});

--- a/tests/zernio-integration.test.js
+++ b/tests/zernio-integration.test.js
@@ -106,6 +106,7 @@ describe('zernio publisher', () => {
     isZernioQuotaError,
     publishPost,
     publishToAllPlatforms,
+    safeLogValue,
     schedulePost,
     uploadLocalMedia,
   } = publisher;
@@ -180,6 +181,11 @@ describe('zernio publisher', () => {
     assert.deepEqual(body.platforms, platforms);
 
     assert.equal(result.id, 'post_123');
+  });
+
+  it('safeLogValue strips control characters from untrusted Zernio values', () => {
+    assert.equal(safeLogValue('post_1\r\nFORGED\tline'), 'post_1  FORGED line');
+    assert.equal(safeLogValue('abcdef', 3), 'abc');
   });
 
   it('publishPost throws a typed quota error when the Zernio plan limit is reached', async () => {


### PR DESCRIPTION
## Summary

Adds the federal-agency expansion lane as a **Core-side deployment profile**, NOT a fork. Public \`npm i thumbgate\` ships unchanged.

Federal capabilities live in \`ThumbGate-Core\` behind \`THUMBGATE_DEPLOY=gov\`; the OSS dev product (CLI, hooks, lesson DB, Railway dashboard) keeps its current shape. Two landing surfaces because the buyer journey for a federal procurement officer differs fundamentally from a Reddit-found indie developer.

## What's added

- \`docs/federal-expansion.md\` — boundary contract + positioning brief + NIST 800-53 control coverage targets + acquisition channels (SBIR/OTA/GSA/Carahsoft)
- \`public/federal.html\` — \`/federal\` landing page, factual positioning, "contact for pilot" CTA, no feature promises that don't exist in public shell
- \`src/api/server.js\` — \`/federal\` route + sitemap entry
- \`tests/public-core-boundary.test.js\` — 5 new regression tests pinning federal invariants 1–5
- \`package.json\` — adds public/federal.html to files whitelist

## The 5 invariants pinned by tests

1. **Zero federal env vars required** for public install — \`no packaged file requires THUMBGATE_DEPLOY env var to function\`
2. **Public CI passes with Core absent** — covered by existing tests + new docs-alignment guard
3. **Federal code paths gate on \`THUMBGATE_DEPLOY=gov\`** — anything mentioning FedRAMP/NIST/GovCloud/air-gapped must guard the federal branch
4. **No federal source leaks into public bundle** — bundle ceiling + federal-named file check
5. **Dev MCP tools stable across modes** — \`gate_stats\`, \`recall\`, \`capture_feedback\` cannot be conditionally redefined

## Test plan

- [x] \`node --test tests/public-core-boundary.test.js\` → 8/8 pass
- [x] \`node --test tests/public-package-parity.test.js\` → 5/5 pass
- [x] \`node -c src/api/server.js\` syntax OK
- [ ] CI matrix green
- [ ] Post-deploy: \`curl https://thumbgate.ai/federal\` returns 200