### PR TITLE
fix(security): patch protobufjs alerts and sanitize logs

### DIFF
--- a/.changeset/protobufjs-security-alerts.md
+++ b/.changeset/protobufjs-security-alerts.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Patch protobufjs security advisories and sanitize social publisher log output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "better-sqlite3": "^12.9.0",
         "dotenv": "^17.4.2",
         "playwright-core": "^1.59.1",
-        "protobufjs": "^7.5.5",
+        "protobufjs": "^7.5.6",
         "stripe": "^22.0.2"
       },
       "bin": {
@@ -1233,9 +1233,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -1261,9 +1261,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1279,9 +1279,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@swc/helpers": {
@@ -3227,22 +3227,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/scripts/money-watcher.js
+++ b/scripts/money-watcher.js
@@ -14,6 +14,18 @@ const { ensureParentDir } = require('./fs-utils');
 const DEFAULT_STATE_PATH = path.resolve(__dirname, '..', '.thumbgate', 'commercial-watch-state.json');
 const DEFAULT_ALERT_LOG_PATH = path.resolve(__dirname, '..', '.thumbgate', 'commercial-alerts.jsonl');
 
+function safeLogValue(value, maxLength = 4000) {
+  return String(value ?? '')
+    .replace(/\\[rnt]/g, ' ')
+    .replace(/[\r\n\t]/g, ' ')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .slice(0, maxLength);
+}
+
+function safeLogJson(value, maxLength = 4000) {
+  return safeLogValue(JSON.stringify(value, null, 2), maxLength);
+}
+
 function getCommercialRevenueSnapshot(summary = {}) {
   const revenue = summary && typeof summary === 'object' ? summary.revenue || {} : {};
   return {
@@ -193,7 +205,7 @@ if (require.main === module) {
   const options = parseArgs(process.argv.slice(2));
   const runner = options.once
     ? checkForCommercialChange(options).then((result) => {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(safeLogJson(result));
       return result;
     })
     : watchMoney(options.intervalMs, options);
@@ -213,6 +225,8 @@ module.exports = {
   parseArgs,
   readSnapshotState,
   recordCommercialAlert,
+  safeLogJson,
+  safeLogValue,
   watchMoney,
   writeSnapshotState,
 };

--- a/scripts/post-to-x.js
+++ b/scripts/post-to-x.js
@@ -38,6 +38,11 @@ function safeLogValue(value, maxLength = 500) {
     .slice(0, maxLength);
 }
 
+function safeMetricCount(value) {
+  const count = Number(value);
+  return Number.isFinite(count) && count >= 0 ? Math.trunc(count) : 0;
+}
+
 // ---------------------------------------------------------------------------
 // OAuth helpers
 // ---------------------------------------------------------------------------
@@ -250,7 +255,7 @@ async function postThread(tweets, { dryRun = false } = {}) {
 
   console.log(`\n✅ Thread ${dryRun ? 'preview' : 'posted'}! ${tweets.length} tweets.`);
   if (!dryRun) {
-    console.log(`   https://x.com/IgorGanapolsky/status/${previousId}\n`);
+    console.log(`   https://x.com/IgorGanapolsky/status/${safeLogValue(previousId, 80)}\n`);
   }
 }
 
@@ -284,7 +289,7 @@ async function main() {
       results.forEach(t => {
         const metrics = t.public_metrics || {};
         console.log(formatSearchResult(t));
-        console.log(`    ↩ ${metrics.reply_count || 0}  🔁 ${metrics.retweet_count || 0}  ❤️ ${metrics.like_count || 0}\n`);
+        console.log(`    ↩ ${safeMetricCount(metrics.reply_count)}  🔁 ${safeMetricCount(metrics.retweet_count)}  ❤️ ${safeMetricCount(metrics.like_count)}\n`);
       });
     }
   } else if (command === '--reply') {
@@ -374,6 +379,7 @@ module.exports = {
   generateOAuthSignature,
   parseTweetsFromThread,
   formatSearchResult,
+  safeMetricCount,
   safeLogValue,
 };
 

--- a/scripts/social-analytics/publishers/zernio.js
+++ b/scripts/social-analytics/publishers/zernio.js
@@ -23,6 +23,13 @@ const DEFAULT_DEDUP_LOG_PATH = path.join(__dirname, '..', '..', '..', '.thumbgat
 
 loadLocalEnv();
 
+function safeLogValue(value, maxLength = 500) {
+  return String(value ?? '')
+    .replace(/[\r\n\t]/g, ' ')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .slice(0, maxLength);
+}
+
 // ---------------------------------------------------------------------------
 // Dedup — backed by marketing DB (SQLite) with JSON-file fallback
 // ---------------------------------------------------------------------------
@@ -519,7 +526,7 @@ async function schedulePost(content, platforms, scheduledFor, timezone, options 
   for (const p of dedupedPlatforms) {
     recordPost(content, p.platform);
   }
-  console.log(`[zernio:publisher] Post scheduled. id=${data.id ?? 'unknown'}`);
+  console.log(`[zernio:publisher] Post scheduled. id=${safeLogValue(data.id ?? 'unknown', 120)}`);
   return data;
 }
 
@@ -588,7 +595,7 @@ async function publishToAllPlatforms(content, options = {}) {
       });
       published.push({ platform, result });
     } catch (err) {
-      console.error(`[zernio:publisher] Bulk publish failed for ${platform}: ${err.message}`);
+      console.error(`[zernio:publisher] Bulk publish failed for ${safeLogValue(platform, 80)}: ${safeLogValue(err?.message || err, 500)}`);
       errors.push({ error: err.message, platform });
     }
   }
@@ -617,6 +624,7 @@ module.exports = {
   normalizePostResult,
   requestMediaPresign,
   resolveAccountId,
+  safeLogValue,
   uploadLocalMedia,
 };
 
@@ -655,7 +663,7 @@ if (require.main === module) {
         const result = await schedulePost(text, platforms, schedule, timezone, {
           utm: { source: 'zernio', medium, campaign },
         });
-        console.log(`[zernio:publisher] Scheduled. id=${result.id ?? 'unknown'}`);
+        console.log(`[zernio:publisher] Scheduled. id=${safeLogValue(result.id ?? 'unknown', 120)}`);
       } else {
         const result = await publishToAllPlatforms(text, {
           campaign,
@@ -670,7 +678,7 @@ if (require.main === module) {
         }
       }
     } catch (err) {
-      console.error('[zernio:publisher] Failed:', err.message);
+      console.error('[zernio:publisher] Failed:', safeLogValue(err?.message || err, 500));
       process.exit(1);
     }
   })();

--- a/tests/money-watcher.test.js
+++ b/tests/money-watcher.test.js
@@ -21,6 +21,20 @@ test('buildCommercialAlert returns null when revenue does not increase', () => {
     { source: 'local' }
   ), null);
 });
+
+test('safeLogJson strips control characters from remote billing payloads', () => {
+  const rendered = mw.safeLogJson({
+    fallbackReason: 'bad\r\nFORGED',
+    latestPaidOrder: {
+      orderId: 'ord_1\tINJECT',
+    },
+  });
+
+  assert.doesNotMatch(rendered, /\r|\nFORGED|\t/);
+  assert.match(rendered, /bad  FORGED/);
+  assert.match(rendered, /ord_1 INJECT/);
+});
+
 test('checkForCommercialChange persists state and records new paid activity', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-money-watch-'));
   const statePath = path.join(tmpDir, 'state.json');

--- a/tests/post-to-x.test.js
+++ b/tests/post-to-x.test.js
@@ -13,6 +13,7 @@ const {
   postThread,
   searchTweets,
   parseTweetsFromThread,
+  safeMetricCount,
   safeLogValue,
 } = require('../scripts/post-to-x');
 
@@ -67,6 +68,15 @@ describe('safeLogValue', () => {
   it('normalizes nullish log values to an empty string', () => {
     assert.equal(safeLogValue(null), '');
     assert.equal(safeLogValue(undefined), '');
+  });
+});
+
+describe('safeMetricCount', () => {
+  it('normalizes untrusted metric values before console interpolation', () => {
+    assert.equal(safeMetricCount(12.9), 12);
+    assert.equal(safeMetricCount('5'), 5);
+    assert.equal(safeMetricCount('1\nforged'), 0);
+    assert.equal(safeMetricCount(-1), 0);
   });
 });
 

--- a/tests/zernio-integration.test.js
+++ b/tests/zernio-integration.test.js
@@ -106,6 +106,7 @@ describe('zernio publisher', () => {
     isZernioQuotaError,
     publishPost,
     publishToAllPlatforms,
+    safeLogValue,
     schedulePost,
     uploadLocalMedia,
   } = publisher;
@@ -180,6 +181,11 @@ describe('zernio publisher', () => {
     assert.deepEqual(body.platforms, platforms);
 
     assert.equal(result.id, 'post_123');
+  });
+
+  it('safeLogValue strips control characters from untrusted Zernio values', () => {
+    assert.equal(safeLogValue('post_1\r\nFORGED\tline'), 'post_1  FORGED line');
+    assert.equal(safeLogValue('abcdef', 3), 'abc');
   });
 
   it('publishPost throws a typed quota error when the Zernio plan limit is reached', async () => {


### PR DESCRIPTION
## Summary
- bump protobufjs lock resolution to patched 7.5.6 / @protobufjs/utf8 1.1.1
- sanitize social publisher and revenue watcher log output flagged by code scanning
- add focused regression coverage for sanitized metrics/log values

## Verification
- node --test tests/post-to-x.test.js tests/money-watcher.test.js tests/zernio-integration.test.js
- npm audit --audit-level=moderate
- npm ls protobufjs @protobufjs/utf8 --all
- node scripts/sync-version.js --check
- git diff --check