### PR TITLE
fix(analytics): wire PLAUSIBLE_* + GITHUB_TOKEN into social-analytics-poll env (dark-funnel bug)

### DIFF
--- a/.github/workflows/social-analytics-poll.yml
+++ b/.github/workflows/social-analytics-poll.yml
@@ -28,15 +28,28 @@ jobs:
     timeout-minutes: 15
 
     env:
+      # ZERNIO-CANONICAL pollers (github + plausible + zernio) per
+      # scripts/social-analytics/poll-all.js — all three need env wiring or
+      # poll-all.js logs "skipped (missing env)" and the run "succeeds"
+      # with zero data ingested.  This was the silent-dark-dashboard bug
+      # fixed 2026-05-14: PLAUSIBLE_* + GITHUB_TOKEN were missing from this
+      # env block while the secrets existed, so the funnel telemetry from
+      # PR #1981 (Plausible custom events on /checkout/pro) was being
+      # collected but never aggregated.
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAUSIBLE_API_KEY: ${{ secrets.PLAUSIBLE_API_KEY }}
+      PLAUSIBLE_SITE_ID: ${{ secrets.PLAUSIBLE_SITE_ID }}
+      # Zernio (aggregates Instagram, LinkedIn, TikTok, YouTube)
+      ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
+
       # X/Twitter analytics polling retired 2026-04-20 — the publisher was
       # quarantined and we no longer maintain an X presence to poll.
-      # Reddit
+      # Reddit direct-poller env retained for THUMBGATE_USE_DIRECT_POLLERS=1
+      # emergency fallback path; not on the canonical poller list.
       REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
       REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
       REDDIT_USERNAME: ${{ secrets.REDDIT_USERNAME }}
       REDDIT_PASSWORD: ${{ secrets.REDDIT_PASSWORD }}
-      # Zernio (aggregates Instagram, LinkedIn, TikTok, YouTube)
-      ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why

CEO question 2026-05-14: *"we have adequate analytics and observability and metrics???? We know exactly who/when/where goes to buy????? and why they abandon???"*

Investigation found we did NOT — the funnel was dark even though it looked instrumented.

## Root cause

1. \`social-analytics-poll.yml\` was **disabled** (last run 2026-05-06, 8 days stale).
2. After re-enabling and dispatching (run 25882297747), the workflow logged \`Mode: ZERNIO-CANONICAL (github + plausible + zernio)\` followed by \`Skipped: github, plausible\` — i.e. the run "succeeded" with no Plausible or GitHub data ingested.
3. \`scripts/social-analytics/poll-all.js\` line 72 skip predicate fires when \`envRequired\` is missing. The canonical pollers need: \`GITHUB_TOKEN\` (github), \`PLAUSIBLE_API_KEY\` (plausible), \`ZERNIO_API_KEY\` (zernio).
4. \`social-analytics-poll.yml\` env block exposed only \`REDDIT_*\` + \`ZERNIO_API_KEY\`. \`PLAUSIBLE_API_KEY\`, \`PLAUSIBLE_SITE_ID\`, and \`GITHUB_TOKEN\` were present as repo secrets (\`gh secret list\` confirms) but never wired into workflow env.

**Net effect**: Plausible custom-event ingest from PR #1981 (\`checkout/view\`, \`checkout/email_submitted\`, \`checkout/stripe_redirect\` on /checkout/pro) is being collected by Plausible's collector but never aggregated locally, while the workflow status badge stayed green. Dashboards-look-fine-but-data-is-zero failure mode.

## What

Single-file fix: add the three missing env entries to the workflow env block. Reorder so canonical-poller env (github + plausible + zernio) appears first with comment explaining why each must stay wired. Reddit direct-poller env retained as the documented \`THUMBGATE_USE_DIRECT_POLLERS=1\` emergency fallback path.

## What this PR does NOT fix (acknowledged gaps)

- **WHY visitors abandon** is still uninstrumented. No exit-intent survey, no session replay, no rage-click detection, no scroll-depth, no form-field abandonment timing. Plausible gives us step-counts, not reasons.
- **WHO buys** is anonymous until they fill the email field — visitorId/traceId only upstream of the conversion.
- Workflow has been disabled for 8 days; even after merge, the first run will only have ~1 day of post-#1981 Plausible data (and that data is sparse — Reddit post fired today at 19:26Z is the only meaningful traffic source).

Both are followup PRs.

## Test plan

- [x] Pre-commit guards pass (package parity, version sync, congruence)
- [ ] CI on push
- [ ] Post-merge: dispatch the workflow, verify log shows \`Succeeded: github, plausible, zernio\` (not \`Skipped\`)
- [ ] Post-merge: \`npm run social:zernio:status\` shows non-zero row counts for /checkout/pro custom events
- [ ] Tomorrow's scheduled 06:00 UTC run lands data in the SQLite analytics DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)