### PR TITLE
feat(marketing): add Rob May / The New Stack social proof to hero + README

### DIFF
--- a/.changeset/tns-rob-may-social-proof.md
+++ b/.changeset/tns-rob-may-social-proof.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+feat(marketing): surface Rob May / The New Stack social proof on the hero + README.
+
+Adds a `<figure>` blockquote on `public/index.html` and a matching quote block under the badges in `README.md`. Quote is from Rob May (CEO, Neurometric AI), as published in [The New Stack](https://thenewstack.io/claude-code-agent-view/) — May 2026 — on Anthropic's Claude Code Agent View. Pure third-party validation of ThumbGate's thesis on a high-credibility outlet read by our buyer ICP.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Under the hood: your thumbs-down becomes one of your **Pre-Action Checks** that 
 
 ---
 
+> *"A better dashboard doesn't make the agents more reliable. The hard part isn't visibility. It's trust."*
+>
+> — **Rob May**, CEO & co-founder, Neurometric AI, quoted in [The New Stack](https://thenewstack.io/claude-code-agent-view/) on Anthropic's Claude Code Agent View (May 2026).
+>
+> ThumbGate is the open-source layer that makes the trust part real: PreToolUse gates, thumbs-down to rule, audit trail on every interception.
+
+---
+
 ## 🎬 90-second demo
 
 Watch the force-push scenario: agent tries to `git push --force`, one thumbs-down, next session it's blocked — zero tokens spent on the repeat.

--- a/public/index.html
+++ b/public/index.html
@@ -720,6 +720,10 @@ __GA_BOOTSTRAP__
       <span>Works with MCP-compatible agents</span>
       <span>Verification evidence in GitHub</span>
     </div>
+    <figure style="max-width:760px;margin:32px auto 0;padding:20px 24px;border-left:3px solid var(--cyan);background:rgba(34,211,238,0.04);border-radius:0 8px 8px 0;">
+      <blockquote style="margin:0;font-size:18px;line-height:1.5;color:var(--text);font-style:italic;">&ldquo;A better dashboard doesn&rsquo;t make the agents more reliable. The hard part isn&rsquo;t visibility. It&rsquo;s trust.&rdquo;</blockquote>
+      <figcaption style="margin-top:12px;font-size:13px;color:var(--text-muted);">— Rob May, CEO &amp; co-founder, Neurometric AI, in <a href="https://thenewstack.io/claude-code-agent-view/" target="_blank" rel="noopener" style="color:var(--cyan);">The New Stack</a> on Anthropic&rsquo;s Claude Code Agent View (May 2026). ThumbGate is the open-source layer that makes the trust part real: PreToolUse gates, thumbs-down to rule, audit trail on every interception.</figcaption>
+    </figure>
     <div class="first-check-card" id="first-check">
       <div class="section-label" style="text-align:left;margin-bottom:8px;">First-Dollar Activation Path</div>
       <h2>Block your first repeated AI mistake in 5 minutes.</h2>


### PR DESCRIPTION
## Why this is the highest-EV marketing change this month

The New Stack ran [a piece on Claude Code Agent View](https://thenewstack.io/claude-code-agent-view/) (May 2026) quoting **Rob May, CEO of Neurometric AI**:

> *"A better dashboard doesn't make the agents more reliable. The hard part isn't visibility. It's trust."*

That sentence is **verbatim ThumbGate's thesis** — from a credible third party (serial AI founder, InsideAI newsletter), on the outlet read by exactly our buyer ICP (platform/devex leaders at 200-2000-eng orgs). The article's conclusion: *"What's still missing... is the governance and auditability to drive trust for production use."* — also our spec verbatim.

This kind of unsolicited third-party validation is the asset we've been missing. Surfacing it on the highest-traffic pages converts visitors who arrive skeptical.

## What changes

- **`public/index.html`** — `<figure>` block under the hero trust bar, with blockquote, attribution, link to TNS, and one-line bridge to ThumbGate's mechanism.
- **`README.md`** — same quote inserted under the badges, surfaces to every npm install candidate.

Both write-once / compound-on-every-visitor.

## Why this is safe to merge immediately (unlike the buyer-list PR)

This is **received social proof from a published article**, not a feature ship. It doesn't depend on pipeline existing. It increases conversion the moment a single visitor reads it. Recommend merging now.

## Test plan

- [x] `npm run test:landing-page-claims` — 23 pass
- [x] Quote attribution is verbatim from the published TNS article (verified via curl)
- [x] Link points at the real article URL
- [x] No load-impact (static HTML/CSS only)

Related: #2060 adds Rob May + Meredith Shubel (TNS author) as buyer-list send targets #11 / #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)