### PR TITLE
ci: install scikit-learn + joblib so eval_gate_classifier e2e runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python deps
-        run: pip install pytest
+        # scikit-learn + joblib are required by scripts/eval_gate_classifier.py
+        # so tests/eval-gate-classifier.test.js can exercise the actual ML
+        # pipeline (train_and_score, joblib.dump, ROC-AUC, classification_report)
+        # in CI instead of skipping the e2e branch. The package is opt-in for
+        # end users — these installs only affect the CI runner.
+        run: pip install pytest scikit-learn joblib
       - name: Setup Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- One-line CI workflow change: adds \`scikit-learn\` and \`joblib\` to the existing \`pip install pytest\` step in \`.github/workflows/ci.yml\`.
- This is the missing half of PR #2083 (ML/DL gate classifier). On the prior CI runs, only the \"sklearn-missing → install hint\" assertion exercised \`scripts/eval_gate_classifier.py\`. The actual classifier code path — \`train_and_score\`, \`stack_features\`, \`LogisticRegression.fit\`, \`joblib.dump\`, ROC-AUC, classification_report, the metrics card — never executed in CI. With sklearn present, both the e2e synthetic-dataset test and the too-few-rows test stop skipping and exercise the real pipeline on every PR.

## Why this matters
The Sonar coverage gate currently passes only because \`scripts/eval_gate_classifier.py\` is in \`sonar.coverage.exclusions\` (matching the precedent for sister Python utilities — the repo emits LCOV but no \`python-coverage.xml\`). That exclusion silences Sonar's measurement; it does NOT mean the code is exercised. Until this PR, the actual ML pipeline was 0% executed in CI even though all checks reported green. This change closes that gap without adding runtime weight to the npm package — sklearn / joblib remain opt-in operator deps.

## Cost
~15s extra on a clean runner for the pip install. Cached on subsequent runs.

## Test plan
- [x] Local: 3/4 tests pass + 1 correctly skipped (sklearn-missing branch)
- [ ] CI: with this change, sklearn-aware tests run instead of skip
- [ ] CI green
- [ ] 0 unresolved review threads

## Dependency
This PR is best merged AFTER #2083 (which introduces \`scripts/eval_gate_classifier.py\` + \`tests/eval-gate-classifier.test.js\`). On its own, this CI change is harmless — the unused sklearn install just sits there. Once #2083 lands, this PR's effect activates immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)