### PR TITLE
docs(positioning): honest 'no LLM in enforcement' + Thompson framing + cross-agent moat

### DIFF
--- a/.changeset/readme-honest-positioning.md
+++ b/.changeset/readme-honest-positioning.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+README + LAUNCH_POSTS docs honesty pass triggered by [r/ClaudeCode comment thread](https://www.reddit.com/r/ClaudeCode/comments/1tc2k1z/comment/oll1dua/). Three corrections:
+
+1. **"No LLM in enforcement" needs the qualifier.** Layer 2 description now distinguishes the deterministic runtime gate decision (literal pattern + AST + scoped lookup, zero LLM) from offline retrieval (local CPU-only `bge-small` embeddings via LanceDB — a model, but no external API call and no inference cost beyond CPU).
+2. **Thompson Sampling does NOT select rules.** Old framing said "Thompson Sampling for adaptive rule selection" / "multi-armed bandit rule selection" which implied the bandit decides whether a rule fires. Corrected: TS tunes per-rule confidence weights for soft-gating rules. Hard rules ("block force-push to main") always fire deterministically — bandit exploration would be terrifying for hard rules.
+3. **Cross-agent propagation + learning loop is the lead differentiator vs hand-rolled hooks.** Layer 4 description now explicitly answers "why ThumbGate over Claude Code's `permissions.deny` or a custom `PreToolUse` script": (a) checks propagate cross-agent over MCP — thumbs-down on Cursor blocks the same pattern on Claude Code, Codex, Gemini in the next session; (b) every feedback event becomes a fresh rule and tunes existing ones, so the corpus sharpens without an operator hand-writing patterns for every new mistake shape.

--- a/LAUNCH_POSTS.md
+++ b/LAUNCH_POSTS.md
@@ -115,7 +115,7 @@ ThumbGate is an MCP server that turns agent feedback into **enforced prevention 
 - SQLite + FTS5 for lesson storage and retrieval
 - LanceDB for vector similarity (optional, Pro only)
 - ContextFS for rule assembly and context packing
-- Thompson Sampling for multi-armed bandit rule selection
+- Thompson Sampling tunes per-rule confidence weights (not which rule fires — hard rules always fire deterministically)
 
 **No Training Required:** This is not RLHF weight training. It's context engineering + enforcement. Rules are human-readable Markdown files. You can edit them, version them, share them.
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,26 @@ ThumbGate operates as a 4-layer enforcement stack between your AI agent and your
 Your thumbs-up/down reactions are captured via MCP protocol, CLI, or the ChatGPT GPT surface. Each reaction is stored as a structured lesson with context, timestamp, and severity.
 
 ### Layer 2: Check Engine
-The check engine converts lessons into enforceable rules using pattern matching, semantic similarity (via LanceDB vectors), and Thompson Sampling for adaptive rule selection. Rules stay in local ThumbGate runtime state.
+The check engine converts lessons into enforceable rules. **The runtime gate decision is deterministic** — literal pattern match → AST match → scoped rule lookup. No LLM call on the enforcement path.
+
+Where retrieval is needed (an agent is about to run a destructive command not on the literal block list, but semantically similar to one we've blocked before), ThumbGate uses local CPU-only `bge-small` embeddings via LanceDB's built-in pipeline. No external API call, no inference cost beyond CPU. So **"no LLM in enforcement"** holds: the gate decision uses no LLM; the rule corpus is just searchable via local embeddings.
+
+**Thompson Sampling tunes per-rule confidence weights** for soft-gating rules so high-noise rules quiet down and high-signal rules sharpen. It never decides *whether* a rule fires — a hard rule like "block `git push --force` on main" always fires deterministically. Bandit exploration would be terrifying for hard rules; we don't do it.
+
+Rules stay in local ThumbGate runtime state.
 
 ### Layer 3: Pre-Action Interception
 Before any agent action executes, ThumbGate's `PreToolUse` hook intercepts the command and evaluates it against all active checks. This happens at the MCP protocol level — the agent physically cannot bypass it.
 
-### Layer 4: Multi-Agent Distribution
-Checks are distributed across all connected agents via MCP stdio protocol. One correction in Claude Code protects Cursor, Codex, Gemini CLI, Cline, and any MCP-compatible agent.
+### Layer 4: Multi-Agent Distribution (the actual moat vs hand-rolled hooks)
+Claude Code already ships `permissions.deny` and `PreToolUse` hooks. Cursor and Codex have their own. So why ThumbGate over a hand-written hook?
+
+Two things hand-written hooks structurally cannot do:
+
+1. **Cross-agent propagation.** A `permissions.deny` pattern lives in one agent's config and stays there. ThumbGate's checks distribute across every connected agent over MCP stdio — thumbs-down once in Cursor, the same pattern blocks on Claude Code, Codex, Gemini CLI, Cline, OpenCode, Amp in the next session, no copy-paste between configs.
+2. **Learning loop.** A hand-written hook covers exactly the patterns you wrote. ThumbGate promotes every thumbs-down into a fresh rule, tunes existing rules' confidence weights from outcomes (Thompson Sampling, see Layer 2), and pulls semantically-near patterns into scope via local embeddings. The rule corpus sharpens without an operator hand-writing a regex for every new mistake shape.
+
+Hand-rolled hooks are the right tool for a small, static denylist you maintain by hand. ThumbGate is the right tool when you want corrections from any agent to harden every agent automatically.
 
 Prompt engineering still matters, but it is only the starting point. ThumbGate adds prompt evaluation on top: proof lanes, benchmarks, and self-heal checks tell you whether your prompt and workflow actually held up under execution instead of leaving you to guess from vibes. Run `npx thumbgate eval --from-feedback --write-report=.thumbgate/prompt-eval-proof.md` to turn real thumbs-up/down feedback into reusable eval cases and a buyer-ready proof report.
 

--- a/docs/marketing/codex-marketplace-revenue-pack.json
+++ b/docs/marketing/codex-marketplace-revenue-pack.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-12T22:29:37.174Z",
+  "generatedAt": "2026-05-15T16:07:52.385Z",
   "channel": "Codex",
   "objective": "Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and qualified workflow sprint conversations.",
   "canonicalIdentity": {

--- a/docs/marketing/codex-marketplace-revenue-pack.md
+++ b/docs/marketing/codex-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Operator Revenue Pack
 
-Updated: 2026-05-12T22:29:37.174Z
+Updated: 2026-05-15T16:07:52.385Z
 
 This is a sales operator artifact. It is not proof of installs, revenue, or marketplace approval by itself.
 


### PR DESCRIPTION
## Summary
Three docs corrections triggered by [r/ClaudeCode comment thread](https://www.reddit.com/r/ClaudeCode/comments/1tc2k1z/comment/oll1dua/) where \`Sad-Pension-5008\` fairly flagged that the README's framing was ambiguous. Our reply on that thread was correct; the README hadn't caught up. CEO confirmed all three fixes.

## Changes

### 1. Layer 2: \"no LLM in enforcement\" qualifier
**Before:** \"semantic similarity (via LanceDB vectors), and Thompson Sampling for adaptive rule selection\"
**After:** Distinguishes the **deterministic runtime gate decision** (literal pattern + AST + scoped lookup, zero LLM) from **offline retrieval** (local CPU-only \`bge-small\` embeddings via LanceDB — a model, but no external API call and no inference cost beyond CPU). \"No LLM in enforcement\" holds; the rule corpus is just searchable via local embeddings.

### 2. Layer 2: Thompson Sampling tunes per-rule weights, not selection
**Before:** \"Thompson Sampling for adaptive rule selection\" / \"multi-armed bandit rule selection\" (in LAUNCH_POSTS.md too)
**After:** TS tunes per-rule confidence weights for soft-gating rules. Hard rules (\"block force-push to main\") always fire deterministically — bandit exploration would be terrifying for hard rules; we don't do it. The Reddit critic was right to question whether a bandit would skip a destructive-write block; the answer is no.

### 3. Layer 4: cross-agent propagation + learning loop is the lead differentiator vs hand-rolled hooks
**Before:** \"Checks are distributed across all connected agents via MCP stdio protocol. One correction in Claude Code protects Cursor, Codex, Gemini CLI, Cline, and any MCP-compatible agent.\" (buried, generic)
**After:** Explicitly answers \"why ThumbGate over Claude Code's \`permissions.deny\` or a custom \`PreToolUse\` script\":
1. **Cross-agent propagation** — a deny pattern in one agent stays there; ThumbGate propagates over MCP stdio to every connected agent.
2. **Learning loop** — every thumbs-down promotes a fresh rule and tunes existing ones; hand-written hooks cover only the patterns you wrote.

The Reddit critic explicitly called cross-agent propagation \"the real differentiator\" — this PR makes the README say so.

## Files
- \`README.md\` — Layer 2 + Layer 4 sections rewritten
- \`LAUNCH_POSTS.md\` — same Thompson framing fix
- \`.changeset/readme-honest-positioning.md\` — patch-level changeset

## Test plan
- [x] No code changes; positioning + accuracy only
- [x] Pre-commit congruence guard passed
- [ ] CI green
- [ ] 0 unresolved review threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)