### PR TITLE
fix(install-mcp): wire Claude Code hooks alongside MCP server entry

### DIFF
--- a/.changeset/install-mcp-wires-hooks.md
+++ b/.changeset/install-mcp-wires-hooks.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+Fix: `scripts/install-mcp.js` now wires the Claude Code lifecycle hooks (PreToolUse, UserPromptSubmit, PostToolUse, SessionStart) alongside the `mcpServers.thumbgate` entry, matching the single-command UX the README and landing page promise (`npx thumbgate init --agent claude-code`).
+
+Previously `install-mcp` wrote only the MCP server entry, silently leaving the gate-enforcement hooks unwired — users who followed the `install-mcp` path got tools/MCP but no PreToolUse blocking. The fix delegates hook wiring to the existing `wireClaudeHooks()` in `scripts/auto-wire-hooks.js`, so the two install paths stay in lock-step. Adds a `--no-hooks` opt-out for callers that genuinely want the bare MCP wiring. New `installHooks` and `installMcpAndHooks` helpers are exported alongside `installMcp` for back-compat. Pinned by 5 new integration tests in `tests/install-mcp.test.js`.

--- a/scripts/install-mcp.js
+++ b/scripts/install-mcp.js
@@ -2,19 +2,33 @@
 'use strict';
 
 /**
- * install-mcp.js — Wire the ThumbGate MCP server into Claude Code settings.
+ * install-mcp.js — Wire the ThumbGate MCP server (and PreToolUse hooks) into
+ * Claude Code settings.
  *
  * Usage:
  *   node scripts/install-mcp.js            # global install (~/.claude/settings.json)
  *   node scripts/install-mcp.js --project  # project-level install (.claude/settings.json)
+ *   node scripts/install-mcp.js --no-hooks # MCP only, skip hook wiring
+ *   node scripts/install-mcp.js --dry-run  # preview without writing
  *
  * Idempotent: re-running does not duplicate the entry.
  * Creates a .bak backup before modifying any settings file.
+ *
+ * By default this command performs BOTH steps a Claude Code install needs:
+ *   1. Add the `thumbgate` MCP server to settings.json (or project .claude/settings.json)
+ *   2. Wire PreToolUse / UserPromptSubmit / PostToolUse / SessionStart hooks
+ *      via wireClaudeHooks() from auto-wire-hooks.js
+ *
+ * Prior to this change, `install-mcp` only handled step 1, silently leaving
+ * the gate-enforcement hooks unwired. The single-command UX in the README and
+ * landing page (`npx thumbgate init --agent claude-code`) expects both steps,
+ * and this matches it.
  */
 
 const fs = require('fs');
 const path = require('path');
 const { resolveMcpEntry } = require('./mcp-config');
+const { wireClaudeHooks } = require('./auto-wire-hooks');
 
 const MCP_SERVER_KEY = 'thumbgate';
 const LEGACY_MCP_SERVER_KEYS = ['mcp-memory-gateway', 'rlhf'];
@@ -35,6 +49,7 @@ function parseFlags(argv) {
   for (const arg of argv) {
     if (arg === '--project') flags.project = true;
     if (arg === '--dry-run') flags.dryRun = true;
+    if (arg === '--no-hooks') flags.noHooks = true;
   }
   return flags;
 }
@@ -149,6 +164,65 @@ function installMcp(flags) {
   return { installed: true, path: settingsPath, backup: backupPath || null };
 }
 
+/**
+ * installHooks — wire the Claude Code PreToolUse/UserPromptSubmit/PostToolUse/
+ * SessionStart hooks. Delegates to wireClaudeHooks() so we stay in sync with
+ * how `thumbgate init --agent=claude-code` writes them. Failures are reported
+ * but do not throw, so a partial install (MCP succeeded, hooks failed) still
+ * leaves the user with a functioning MCP server.
+ *
+ * @param {{ project?: boolean, dryRun?: boolean }} flags
+ * @returns {{ wired: boolean, settingsPath: string|null, added: Array, error?: string }}
+ */
+function installHooks(flags) {
+  try {
+    const wireOptions = { dryRun: Boolean(flags.dryRun) };
+    if (flags.project) {
+      wireOptions.projectDir = process.cwd();
+    }
+    const result = wireClaudeHooks(wireOptions);
+    return {
+      wired: Boolean(result && result.changed),
+      settingsPath: (result && result.settingsPath) || null,
+      added: (result && result.added) || [],
+    };
+  } catch (err) {
+    return {
+      wired: false,
+      settingsPath: null,
+      added: [],
+      error: err && err.message ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * installMcpAndHooks — top-level entry that combines MCP server install and
+ * hook wiring into one operation. Maintained alongside the bare `installMcp`
+ * for back-compat with callers that only want the MCP wiring.
+ */
+function installMcpAndHooks(flags = {}) {
+  const mcpResult = installMcp(flags);
+  if (flags.noHooks) {
+    return { mcp: mcpResult, hooks: { wired: false, skipped: true } };
+  }
+
+  const hooksResult = installHooks(flags);
+  if (hooksResult.error) {
+    console.warn(`  Hooks: skipped (${hooksResult.error})`);
+  } else if (hooksResult.wired) {
+    console.log(`ThumbGate hooks wired.`);
+    if (hooksResult.settingsPath) console.log(`  Path: ${hooksResult.settingsPath}`);
+    for (const entry of hooksResult.added) {
+      console.log(`  ${entry.lifecycle}: ${entry.command}`);
+    }
+  } else if (hooksResult.added.length === 0) {
+    console.log('ThumbGate hooks already wired.');
+  }
+
+  return { mcp: mcpResult, hooks: hooksResult };
+}
+
 // Exported for testing
 module.exports = {
   MCP_SERVER_KEY,
@@ -160,10 +234,14 @@ module.exports = {
   isAlreadyInstalled,
   buildMcpConfig,
   installMcp,
+  installHooks,
+  installMcpAndHooks,
   parseFlags,
 };
 
-if (require.main === module) {
+// Use a path-based main check per CLAUDE.md (SonarCloud S3403 — require.main
+// can be unreliable under some module loaders).
+if (path.resolve(process.argv[1] || '') === path.resolve(__filename)) {
   const flags = parseFlags(process.argv.slice(2));
-  installMcp(flags);
+  installMcpAndHooks(flags);
 }

--- a/tests/cli-agent-experience.test.js
+++ b/tests/cli-agent-experience.test.js
@@ -341,8 +341,10 @@ describe('agent-first CLI experience', () => {
   // help includes new commands
   // -------------------------------------------------------------------------
 
-  test('help lists status, demo, and explore subcommands', () => {
-    const result = runCliSync(['help'], { cwd: tmpDir });
+  test('help all lists status, demo, and explore subcommands', () => {
+    // These specialist + sub-mode commands live in the full surface now;
+    // default `help` is curated to 8 common commands. (Shortened 2026-05-18.)
+    const result = runCliSync(['help', 'all'], { cwd: tmpDir });
     assert.equal(result.status, 0);
     assert.match(result.stdout, /status/);
     assert.match(result.stdout, /demo/);

--- a/tests/install-mcp.test.js
+++ b/tests/install-mcp.test.js
@@ -24,6 +24,8 @@ const {
   isAlreadyInstalled,
   buildMcpConfig,
   installMcp,
+  installHooks,
+  installMcpAndHooks,
   parseFlags,
 } = require('../scripts/install-mcp');
 
@@ -367,6 +369,134 @@ describe('install-mcp', () => {
     } finally {
       process.env.HOME = origHome;
       fs.rmSync(isolatedDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// install-mcp + hooks integration
+// ---------------------------------------------------------------------------
+// The headline UX in README/landing-page is a single command. Prior to this
+// suite, `install-mcp` only wrote mcpServers and silently left the gate hooks
+// unwired, leaving every user with a half-installed system. These tests pin
+// the unified install path: by default, install-mcp wires BOTH the MCP server
+// and the Claude Code lifecycle hooks. `--no-hooks` opts out for callers that
+// only want the server entry.
+
+describe('install-mcp + hooks integration', () => {
+  test('parseFlags detects --no-hooks flag', () => {
+    assert.equal(parseFlags(['--no-hooks']).noHooks, true);
+    assert.equal(parseFlags([]).noHooks, undefined);
+  });
+
+  test('installMcpAndHooks wires both server entry and Claude hook lifecycles', () => {
+    const isolatedDir = makeTmpDir();
+    const origHome = process.env.HOME;
+    process.env.HOME = isolatedDir;
+    try {
+      const result = installMcpAndHooks({});
+      assert.equal(result.mcp.installed, true, 'MCP server should be installed');
+      assert.ok(!result.hooks.error, `hook wiring should not error: ${result.hooks.error || ''}`);
+
+      // Hooks land in settings.local.json per Claude Code's per-machine
+      // override convention; the MCP entry + statusLine land in settings.json.
+      const mcpSettings = JSON.parse(
+        fs.readFileSync(path.join(isolatedDir, '.claude', 'settings.json'), 'utf8')
+      );
+      assert.ok(
+        mcpSettings.mcpServers && mcpSettings.mcpServers[MCP_SERVER_KEY],
+        'MCP server entry must be present in settings.json'
+      );
+
+      const hookSettingsPath = path.join(isolatedDir, '.claude', 'settings.local.json');
+      assert.ok(fs.existsSync(hookSettingsPath), 'hook settings.local.json must exist');
+      const hookSettings = JSON.parse(fs.readFileSync(hookSettingsPath, 'utf8'));
+      assert.ok(hookSettings.hooks, 'hooks block must exist in settings.local.json');
+
+      // Every Claude lifecycle this installer is responsible for must land.
+      for (const lifecycle of ['PreToolUse', 'UserPromptSubmit', 'PostToolUse', 'SessionStart']) {
+        assert.ok(
+          Array.isArray(hookSettings.hooks[lifecycle]) && hookSettings.hooks[lifecycle].length > 0,
+          `expected hooks.${lifecycle} to be wired`
+        );
+      }
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(isolatedDir, { recursive: true, force: true });
+    }
+  });
+
+  test('installMcpAndHooks respects --no-hooks (MCP only, no hook writes)', () => {
+    const isolatedDir = makeTmpDir();
+    const origHome = process.env.HOME;
+    process.env.HOME = isolatedDir;
+    try {
+      const result = installMcpAndHooks({ noHooks: true });
+      assert.equal(result.mcp.installed, true, 'MCP server should still be installed');
+      assert.equal(result.hooks.skipped, true, 'hooks should be marked skipped');
+      assert.equal(result.hooks.wired, false, 'hooks should not be wired');
+
+      const hookSettingsPath = path.join(isolatedDir, '.claude', 'settings.local.json');
+      // Either the file doesn't exist, or it exists with no hooks block.
+      if (fs.existsSync(hookSettingsPath)) {
+        const hookSettings = JSON.parse(fs.readFileSync(hookSettingsPath, 'utf8'));
+        assert.equal(
+          hookSettings.hooks,
+          undefined,
+          '--no-hooks must NOT write a hooks block to settings.local.json'
+        );
+      }
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(isolatedDir, { recursive: true, force: true });
+    }
+  });
+
+  test('installMcpAndHooks is idempotent across both MCP and hook surfaces', () => {
+    const isolatedDir = makeTmpDir();
+    const origHome = process.env.HOME;
+    process.env.HOME = isolatedDir;
+    try {
+      const first = installMcpAndHooks({});
+      assert.equal(first.mcp.installed, true);
+      assert.ok(!first.hooks.error);
+
+      const second = installMcpAndHooks({});
+      // MCP install reports `installed: false` with reason already-installed on
+      // re-run; the hook wiring should likewise be a no-op (no added entries).
+      assert.equal(second.mcp.installed, false);
+      assert.equal(second.mcp.reason, 'already-installed');
+      assert.ok(!second.hooks.error);
+      assert.equal(
+        (second.hooks.added || []).length,
+        0,
+        're-run should not add hook entries that were already wired'
+      );
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(isolatedDir, { recursive: true, force: true });
+    }
+  });
+
+  test('installHooks returns a structured failure rather than throwing', () => {
+    // Confirm the contract: callers should always get {wired, settingsPath,
+    // added, error?}. We force the error path by pointing HOME at a path
+    // where mkdir will fail (an existing regular file).
+    const tmpFile = path.join(makeTmpDir(), 'home-as-file');
+    fs.writeFileSync(tmpFile, 'not-a-dir');
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpFile;
+    try {
+      const result = installHooks({});
+      // Either the helper recovered (wired: true/false) or it captured the
+      // error — both are fine; the contract is "do not throw".
+      assert.equal(typeof result, 'object');
+      assert.equal('wired' in result, true);
+      assert.equal('settingsPath' in result, true);
+      assert.equal('added' in result, true);
+    } finally {
+      process.env.HOME = origHome;
+      fs.rmSync(tmpFile, { force: true });
     }
   });
 });

--- a/tests/obsidian-export.test.js
+++ b/tests/obsidian-export.test.js
@@ -749,12 +749,15 @@ test('CLI: obsidian-export command is wired in cli.js', () => {
   assert.ok(cliSource.includes('obsidianExport'), 'CLI should reference obsidianExport function');
 });
 
-test('CLI: help output includes obsidian-export', () => {
-  const result = spawnSync(process.execPath, [CLI, 'help'], { encoding: 'utf-8' });
+test('CLI: help all output includes obsidian-export', () => {
+  // `obsidian-export` is a specialist Export-group command, not in the curated
+  // short surface — it lives in `help all` along with the rest of the ~70
+  // subcommands. (Default `help` was shortened 2026-05-18.)
+  const result = spawnSync(process.execPath, [CLI, 'help', 'all'], { encoding: 'utf-8' });
   assert.equal(result.status, 0);
   assert.ok(
     result.stdout.includes('obsidian-export') || result.stderr.includes('obsidian-export'),
-    'Help output should mention obsidian-export'
+    '`help all` output should mention obsidian-export'
   );
 });
 


### PR DESCRIPTION
## Summary

`scripts/install-mcp.js` previously only wrote the `mcpServers.thumbgate` entry to settings.json, silently leaving the gate-enforcement hooks unwired. Users following the `install-mcp` path got MCP tools but no PreToolUse / UserPromptSubmit / PostToolUse / SessionStart hooks — a half-installed system that contradicted the single-command UX the README + thumbgate.ai landing page promise.

This PR makes `install-mcp` delegate hook wiring to the existing `wireClaudeHooks()` in `scripts/auto-wire-hooks.js`, so `install-mcp` and `init --agent claude-code` produce the same final state.

### Changes

- **`scripts/install-mcp.js`** — after the MCP server upsert, call `wireClaudeHooks()`. Adds `--no-hooks` flag, `installHooks(flags)` helper (returns `{wired, settingsPath, added}`, never throws), and `installMcpAndHooks(flags)` top-level entry. Replaces `require.main === module` with path-based main check (CLAUDE.md / SonarCloud S3403).
- **`tests/install-mcp.test.js`** — 5 new integration tests: parseFlags --no-hooks, installMcpAndHooks wires both, --no-hooks opts out, idempotent, structured failure.
- **`.changeset/install-mcp-wires-hooks.md`** — patch.

### Diagnostic context

Found while onboarding a fresh user setup. Running `mcp-memory-gateway install-mcp` (or the renamed `thumbgate install-mcp`) left \`hooks: NONE\` in \`~/.claude/settings.json\` even though MCP was registered correctly. The README/landing-page directs users to \`npx thumbgate init --agent claude-code\` which DOES wire both — but the divergence between the two install paths is a footgun, and this PR closes it.

## Test plan

- [x] \`node --test tests/install-mcp.test.js\` — **21/21 pass** (16 existing + 5 new)
- [x] \`node --test tests/auto-wire-hooks.test.js\` — **54/54 pass** (no regression)
- [x] \`node --test tests/mcp-config.test.js\` — **11/11 pass** (no regression)
- [x] Manual smoke: \`installMcpAndHooks({})\` against isolated HOME creates both \`settings.json\` (mcpServers) and \`settings.local.json\` (hooks).
- [ ] Full \`npm test\` CI run on this branch.
- [ ] Reviewer to confirm no impact on existing \`thumbgate init\` callers (no API removed; new helpers only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)