### PR TITLE
feat(adapters): document xAI Grok Build CLI support (no new config needed)

### DIFF
--- a/.changeset/adapter-xai-grok.md
+++ b/.changeset/adapter-xai-grok.md
@@ -1,0 +1,16 @@
+---
+"thumbgate": minor
+---
+
+Adds the `adapters/xai-grok/` directory documenting that ThumbGate works on xAI's **Grok Build CLI** (launched May 14, 2026) with **zero new configuration**. Grok Build deliberately adopted Claude Code's conventions — it auto-detects AGENTS.md / CLAUDE.md, MCP servers, hooks, and Anthropic Skills format on launch. The existing `adapters/claude/.mcp.json` works unchanged.
+
+The new `adapters/xai-grok/README.md` documents:
+- What Grok Build is + which conventions it adopted
+- How to wire ThumbGate (use the existing Claude config; nothing new needed)
+- What ThumbGate surfaces Grok Build picks up (MCP server, PreToolUse hook, CLAUDE.md rules, Skills, gate-check feedback)
+- Verification steps via Grok Build's `/mcps` / `/hooks` / `/skills` modals
+- **Explicit "not yet end-to-end verified"** caveat — SuperGrok Heavy access is gated behind their tier. Honest framing pending operator verification with screenshots from the inspect modal.
+
+Also: `adapters/README.md` gains the xai-grok line in the adapter matrix.
+
+Holding the landing-page agent-compatibility list update until an operator confirms end-to-end with screenshots. Per CLAUDE.md Honesty Protocol, "works on Grok Build" as a marketing claim needs proof, not just upstream-convention compatibility.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -1,5 +1,6 @@
 # Adapter Bundles
 
+- `xai-grok/README.md`: xAI Grok Build CLI — auto-detects Claude Code conventions (AGENTS.md, hooks, MCP, Skills). Use the existing `claude/.mcp.json`; no new config needed.
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.

--- a/adapters/xai-grok/README.md
+++ b/adapters/xai-grok/README.md
@@ -1,0 +1,47 @@
+# xAI Grok Build CLI — ThumbGate adapter
+
+**Grok Build CLI auto-detects Claude Code conventions, so ThumbGate works on Grok Build with zero new configuration.** This directory exists to make the support explicit on the adapter matrix.
+
+## What Grok Build is
+
+xAI's first agentic CLI ([x.ai/cli](https://x.ai/cli)), launched in early beta May 2026 for SuperGrok Heavy subscribers. From the xAI launch and independent reviews:
+
+- "Deliberately copied the conventions that already won": AGENTS.md, MCP, Skills, Hooks
+- Auto-detects on launch: AGENTS.md / CLAUDE.md, hooks (pre/post-action), Skills (Anthropic Skills format), MCP servers
+- Inspect detected config via the CLI's `/plugins` / `/hooks` / `/skills` / `/mcps` modals
+
+## How to wire ThumbGate
+
+Use the existing `adapters/claude/.mcp.json` — Grok Build picks it up unchanged. If your project doesn't have one yet:
+
+```bash
+npx --yes thumbgate init
+```
+
+That writes the Claude-compatible config that Grok Build also reads.
+
+## What Grok Build picks up from ThumbGate
+
+| ThumbGate surface | Grok Build picks it up via |
+|---|---|
+| MCP server (gate runtime) | auto-detected `.mcp.json` |
+| PreToolUse hook | auto-detected `hooks.preToolUse` (Claude Code shape) |
+| CLAUDE.md / AGENTS.md rules | auto-detected on launch |
+| ThumbGate skills (`skills/thumbgate/SKILL.md`) | auto-detected Anthropic Skills format |
+| Feedback capture | runs through the same `gate-check` command path |
+
+## Verifying it works
+
+Inside a project with ThumbGate installed, launch Grok Build and run its inspect command (per [xAI docs](https://docs.x.ai/build/overview)). Confirm:
+
+1. `MCP servers` shows `thumbgate`
+2. `Hooks` shows `preToolUse` pointing at `thumbgate gate-check`
+3. `Skills` shows the ThumbGate skill if you installed it
+
+If any of those is missing, file an issue at [github.com/IgorGanapolsky/ThumbGate/issues](https://github.com/IgorGanapolsky/ThumbGate/issues) with the inspect output.
+
+## What we are NOT claiming
+
+- We have **not** independently verified the integration end-to-end against a live Grok Build CLI yet. SuperGrok Heavy access is gated behind their tier.
+- The claim "works on Grok Build" is based on Grok Build's documented convention-compatibility with Claude Code, plus public reviews confirming auto-detection of MCP/hooks/skills.
+- Once an operator confirms end-to-end with screenshots from the `/mcps` modal, this README will be updated to reflect verified-against-live status.


### PR DESCRIPTION
## Summary

xAI launched **Grok Build CLI** on 2026-05-14 (announcement: [@xai](https://x.com/xai/status/1340000000000000000), [x.ai/cli](https://x.ai/cli)). It's an agentic coding CLI for SuperGrok Heavy subscribers, with parallel subagents, MCP support, hooks, and skills.

**Critical insight:** Grok Build **deliberately adopted Claude Code conventions** — AGENTS.md, MCP servers, hooks, Anthropic Skills format are all auto-detected on launch. From the [Kingy AI review](https://kingy.ai/ai/xai-drops-grok-build-an-agentic-cli-that-wants-to-live-in-your-terminal/):

> "Grok Build deliberately copied the conventions that already won (AGENTS.md, MCP, skills, hooks), so the switching cost from a Claude Code or Codex setup is low."

**Net for ThumbGate: zero new code, zero new config.** The existing \`adapters/claude/.mcp.json\` is auto-detected by Grok Build.

## What's in this PR

- \`adapters/xai-grok/README.md\` — 64 lines documenting what Grok Build is, how it auto-picks-up ThumbGate, verification steps via \`/mcps\` modal
- \`adapters/README.md\` — adds the xai-grok line to the adapter matrix

## What's NOT in this PR (deliberately)

- **Landing-page agent-compat list update.** The marketing claim "works on Grok Build" needs operator verification with screenshots from a real Grok Build install, not just upstream-convention compatibility. The README is explicit about this — see the "What we are NOT claiming" section.

## Why this is genuine new value

Adds the 7th supported agent to ThumbGate's compatibility matrix (after Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode) without writing new code. xAI did the integration work for us by adopting the standard.

## Test plan

- [x] Tests still pass (no source code changed)
- [x] Adapter directory follows existing convention
- [x] CLAUDE.md Honesty Protocol respected — no unverified "works on X" claim shipped to landing