### PR TITLE
feat(hero,pricing): consultancy-wedge H1 + counter-position Pro vs memory layers (hypothesis-grade, do not auto-merge)

### DIFF
--- a/.changeset/hero-pro-copy-rewrite.md
+++ b/.changeset/hero-pro-copy-rewrite.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+Copy reposition: hero H1 + lede now name the buyer (dev teams + consultancies) and concrete agent-failure modes (destructive command, force-push, refactor) instead of the abstract "stop paying for mistakes" framing.
+
+Pro $19 sub-headline counter-positions vs the memory-layer category (Mem0 Starter is $19/mo). Old: "Stop paying tokens to re-correct…". New: "Not a memory layer. A hard execution boundary your agent cannot bypass."
+
+Hypothesis-grade. Suggest A/B vs control if analytics support it.

--- a/public/index.html
+++ b/public/index.html
@@ -717,8 +717,8 @@ __GA_BOOTSTRAP__
 <section class="hero">
   <div class="container">
     <div class="hero-badge">👍 👎 Pre-action gates for AI coding agents</div>
-    <h1>Stop paying for the same AI mistake twice.</h1>
-    <p class="hero-lede">ThumbGate turns a single thumbs-down into a rule that blocks the next repeat before Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, or OpenCode runs the tool call.</p>
+    <h1>Your AI coding agent shouldn't ship the same bug twice.</h1>
+    <p class="hero-lede">ThumbGate captures one thumbs-down as a permanent pre-action gate. The next time your agent reaches for the same destructive command, force-push, or refactor you already rejected — it's blocked. Built for dev teams and consultancies who can't afford repeat mistakes in client work. Works with Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, and OpenCode.</p>
 
     <div class="hero-proof-card" aria-label="ThumbGate blocking example">
       <div class="terminal-row muted">$ agent attempts risky action</div>
@@ -1262,7 +1262,7 @@ __GA_BOOTSTRAP__
       <div class="price-card pro" data-price-dollars="19">
         <div class="tier">Pro</div>
         <div class="price">$19<span style="font-size:16px;color:var(--text-dim)">/mo</span></div>
-        <div class="price-sub">Stop paying tokens to re-correct the same agent mistake across sessions.</div>
+        <div class="price-sub">Not a memory layer. A hard execution boundary your agent cannot bypass.</div>
         <ul>
           <li><strong>Block every repeat mistake</strong> — unlimited feedback captures and prevention rules (Free caps at 5 active rules)</li>
           <li><strong>Never re-explain a correction</strong> — lesson recall and search across sessions on every agent surface</li>


### PR DESCRIPTION
## What

**Hypothesis-grade copy changes. NOT auto-merged. Wants a CEO eyeball before going live.**

### Hero (`public/index.html` ~line 720)

H1:
- Before: *"Stop paying for the same AI mistake twice."*
- After: *"Your AI coding agent shouldn't ship the same bug twice."*

Lede rewritten to name the target buyer (dev teams + consultancies shipping client work) and concrete failure modes (destructive command, force-push, refactor) rather than the abstract "stop paying for mistakes" framing.

### Pricing — Pro $19 sub-headline (`public/index.html` ~line 1265)

- Before: *"Stop paying tokens to re-correct the same agent mistake across sessions."*
- After: *"Not a memory layer. A hard execution boundary your agent cannot bypass."*

## Why

### Hero
Current H1 leads with a verb and is abstract ("paying for mistakes" — paying what? for what?). Proposed H1 names the visceral buyer pain: an agent shipping a bug into a client repo. Lede shift narrows the target persona toward dev teams + consultancies who can't afford agent-shipped repeats in client work.

### Pro counter-positioning
Mem0 Starter is also **$19/mo** (50K memories, 5K retrieval calls). 53k GitHub stars. AWS exclusive memory provider for the Agent SDK. At identical price points, buyers comparison-shop ThumbGate against Mem0 on the memory-category axis — an axis where Mem0 has every advantage.

Current Pro sub-copy ("Stop paying tokens to re-correct") competes with Mem0 on the same memory/recall efficiency axis. Proposed sub-copy collapses the comparison: ThumbGate is **enforcement**, not memory. Different category, different buy.

Source: web search 2026-05-18, multiple comparison articles confirm Mem0 Starter $19/mo + AWS Agent SDK exclusivity. Re-verify before quoting in any external content; pricing pages change.

## What this does NOT fix

This PR does nothing for the actual #1 revenue blocker, which is the Stripe-side funnel collapse (1000 sessions / 0 paid on `acct_1TWIXn73`, per commit ef92c9d). Until charges flow, even the world's best hero copy converts at 0%.

Apply this only after the Stripe-side diagnostic from `scripts/stripe-checkout-diagnostic.js` clears.

## Why not auto-merged

1. Hero + pricing copy is brand-tier. AI-authored marketing copy should not auto-ship.
2. Both changes are hypothesis-grade, not bug fixes. They might convert worse than the control.
3. A/B test if any analytics infrastructure can support it. Otherwise: read it once, decide.

## Tests

78/78 landing tests pass:

```
$ node --test tests/public-landing.test.js tests/landing-page-claims.test.js tests/pro-landing.test.js
# tests 78
# pass 78
```

## Provenance

Authored by Claude in a chat session, pushed via `gh` CLI authenticated as `IgorGanapolsky`.
