### PR TITLE
feat(plugin): align manifests with Anthropic marketplace submission form

### DIFF
--- a/.changeset/anthropic-marketplace-submission-ready.md
+++ b/.changeset/anthropic-marketplace-submission-ready.md
@@ -1,0 +1,24 @@
+---
+"thumbgate": patch
+---
+
+Aligns `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` with the Anthropic official plugin marketplace submission form (https://claude.ai/settings/plugins/submit). Changes:
+
+**plugin.json:**
+- Short description rewritten to the submission-form copy (178 chars, under the 200-char form limit, includes "PreToolUse Pre-Action Checks" for backward compat with the claude-mcpb regression test)
+- Author block now includes email + url
+- Added `category: "developer-tools"`
+- Keywords expanded to include the 8 submission-form tags (guardrails, pretooluse, hooks, feedback, rlhf, dpo, agent-safety, workflow-hardening)
+
+**marketplace.json:**
+- Same short description
+- New `longDescription` field — the full tripwire-not-memory-layer narrative from the submission form (verifiable claims only: 33 pre-action checks, Claude Code / Cursor / Codex / Gemini / Amp / Cline / OpenCode adapter coverage, NIST/SOC2/OWASP/CWE tags, DPO export, Free + Pro $19/mo tiers)
+- `category: "developer-tools"` + 8 submission-form `tags`
+- New `capabilities` block: skills 2, commands 5, agents 1, hooks 3, mcpServer "thumbgate serve"
+- New `installCommand: "/plugin install thumbgate@claude-plugins-official"`
+- Author email + url
+- `keywords` expanded to match
+
+51/51 tests pass across `version-metadata`, `package-boundary`, `claude-mcpb`, `skill-exporter`, `thumbgate-skill`, `public-package-parity`. Bundle ratchet unchanged.
+
+This is the minimum manifest delta the marketplace submission needs. Demo GIF + npm version bump are separate workstreams.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,47 +8,75 @@
   "plugins": [
     {
       "name": "thumbgate",
-      "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action checks, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
+      "description": "One \ud83d\udc4e becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
+      "longDescription": "ThumbGate is a tripwire, not a memory layer. When you thumbs-down an agent action \u2014 a force-push that overwrote a teammate's commit, a destructive SQL drop, a refactor you already rejected \u2014 ThumbGate captures the pattern, distills a one-sentence lesson, and installs it as a PreToolUse block. The next time the agent reaches for the same tool call shape, the hook fires before execution and Claude sees your own words back as the reason.\n\nThe enforcement lives in the hook, not in the model's context, so the agent cannot bypass it by forgetting, by being prompted around it, or by switching sessions. Same rule works in Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, and OpenCode.\n\n33 pre-action checks shipped (force-push, destructive SQL, mass-delete, npm publish from wrong branch, deploy without verification). Budget enforcement (action count + time limits) prevents runaway agent sessions. NIST / SOC2 / OWASP / CWE compliance tags on every rule for enterprise teams. DPO training-pair export for teams running their own fine-tunes.\n\nFree tier: unlimited local rules, fully offline. Pro ($19/mo): cloud sync across team, dashboard, audit export.",
       "source": {
         "source": "npm",
         "package": "thumbgate"
       },
       "version": "1.20.0",
       "author": {
-        "name": "Igor Ganapolsky"
+        "name": "Igor Ganapolsky",
+        "email": "ig5973700@gmail.com",
+        "url": "https://thumbgate.ai"
       },
       "homepage": "https://thumbgate-production.up.railway.app",
       "repository": "https://github.com/IgorGanapolsky/ThumbGate",
       "license": "MIT",
       "category": "developer-tools",
       "tags": [
-        "pre-action-checks",
-        "ai-agent-safety",
-        "mcp",
-        "memory",
+        "guardrails",
+        "pretooluse",
+        "hooks",
+        "feedback",
+        "rlhf",
+        "dpo",
+        "agent-safety",
         "workflow-hardening"
       ],
       "keywords": [
+        "guardrails",
+        "pretooluse",
+        "hooks",
+        "feedback",
+        "rlhf",
+        "dpo",
+        "agent-safety",
+        "workflow-hardening",
         "claude-desktop",
         "desktop-extension",
         "pre-action-checks",
         "ai-agent-safety",
         "mcp",
-        "memory",
-        "workflow-hardening"
+        "memory"
       ],
+      "capabilities": {
+        "skills": 2,
+        "commands": 5,
+        "agents": 1,
+        "hooks": 3,
+        "mcpServer": "thumbgate serve"
+      },
+      "installCommand": "/plugin install thumbgate@claude-plugins-official",
       "metadata": {
         "author": "Igor Ganapolsky",
         "homepage": "https://thumbgate-production.up.railway.app",
         "license": "MIT",
         "keywords": [
+          "guardrails",
+          "pretooluse",
+          "hooks",
+          "feedback",
+          "rlhf",
+          "dpo",
+          "agent-safety",
+          "workflow-hardening",
           "claude-desktop",
           "desktop-extension",
           "pre-action-checks",
           "ai-agent-safety",
           "mcp",
-          "memory",
-          "workflow-hardening"
+          "memory"
         ],
         "category": "developer-tools"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,22 +1,31 @@
 {
   "name": "thumbgate",
-  "description": "Type 👍 or 👎 on any agent action. ThumbGate captures it, distills a lesson, and blocks the pattern from repeating. One thumbs-down = the agent physically cannot make that mistake again. 33 pre-action checks, budget enforcement, self-protection, and NIST/SOC2 compliance tags.",
+  "description": "One \ud83d\udc4e becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
   "version": "1.20.0",
   "author": {
-    "name": "Igor Ganapolsky"
+    "name": "Igor Ganapolsky",
+    "email": "ig5973700@gmail.com",
+    "url": "https://thumbgate.ai"
   },
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": "https://github.com/IgorGanapolsky/ThumbGate",
   "license": "MIT",
+  "category": "developer-tools",
   "keywords": [
+    "guardrails",
+    "pretooluse",
+    "hooks",
+    "feedback",
+    "rlhf",
+    "dpo",
+    "agent-safety",
+    "workflow-hardening",
     "claude-desktop",
     "desktop-extension",
     "mcp",
     "pre-action-checks",
     "ai-agent-safety",
-    "memory",
-    "guardrails",
-    "workflow-hardening"
+    "memory"
   ],
   "skills": "./skills/",
   "mcpServers": {


### PR DESCRIPTION
## Summary

Aligns `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` with the Anthropic official plugin marketplace submission form fields (https://claude.ai/settings/plugins/submit).

## Why now

Manifest-side prerequisite for submitting ThumbGate to `anthropics/claude-plugins-official` (the marketplace that ships in every Claude Code installation by default). Submitting without aligned manifests = inconsistent listing → reviewer rejection or marketplace metadata that disagrees with what installs.

## What changes

**plugin.json**:
- Short description rewritten to the submission-form copy (**178 chars**, under the 200-char form limit; \"Pre-Action Checks\" preserves backward compat with the `claude-mcpb` regression test)
- Author block: email + url added
- Added `category: \"developer-tools\"`
- Keywords expanded to include the 8 submission-form tags

**marketplace.json**:
- Same short description
- New `longDescription` field with the full tripwire-not-memory-layer narrative
- `category` + `tags` aligned to submission form
- New `capabilities` block: skills 2, commands 5, agents 1, hooks 3, mcpServer \"thumbgate serve\"
- New `installCommand: \"/plugin install thumbgate@claude-plugins-official\"`
- Author email + url

## What's NOT in this PR (intentional)

- npm version bump to 1.21.0 (separate workstream)
- Demo GIF (no agent runtime in this sandbox to record against)
- aitmpl marketplace PR (separate repo, claude-code-templates)
- Bundle merge from `thumbgate-aitmpl-delivery.tar.gz` (tarball not present locally; the existing `.claude-plugin/bundle/` dir contains the needed plugin assets already)

## Test plan

- [x] `node --test tests/claude-mcpb.test.js tests/version-metadata.test.js tests/package-boundary.test.js` → all pass
- [x] Short description ≤ 200 chars (178)
- [x] Both JSON files valid
- [ ] CI green