### PR TITLE
Bound Railway CLI command hangs in deploy workflows

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -30,6 +30,8 @@ jobs:
       RAILWAY_LOG_LINES: ${{ vars.RAILWAY_LOG_LINES || '200' }}
       RAILWAY_HTTP_LOG_LINES: ${{ vars.RAILWAY_HTTP_LOG_LINES || '50' }}
       RAILWAY_VARIABLE_SYNC_REQUIRED: ${{ vars.RAILWAY_VARIABLE_SYNC_REQUIRED || 'false' }}
+      RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS || '45' }}
+      RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS || '180' }}
       THUMBGATE_PUBLIC_APP_ORIGIN: ${{ vars.THUMBGATE_PUBLIC_APP_ORIGIN || 'https://thumbgate-production.up.railway.app' }}
       THUMBGATE_BILLING_API_BASE_URL: ${{ vars.THUMBGATE_BILLING_API_BASE_URL || vars.THUMBGATE_PUBLIC_APP_ORIGIN || 'https://thumbgate-production.up.railway.app' }}
       THUMBGATE_FEEDBACK_DIR: ${{ vars.THUMBGATE_FEEDBACK_DIR }}
@@ -121,8 +123,9 @@ jobs:
             local attempt=1
             local max_attempts=4
             local sleep_seconds=10
+            local timeout_seconds="${RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS:-45}"
 
-            until "$@"; do
+            until timeout --foreground "${timeout_seconds}s" "$@"; do
               if [ "$attempt" -ge "$max_attempts" ]; then
                 echo "Railway command failed after $attempt attempts: $description"
                 return 1
@@ -184,8 +187,9 @@ jobs:
             local attempt=1
             local max_attempts=4
             local sleep_seconds=15
+            local timeout_seconds="${RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS:-180}"
 
-            until "$@"; do
+            until timeout --foreground "${timeout_seconds}s" "$@"; do
               if [ "$attempt" -ge "$max_attempts" ]; then
                 echo "Railway command failed after $attempt attempts: $description"
                 return 1

--- a/.github/workflows/railway-diagnostics.yml
+++ b/.github/workflows/railway-diagnostics.yml
@@ -46,6 +46,7 @@ jobs:
       RAILWAY_LOG_LINES: ${{ github.event.inputs.log_lines || '200' }}
       RAILWAY_HTTP_LOG_LINES: ${{ github.event.inputs.http_log_lines || '50' }}
       RAILWAY_SETTLE_SECONDS: ${{ github.event.inputs.settle_seconds || '20' }}
+      RAILWAY_CLI_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_CLI_COMMAND_TIMEOUT_SECONDS || '60' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -76,13 +77,13 @@ jobs:
         if: github.event.inputs.action == 'restart'
         run: |
           set -o pipefail
-          railway restart --service "$RAILWAY_SERVICE" --yes --json | tee railway-restart.json
+          timeout --foreground "${RAILWAY_CLI_COMMAND_TIMEOUT_SECONDS}s" railway restart --service "$RAILWAY_SERVICE" --yes --json | tee railway-restart.json
 
       - name: Redeploy Railway service
         if: github.event.inputs.action == 'redeploy'
         run: |
           set -o pipefail
-          railway redeploy --service "$RAILWAY_SERVICE" --yes --json | tee railway-redeploy.json
+          timeout --foreground "${RAILWAY_CLI_COMMAND_TIMEOUT_SECONDS}s" railway redeploy --service "$RAILWAY_SERVICE" --yes --json | tee railway-redeploy.json
 
       - name: Allow Railway action to settle
         if: github.event.inputs.action != 'inspect'

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -233,6 +233,8 @@ test('Deploy to Railway workflow is the single authoritative Railway deploy lane
   assert.match(workflow, /RAILWAY_LOG_LINES/);
   assert.match(workflow, /RAILWAY_HTTP_LOG_LINES/);
   assert.match(workflow, /RAILWAY_VARIABLE_SYNC_REQUIRED/);
+  assert.match(workflow, /RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS/);
+  assert.match(workflow, /RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS/);
   assert.match(workflow, /DEPLOYABLE_PATTERN=.*\\\.github\/workflows\/deploy-railway\\\.yml/);
   assert.match(workflow, /secrets\.THUMBGATE_API_KEY/);
   assert.match(workflow, /RESEND_API_KEY:\s*\$\{\{\s*secrets\.RESEND_API_KEY\s*\}\}/);
@@ -306,6 +308,8 @@ test('Railway diagnostics workflow can inspect or bounce the service with the li
   assert.match(workflow, /RAILWAY_SERVICE/);
   assert.match(workflow, /railway restart --service "\$RAILWAY_SERVICE" --yes --json/);
   assert.match(workflow, /railway redeploy --service "\$RAILWAY_SERVICE" --yes --json/);
+  assert.match(workflow, /timeout --foreground "\$\{RAILWAY_CLI_COMMAND_TIMEOUT_SECONDS\}s" railway restart/);
+  assert.match(workflow, /timeout --foreground "\$\{RAILWAY_CLI_COMMAND_TIMEOUT_SECONDS\}s" railway redeploy/);
   assert.match(workflow, /bash scripts\/capture-railway-diagnostics\.sh railway-diagnostics/);
   assert.match(workflow, /actions\/upload-artifact@v7/);
 });
@@ -341,6 +345,7 @@ test('Deploy to Railway workflow retries transient Railway CLI failures before f
   assert.match(workflow, /Railway variable sync failed after retries; continuing to deploy with existing Railway runtime variables/);
   assert.match(workflow, /RAILWAY_VARIABLE_SYNC_REQUIRED=true/);
   assert.match(workflow, /Health verification must still prove the new build/);
+  assert.match(workflow, /timeout --foreground "\$\{timeout_seconds\}s" "\$@"/);
   assert.match(workflow, /deploy with railway up/);
   assert.match(workflow, /Railway command failed \(attempt \$attempt\/\$max_attempts\)/);
   assert.match(workflow, /Retrying in \$\{sleep_seconds\}s/);


### PR DESCRIPTION
## Summary\n- add hard timeouts around Railway variable and deploy CLI commands\n- keep deploy success gated on build-SHA health verification\n- add timeouts to Railway diagnostics restart/redeploy commands\n\n## Verification\n- npm run test:deployment\n- git diff --check\n- prior main deploy reached variable sync, then hung in railway up until cancelled