### PR TITLE
Skip Railway variable sync by default

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -29,6 +29,7 @@ jobs:
       RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS: ${{ vars.RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS || '20' }}
       RAILWAY_LOG_LINES: ${{ vars.RAILWAY_LOG_LINES || '200' }}
       RAILWAY_HTTP_LOG_LINES: ${{ vars.RAILWAY_HTTP_LOG_LINES || '50' }}
+      RAILWAY_SYNC_VARIABLES: ${{ vars.RAILWAY_SYNC_VARIABLES || 'false' }}
       RAILWAY_VARIABLE_SYNC_REQUIRED: ${{ vars.RAILWAY_VARIABLE_SYNC_REQUIRED || 'false' }}
       RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS || '45' }}
       RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS || '180' }}
@@ -141,6 +142,11 @@ jobs:
           SERVICE_ARGS=()
           if [ -n "$RAILWAY_SERVICE" ]; then
             SERVICE_ARGS+=(--service "$RAILWAY_SERVICE")
+          fi
+
+          if [ "$RAILWAY_SYNC_VARIABLES" != "true" ]; then
+            echo "Railway variable sync skipped because RAILWAY_SYNC_VARIABLES is not true. Deploy will use existing Railway runtime variables and stamped build metadata."
+            exit 0
           fi
 
           sync_railway_variables() {

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -232,6 +232,7 @@ test('Deploy to Railway workflow is the single authoritative Railway deploy lane
   assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS/);
   assert.match(workflow, /RAILWAY_LOG_LINES/);
   assert.match(workflow, /RAILWAY_HTTP_LOG_LINES/);
+  assert.match(workflow, /RAILWAY_SYNC_VARIABLES/);
   assert.match(workflow, /RAILWAY_VARIABLE_SYNC_REQUIRED/);
   assert.match(workflow, /RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS/);
   assert.match(workflow, /RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS/);
@@ -342,6 +343,7 @@ test('Deploy to Railway workflow retries transient Railway CLI failures before f
   assert.match(workflow, /set RESEND_API_KEY/);
   assert.match(workflow, /set THUMBGATE_TRIAL_EMAIL_FROM/);
   assert.match(workflow, /sync_railway_variables\(\) \{/);
+  assert.match(workflow, /Railway variable sync skipped because RAILWAY_SYNC_VARIABLES is not true/);
   assert.match(workflow, /Railway variable sync failed after retries; continuing to deploy with existing Railway runtime variables/);
   assert.match(workflow, /RAILWAY_VARIABLE_SYNC_REQUIRED=true/);
   assert.match(workflow, /Health verification must still prove the new build/);


### PR DESCRIPTION
## Summary\n- make Railway variable sync opt-in via RAILWAY_SYNC_VARIABLES=true\n- keep existing runtime variables and stamped build metadata for normal deploy recovery\n- preserve strict failure mode with RAILWAY_VARIABLE_SYNC_REQUIRED=true when explicitly syncing\n\n## Verification\n- npm run test:deployment\n- git diff --check\n- observed main deploy after #2226 still spending too long in variable sync before reaching deploy