### PR TITLE
fix(deploy): hard cap Railway CLI hangs

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -32,7 +32,12 @@ jobs:
       RAILWAY_SYNC_VARIABLES: ${{ vars.RAILWAY_SYNC_VARIABLES || 'false' }}
       RAILWAY_VARIABLE_SYNC_REQUIRED: ${{ vars.RAILWAY_VARIABLE_SYNC_REQUIRED || 'false' }}
       RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS || '45' }}
-      RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS || '180' }}
+      RAILWAY_VARIABLE_COMMAND_KILL_AFTER_SECONDS: ${{ vars.RAILWAY_VARIABLE_COMMAND_KILL_AFTER_SECONDS || '15' }}
+      RAILWAY_DEPLOY_COMMAND_MAX_ATTEMPTS: ${{ vars.RAILWAY_DEPLOY_COMMAND_MAX_ATTEMPTS || '2' }}
+      RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS: ${{ vars.RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS || '90' }}
+      RAILWAY_DEPLOY_COMMAND_KILL_AFTER_SECONDS: ${{ vars.RAILWAY_DEPLOY_COMMAND_KILL_AFTER_SECONDS || '15' }}
+      RAILWAY_POST_FAILURE_HEALTHCHECK_MAX_ATTEMPTS: ${{ vars.RAILWAY_POST_FAILURE_HEALTHCHECK_MAX_ATTEMPTS || '12' }}
+      RAILWAY_POST_FAILURE_HEALTHCHECK_SLEEP_SECONDS: ${{ vars.RAILWAY_POST_FAILURE_HEALTHCHECK_SLEEP_SECONDS || '10' }}
       THUMBGATE_PUBLIC_APP_ORIGIN: ${{ vars.THUMBGATE_PUBLIC_APP_ORIGIN || 'https://thumbgate-production.up.railway.app' }}
       THUMBGATE_BILLING_API_BASE_URL: ${{ vars.THUMBGATE_BILLING_API_BASE_URL || vars.THUMBGATE_PUBLIC_APP_ORIGIN || 'https://thumbgate-production.up.railway.app' }}
       THUMBGATE_FEEDBACK_DIR: ${{ vars.THUMBGATE_FEEDBACK_DIR }}
@@ -125,8 +130,9 @@ jobs:
             local max_attempts=4
             local sleep_seconds=10
             local timeout_seconds="${RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS:-45}"
+            local kill_after_seconds="${RAILWAY_VARIABLE_COMMAND_KILL_AFTER_SECONDS:-15}"
 
-            until timeout --foreground "${timeout_seconds}s" "$@"; do
+            until timeout --foreground --kill-after="${kill_after_seconds}s" "${timeout_seconds}s" "$@"; do
               if [ "$attempt" -ge "$max_attempts" ]; then
                 echo "Railway command failed after $attempt attempts: $description"
                 return 1
@@ -186,16 +192,18 @@ jobs:
           fi
       - name: Deploy to Railway
         if: steps.railway-config.outputs.enabled == 'true'
+        timeout-minutes: 8
         run: |
           retry_railway() {
             local description="$1"
             shift
             local attempt=1
-            local max_attempts=4
+            local max_attempts="${RAILWAY_DEPLOY_COMMAND_MAX_ATTEMPTS:-2}"
             local sleep_seconds=15
-            local timeout_seconds="${RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS:-180}"
+            local timeout_seconds="${RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS:-90}"
+            local kill_after_seconds="${RAILWAY_DEPLOY_COMMAND_KILL_AFTER_SECONDS:-15}"
 
-            until timeout --foreground "${timeout_seconds}s" "$@"; do
+            until timeout --foreground --kill-after="${kill_after_seconds}s" "${timeout_seconds}s" "$@"; do
               if [ "$attempt" -ge "$max_attempts" ]; then
                 echo "Railway command failed after $attempt attempts: $description"
                 return 1
@@ -209,8 +217,8 @@ jobs:
           }
 
           verify_live_build_sha_after_railway_failure() {
-            local max_attempts="${RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:-120}"
-            local sleep_seconds="${RAILWAY_HEALTHCHECK_SLEEP_SECONDS:-10}"
+            local max_attempts="${RAILWAY_POST_FAILURE_HEALTHCHECK_MAX_ATTEMPTS:-12}"
+            local sleep_seconds="${RAILWAY_POST_FAILURE_HEALTHCHECK_SLEEP_SECONDS:-10}"
             local connect_timeout_seconds="${RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS:-5}"
             local max_time_seconds="${RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS:-20}"
             local response_file

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -347,7 +347,12 @@ test('Deploy to Railway workflow retries transient Railway CLI failures before f
   assert.match(workflow, /Railway variable sync failed after retries; continuing to deploy with existing Railway runtime variables/);
   assert.match(workflow, /RAILWAY_VARIABLE_SYNC_REQUIRED=true/);
   assert.match(workflow, /Health verification must still prove the new build/);
-  assert.match(workflow, /timeout --foreground "\$\{timeout_seconds\}s" "\$@"/);
+  assert.match(workflow, /RAILWAY_VARIABLE_COMMAND_KILL_AFTER_SECONDS/);
+  assert.match(workflow, /RAILWAY_DEPLOY_COMMAND_MAX_ATTEMPTS/);
+  assert.match(workflow, /RAILWAY_DEPLOY_COMMAND_KILL_AFTER_SECONDS/);
+  assert.match(workflow, /RAILWAY_POST_FAILURE_HEALTHCHECK_MAX_ATTEMPTS/);
+  assert.match(workflow, /timeout-minutes:\s*8/);
+  assert.match(workflow, /timeout --foreground --kill-after="\$\{kill_after_seconds\}s" "\$\{timeout_seconds\}s" "\$@"/);
   assert.match(workflow, /deploy with railway up/);
   assert.match(workflow, /Railway command failed \(attempt \$attempt\/\$max_attempts\)/);
   assert.match(workflow, /Retrying in \$\{sleep_seconds\}s/);


### PR DESCRIPTION
## Summary
- Add a GitHub step timeout to the Railway deploy step so stuck `railway up` cannot hold the lane indefinitely.
- Add `timeout --kill-after` guards for Railway variable and deploy commands.
- Shorten deploy retry defaults and bound post-failure health probing separately from normal promotion verification.

## Verification
- npm run test:deployment
- git diff --check
- pre-commit guard
- pre-push guard

## Evidence from production deploy
- Main deploy run 26135587383 skipped variable sync quickly after #2228, then hung in `Deploy to Railway` for 15+ minutes and was cancelled.
- This patch makes that failure mode bounded and diagnosable.