### PR TITLE
fix(cli): wire Claude Code during init

### DIFF
--- a/.changeset/fix-claude-init-wiring.md
+++ b/.changeset/fix-claude-init-wiring.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Wire Claude Code during `thumbgate init` through the canonical hook installer, add CLI version flags, forward hook subcommands through installed-runtime fast paths, and make the default Claude statusline compact.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -41,13 +41,6 @@ const {
 } = require(path.join(__dirname, '..', 'scripts', 'mcp-config'));
 const { trackEvent } = require(path.join(__dirname, '..', 'scripts', 'cli-telemetry'));
 const {
-  cacheUpdateHookCommand,
-  preToolHookCommand,
-  sessionStartHookCommand,
-  statuslineCommand,
-  userPromptHookCommand,
-} = require(path.join(__dirname, '..', 'scripts', 'hook-runtime'));
-const {
   PRO_MONTHLY_PAYMENT_LINK,
   PRO_PRICE_LABEL,
 } = require(path.join(__dirname, '..', 'scripts', 'commercial-offer'));
@@ -395,84 +388,24 @@ function whichExists(cmd) {
 
 function setupClaude() {
   const mcpChanged = mergeMcpJson(path.join(CWD, '.mcp.json'), 'Claude Code', 'project');
+  const { wireHooks } = require(path.join(PKG_ROOT, 'scripts', 'auto-wire-hooks'));
+  const hookResult = wireHooks({ agent: 'claude-code' });
 
-  // Wire the canonical ThumbGate gate hooks (PreToolUse pre-action check,
-  // UserPromptSubmit, PostToolUse, SessionStart) through the shared wiring
-  // path so `init`, `init --agent claude-code`, and `install` all produce the
-  // same hook set. Before this, `install` shipped a Claude config with no
-  // PreToolUse gate — the core ThumbGate feature was silently missing.
-  let wireChanged = false;
-  try {
-    const { wireHooks } = require(path.join(PKG_ROOT, 'scripts', 'auto-wire-hooks'));
-    const wireResult = wireHooks({ agent: 'claude-code' });
-    if (wireResult.error) {
-      console.log(`  Claude Code: ${wireResult.error}`);
-    } else if (wireResult.changed) {
-      wireChanged = true;
-      const lifecycles = [...new Set(wireResult.added.map((h) => h.lifecycle))].join(', ');
-      console.log(`  Claude Code: wired gate hooks (${lifecycles})`);
+  if (hookResult.error) {
+    console.log(`  Claude Code hooks: ${hookResult.error}`);
+    return mcpChanged;
+  }
+
+  if (!hookResult.changed) {
+    console.log(`  Claude Code hooks: already configured at ${hookResult.settingsPath}`);
+  } else {
+    for (const h of hookResult.added) {
+      console.log(`  Claude Code: wired ${h.lifecycle} hook`);
     }
-  } catch (err) {
-    console.log(`  Claude Code: hook wiring skipped (${err.message})`);
+    console.log(`  Claude Code settings: ${hookResult.settingsPath}`);
   }
 
-  // Upsert Stop hook into .claude/settings.json for autonomous self-scoring
-  const settingsPath = path.join(CWD, '.claude', 'settings.json');
-  const stopHookCommand = 'bash scripts/hook-stop-self-score.sh';
-
-  let settings = { hooks: {} };
-  if (fs.existsSync(settingsPath)) {
-    try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch (_) { /* fresh */ }
-  }
-  settings.hooks = settings.hooks || {};
-
-  const stopAlreadyPresent = (settings.hooks.Stop || [])
-    .some(entry => (entry.hooks || []).some(h => h.command === stopHookCommand));
-
-  let hooksChanged = false;
-  if (!stopAlreadyPresent) {
-    settings.hooks.Stop = settings.hooks.Stop || [];
-    settings.hooks.Stop.push({ hooks: [{ type: 'command', command: stopHookCommand }] });
-    hooksChanged = true;
-    console.log('  Claude Code: installed Stop hook');
-  }
-
-  // Upsert PostToolUse hook for ThumbGate statusline cache updates
-  const cacheHookCommand = cacheUpdateHookCommand();
-  const originalPostToolUseCount = (settings.hooks.PostToolUse || []).length;
-  settings.hooks.PostToolUse = (settings.hooks.PostToolUse || []).filter(
-    (entry) => !(entry.hooks || []).some((h) => h.command && h.command !== cacheHookCommand && /(hook-thumbgate-cache-updater|cache-update\b)/.test(h.command))
-  );
-  if (settings.hooks.PostToolUse.length !== originalPostToolUseCount) {
-    hooksChanged = true;
-  }
-  const cacheAlreadyPresent = (settings.hooks.PostToolUse || [])
-    .some(entry => (entry.hooks || []).some(h => h.command === cacheHookCommand || (h.command && h.command.includes('cache-update'))));
-
-  if (!cacheAlreadyPresent) {
-    settings.hooks.PostToolUse = settings.hooks.PostToolUse || [];
-    settings.hooks.PostToolUse.push({
-      matcher: 'mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard',
-      hooks: [{ type: 'command', command: cacheHookCommand }]
-    });
-    hooksChanged = true;
-    console.log('  Claude Code: installed ThumbGate cache updater hook');
-  }
-
-  // Upsert statusLine for ThumbGate feedback display
-  const statuslineScript = statuslineCommand();
-  if (!settings.statusLine || settings.statusLine.command !== statuslineScript) {
-    settings.statusLine = { type: 'command', command: statuslineScript };
-    hooksChanged = true;
-    console.log('  Claude Code: installed ThumbGate status line');
-  }
-
-  if (hooksChanged) {
-    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-  }
-
-  return mcpChanged || hooksChanged || wireChanged;
+  return mcpChanged || hookResult.changed;
 }
 
 function setupCodex() {
@@ -744,7 +677,11 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
   let configured = 0;
 
   const platforms = [
-    { name: 'Claude Code', detect: [() => whichExists('claude'), () => fs.existsSync(path.join(HOME, '.claude'))], setup: setupClaude },
+    { name: 'Claude Code', detect: [
+      () => whichExists('claude'),
+      () => fs.existsSync(path.join(HOME, '.claude')),
+      () => fs.existsSync(path.join(CWD, '.claude')),
+    ], setup: setupClaude },
     { name: 'Codex', detect: [() => whichExists('codex'), () => fs.existsSync(path.join(HOME, '.codex'))], setup: setupCodex },
     { name: 'Gemini', detect: [() => whichExists('gemini'), () => fs.existsSync(path.join(HOME, '.gemini'))], setup: setupGemini },
     { name: 'Amp', detect: [() => whichExists('amp'), () => fs.existsSync(path.join(HOME, '.amp'))], setup: setupAmp },

--- a/scripts/hook-runtime.js
+++ b/scripts/hook-runtime.js
@@ -33,34 +33,34 @@ function publishedHookCommandsAvailable(version) {
   return available;
 }
 
-function resolveCliBaseCommand() {
+function resolveCliCommand(subcommand) {
   const version = packageVersion();
   if (publishedHookCommandsAvailable(version)) {
-    return publishedCliShellCommand(version);
+    return publishedCliShellCommand(version, [subcommand]);
   }
   if (isSourceCheckout(PKG_ROOT)) {
-    return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))}`;
+    return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))} ${subcommand}`;
   }
-  return publishedCliShellCommand(version);
+  return publishedCliShellCommand(version, [subcommand]);
 }
 
-function resolveCodexCliBaseCommand() {
+function resolveCodexCliCommand(subcommand) {
   const version = packageVersion();
   if (publishedHookCommandsAvailable(version)) {
-    return publishedCliShellCommand('latest', [], { preferInstalled: false });
+    return publishedCliShellCommand('latest', [subcommand], { preferInstalled: false });
   }
   if (isSourceCheckout(PKG_ROOT)) {
-    return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))}`;
+    return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))} ${subcommand}`;
   }
-  return publishedCliShellCommand('latest', [], { preferInstalled: false });
+  return publishedCliShellCommand('latest', [subcommand], { preferInstalled: false });
 }
 
 function buildPortableHookCommand(subcommand) {
-  return `${resolveCliBaseCommand()} ${subcommand}`;
+  return resolveCliCommand(subcommand);
 }
 
 function buildCodexPortableHookCommand(subcommand) {
-  return `${resolveCodexCliBaseCommand()} ${subcommand}`;
+  return resolveCodexCliCommand(subcommand);
 }
 
 function preToolHookCommand() {
@@ -115,8 +115,8 @@ module.exports = {
   packageVersion,
   publishedHookCommandsAvailable,
   preToolHookCommand,
-  resolveCodexCliBaseCommand,
-  resolveCliBaseCommand,
+  resolveCodexCliCommand,
+  resolveCliCommand,
   sessionStartHookCommand,
   statuslineCommand,
   userPromptHookCommand,

--- a/scripts/prove-packaged-runtime.js
+++ b/scripts/prove-packaged-runtime.js
@@ -249,8 +249,20 @@ async function runPackagedRuntimeSmoke(options = {}) {
     if (!initialStatusline.includes(`ThumbGate v${expectedVersion}`)) {
       throw new Error(`Statusline version mismatch before boot: ${initialStatusline.trim()}`);
     }
-    if (!/(Dashboard|Dashboard…)/.test(initialStatusline) || !/(Lessons|Lessons…)/.test(initialStatusline)) {
-      throw new Error(`Statusline missing dashboard affordances before boot: ${initialStatusline.trim()}`);
+    if (/Common commands:|Detect agent and wire ThumbGate hooks/.test(initialStatusline)) {
+      throw new Error(`Statusline rendered CLI help instead of compact status: ${initialStatusline.trim()}`);
+    }
+    if (/(Dashboard|Dashboard…|Lessons|Lessons…)/.test(initialStatusline)) {
+      throw new Error(`Default statusline should stay compact before boot: ${initialStatusline.trim()}`);
+    }
+
+    const verboseEnv = {
+      ...env,
+      THUMBGATE_STATUSLINE_VERBOSE: '1',
+    };
+    const initialVerboseStatusline = renderStatusline(runtimeBin, projectDir, verboseEnv);
+    if (!/(Dashboard|Dashboard…)/.test(initialVerboseStatusline) || !/(Lessons|Lessons…)/.test(initialVerboseStatusline)) {
+      throw new Error(`Verbose statusline missing dashboard affordances before boot: ${initialVerboseStatusline.trim()}`);
     }
 
     const health = await waitForHealthy(origin, expectedVersion, Number(options.timeoutMs || DEFAULT_TIMEOUT_MS));
@@ -263,7 +275,7 @@ async function runPackagedRuntimeSmoke(options = {}) {
       throw new Error(`Packaged lessons returned ${lessons.statusCode}`);
     }
 
-    const readyStatusline = renderStatusline(runtimeBin, projectDir, env);
+    const readyStatusline = renderStatusline(runtimeBin, projectDir, verboseEnv);
     if (!/(Dashboard|Dashboard…)/.test(readyStatusline)) {
       throw new Error(`Ready statusline missing dashboard label: ${readyStatusline.trim()}`);
     }

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -7,6 +7,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 case "$SCRIPT_DIR" in *[!a-zA-Z0-9/_.-]*) echo "ThumbGate: invalid script path"; exit 1;; esac
 LOCAL_API_ORIGIN="${THUMBGATE_LOCAL_API_ORIGIN:-http://localhost:3456}"
+STATUSLINE_VERBOSE="${THUMBGATE_STATUSLINE_VERBOSE:-0}"
 
 # ── Parse Claude Code session JSON from stdin ─────────────────────
 eval "$(cat | jq -r '
@@ -92,17 +93,19 @@ fi
 LINK_STATE="offline"
 UP_URL=""; DOWN_URL=""; DASHBOARD_URL=""; LESSONS_URL=""
 DASHBOARD_LABEL="Dashboard"; LESSONS_LABEL="Lessons"
-_LINKS_JSON=$(node "${SCRIPT_DIR}/statusline-links.js" 2>/dev/null)
-if [ -n "$_LINKS_JSON" ]; then
-  eval "$(echo "$_LINKS_JSON" | jq -r '
-    @sh "LINK_STATE=\(.state // "offline")",
-    @sh "UP_URL=\(.upUrl // "")",
-    @sh "DOWN_URL=\(.downUrl // "")",
-    @sh "DASHBOARD_URL=\(.dashboardUrl // "")",
-    @sh "LESSONS_URL=\(.lessonsUrl // "")",
-    @sh "DASHBOARD_LABEL=\(.dashboardLabel // "Dashboard")",
-    @sh "LESSONS_LABEL=\(.lessonsLabel // "Lessons")"
-  ' 2>/dev/null)"
+if [[ "$STATUSLINE_VERBOSE" = "1" ]]; then
+  _LINKS_JSON=$(node "${SCRIPT_DIR}/statusline-links.js" 2>/dev/null)
+  if [ -n "$_LINKS_JSON" ]; then
+    eval "$(echo "$_LINKS_JSON" | jq -r '
+      @sh "LINK_STATE=\(.state // "offline")",
+      @sh "UP_URL=\(.upUrl // "")",
+      @sh "DOWN_URL=\(.downUrl // "")",
+      @sh "DASHBOARD_URL=\(.dashboardUrl // "")",
+      @sh "LESSONS_URL=\(.lessonsUrl // "")",
+      @sh "DASHBOARD_LABEL=\(.dashboardLabel // "Dashboard")",
+      @sh "LESSONS_LABEL=\(.lessonsLabel // "Lessons")"
+    ' 2>/dev/null)"
+  fi
 fi
 
 # ── ThumbGate package metadata ────────────────────────────────────────
@@ -117,13 +120,15 @@ fi
 
 # ── Repo context (branch / work item / PR) ───────────────────────────
 BRANCH_NAME=""; WORK_ITEM_LABEL=""; PR_LABEL=""
-_CONTEXT_JSON=$(node "${SCRIPT_DIR}/statusline-context.js" 2>/dev/null)
-if [[ -n "$_CONTEXT_JSON" ]]; then
-  eval "$(echo "$_CONTEXT_JSON" | jq -r '
-    @sh "BRANCH_NAME=\(.branchName // "")",
-    @sh "WORK_ITEM_LABEL=\(.workItemLabel // "")",
-    @sh "PR_LABEL=\(.prLabel // "")"
-  ' 2>/dev/null)"
+if [[ "$STATUSLINE_VERBOSE" = "1" ]]; then
+  _CONTEXT_JSON=$(node "${SCRIPT_DIR}/statusline-context.js" 2>/dev/null)
+  if [[ -n "$_CONTEXT_JSON" ]]; then
+    eval "$(echo "$_CONTEXT_JSON" | jq -r '
+      @sh "BRANCH_NAME=\(.branchName // "")",
+      @sh "WORK_ITEM_LABEL=\(.workItemLabel // "")",
+      @sh "PR_LABEL=\(.prLabel // "")"
+    ' 2>/dev/null)"
+  fi
 fi
 
 # ── Control Tower stats ──────────────────────────────────────────
@@ -139,14 +144,16 @@ fi
 
 # ── Latest lesson (data available for extensions; not rendered in statusbar) ──
 LESSON_TEXT=""; LESSON_ID=""; LESSON_LABEL=""; LESSON_LINK=""
-_LESSON_JSON=$(node "${SCRIPT_DIR}/statusline-lesson.js" 2>/dev/null)
-if [[ -n "$_LESSON_JSON" ]]; then
-  eval "$(echo "$_LESSON_JSON" | jq -r '
-    @sh "LESSON_TEXT=\(.text // "")",
-    @sh "LESSON_ID=\(.lessonId // "")",
-    @sh "LESSON_LABEL=\(.label // "")",
-    @sh "LESSON_LINK=\(.link // "")"
-  ' 2>/dev/null)"
+if [[ "$STATUSLINE_VERBOSE" = "1" ]]; then
+  _LESSON_JSON=$(node "${SCRIPT_DIR}/statusline-lesson.js" 2>/dev/null)
+  if [[ -n "$_LESSON_JSON" ]]; then
+    eval "$(echo "$_LESSON_JSON" | jq -r '
+      @sh "LESSON_TEXT=\(.text // "")",
+      @sh "LESSON_ID=\(.lessonId // "")",
+      @sh "LESSON_LABEL=\(.label // "")",
+      @sh "LESSON_LINK=\(.link // "")"
+    ' 2>/dev/null)"
+  fi
 fi
 
 # ── Colors ────────────────────────────────────────────────────────
@@ -199,8 +206,10 @@ LINE="${LINE:+${LINE} · }ThumbGate v${TG_VERSION} · ${TG_TIER}"
 if [[ "$UP" = "0" && "$DOWN" = "0" ]]; then
   LINE="${D}${LINE}${RST} · no feedback yet"
   [[ -n "$PR_LABEL" ]] && LINE="${LINE} · ${D}${PR_LABEL}${RST}"
-  LINE="${LINE} · ${C}${DASHBOARD_LINK}${RST} · ${M}${LESSONS_LINK}${RST}"
-  [[ -n "$LATEST_LESSON_LINK" ]] && LINE="${LINE} · ${D}${LATEST_LESSON_LINK}${RST}"
+  if [[ "$STATUSLINE_VERBOSE" = "1" ]]; then
+    LINE="${LINE} · ${C}${DASHBOARD_LINK}${RST} · ${M}${LESSONS_LINK}${RST}"
+    [[ -n "$LATEST_LESSON_LINK" ]] && LINE="${LINE} · ${D}${LATEST_LESSON_LINK}${RST}"
+  fi
   printf '%b\n' "$LINE"
 else
   LINE="${LINE} · ${G}${BD}${UP}${RST}${UP_LINK} ${R}${BD}${DOWN}${RST}${DOWN_LINK} ${ARROW}"
@@ -210,8 +219,10 @@ else
   [[ "${AT_RISK:-0}" -gt 0 ]] && LINE="${LINE} ${R}${AT_RISK}⚠${RST}"
   [[ "${ANOMALIES:-0}" -gt 0 ]] && LINE="${LINE} ${R}${ANOMALIES}☠${RST}"
   [[ -n "$PR_LABEL" ]] && LINE="${LINE} · ${D}${PR_LABEL}${RST}"
-  LINE="${LINE} · ${C}${DASHBOARD_LINK}${RST} · ${M}${LESSONS_LINK}${RST}"
-  [[ -n "$LATEST_LESSON_LINK" ]] && LINE="${LINE} · ${D}${LATEST_LESSON_LINK}${RST}"
+  if [[ "$STATUSLINE_VERBOSE" = "1" ]]; then
+    LINE="${LINE} · ${C}${DASHBOARD_LINK}${RST} · ${M}${LESSONS_LINK}${RST}"
+    [[ -n "$LATEST_LESSON_LINK" ]] && LINE="${LINE} · ${D}${LATEST_LESSON_LINK}${RST}"
+  fi
 
   printf '%b\n' "$LINE"
 fi

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -21,6 +21,7 @@ const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const { PRO_MONTHLY_PAYMENT_LINK } = require('../scripts/commercial-offer');
 const { resolveLocalServerPath } = require('../scripts/mcp-config');
+const PKG_VERSION = require('../package.json').version;
 
 const CLI = path.resolve(__dirname, '../bin/cli.js');
 const PKG_ROOT = path.resolve(__dirname, '..');
@@ -1909,6 +1910,42 @@ describe('bin/cli.js', () => {
     fs.rmSync(isolatedHome, { recursive: true, force: true });
   });
 
+  test('init detects Claude Code and wires the canonical PreToolUse hook bundle', () => {
+    const isolatedDir = makeTmpDir();
+    const isolatedHome = makeTmpDir();
+    fs.mkdirSync(path.join(isolatedHome, '.claude'), { recursive: true });
+
+    const result = runCliSync(['init'], {
+      cwd: isolatedDir,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        USERPROFILE: isolatedHome,
+        PATH: '/usr/bin:/bin',
+        THUMBGATE_NO_NUDGE: '1',
+        THUMBGATE_PUBLISH_STATE: 'unpublished',
+      },
+    });
+
+    assert.equal(result.status, 0, `init failed:\n${result.stderr}`);
+    assert.match(result.stdout, /Claude Code/);
+
+    const settingsPath = path.join(isolatedHome, '.claude', 'settings.local.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.equal(settings.hooks.PreToolUse[0].matcher, 'Bash|Edit|Write|MultiEdit');
+    assert.match(settings.hooks.PreToolUse[0].hooks[0].command, /gate-check/);
+    assert.match(settings.hooks.UserPromptSubmit[0].hooks[0].command, /hook-auto-capture/);
+    assert.match(settings.hooks.PostToolUse[0].hooks[0].command, /cache-update/);
+    assert.match(settings.hooks.SessionStart[0].hooks[0].command, /session-start/);
+    assert.match(settings.statusLine.command, /statusline-render/);
+
+    const sharedSettings = JSON.parse(fs.readFileSync(path.join(isolatedHome, '.claude', 'settings.json'), 'utf8'));
+    assert.match(sharedSettings.statusLine.command, /statusline-render/);
+
+    fs.rmSync(isolatedDir, { recursive: true, force: true });
+    fs.rmSync(isolatedHome, { recursive: true, force: true });
+  });
+
   test('init --wire-hooks accepts split --agent value and writes Codex hooks plus status line', () => {
     const isolatedDir = makeTmpDir();
     const isolatedHome = makeTmpDir();
@@ -2316,6 +2353,12 @@ describe('bin/cli.js', () => {
       result.stdout.includes('Detecting platforms'),
       `Expected platform detection in output:\n${result.stdout}`
     );
+  });
+
+  test('--version prints package version', () => {
+    const result = runCliSync(['--version'], { cwd: tmpDir });
+    assert.equal(result.status, 0, `--version failed:\n${result.stderr}`);
+    assert.equal(result.stdout.trim(), PKG_VERSION);
   });
 
   test('capture --feedback=up routes to full engine', () => {

--- a/tests/statusline.test.js
+++ b/tests/statusline.test.js
@@ -57,6 +57,7 @@ function runStatusline(cachePayload, extraEnv = {}) {
         ...process.env,
         HOME: homeDir,
         THUMBGATE_FEEDBACK_DIR: tmpDir,
+        THUMBGATE_STATUSLINE_VERBOSE: '1',
         ...extraEnv,
       },
       timeout: 5000,
@@ -94,6 +95,28 @@ test('statusline script reads jq input and outputs ThumbGate line', () => {
   assert.match(out, /Lessons/);
   assert.doesNotMatch(out, /Dashboard \(http:\/\/localhost:3456\/dashboard\)/);
   assert.doesNotMatch(out, /Lessons \(http:\/\/localhost:3456\/lessons\)/);
+});
+
+test('statusline is compact by default for Claude chrome', () => {
+  const out = runStatusline({
+    thumbs_up: '10', thumbs_down: '5', lessons: '3', trend: 'improving'
+  }, {
+    THUMBGATE_STATUSLINE_VERBOSE: '0',
+    _TEST_THUMBGATE_STATUSLINE_LINKS_JSON: JSON.stringify(linkFixture()),
+    _TEST_THUMBGATE_STATUSLINE_CONTEXT_JSON: JSON.stringify({
+      branchName: 'codex/fix-verbose-statusline',
+      prLabel: 'PR #999',
+    }),
+  });
+  const plain = stripStatuslineFormatting(out);
+  assert.match(plain, /ThumbGate v/);
+  assert.match(plain, /10/);
+  assert.match(plain, /5/);
+  assert.doesNotMatch(plain, /codex\/fix-verbose-statusline/);
+  assert.doesNotMatch(plain, /PR #999/);
+  assert.doesNotMatch(plain, /Dashboard/);
+  assert.doesNotMatch(plain, /Lessons/);
+  assert.doesNotMatch(plain, /Latest mistake/);
 });
 
 test('statusline includes branch, inferred work item, and PR context when available', () => {
@@ -481,6 +504,7 @@ test('statusline preserves dashboard links under a tight width budget', () => {
         ...process.env,
         HOME: homeDir,
         THUMBGATE_FEEDBACK_DIR: tmpDir,
+        THUMBGATE_STATUSLINE_VERBOSE: '1',
         THUMBGATE_STATUSLINE_MAX_CHARS: '72',
         _TEST_THUMBGATE_STATUSLINE_LINKS_JSON: JSON.stringify(linkFixture()),
       },
@@ -560,13 +584,18 @@ test('cache updater writes cache from feedback_stats input', () => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-test('setupClaude uses portable ThumbGate commands for status line and cache updates', () => {
+test('Claude Code wiring uses portable ThumbGate commands for status line and cache updates', () => {
   const cliSource = fs.readFileSync(path.join(__dirname, '..', 'bin', 'cli.js'), 'utf8');
-  assert.ok(cliSource.includes('statusLine'), 'cli.js must wire statusLine');
-  assert.ok(cliSource.includes('cacheUpdateHookCommand'), 'cli.js must wire the portable cache updater command');
-  assert.ok(cliSource.includes('statuslineCommand'), 'cli.js must wire the portable statusline command');
+  assert.match(cliSource, /wireHooks\(\{\s*agent:\s*'claude-code'\s*\}\)/, 'cli.js must delegate Claude setup to canonical hook wiring');
   const cacheCommand = cacheUpdateHookCommand();
   const statusCommand = statuslineCommand();
+  assert.ok(
+    // Published install: subcommand in both fast-path exec and fallback npm-exec
+    /thumbgate["']?\s+"statusline-render".*\|\|.*thumbgate"\s+"statusline-render"/.test(statusCommand)
+      // Source checkout: direct node invocation
+      || /bin\/cli\.js"\s+statusline-render/.test(statusCommand),
+    `statusline command must forward statusline-render in both fast and fallback paths: ${statusCommand}`
+  );
   assert.ok(
     (cacheCommand.includes('--package') && cacheCommand.includes('thumbgate@') && cacheCommand.includes('thumbgate') && cacheCommand.includes('cache-update'))
       || cacheCommand.includes('bin/cli.js" cache-update'),
@@ -579,6 +608,76 @@ test('setupClaude uses portable ThumbGate commands for status line and cache upd
   );
 });
 
+test('hook runtime forwards subcommands for published-package Claude hooks', () => {
+  const hookRuntimePath = require.resolve('../scripts/hook-runtime');
+  const mcpConfigPath = require.resolve('../scripts/mcp-config');
+  const mcpConfig = require(mcpConfigPath);
+  const originalIsSourceCheckout = mcpConfig.isSourceCheckout;
+  const originalPublishedCliAvailable = mcpConfig.publishedCliAvailable;
+
+  try {
+    delete require.cache[hookRuntimePath];
+    mcpConfig.isSourceCheckout = () => false;
+    mcpConfig.publishedCliAvailable = () => true;
+    const publishedRuntime = require(hookRuntimePath);
+    const command = publishedRuntime.statuslineCommand();
+
+    assert.match(command, /\[ -x /);
+    assert.match(command, /thumbgate["']?\s+"statusline-render"/);
+    assert.match(command, /\|\|.*npm "exec"/);
+    assert.match(command, /"--"\s+"thumbgate"\s+"statusline-render"/);
+  } finally {
+    mcpConfig.isSourceCheckout = originalIsSourceCheckout;
+    mcpConfig.publishedCliAvailable = originalPublishedCliAvailable;
+    delete require.cache[hookRuntimePath];
+  }
+});
+
+test('hook runtime preserves subcommands in external fallback launchers', () => {
+  const hookRuntimePath = require.resolve('../scripts/hook-runtime');
+  const mcpConfigPath = require.resolve('../scripts/mcp-config');
+  const mcpConfig = require(mcpConfigPath);
+  const originalIsSourceCheckout = mcpConfig.isSourceCheckout;
+  const originalPublishedCliAvailable = mcpConfig.publishedCliAvailable;
+
+  try {
+    delete require.cache[hookRuntimePath];
+    mcpConfig.isSourceCheckout = () => false;
+    mcpConfig.publishedCliAvailable = () => false;
+    const fallbackRuntime = require(hookRuntimePath);
+
+    assert.match(fallbackRuntime.statuslineCommand(), /"--"\s+"thumbgate"\s+"statusline-render"/);
+    assert.match(fallbackRuntime.codexStatuslineCommand(), /thumbgate@latest/);
+    assert.match(fallbackRuntime.codexStatuslineCommand(), /node_modules\/\.bin\/thumbgate"\s+"statusline-render"/);
+  } finally {
+    mcpConfig.isSourceCheckout = originalIsSourceCheckout;
+    mcpConfig.publishedCliAvailable = originalPublishedCliAvailable;
+    delete require.cache[hookRuntimePath];
+  }
+});
+
+test('hook runtime preserves subcommands for source-checkout launchers', () => {
+  const hookRuntimePath = require.resolve('../scripts/hook-runtime');
+  const mcpConfigPath = require.resolve('../scripts/mcp-config');
+  const mcpConfig = require(mcpConfigPath);
+  const originalIsSourceCheckout = mcpConfig.isSourceCheckout;
+  const originalPublishedCliAvailable = mcpConfig.publishedCliAvailable;
+
+  try {
+    delete require.cache[hookRuntimePath];
+    mcpConfig.isSourceCheckout = () => true;
+    mcpConfig.publishedCliAvailable = () => false;
+    const sourceRuntime = require(hookRuntimePath);
+
+    assert.match(sourceRuntime.statuslineCommand(), /bin\/cli\.js"\s+statusline-render/);
+    assert.match(sourceRuntime.codexStatuslineCommand(), /bin\/cli\.js"\s+statusline-render/);
+  } finally {
+    mcpConfig.isSourceCheckout = originalIsSourceCheckout;
+    mcpConfig.publishedCliAvailable = originalPublishedCliAvailable;
+    delete require.cache[hookRuntimePath];
+  }
+});
+
 test('statusline shell wires dashboard and lesson links through osc_link', () => {
   const shellSource = fs.readFileSync(STATUSLINE_PATH, 'utf8');
   assert.match(shellSource, /statusline-links\.js/);
@@ -589,9 +688,9 @@ test('statusline shell wires dashboard and lesson links through osc_link', () =>
   assert.match(shellSource, /LATEST_LESSON_LINK="\$\(osc_link/);
 });
 
-test('statusline output ends with Dashboard and Lessons links (regression guard)', () => {
+test('verbose statusline output ends with Dashboard and Lessons links (regression guard)', () => {
   const shellSource = fs.readFileSync(STATUSLINE_PATH, 'utf8');
-  // Both branches (no-feedback and has-feedback) must retain Dashboard + Lessons links
+  // Both verbose branches (no-feedback and has-feedback) must retain Dashboard + Lessons links.
   const outputLines = shellSource.split('\n').filter(l => l.includes('DASHBOARD_LINK') && l.includes('LESSONS_LINK'));
   assert.ok(outputLines.length >= 2, `Expected at least 2 output lines with Dashboard+Lessons links, got ${outputLines.length}`);
   const lineAssembly = shellSource.split('\n').filter(l => l.includes('LATEST_LESSON_LINK') && l.includes('LINE='));


### PR DESCRIPTION
## Summary
- Add Claude Code to `thumbgate init` platform detection.
- Delegate Claude setup to canonical `auto-wire-hooks` so init/plugin use the same full hook bundle.
- Add `thumbgate --version`, `-v`, and `version`.
- Add regression coverage and a patch changeset.

## Verification
- `npm run test:statusline`
- `npm run test:cli`
- `git diff --check`
- pre-commit guards passed
- pre-push npm pack/link/regression guards passed