### PR TITLE
fix(init): auto-detect and wire Claude Code; unify install hook set; add --version

### DIFF
--- a/.changeset/init-claude-code-detection.md
+++ b/.changeset/init-claude-code-detection.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+Fix `thumbgate init` to auto-detect and wire Claude Code.
+
+The platform-detection loop in `init` listed Codex, Gemini, Amp, Cursor, ForgeCode and Cline but had no Claude Code entry — so running `thumbgate init` inside Claude Code silently skipped the flagship agent, printing no status and wiring no hooks unless `--agent claude-code` was passed explicitly.
+
+`init` now detects Claude Code (`which claude` / `~/.claude`) and wires it through the shared `wireHooks` path like every other agent. `setupClaude()` (used by `thumbgate install`) now delegates gate-hook wiring to that same path, so `init`, `init --agent claude-code`, and `install` all produce the identical hook set — including the PreToolUse pre-action gate, which `install` previously omitted entirely. `thumbgate --version` / `-v` now prints the package version instead of `Unknown command`.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -396,6 +396,26 @@ function whichExists(cmd) {
 function setupClaude() {
   const mcpChanged = mergeMcpJson(path.join(CWD, '.mcp.json'), 'Claude Code', 'project');
 
+  // Wire the canonical ThumbGate gate hooks (PreToolUse pre-action check,
+  // UserPromptSubmit, PostToolUse, SessionStart) through the shared wiring
+  // path so `init`, `init --agent claude-code`, and `install` all produce the
+  // same hook set. Before this, `install` shipped a Claude config with no
+  // PreToolUse gate — the core ThumbGate feature was silently missing.
+  let wireChanged = false;
+  try {
+    const { wireHooks } = require(path.join(PKG_ROOT, 'scripts', 'auto-wire-hooks'));
+    const wireResult = wireHooks({ agent: 'claude-code' });
+    if (wireResult.error) {
+      console.log(`  Claude Code: ${wireResult.error}`);
+    } else if (wireResult.changed) {
+      wireChanged = true;
+      const lifecycles = [...new Set(wireResult.added.map((h) => h.lifecycle))].join(', ');
+      console.log(`  Claude Code: wired gate hooks (${lifecycles})`);
+    }
+  } catch (err) {
+    console.log(`  Claude Code: hook wiring skipped (${err.message})`);
+  }
+
   // Upsert Stop hook into .claude/settings.json for autonomous self-scoring
   const settingsPath = path.join(CWD, '.claude', 'settings.json');
   const stopHookCommand = 'bash scripts/hook-stop-self-score.sh';
@@ -452,7 +472,7 @@ function setupClaude() {
     fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
   }
 
-  return mcpChanged || hooksChanged;
+  return mcpChanged || hooksChanged || wireChanged;
 }
 
 function setupCodex() {
@@ -724,6 +744,7 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
   let configured = 0;
 
   const platforms = [
+    { name: 'Claude Code', detect: [() => whichExists('claude'), () => fs.existsSync(path.join(HOME, '.claude'))], setup: setupClaude },
     { name: 'Codex', detect: [() => whichExists('codex'), () => fs.existsSync(path.join(HOME, '.codex'))], setup: setupCodex },
     { name: 'Gemini', detect: [() => whichExists('gemini'), () => fs.existsSync(path.join(HOME, '.gemini'))], setup: setupGemini },
     { name: 'Amp', detect: [() => whichExists('amp'), () => fs.existsSync(path.join(HOME, '.amp'))], setup: setupAmp },
@@ -2458,6 +2479,11 @@ if (COMMAND === 'daemon' || COMMAND === 'serve-daemon') {
 }
 
 switch (COMMAND) {
+  case '--version':
+  case '-v':
+  case 'version':
+    console.log(pkgVersion());
+    break;
   case 'init':
     init();
     upgradeNudge();


### PR DESCRIPTION
## Problem

`thumbgate init`'s platform-detection loop (`bin/cli.js`, `cmdInit`) listed **Codex, Gemini, Amp, Cursor, ForgeCode, Cline** — but had **no Claude Code entry**.

Running `thumbgate init` inside Claude Code therefore silently skipped the flagship agent: no status line for it, no hooks wired, and no line printed in the "Detecting platforms…" output. Claude Code was only ever wired when the user passed `--agent claude-code` explicitly.

A second, related defect: `setupClaude()` (the path used by `thumbgate install`) wrote only a `Stop` + cache `PostToolUse` hook to project `.claude/settings.json` — it never wired the **`PreToolUse` pre-action gate**, which is ThumbGate's core feature. So `init --agent claude-code`, plain `init`, and `install` produced three different Claude configurations.

## Fix

- **init** — added a `Claude Code` entry to the platform list. Plain `thumbgate init` now detects Claude Code (`which claude` / `~/.claude`) and wires it like every other agent, reporting it in the "Detecting platforms…" output.
- **setupClaude()** — now delegates gate-hook wiring to the shared `wireHooks` path (`PreToolUse` / `UserPromptSubmit` / `PostToolUse` / `SessionStart`). `init`, `init --agent claude-code`, and `install` now all produce the **same** hook set, including the `PreToolUse` gate.
- **cli** — `thumbgate --version` / `-v` / `version` now print the package version instead of erroring with `Unknown command`.

## Verification

```
$ node bin/cli.js --version
1.21.0

$ node bin/cli.js init
Detecting platforms...
  Claude Code: wired gate hooks (PreToolUse, UserPromptSubmit, PostToolUse, SessionStart, statusLine)
  ...
```

- `node --check bin/cli.js` — passes
- `node scripts/sync-version.js --check` — all 32 targets in sync
- `node scripts/changeset-check.js` — 1 valid changeset found
- Targeted suites green: `cli-schema`, `cli-agent-experience`, `auto-wire-hooks`, `published-cli`, `cursor-wiring`, `pretooluse-lesson-injection` — **135/135 pass**
- The two failures in `cli.test.js` (`pro` hosted-link, 20s network timeout) and `statusline.test.js` (license-tier / `jq`) are **pre-existing on `main`** — reproduced identically without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)