### PR TITLE
fix(dashboard): wire stat-card filters + Playwright E2E + CI

### DIFF
--- a/.changeset/dashboard-stat-card-filters.md
+++ b/.changeset/dashboard-stat-card-filters.md
@@ -1,0 +1,12 @@
+---
+"thumbgate": patch
+---
+
+Fix Operations Dashboard stat-card filters so clicking Positive/Negative/Total navigates to the Lessons Timeline tab pre-filtered to that signal (previously all three cards landed on the Rules tab unfiltered — the dashboard emitted `?signal=positive|negative` but `lessons.html` never parsed the query param).
+
+Two changes:
+
+1. **`public/dashboard.html`** — switch stat-card hrefs to the canonical `up|down|all` vocabulary the rest of the codebase uses (was `positive|negative`).
+2. **`public/lessons.html`** — read `?signal` at bootstrap, accept both canonical (`up|down|all`) and legacy (`positive|negative`) aliases, call `switchTab('timeline') + filterTimeline(mapped)` before falling through to the default Rules tab.
+
+Adds a Playwright E2E suite (`tests/e2e/dashboard-stat-cards.spec.js`) and a sharded GitHub Actions workflow (`.github/workflows/e2e.yml`) so this regression class is caught in CI on any future change to `public/`, `src/api/`, or the test infrastructure itself.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,130 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'public/**'
+      - 'src/api/**'
+      - 'tests/e2e/**'
+      - 'playwright.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'public/**'
+      - 'src/api/**'
+      - 'tests/e2e/**'
+      - 'playwright.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/e2e.yml'
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  e2e:
+    name: Playwright (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2]
+        shardTotal: [2]
+    env:
+      CI: 'true'
+      THUMBGATE_ALLOW_INSECURE: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --onnxruntime-node-install-cuda=skip --no-audit --no-fund
+
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-browsers-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: blob-report
+          retention-days: 7
+
+      - name: Upload trace+screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-artifacts-${{ matrix.shardIndex }}
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 14
+
+  merge-reports:
+    name: Merge blob reports
+    if: ${{ !cancelled() }}
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --onnxruntime-node-install-cuda=skip --no-audit --no-fund
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-html-report
+          path: playwright-report
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ reports/gtm/2026-05-05-money-today/sales-pipeline-latest.md
 
 # RLHF runtime artifacts (per-checkout local state)
 .rlhf/
+test-results/
+playwright-report/
+blob-report/
+/all-blob-reports/

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
         "@changesets/cli": "^2.31.0",
+        "@playwright/test": "^1.60.0",
         "c8": "^11.0.0",
         "undici": "^8.2.0"
       },
@@ -1245,6 +1246,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2255,6 +2272,21 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/gaxios": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
@@ -3230,6 +3262,25 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
     },
     "node_modules/playwright-core": {
       "version": "1.60.0",

--- a/package.json
+++ b/package.json
@@ -640,6 +640,10 @@
     "test:competitive-positioning-marketing": "node --test tests/competitive-positioning-marketing.test.js tests/knowledge-graph-guardrails.test.js tests/supply-chain-guardrails.test.js",
     "test:medium-weekly": "node --test tests/medium-weekly.test.js",
     "test:dashboard-deeplink-e2e": "node --test tests/dashboard-deeplink-e2e.test.js",
+    "test:e2e:playwright": "playwright test",
+    "test:e2e:playwright:headed": "playwright test --headed",
+    "test:e2e:playwright:ui": "playwright test --ui",
+    "test:e2e:playwright:report": "playwright show-report",
     "test:public-package-parity": "node --test tests/public-package-parity.test.js",
     "prepare": "bash bin/install-hooks.sh >/dev/null 2>&1 || true",
     "install:hooks": "bash bin/install-hooks.sh",
@@ -731,6 +735,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
+    "@playwright/test": "^1.60.0",
     "c8": "^11.0.0",
     "undici": "^8.2.0"
   }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,47 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT || process.env.PORT || 18787);
+const HOST = process.env.PLAYWRIGHT_HOST || '127.0.0.1';
+const baseURL = `http://${HOST}:${PORT}`;
+
+const isCI = !!process.env.CI;
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 2 : undefined,
+  reporter: isCI
+    ? [['blob'], ['github']]
+    : [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
+  outputDir: 'test-results',
+  expect: {
+    timeout: 7_500,
+  },
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 7_500,
+    navigationTimeout: 15_000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: `node src/api/server.js`,
+    url: `${baseURL}/dashboard`,
+    reuseExistingServer: !isCI,
+    timeout: 30_000,
+    stdout: 'ignore',
+    stderr: 'pipe',
+    env: {
+      PORT: String(PORT),
+      HOST,
+      THUMBGATE_ALLOW_INSECURE: 'true',
+      NODE_ENV: 'test',
+    },
+  },
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -247,9 +247,9 @@
 
   <!-- STATS -->
   <div class="stats-grid" id="statsGrid">
-    <a class="stat-card" data-card-action="all" onclick="selectCard(this,'all')" href="/lessons" style="cursor:pointer;text-decoration:none;color:inherit;display:block;" title="Click to view all feedback → Lessons page"><div class="stat-label">Total Feedback</div><div class="stat-value cyan" id="statTotal">—</div></a>
-    <a class="stat-card" data-card-action="up" onclick="selectCard(this,'up')" href="/lessons?signal=positive" style="cursor:pointer;text-decoration:none;color:inherit;display:block;" title="Click to view positive feedback → Lessons page"><div class="stat-label">👍 Positive</div><div class="stat-value green" id="statPositive">—</div></a>
-    <a class="stat-card" data-card-action="down" onclick="selectCard(this,'down')" href="/lessons?signal=negative" style="cursor:pointer;text-decoration:none;color:inherit;display:block;" title="Click to view negative feedback → Lessons page"><div class="stat-label">👎 Negative</div><div class="stat-value red" id="statNegative">—</div></a>
+    <a class="stat-card" data-card-action="all" onclick="selectCard(this,'all')" href="/lessons?signal=all" style="cursor:pointer;text-decoration:none;color:inherit;display:block;" title="Click to view all feedback → Lessons page"><div class="stat-label">Total Feedback</div><div class="stat-value cyan" id="statTotal">—</div></a>
+    <a class="stat-card" data-card-action="up" onclick="selectCard(this,'up')" href="/lessons?signal=up" style="cursor:pointer;text-decoration:none;color:inherit;display:block;" title="Click to view positive feedback → Lessons page"><div class="stat-label">👍 Positive</div><div class="stat-value green" id="statPositive">—</div></a>
+    <a class="stat-card" data-card-action="down" onclick="selectCard(this,'down')" href="/lessons?signal=down" style="cursor:pointer;text-decoration:none;color:inherit;display:block;" title="Click to view negative feedback → Lessons page"><div class="stat-label">👎 Negative</div><div class="stat-value red" id="statNegative">—</div></a>
     <a class="stat-card" data-card-action="gates" onclick="selectCard(this,'gates');return false;" href="#" style="cursor:pointer;text-decoration:none;color:inherit;display:block;" title="Click to view active checks"><div class="stat-label">Active Gates</div><div class="stat-value cyan" id="statGates">—</div></a>
   </div>
 

--- a/public/lessons.html
+++ b/public/lessons.html
@@ -922,6 +922,28 @@ async function loadLive() {
 }
 
 loadLive().then(function() {
+  // Handle ?signal= query param from dashboard stat-card navigation.
+  // Vocabulary: 'up' | 'down' | 'all' (canonical). Also accepts the legacy
+  // 'positive' | 'negative' aliases the dashboard once emitted.
+  var qsSignal = new URLSearchParams(window.location.search).get('signal');
+  if (qsSignal) {
+    var signalMap = { positive: 'up', negative: 'down', up: 'up', down: 'down', all: 'all' };
+    var mapped = signalMap[qsSignal];
+    if (mapped) {
+      switchTab('timeline');
+      filterTimeline(mapped, null);
+      var filterBtns = document.querySelectorAll('#tab-timeline .filter-btn');
+      filterBtns.forEach(function(b) {
+        var label = b.textContent.trim().toLowerCase();
+        var match = (mapped === 'all' && label === 'all') ||
+                    (mapped === 'up' && (label.indexOf('👍') !== -1 || label.indexOf('positive') !== -1 || label === 'up')) ||
+                    (mapped === 'down' && (label.indexOf('👎') !== -1 || label.indexOf('negative') !== -1 || label === 'down'));
+        b.classList.toggle('active', match);
+      });
+      return;
+    }
+  }
+
   // Default: highlight Active Rules card on page load
   highlightCard(0);
 

--- a/tests/e2e/dashboard-stat-cards.spec.js
+++ b/tests/e2e/dashboard-stat-cards.spec.js
@@ -1,0 +1,53 @@
+const { test, expect } = require('@playwright/test');
+const { mockDashboardApis } = require('./helpers/mock-api');
+
+test.describe('Operations Dashboard stat cards', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockDashboardApis(page);
+  });
+
+  test('renders the four stat cards with numeric values (demo mode auto-loads)', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page.locator('#statTotal')).toHaveText(/\d+/);
+    await expect(page.locator('#statPositive')).toHaveText(/\d+/);
+    await expect(page.locator('#statNegative')).toHaveText(/\d+/);
+    await expect(page.locator('#statGates')).toHaveText(/\d+/);
+  });
+
+  test('clicking Positive card lands on Timeline tab filtered to positive feedback', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.locator('[data-card-action="up"]').click();
+    await page.waitForURL(/\/lessons\?signal=(up|positive)\b/);
+    await expect(page.locator('#tab-timeline')).toHaveClass(/(^|\s)active(\s|$)/);
+    await expect(page.locator('#tab-rules')).not.toHaveClass(/(^|\s)active(\s|$)/);
+    const signal = await page.evaluate(() => window.activeTimelineSignal);
+    expect(signal).toBe('up');
+  });
+
+  test('clicking Negative card lands on Timeline tab filtered to negative feedback', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.locator('[data-card-action="down"]').click();
+    await page.waitForURL(/\/lessons\?signal=(down|negative)\b/);
+    await expect(page.locator('#tab-timeline')).toHaveClass(/(^|\s)active(\s|$)/);
+    await expect(page.locator('#tab-rules')).not.toHaveClass(/(^|\s)active(\s|$)/);
+    const signal = await page.evaluate(() => window.activeTimelineSignal);
+    expect(signal).toBe('down');
+  });
+
+  test('clicking Total Feedback card lands on Timeline tab with no signal filter', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.locator('[data-card-action="all"]').click();
+    await page.waitForURL(/\/lessons(\?|$)/);
+    await expect(page.locator('#tab-timeline')).toHaveClass(/(^|\s)active(\s|$)/);
+    const signal = await page.evaluate(() => window.activeTimelineSignal);
+    expect(signal).toBe('all');
+  });
+
+  test('clicking Active Gates card does not navigate away from /dashboard', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.locator('[data-card-action="gates"]').click();
+    await page.waitForTimeout(250);
+    expect(new URL(page.url()).pathname).toBe('/dashboard');
+    await expect(page.locator('[data-card-action="gates"]')).toHaveClass(/selected/);
+  });
+});

--- a/tests/e2e/fixtures/dashboard.json
+++ b/tests/e2e/fixtures/dashboard.json
@@ -1,0 +1,30 @@
+{
+  "operational": {
+    "source": "live",
+    "fallbackReason": null,
+    "window": {
+      "window": "lifetime",
+      "timeZone": "UTC",
+      "bounded": false,
+      "startLocalDate": null,
+      "endLocalDate": "2026-05-20",
+      "now": "2026-05-20T00:00:00.000Z"
+    }
+  },
+  "approval": {
+    "total": 12,
+    "positive": 10,
+    "negative": 2,
+    "approvalRate": 83,
+    "recentRate": 80,
+    "trendDirection": "stable"
+  },
+  "gateStats": {
+    "totalGates": 5,
+    "manualCount": 3,
+    "autoCount": 2,
+    "blockedCount": 0
+  },
+  "reviewDelta": null,
+  "since": null
+}

--- a/tests/e2e/fixtures/feedback-stats.json
+++ b/tests/e2e/fixtures/feedback-stats.json
@@ -1,0 +1,6 @@
+{
+  "total": 12,
+  "up": 10,
+  "down": 2,
+  "approvalRate": 83
+}

--- a/tests/e2e/fixtures/lessons-search.json
+++ b/tests/e2e/fixtures/lessons-search.json
@@ -1,0 +1,10 @@
+{
+  "results": [
+    {
+      "id": "rule_001",
+      "title": "Always validate input",
+      "severity": "high",
+      "tags": ["validation"]
+    }
+  ]
+}

--- a/tests/e2e/fixtures/timeline-search.json
+++ b/tests/e2e/fixtures/timeline-search.json
@@ -1,0 +1,25 @@
+{
+  "results": [
+    {
+      "id": "fb_pos_001",
+      "signal": "up",
+      "text": "great suggestion",
+      "createdAt": "2026-05-20T10:00:00.000Z",
+      "dayKey": "2026-05-20"
+    },
+    {
+      "id": "fb_pos_002",
+      "signal": "up",
+      "text": "exactly what I wanted",
+      "createdAt": "2026-05-20T11:00:00.000Z",
+      "dayKey": "2026-05-20"
+    },
+    {
+      "id": "fb_neg_001",
+      "signal": "down",
+      "text": "wrong approach",
+      "createdAt": "2026-05-20T12:00:00.000Z",
+      "dayKey": "2026-05-20"
+    }
+  ]
+}

--- a/tests/e2e/helpers/mock-api.js
+++ b/tests/e2e/helpers/mock-api.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const fs = require('fs');
+
+const FIXTURE_DIR = path.join(__dirname, '..', 'fixtures');
+
+function loadFixture(name) {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURE_DIR, name), 'utf8'));
+}
+
+async function mockDashboardApis(page, overrides = {}) {
+  const dashboard = overrides.dashboard || loadFixture('dashboard.json');
+  const feedbackStats = overrides.feedbackStats || loadFixture('feedback-stats.json');
+  const timeline = overrides.timeline || loadFixture('timeline-search.json');
+  const lessons = overrides.lessons || loadFixture('lessons-search.json');
+
+  await page.route(/\/v1\/dashboard(\?|$)/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(dashboard) }),
+  );
+  await page.route(/\/v1\/dashboard\/render-spec/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ blocks: [] }) }),
+  );
+  await page.route(/\/v1\/dashboard\/review-state/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ since: null }) }),
+  );
+  await page.route(/\/v1\/feedback\/stats/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(feedbackStats) }),
+  );
+  await page.route(/\/v1\/search/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(timeline) }),
+  );
+  await page.route(/\/v1\/lessons\/search/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(lessons) }),
+  );
+  await page.route(/\/v1\/events/, (route) =>
+    route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' }),
+  );
+  await page.route(/\/v1\/dpo\/export/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ records: [] }) }),
+  );
+}
+
+module.exports = { mockDashboardApis, loadFixture };


### PR DESCRIPTION
## Summary

- **Bug fix**: Operations Dashboard stat cards (`Positive` / `Negative` / `Total Feedback`) navigated to `/lessons` but the lessons page never read the `?signal` query param — every card landed on the Rules tab unfiltered. CEO reported via screenshot: clicking POSITIVE did not show positives.
- **Test infrastructure**: Added Playwright 1.x with chromium, `page.route()` API mocking, fully-parallel local execution, 2-shard matrix in CI.
- **CI**: New `.github/workflows/e2e.yml` runs on pushes / PRs that touch `public/`, `src/api/`, `tests/e2e/`, `playwright.config.js`, or `package.json`. Sharded matrix with blob reporter + dependent merge-reports job. Browser cache keyed on `@playwright/test` version.

## Root cause

`public/dashboard.html:251-252` emitted `?signal=positive|negative`. The rest of the codebase uses canonical `up|down` vocabulary. `public/lessons.html` never parsed the query param at all — `loadLive().then(...)` went straight to `highlightCard(0)` (Rules tab). Same root cause hit Total Feedback and Negative cards.

## Minimal fix

- `public/dashboard.html` — switch hrefs to `?signal=up|down|all` (canonical vocab).
- `public/lessons.html` — at bootstrap, read `?signal`, accept canonical + legacy aliases, call `switchTab('timeline') + filterTimeline(mapped)`.

## Rebase note (history was rewritten)

Earlier revisions of this branch bundled an unrelated `fix(sentinel)` commit (`7f09dce7`) pushed by a parallel agent session, plus follow-up version-sync and codex-pack regen commits that became obsolete once main shipped v1.21.2 via #2241. The branch has been **force-rebased onto current main** (1.21.2) and reduced to two commits:

- `8378c588` — dashboard fix + Playwright suite + e2e.yml workflow
- `f29148b4` — changeset entry

The original sentinel commit is preserved on tag [`wip/sentinel-from-parallel-session-2026-05-20`](https://github.com/IgorGanapolsky/ThumbGate/releases/tag/wip/sentinel-from-parallel-session-2026-05-20) so the parallel session can re-PR it cleanly.

## Verification

- [x] Playwright suite green (5/5 specs locally on rebased state).
- [x] All 128 existing tests across the 13 dashboard/lessons-touching test files pass locally.
- [x] `node scripts/sync-version.js --check` → ✔ All 32 targets in sync at v1.21.2.
- [x] Codex marketplace pack test green (no regen needed on rebased state).
- [x] Pre-push regression-guard hook passes.
- [x] No new files leak into the npm bundle (delta vs `origin/main` = 0).
- [ ] Full CI green on rebased branch (in flight).

## What's NOT in this PR (intentional)

- `selectCard()` in dashboard.html still does in-page filtering work that gets discarded because the `<a href>` navigates. Removing that dead code is a separate cleanup.
- `Active Gates` card still uses `href="#"` + `return false`. Test asserts it stays on `/dashboard`; routing it to a real gates view is a product decision for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)