### PR TITLE
fix(ci): improve Railway deploy reliability

### DIFF
--- a/.changeset/railway-deploy-reliability.md
+++ b/.changeset/railway-deploy-reliability.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Improve Railway deploy reliability: fix deploy-scope false positive when BEFORE_SHA is unreachable in shallow clone, reduce health check window from 20 minutes to 6 minutes (matching Railway's 300s healthcheck timeout), simplify concurrency group, add explicit timeout to health verification step.

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: deploy-railway-${{ github.workflow }}-${{ github.ref }}
+  group: deploy-railway
   cancel-in-progress: true
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
       RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
       RAILWAY_SERVICE: ${{ vars.RAILWAY_SERVICE }}
       RAILWAY_HEALTHCHECK_URL: ${{ vars.RAILWAY_HEALTHCHECK_URL || 'https://thumbgate-production.up.railway.app/health' }}
-      RAILWAY_HEALTHCHECK_MAX_ATTEMPTS: ${{ vars.RAILWAY_HEALTHCHECK_MAX_ATTEMPTS || '120' }}
+      RAILWAY_HEALTHCHECK_MAX_ATTEMPTS: ${{ vars.RAILWAY_HEALTHCHECK_MAX_ATTEMPTS || '36' }}
       RAILWAY_HEALTHCHECK_SLEEP_SECONDS: ${{ vars.RAILWAY_HEALTHCHECK_SLEEP_SECONDS || '10' }}
       RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS: ${{ vars.RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS || '5' }}
       RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS: ${{ vars.RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS || '20' }}
@@ -60,10 +60,20 @@ jobs:
           SHOULD_DEPLOY=true
           DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
 
-          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" | sed '/^$/d')"
-            if [ -n "$CHANGED_FILES" ] && ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
-              SHOULD_DEPLOY=false
+          # workflow_dispatch always deploys — no scope filter
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch: deploying unconditionally"
+            SHOULD_DEPLOY=true
+          elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            # Verify BEFORE_SHA exists in the shallow clone; if not, deploy unconditionally
+            # (this prevents the false-positive "skip" when the SHA is unreachable)
+            if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+              CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" | sed '/^$/d')"
+              if [ -n "$CHANGED_FILES" ] && ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
+                SHOULD_DEPLOY=false
+              fi
+            else
+              echo "::warning::BEFORE_SHA ($BEFORE_SHA) not reachable in shallow clone — deploying unconditionally"
             fi
           fi
 
@@ -191,8 +201,9 @@ jobs:
             echo "::warning::Railway variable sync failed after retries; continuing to deploy with existing Railway runtime variables. Health verification must still prove the new build."
           fi
       - name: Deploy to Railway
+        id: railway-deploy
         if: steps.railway-config.outputs.enabled == 'true'
-        timeout-minutes: 8
+        timeout-minutes: 5
         run: |
           retry_railway() {
             local description="$1"
@@ -267,9 +278,10 @@ jobs:
           fi
       - name: Verify deployment health
         if: steps.railway-config.outputs.enabled == 'true'
+        timeout-minutes: 7
         run: |
-          # Railway promotion can lag well past five minutes after a detached upload succeeds.
-          MAX_ATTEMPTS="${RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:-120}"
+          # Railway healthcheck default timeout is 300s. With 36 attempts × 10s = 6 min max.
+          MAX_ATTEMPTS="${RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:-36}"
           SLEEP_SECONDS="${RAILWAY_HEALTHCHECK_SLEEP_SECONDS:-10}"
           CONNECT_TIMEOUT_SECONDS="${RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS:-5}"
           MAX_TIME_SECONDS="${RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS:-20}"

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -256,7 +256,7 @@ test('Deploy to Railway workflow is the single authoritative Railway deploy lane
   assert.match(workflow, /--detach/);
   assert.match(workflow, /--project "\$RAILWAY_PROJECT_ID"/);
   assert.match(workflow, /--environment "\$RAILWAY_ENVIRONMENT_ID"/);
-  assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_MAX_ATTEMPTS\s*\|\|\s*'120'\s*\}\}/);
+  assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_MAX_ATTEMPTS\s*\|\|\s*'36'\s*\}\}/);
   assert.match(workflow, /RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS\s*\|\|\s*'5'\s*\}\}/);
   assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS\s*\|\|\s*'20'\s*\}\}/);
   assert.doesNotMatch(workflow, /secrets\.THUMBGATE_API_KEY\s*\|\|/);
@@ -271,11 +271,11 @@ test('Deploy to Railway workflow waits long enough to verify the promoted build 
   assert.match(workflow, /node scripts\/build-metadata\.js --sha "\$GITHUB_SHA" --output config\/build-metadata\.json/);
   assert.match(workflow, /railway up --ci --detach --project "\$RAILWAY_PROJECT_ID" --environment "\$RAILWAY_ENVIRONMENT_ID"/);
   assert.match(workflow, /--detach/);
-  assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_MAX_ATTEMPTS\s*\|\|\s*'120'\s*\}\}/);
+  assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_MAX_ATTEMPTS\s*\|\|\s*'36'\s*\}\}/);
   assert.match(workflow, /RAILWAY_HEALTHCHECK_SLEEP_SECONDS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_SLEEP_SECONDS\s*\|\|\s*'10'\s*\}\}/);
   assert.match(workflow, /RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS\s*\|\|\s*'5'\s*\}\}/);
   assert.match(workflow, /RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS:\s*\$\{\{\s*vars\.RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS\s*\|\|\s*'20'\s*\}\}/);
-  assert.match(workflow, /MAX_ATTEMPTS="\$\{RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:-120\}"/);
+  assert.match(workflow, /MAX_ATTEMPTS="\$\{RAILWAY_HEALTHCHECK_MAX_ATTEMPTS:-36\}"/);
   assert.match(workflow, /SLEEP_SECONDS="\$\{RAILWAY_HEALTHCHECK_SLEEP_SECONDS:-10\}"/);
   assert.match(workflow, /CONNECT_TIMEOUT_SECONDS="\$\{RAILWAY_HEALTHCHECK_CONNECT_TIMEOUT_SECONDS:-5\}"/);
   assert.match(workflow, /MAX_TIME_SECONDS="\$\{RAILWAY_HEALTHCHECK_MAX_TIME_SECONDS:-20\}"/);
@@ -351,7 +351,7 @@ test('Deploy to Railway workflow retries transient Railway CLI failures before f
   assert.match(workflow, /RAILWAY_DEPLOY_COMMAND_MAX_ATTEMPTS/);
   assert.match(workflow, /RAILWAY_DEPLOY_COMMAND_KILL_AFTER_SECONDS/);
   assert.match(workflow, /RAILWAY_POST_FAILURE_HEALTHCHECK_MAX_ATTEMPTS/);
-  assert.match(workflow, /timeout-minutes:\s*8/);
+  assert.match(workflow, /timeout-minutes:\s*5/);
   assert.match(workflow, /timeout --foreground --kill-after="\$\{kill_after_seconds\}s" "\$\{timeout_seconds\}s" "\$@"/);
   assert.match(workflow, /deploy with railway up/);
   assert.match(workflow, /Railway command failed \(attempt \$attempt\/\$max_attempts\)/);
@@ -584,7 +584,7 @@ test('Deploy to Railway workflow serializes main deploys and cancels superseded 
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'deploy-railway.yml'), 'utf8');
 
   assert.match(workflow, /concurrency:/);
-  assert.match(workflow, /group:\s*deploy-railway-\$\{\{\s*github\.workflow\s*\}\}-\$\{\{\s*github\.ref\s*\}\}/);
+  assert.match(workflow, /group:\s*deploy-railway/);
   assert.match(workflow, /cancel-in-progress:\s*true/);
 });
 


### PR DESCRIPTION
## Summary
- Fix deploy-scope false positive: verify `BEFORE_SHA` exists in shallow clone before diffing; deploy unconditionally when SHA is unreachable (root cause of Railway stuck at v1.20.0)
- Reduce health check window: 120×10s (20 min) → 36×10s (6 min), matching Railway's 300s healthcheck timeout
- Add explicit `timeout-minutes: 7` to health verification step
- Simplify concurrency group; `workflow_dispatch` always deploys

## Root cause
Railway CLI issue #787: `railway up --detach` can accept uploads but never promote builds. Our deploy-scope filter was also producing false "success" exits when `BEFORE_SHA` was unreachable in the shallow clone (fetch-depth: 2), causing the workflow to skip deployment silently.

## Test plan
- [ ] Merge to main triggers a deploy that actually promotes a new build
- [ ] `workflow_dispatch` bypasses scope filter and deploys unconditionally
- [ ] Health check fails within 7 minutes instead of hanging for 20 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)