### PR TITLE
fix(docker): unblock Railway deploys — Alpine builder missing Python+g++ for better-sqlite3

### DIFF
--- a/.changeset/dockerfile-musl-native-build-deps.md
+++ b/.changeset/dockerfile-musl-native-build-deps.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+Fix Railway production deploys that have been failing since the better-sqlite3@12.10.0 bump. The Dockerfile's `node:20-alpine` builder stage was missing Python and a C++ toolchain, so when better-sqlite3's prebuilt musl binary wasn't found, the `node-gyp rebuild` fallback failed with `Could not find any Python installation to use`. Every Railway deploy since the bump has built green in GitHub Actions, sent `railway up` successfully, then failed inside Railway's Docker build — and Railway's restart policy kept serving the old container (buildSha `92f8e4b1`, version 1.20.0) for hours.
+
+Added `RUN apk add --no-cache python3 make g++` to the builder stage. Runtime stage stays slim (Python isn't needed at runtime, only at install).

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+# Native build deps for better-sqlite3 et al. — Alpine uses musl libc and most
+# native-module prebuilt binaries ship glibc-only, so node-gyp falls back to
+# compiling from source and needs Python + a C++ toolchain.
+RUN apk add --no-cache python3 make g++
+
 # Copy manifests first to leverage layer cache
 COPY package*.json ./
 


### PR DESCRIPTION
## ⚠️ Production-blocking: Railway deploys have been failing silently for hours

`thumbgate-production.up.railway.app` is stuck on buildSha `92f8e4b1` / version `1.20.0`. Five subsequent merges have NOT shipped:
- `a7dc07cd` chore(deps): ws bump
- `edced978` chore(release): publish v1.21.2 (#2241)
- `4a0a3bb0` fix(dashboard): stat-card filters (#2242)
- `f52ef0b6` fix(sentinel): customer-system checkpoint (#2243)
- `51f545cc` feat(hooks): Volta auto-update shim (#2244)

GitHub Actions reports each deploy step as ✓ — but the actual Docker build inside Railway fails. Diagnostic capture from run `26177996910` (edced978 deploy):

```
== railway service status ==
"status": "FAILED",
"stopped": true

== railway build logs ==
npm error path /app/node_modules/better-sqlite3
npm error command failed
npm error prebuild-install warn install No prebuilt binaries found
  (target=20.20.2 runtime=node arch=x64 libc=musl platform=linux)
npm error gyp ERR! find Python "" could not be run
npm error gyp ERR! stack Error: Could not find any Python installation to use
[builder 4/4] RUN npm ci --omit=dev --no-audit --no-fund: exit code 1
```

## Root cause

`better-sqlite3@12.10.0` (bumped recently per `bump-better-sqlite3-12-10-0.md`) doesn't ship a prebuilt musl/Alpine binary for Linux x64. The install falls back to `node-gyp rebuild`, which needs **Python + a C/C++ toolchain**. `node:20-alpine` ships neither. Result: build fails inside Railway, Railway's restart policy keeps the old container serving requests, GitHub Actions' "Deploy to Railway" step still returns success because `railway up --detach` only uploads.

## Fix

One change to `Dockerfile`: add `RUN apk add --no-cache python3 make g++` to the builder stage. Runtime stage unchanged — toolchain isn't needed once `node_modules` is already compiled and copied across (multistage Dockerfile keeps the final image slim).

## Why this didn't get caught earlier

- GitHub Actions never builds the production Dockerfile (CI uses host Node, not Docker)
- The `Deploy to Railway` step uses `--detach`, so it doesn't observe Railway-side build failures
- The `Verify deployment health` polls `/health` for 120 attempts but the old container responds successfully — so the only signal of failure is "version field never changes," which is exactly what happened

Recommend a follow-up PR adding `docker build .` to CI to catch this class of regression before merge.

## Test plan

- [x] Verified via Railway's own diagnostic capture that the failure is in `[builder 4/4] RUN npm ci`
- [x] Verified by reading the Dockerfile that musl + native modules + no Python = guaranteed failure on this dep
- [ ] CI green on this PR
- [ ] After merge: prod `/health` should return version `1.21.3` (or whatever the next changeset version is) and buildSha matching this merge commit
- [ ] After merge: backlogged dashboard fix from #2242 should finally be live (`curl /dashboard | grep 'signal=up'` returns hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)