### PR TITLE
fix(build-metadata): file-baked SHA wins over runtime env (anti-drift)

### DIFF
--- a/.changeset/build-metadata-file-wins-precedence.md
+++ b/.changeset/build-metadata-file-wins-precedence.md
@@ -1,0 +1,13 @@
+---
+"thumbgate": patch
+---
+
+Fix `/health` reporting the wrong `buildSha` when a stale `THUMBGATE_BUILD_SHA` env var lingers on the runtime host. Invert precedence in `scripts/build-metadata.js`: the immutable JSON file baked into the Docker image at build time (which always matches the deployed code) now wins over mutable runtime env vars. Env vars fill in only when the file has no SHA.
+
+Also tightens the env-branch condition: previously a stray `THUMBGATE_BUILD_GENERATED_AT` with no SHA would short-circuit to `{ buildSha: null }`, losing both signals. Now the env branch requires an explicit SHA before being trusted.
+
+Background: 2026-05-20 — prod `/health` reported `version=1.21.2` but `buildSha=92f8e4b1` (a commit from days earlier). Root cause: the `Set Railway environment variables` step is gated by `RAILWAY_SYNC_VARIABLES=false` by default, so a once-set `THUMBGATE_BUILD_SHA` on Railway was never refreshed by subsequent deploys. The freshly-stamped `config/build-metadata.json` baked into the image had the correct SHA, but the env-wins precedence caused `resolveBuildMetadata` to return the stale env value instead.
+
+Side benefit: the `Verify deployment health` step in `.github/workflows/deploy-railway.yml` compares `LIVE_SHA` to `$GITHUB_SHA`; with this fix, that comparison now succeeds against the freshly-baked file SHA, unblocking the gate.
+
+Operator note: the persistent `THUMBGATE_BUILD_SHA` and `THUMBGATE_BUILD_GENERATED_AT` env vars on the Railway service can now be safely deleted from the dashboard — file precedence makes them moot.

--- a/scripts/build-metadata.js
+++ b/scripts/build-metadata.js
@@ -16,6 +16,13 @@ function normalizeNullableText(value) {
 }
 
 function resolveBuildMetadata({ env = process.env, filePath } = {}) {
+  // Precedence: immutable JSON file (baked into Docker image at build time, so it
+  // ALWAYS matches the deployed code) wins over runtime env vars. Env vars are
+  // mutable Railway/host config that can drift — they shadowed the freshly-stamped
+  // SHA in prod on 2026-05-20 and made /health lie about the deployed commit.
+  // Fall back to env vars only when the file is missing or its values are null,
+  // and require an explicit SHA env var (not just a stray GENERATED_AT) before
+  // trusting the env branch.
   const resolvedPath =
     normalizeNullableText(filePath) ||
     normalizeNullableText(env.THUMBGATE_BUILD_METADATA_PATH) ||
@@ -23,7 +30,28 @@ function resolveBuildMetadata({ env = process.env, filePath } = {}) {
   const envBuildSha = normalizeNullableText(env[BUILD_SHA_ENV_KEY]);
   const envGeneratedAt = normalizeNullableText(env[BUILD_GENERATED_AT_ENV_KEY]);
 
-  if (envBuildSha || envGeneratedAt) {
+  let fileBuildSha = null;
+  let fileGeneratedAt = null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+    fileBuildSha = normalizeNullableText(parsed.buildSha);
+    fileGeneratedAt = normalizeNullableText(parsed.generatedAt);
+  } catch {
+    // file missing or unreadable — fall through to env branch
+  }
+
+  if (fileBuildSha) {
+    return {
+      path: resolvedPath,
+      buildSha: fileBuildSha,
+      generatedAt: fileGeneratedAt || envGeneratedAt,
+    };
+  }
+
+  // No SHA in the file — fall back to env only if an explicit SHA is set.
+  // (Previously a bare GENERATED_AT with no SHA could short-circuit and return
+  // { buildSha: null }, losing both signals; now we require the SHA.)
+  if (envBuildSha) {
     return {
       path: resolvedPath,
       buildSha: envBuildSha,
@@ -31,20 +59,11 @@ function resolveBuildMetadata({ env = process.env, filePath } = {}) {
     };
   }
 
-  try {
-    const parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
-    return {
-      path: resolvedPath,
-      buildSha: normalizeNullableText(parsed.buildSha),
-      generatedAt: normalizeNullableText(parsed.generatedAt),
-    };
-  } catch {
-    return {
-      path: resolvedPath,
-      buildSha: null,
-      generatedAt: null,
-    };
-  }
+  return {
+    path: resolvedPath,
+    buildSha: null,
+    generatedAt: fileGeneratedAt || envGeneratedAt,
+  };
 }
 
 function writeBuildMetadataFile({ sha, outputPath, generatedAt = new Date().toISOString() }) {

--- a/tests/build-metadata.test.js
+++ b/tests/build-metadata.test.js
@@ -48,19 +48,57 @@ describe('build-metadata', () => {
     }
   });
 
-  it('resolveBuildMetadata prefers deployment env metadata over file metadata', () => {
-    const tmpFile = path.join(os.tmpdir(), `build-meta-env-priority-${Date.now()}.json`);
+  // Precedence inversion (2026-05-20): the immutable JSON file (baked into the
+  // Docker image at build time, so it ALWAYS matches the deployed code) MUST
+  // win over runtime env vars. Env vars are mutable Railway/host config that
+  // can drift — a stale THUMBGATE_BUILD_SHA env var on Railway shadowed the
+  // freshly-stamped JSON file in prod and made /health lie about the deployed
+  // commit. Env vars now only fill in when the file has no SHA at all.
+  it('resolveBuildMetadata prefers immutable file metadata over runtime env vars (anti-drift)', () => {
+    const tmpFile = path.join(os.tmpdir(), `build-meta-file-priority-${Date.now()}.json`);
     try {
       writeBuildMetadataFile({ sha: 'file-sha', outputPath: tmpFile, generatedAt: '2026-01-01T00:00:00Z' });
       const result = resolveBuildMetadata({
         filePath: tmpFile,
         env: {
-          [BUILD_SHA_ENV_KEY]: 'env-sha',
+          [BUILD_SHA_ENV_KEY]: 'stale-env-sha',
           [BUILD_GENERATED_AT_ENV_KEY]: '2026-04-08T14:20:00Z',
         },
       });
-      assert.strictEqual(result.buildSha, 'env-sha');
-      assert.strictEqual(result.generatedAt, '2026-04-08T14:20:00Z');
+      assert.strictEqual(result.buildSha, 'file-sha', 'file-baked SHA wins (immutable image artifact)');
+      assert.strictEqual(result.generatedAt, '2026-01-01T00:00:00Z', 'file-baked generatedAt wins too');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('resolveBuildMetadata falls back to env SHA only when file has no SHA', () => {
+    const result = resolveBuildMetadata({
+      filePath: '/tmp/nonexistent-build-meta.json',
+      env: {
+        [BUILD_SHA_ENV_KEY]: 'env-only-sha',
+        [BUILD_GENERATED_AT_ENV_KEY]: '2026-04-08T14:20:00Z',
+      },
+    });
+    assert.strictEqual(result.buildSha, 'env-only-sha');
+    assert.strictEqual(result.generatedAt, '2026-04-08T14:20:00Z');
+  });
+
+  it('resolveBuildMetadata does NOT short-circuit to a null SHA when only generatedAt env is set', () => {
+    // Regression for the secondary bug: previously `envBuildSha || envGeneratedAt`
+    // returned { buildSha: null } when only GENERATED_AT was set, losing the
+    // chance to read the file. Now the env branch requires an explicit SHA.
+    const tmpFile = path.join(os.tmpdir(), `build-meta-stray-${Date.now()}.json`);
+    try {
+      writeBuildMetadataFile({ sha: 'file-sha', outputPath: tmpFile, generatedAt: '2026-01-01T00:00:00Z' });
+      const result = resolveBuildMetadata({
+        filePath: tmpFile,
+        env: {
+          [BUILD_GENERATED_AT_ENV_KEY]: '2026-04-08T14:20:00Z',
+          // intentionally no BUILD_SHA env
+        },
+      });
+      assert.strictEqual(result.buildSha, 'file-sha', 'stray generatedAt env must not lose the SHA');
     } finally {
       fs.unlinkSync(tmpFile);
     }

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -65,10 +65,15 @@ test('GET /health returns package version', async () => {
   assert.equal(body.version, pkg.version);
 });
 
-test('GET /health returns stamped build metadata', async () => {
+test('GET /health returns stamped build metadata (file wins over env per precedence inversion)', async () => {
+  // Precedence inversion (2026-05-20): the immutable JSON file baked into the
+  // Docker image at build time wins over runtime env vars. Test setup writes
+  // 'deploy-test-build-sha' to the file AND sets THUMBGATE_BUILD_SHA='deploy-test-env-build-sha'
+  // — file value is what /health must report. Old (env-wins) precedence let
+  // a stale Railway env var shadow the freshly-stamped image artifact.
   const res = await fetch(deployUrl('/health'));
   const body = await res.json();
-  assert.equal(body.buildSha, 'deploy-test-env-build-sha');
+  assert.equal(body.buildSha, 'deploy-test-build-sha');
 });
 
 test('GET /health returns numeric uptime', async () => {


### PR DESCRIPTION
**Why**

Prod \`/health\` has been lying for hours: returns \`version=1.21.2\` but \`buildSha=92f8e4b1...\` — a commit from days before the v1.21.2 release. Verified the actual deployed code IS new (the dashboard click fix from #2242 is live), but the SHA telemetry is stale.

**Root cause**

\`resolveBuildMetadata()\` in \`scripts/build-metadata.js\` reads env vars first, JSON file second. The Railway service has a stale \`THUMBGATE_BUILD_SHA=92f8e4b1\` env var from a previous deploy, and the \`Set Railway environment variables\` step in \`.github/workflows/deploy-railway.yml\` is gated by \`RAILWAY_SYNC_VARIABLES=false\` (default) — so the env var never gets refreshed, shadowing the freshly-stamped JSON file forever.

Secondary bug: condition \`envBuildSha || envGeneratedAt\` short-circuits to \`{ buildSha: null }\` if only a stray \`GENERATED_AT\` env is set, losing both signals.

**Fix**

Invert precedence: the immutable JSON file baked into the Docker image at build time (which **always** matches the deployed code) wins over mutable runtime env vars. Env vars now fill in only when the file has no SHA, AND the env branch requires an explicit SHA (no more null-return when only GENERATED_AT is set).

**Side benefit — unblocks \`Verify deployment health\`**

That step compares \`LIVE_SHA\` to \`\$GITHUB_SHA\` (line 313 of deploy-railway.yml). With the env-wins bug, it would compare \`92f8e4b1\` against the actual merge commit and fail — likely contributing to today's repeated deploy failures.

**Tests**

- Existing roundtrip test still passes.
- New tests: file-wins (anti-drift), env-fallback when file empty, regression for stray-generatedAt short-circuit.
- 7/7 pass locally.

**Operator follow-up (no code change required)**

Once this merges + deploys, you can safely delete the persistent \`THUMBGATE_BUILD_SHA\` and \`THUMBGATE_BUILD_GENERATED_AT\` env vars on the Railway service via the dashboard. File precedence makes them moot. (Optional cleanup, not required for the fix to work.)

:robot_face: Generated with [Claude Code](https://claude.com/claude-code)