### PR TITLE
fix(deploy): harden Railway pipeline against today's "Stopping Container" cascade

### DIFF
--- a/.changeset/deploy-pipeline-hardening.md
+++ b/.changeset/deploy-pipeline-hardening.md
@@ -1,0 +1,31 @@
+---
+"thumbgate": patch
+---
+
+Harden the Railway deploy pipeline against the failure mode that took prod down on 2026-05-20 ("Stopping Container" right after healthcheck passes; cascading retry exhaustion on a single replica). Four targeted changes:
+
+**1. `railway.json` — give cold start room + tolerate transient failures + keep old container alive during swap**
+- `healthcheckTimeout`: 30 → 300 (per-deploy grace; better-sqlite3 native load + Node boot routinely exceeds 30s)
+- `restartPolicyMaxRetries`: 3 → 10 (3 healthcheck flaps was a hair-trigger for full service stop)
+- Added `overlapSeconds: 30` (Railway keeps the old container serving traffic for 30s after the new one is healthy, eliminating the gap window that caused today's HTTP 502)
+
+**2. `Dockerfile` HEALTHCHECK — align with actual startup time**
+- `--start-period=10s --retries=3` → `--start-period=60s --retries=5`
+- 10 seconds was below the observed cold-start of ~15-30s; healthcheck failed before the app was ready, marked unhealthy, killed.
+
+**3. `.github/workflows/deploy-railway.yml` — queue deploys, don't guillotine them**
+- `cancel-in-progress: true` → `cancel-in-progress: false`
+- Today's cascade: 4a0a3bb0 push → deploy starts → f52ef0b6 push 17 min later cancels it mid-flight → 51f545cc push 4 sec after that cancels f52ef0b6 mid-flight. Net result: 3 deploys started, 0 completed cleanly, prod stuck between containers.
+
+**4. `src/api/server.js` — graceful SIGTERM handler**
+- Without a handler, Node exits immediately on SIGTERM; Railway may flag the container as crashed (vs gracefully stopped), wasting restart-budget on healthy shutdowns and dropping in-flight requests.
+- Now drains HTTP connections for up to 25s before force-exit. Logs shutdown phase for debuggability.
+
+Background sources:
+- Railway docs: [Deployment Teardown](https://docs.railway.com/deployments/deployment-teardown), [Healthchecks](https://docs.railway.com/reference/healthchecks)
+- Railway community: [Container terminates after healthcheck](https://station.railway.com/questions/container-terminates-after-successful-he-67400aaf), [SIGTERM after 60-65s](https://station.railway.com/questions/container-sigterm-after-60-65-seconds-de-1e20ea2f)
+- Today's incident report: [Railway GCP suspension May 19 2026](https://blog.railway.com/p/incident-report-may-19-2026-gcp-account-outage)
+
+Not included (separate follow-up PRs):
+- Migrate Dockerfile base to `node:20-bookworm-slim` (drops the `python3 make g++` toolchain crutch + gets prebuilt better-sqlite3 binaries; ~50% build time cut). Higher-leverage but bigger blast radius.
+- Move to build-once-in-CI + push-to-GHCR + Railway image-auto-update. Eliminates `railway up` rebuild flakiness entirely.

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: deploy-railway
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV NODE_ENV=production
 
 EXPOSE ${PORT}
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=5 \
   CMD wget -qO- http://localhost:${PORT}/health || exit 1
 
 CMD ["node", "src/api/server.js"]

--- a/railway.json
+++ b/railway.json
@@ -7,8 +7,9 @@
   "deploy": {
     "startCommand": "node src/api/server.js",
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 30,
+    "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 3
+    "restartPolicyMaxRetries": 10,
+    "overlapSeconds": 30
   }
 }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -7729,6 +7729,7 @@ function startServer({ port, host } = {}) {
   const listenPort = Number(port ?? process.env.PORT ?? 8787);
   const listenHost = String(host ?? process.env.HOST ?? '0.0.0.0').trim() || '0.0.0.0';
   const server = createApiServer();
+  registerGracefulShutdown(server);
   return new Promise((resolve) => {
     server.listen(listenPort, listenHost, () => {
       const address = server.address();
@@ -7743,6 +7744,39 @@ function startServer({ port, host } = {}) {
     });
   });
 }
+
+// Railway / Cloud Run / Kubernetes deploy rotations send SIGTERM to swap
+// containers. Without a handler, Node exits immediately — in-flight requests
+// are killed and the orchestrator may mark the container as "crashed" (instead
+// of "gracefully stopped"), wasting its restart-policy budget on a healthy
+// shutdown. Drain HTTP, give a deadline, then force-exit if anything hangs.
+function registerGracefulShutdown(server, { gracePeriodMs = 25_000 } = {}) {
+  if (server[GRACEFUL_SHUTDOWN_KEY]) return;
+  server[GRACEFUL_SHUTDOWN_KEY] = true;
+  let shuttingDown = false;
+  const stop = (signal) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`[shutdown] ${signal} received — draining connections (deadline ${gracePeriodMs}ms)`);
+    const forceTimer = setTimeout(() => {
+      console.error('[shutdown] grace period elapsed — forcing exit');
+      process.exit(1);
+    }, gracePeriodMs);
+    if (typeof forceTimer.unref === 'function') forceTimer.unref();
+    server.close((err) => {
+      if (err) {
+        console.error('[shutdown] server.close error:', err.message);
+        process.exit(1);
+      }
+      console.log('[shutdown] drained cleanly');
+      process.exit(0);
+    });
+  };
+  process.on('SIGTERM', () => stop('SIGTERM'));
+  process.on('SIGINT', () => stop('SIGINT'));
+}
+
+const GRACEFUL_SHUTDOWN_KEY = Symbol.for('thumbgate.gracefulShutdownRegistered');
 
 module.exports = {
   createApiServer,

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -580,12 +580,12 @@ test('Claude Code Review workflow only cancels manual issue-comment review rerun
   assert.match(workflow, /cancel-in-progress:\s*\$\{\{\s*github\.event_name == 'issue_comment'\s*\}\}/);
 });
 
-test('Deploy to Railway workflow serializes main deploys and cancels superseded runs', () => {
+test('Deploy to Railway workflow serializes main deploys without cancelling in-flight deploys', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'deploy-railway.yml'), 'utf8');
 
   assert.match(workflow, /concurrency:/);
   assert.match(workflow, /group:\s*deploy-railway/);
-  assert.match(workflow, /cancel-in-progress:\s*true/);
+  assert.match(workflow, /cancel-in-progress:\s*false/);
 });
 
 test('Publish Tessl workflow verifies exports and only publishes when a Tessl token exists', () => {


### PR DESCRIPTION
## Why this PR exists

Today (2026-05-20) prod went down for ~15 min after a sequence of Railway deploy failures. Deep audit (parallel code-analyzer + web-research agents) identified that **the failure mode was independent of Railway's GCP-suspension incident** — our pipeline config was hair-trigger and would have failed under normal load too.

Specifically:

| Symptom | Root cause |
|---|---|
| "Stopping Container" right after healthcheck passes | `restartPolicyMaxRetries: 3` + `healthcheckTimeout: 30s` |
| ~15s gap between containers (HTTP 502) | no `overlapSeconds` — defaults to aggressive teardown |
| Cold-start failures on better-sqlite3 native load | Dockerfile HEALTHCHECK `start-period: 10s` vs ~20s actual |
| Two deploys racing each other | GH workflow `cancel-in-progress: true` |
| In-flight requests dropped on swap | no SIGTERM handler in src/api/server.js |

## Four targeted changes

### 1. `railway.json` — give cold start room + tolerate flaps + soft-swap
```diff
-  "healthcheckTimeout": 30,
+  "healthcheckTimeout": 300,
-  "restartPolicyMaxRetries": 3
+  "restartPolicyMaxRetries": 10,
+  "overlapSeconds": 30
```

### 2. `Dockerfile` HEALTHCHECK — align with actual startup
```diff
- HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=5 \
```

### 3. `.github/workflows/deploy-railway.yml` — queue, don't guillotine
```diff
-  cancel-in-progress: true
+  cancel-in-progress: false
```
Today's cascade: 4a0a3bb0 push → deploy starts → f52ef0b6 push 17min later cancels it mid-flight → 51f545cc push 4s later cancels f52ef0b6 mid-flight. Net: 3 deploys started, 0 completed cleanly.

### 4. `src/api/server.js` — graceful SIGTERM handler
New `registerGracefulShutdown(server, { gracePeriodMs: 25_000 })`. Drains HTTP connections on SIGTERM/SIGINT, force-exits if anything hangs past 25s. Logs phase transitions. Idempotent (Symbol guard).

## Verification

- ✅ 130/130 `tests/api-server.test.js` pass with the SIGTERM handler
- ✅ `railway.json` valid JSON
- ✅ `node -c src/api/server.js` clean
- ✅ Pre-commit + pre-push regression guards pass

## Sources for the design decisions

- [Railway Deployment Teardown docs](https://docs.railway.com/deployments/deployment-teardown) — `overlapSeconds` semantics
- [Railway Healthchecks reference](https://docs.railway.com/reference/healthchecks) — `healthcheckTimeout` is per-deploy grace, not per-probe
- [Railway help: container terminates after healthcheck passes](https://station.railway.com/questions/container-terminates-after-successful-he-67400aaf) — exact symptom we hit
- [Railway help: SIGTERM after 60-65s](https://station.railway.com/questions/container-sigterm-after-60-65-seconds-de-1e20ea2f) — known pattern when no SIGTERM handler
- [Railway May 19 2026 incident report](https://blog.railway.com/p/incident-report-may-19-2026-gcp-account-outage) — context for today's compounding outage

## Intentionally NOT in this PR (separate follow-ups for blast-radius reasons)

- **Migrate Dockerfile base from `node:20-alpine` to `node:20-bookworm-slim`.** Drops the `python3 make g++` toolchain entirely, gets prebuilt better-sqlite3 binaries, ~50% build time cut. Higher-leverage but ~30MB image size change + glibc vs musl security surface change. Separate PR.
- **Build-once-in-CI + push-to-GHCR + Railway image-auto-update.** Eliminates `railway up` rebuild flakiness, makes rollback a re-tag. Bigger workflow rewrite. Separate PR after the bookworm-slim base.

## Recover from current outage

Once this lands and deploys, the four config changes alone should restore stability. The `overlapSeconds: 30` ensures the old container keeps serving traffic for 30s after the new one is healthy, eliminating the gap that's causing the current HTTP 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)