### PR TITLE
fix(codex): use published CLI in plugin instructions

### DIFF
--- a/.changeset/codex-plugin-cli-instructions.md
+++ b/.changeset/codex-plugin-cli-instructions.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Update the Codex plugin agent instructions to use the published ThumbGate CLI entrypoints and add a regression test that blocks stale repo-local feedback commands.

--- a/plugins/codex-profile/AGENTS.md
+++ b/plugins/codex-profile/AGENTS.md
@@ -6,15 +6,15 @@ If user gives explicit positive/negative outcome feedback, capture it immediatel
 ## Commands
 
 ```bash
-node .claude/scripts/feedback/capture-feedback.js --feedback=up --context="..." --tags="..."
-node .claude/scripts/feedback/capture-feedback.js --feedback=down --context="..." --tags="..."
+thumbgate capture --feedback=up --context="..." --tags="..."
+thumbgate capture --feedback=down --context="..." --tags="..."
 ```
 
 ## Session Start
 
 ```bash
-npm run feedback:summary
-npm run feedback:rules
+thumbgate stats
+thumbgate lessons
 ```
 
 Use generated rules as hard guardrails to avoid repeated mistakes.

--- a/tests/adapters.test.js
+++ b/tests/adapters.test.js
@@ -104,6 +104,18 @@ test('codex config.toml contains mcp_servers section', () => {
   }
 });
 
+test('codex plugin instructions use published ThumbGate CLI entrypoints', () => {
+  const filePath = path.join(root, 'plugins/codex-profile/AGENTS.md');
+  const content = fs.readFileSync(filePath, 'utf-8');
+
+  assert.match(content, /thumbgate capture --feedback=up/, 'Codex plugin must capture positive feedback through the published CLI');
+  assert.match(content, /thumbgate capture --feedback=down/, 'Codex plugin must capture negative feedback through the published CLI');
+  assert.match(content, /thumbgate stats/, 'Codex plugin session start should use the published stats command');
+  assert.match(content, /thumbgate lessons/, 'Codex plugin session start should use the published lessons command');
+  assert.doesNotMatch(content, /\.claude\/scripts\/feedback/, 'Codex plugin must not point at repo-local Claude scripts');
+  assert.doesNotMatch(content, /npm run feedback:/, 'Codex plugin must not depend on repo-local npm scripts');
+});
+
 test('opencode adapter is valid JSON with a version-pinned local MCP server', () => {
   const filePath = path.join(root, 'adapters/opencode/opencode.json');
   const payload = JSON.parse(fs.readFileSync(filePath, 'utf-8'));


### PR DESCRIPTION
## Summary\n- updates the Codex plugin AGENTS instructions to use the published thumbgate CLI instead of stale repo-local Claude feedback scripts\n- adds an adapter regression test so Codex plugin docs cannot drift back to old commands\n- includes a patch changeset\n\n## Verification\n- node --test tests/adapters.test.js tests/changeset-check.test.js\n- npm run build:codex-plugin\n