### PR TITLE
fix(docker): migrate base image alpine → bookworm-slim, drop python3+make+g++ toolchain

### DIFF
--- a/.changeset/dockerfile-bookworm-slim-migration.md
+++ b/.changeset/dockerfile-bookworm-slim-migration.md
@@ -1,0 +1,32 @@
+---
+"thumbgate": patch
+---
+
+Migrates the Docker base image from `node:20-alpine` to `node:22-bookworm-slim`
+for both the builder and runtime stages.
+
+**Why:** `better-sqlite3@12.10.0` does not ship a prebuilt binary for the Node 20
+ABI (v115). On the previous Alpine image that meant `prebuild-install` always
+fell back to `node-gyp rebuild`, which required `python3 + make + g++` to be
+installed at build time. That toolchain added build minutes, image surface
+area, and one more thing to keep patched. The upstream WiseLibs prebuild
+matrix DOES include `node-v127-linux-x64` (Node 22), so moving the base to
+Node 22 lets `prebuild-install` resolve a ready-made `better_sqlite3.node`
+and skip the native compile entirely.
+
+**What changed:**
+- Builder + runtime: `node:20-alpine` → `node:22-bookworm-slim`
+- Removed `apk add --no-cache python3 make g++` from the builder stage
+- Swapped `apk add --no-cache git` for `apt-get install -y --no-install-recommends git wget` (wget is required by the existing HEALTHCHECK and is not preinstalled on bookworm-slim)
+- Swapped `addgroup -S / adduser -S` for the Debian-equivalent `groupadd -r / useradd -r`
+- Kept HEALTHCHECK timing, USER, EXPOSE, CMD, and the entire COPY layout identical
+
+**Verification (local, linux/amd64):**
+- `docker build` succeeds in ~61s (vs ~122s for the previous Alpine image, a ~2x speedup on a cold build)
+- `better_sqlite3.node` is present at `node_modules/better-sqlite3/build/Release/` and dated to upstream's release, confirming a prebuild download rather than a local compile
+- In-container `require('better-sqlite3')(':memory:')` round-trips a row correctly
+- Container starts and `/health` returns the expected JSON payload
+
+**Image size delta:** 511 MB → 564 MB (+53 MB). Acceptable trade-off given the
+build-time win, removal of the build-toolchain attack surface, and the
+reliability win of staying on prebuilt binaries.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ────────────────────────────────────────────────────────────────
-FROM node:20-alpine AS builder
+FROM node:22-bookworm-slim AS builder
 
 WORKDIR /app
 
-# Native build deps for better-sqlite3 et al. — Alpine uses musl libc and most
-# native-module prebuilt binaries ship glibc-only, so node-gyp falls back to
-# compiling from source and needs Python + a C++ toolchain.
-RUN apk add --no-cache python3 make g++
+# Debian/glibc base + Node 22 LTS — better-sqlite3 12.10.0 ships prebuilt
+# glibc binaries for node ABI v127 (Node 22) / v137 (Node 23) / v141 (Node 24)
+# / v147 (Node 25) via prebuild-install. Node 20 (ABI v115) has NO prebuild,
+# which is why the previous Alpine+Node20 image had to compile from source
+# with python3+make+g++. Moving to Node 22 lets prebuild-install resolve a
+# ready binary and skip node-gyp entirely.
 
 # Copy manifests first to leverage layer cache
 COPY package*.json ./
@@ -17,12 +19,16 @@ COPY package*.json ./
 RUN npm ci --omit=dev --no-audit --no-fund
 
 # ── Runtime stage ──────────────────────────────────────────────────────────────
-FROM node:20-alpine AS runtime
+FROM node:22-bookworm-slim AS runtime
 
-RUN apk add --no-cache git
+# git is invoked by some maintenance scripts; wget is used by the HEALTHCHECK
+# and is NOT preinstalled on bookworm-slim, so install both here.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git wget \
+    && rm -rf /var/lib/apt/lists/*
 
 # Non-root user for security
-RUN addgroup -S thumbgate && adduser -S thumbgate -G thumbgate
+RUN groupadd -r thumbgate && useradd -r -g thumbgate thumbgate
 
 WORKDIR /app
 

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -214,8 +214,12 @@ test('CI workflow writes and uploads a prompt evaluation artifact', () => {
 test('runtime Docker image installs git for operational integrity checks', () => {
   const dockerfile = fs.readFileSync(path.join(PROJECT_ROOT, 'Dockerfile'), 'utf8');
 
-  assert.match(dockerfile, /FROM node:20-alpine AS runtime/);
-  assert.match(dockerfile, /RUN apk add --no-cache git/);
+  // Migrated 2026-05-20: node:20-alpine → node:22-bookworm-slim to get
+  // prebuilt better-sqlite3 binaries (Node 20 has no prebuilds in 12.10.0,
+  // and Alpine has no musl prebuilds either). bookworm-slim is glibc/debian,
+  // so install git via apt instead of apk.
+  assert.match(dockerfile, /FROM node:22-bookworm-slim AS runtime/);
+  assert.match(dockerfile, /apt-get install[^\n]*\bgit\b/);
 });
 
 test('Deploy to Railway workflow is the single authoritative Railway deploy lane', () => {


### PR DESCRIPTION
## Summary

Migrates the Docker base image from `node:20-alpine` to `node:22-bookworm-slim` for both builder and runtime stages and removes the `python3 + make + g++` toolchain that PR #2249 had to add as a hotfix.

### Why now (May 2026 research consensus)

`better-sqlite3@12.10.0` ships prebuilt native binaries via `prebuild-install` for these Node ABIs:

- v127 → Node 22
- v137 → Node 23
- v141 → Node 24
- v147 → Node 25

It ships **no** prebuild for v115 (Node 20). On the previous `node:20-alpine` base, `prebuild-install` always failed and fell back to `node-gyp rebuild`, which required `python3 + make + g++` in the build stage. Switching to **Node 22** on bookworm-slim means the linux-x64 prebuild downloads cleanly and the native-toolchain crutch can be removed entirely.

(Sanity check: simply switching to `node:20-bookworm-slim` is **not** enough — the issue is the ABI, not the libc. It was tested locally first and reproduced the same `find Python` failure as Alpine.)

## What changed

- Builder + runtime: `node:20-alpine` → `node:22-bookworm-slim`
- Removed `apk add --no-cache python3 make g++` from the builder stage
- Swapped `apk add --no-cache git` for `apt-get install -y --no-install-recommends git wget && rm -rf /var/lib/apt/lists/*` — `wget` is required by the existing HEALTHCHECK and is not preinstalled on bookworm-slim
- Swapped `addgroup -S / adduser -S` for the Debian-equivalent `groupadd -r / useradd -r`
- Kept HEALTHCHECK timing, USER, EXPOSE, CMD, and the full COPY layout identical
- Did **not** touch `railway.json` (#2260 already set the right values) or any GH Actions workflow

## Local verification (linux/amd64)

| metric | alpine baseline (main) | bookworm-slim (this PR) |
|---|---|---|
| `docker build` cold time | ~122 s | ~61 s (≈ 2× faster) |
| image size (`docker image inspect .Size`) | 511 MB | 564 MB (+53 MB) |
| `better_sqlite3.node` source | compiled by node-gyp | downloaded prebuild (May 12 mtime) |

Functional checks:

- `docker build -f Dockerfile -t thumbgate-bookworm:test .` exits 0
- `ls node_modules/better-sqlite3/build/Release/` shows `better_sqlite3.node` (2.1 MB)
- `node -e "require('better-sqlite3')(':memory:').prepare('select 1 as x').get()"` returns `{ x: 1 }`
- Container starts: `ThumbGate API listening on http://0.0.0.0:8787`
- `/health` returns the expected JSON payload (HTTP 503 "degraded" in a bare test container is from missing `feedbackDir`/`buildSha` env, not a Dockerfile regression — schema is intact)

## Test plan

- [ ] CI build of the image on Railway succeeds without python/make/g++
- [ ] Post-merge: confirm container starts on Railway and `/health` returns the same shape it returned before the migration
- [ ] Monitor first 24 h for any new native-module load errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)