### PR TITLE
revert(api): remove graceful shutdown listener cleanup

### DIFF
--- a/.changeset/graceful-shutdown-listener-cleanup.md
+++ b/.changeset/graceful-shutdown-listener-cleanup.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Clean up graceful shutdown signal listeners after container drain, close-error, or timeout paths, and add direct API-server coverage for the shutdown behavior.

--- a/.changeset/revert-runtime-cleanup.md
+++ b/.changeset/revert-runtime-cleanup.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Revert the graceful shutdown listener cleanup after production verification showed the cleanup path could leave Railway without a healthy running container.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -7750,55 +7750,30 @@ function startServer({ port, host } = {}) {
 // are killed and the orchestrator may mark the container as "crashed" (instead
 // of "gracefully stopped"), wasting its restart-policy budget on a healthy
 // shutdown. Drain HTTP, give a deadline, then force-exit if anything hangs.
-function registerGracefulShutdown(server, {
-  gracePeriodMs = 25_000,
-  processRef = process,
-  logger = console,
-  exit = process.exit,
-  setTimeoutFn = setTimeout,
-  clearTimeoutFn = clearTimeout,
-} = {}) {
-  if (server[GRACEFUL_SHUTDOWN_KEY]) return server[GRACEFUL_SHUTDOWN_KEY];
+function registerGracefulShutdown(server, { gracePeriodMs = 25_000 } = {}) {
+  if (server[GRACEFUL_SHUTDOWN_KEY]) return;
   server[GRACEFUL_SHUTDOWN_KEY] = true;
   let shuttingDown = false;
-  let forceTimer = null;
-  const cleanup = () => {
-    processRef.removeListener('SIGTERM', onSigterm);
-    processRef.removeListener('SIGINT', onSigint);
-    if (forceTimer) {
-      clearTimeoutFn(forceTimer);
-      forceTimer = null;
-    }
-  };
   const stop = (signal) => {
     if (shuttingDown) return;
     shuttingDown = true;
-    logger.log(`[shutdown] ${signal} received — draining connections (deadline ${gracePeriodMs}ms)`);
-    forceTimer = setTimeoutFn(() => {
-      logger.error('[shutdown] grace period elapsed — forcing exit');
-      cleanup();
-      exit(1);
+    console.log(`[shutdown] ${signal} received — draining connections (deadline ${gracePeriodMs}ms)`);
+    const forceTimer = setTimeout(() => {
+      console.error('[shutdown] grace period elapsed — forcing exit');
+      process.exit(1);
     }, gracePeriodMs);
     if (typeof forceTimer.unref === 'function') forceTimer.unref();
     server.close((err) => {
       if (err) {
-        logger.error('[shutdown] server.close error:', err.message);
-        cleanup();
-        exit(1);
-        return;
+        console.error('[shutdown] server.close error:', err.message);
+        process.exit(1);
       }
-      logger.log('[shutdown] drained cleanly');
-      cleanup();
-      exit(0);
+      console.log('[shutdown] drained cleanly');
+      process.exit(0);
     });
   };
-  const onSigterm = () => stop('SIGTERM');
-  const onSigint = () => stop('SIGINT');
-  processRef.on('SIGTERM', onSigterm);
-  processRef.on('SIGINT', onSigint);
-  server.once('close', cleanup);
-  server[GRACEFUL_SHUTDOWN_KEY] = { cleanup, stop };
-  return server[GRACEFUL_SHUTDOWN_KEY];
+  process.on('SIGTERM', () => stop('SIGTERM'));
+  process.on('SIGINT', () => stop('SIGINT'));
 }
 
 const GRACEFUL_SHUTDOWN_KEY = Symbol.for('thumbgate.gracefulShutdownRegistered');
@@ -7819,7 +7794,6 @@ module.exports = {
     renderPackagedDashboardHtml,
     renderPackagedLessonsHtml,
     readOptionalPublicTemplate,
-    registerGracefulShutdown,
     resolveLocalPageBootstrap,
   },
 };

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -5,7 +5,6 @@ const path = require('node:path');
 const fs = require('node:fs');
 const https = require('node:https');
 const Module = require('node:module');
-const { EventEmitter } = require('node:events');
 const { Readable } = require('node:stream');
 
 if (process.env.CODEX_SANDBOX) {
@@ -440,90 +439,6 @@ test('startServer accepts an explicit bind host', async () => {
   } finally {
     await new Promise((resolve) => explicit.server.close(resolve));
   }
-});
-
-test('registerGracefulShutdown drains once, exits cleanly, and removes signal listeners', () => {
-  const processRef = new EventEmitter();
-  const logs = [];
-  const exits = [];
-  const timers = new Set();
-  let closeCalls = 0;
-  const server = new EventEmitter();
-  server.close = (callback) => {
-    closeCalls += 1;
-    callback();
-  };
-
-  const registration = __test__.registerGracefulShutdown(server, {
-    gracePeriodMs: 10,
-    processRef,
-    logger: {
-      log: (message) => logs.push(message),
-      error: (message) => logs.push(message),
-    },
-    exit: (code) => exits.push(code),
-    setTimeoutFn: (callback) => {
-      const timer = { callback, unref() {} };
-      timers.add(timer);
-      return timer;
-    },
-    clearTimeoutFn: (timer) => timers.delete(timer),
-  });
-
-  assert.equal(typeof registration.cleanup, 'function');
-  assert.equal(processRef.listenerCount('SIGTERM'), 1);
-  assert.equal(processRef.listenerCount('SIGINT'), 1);
-
-  processRef.emit('SIGTERM');
-  processRef.emit('SIGTERM');
-
-  assert.equal(closeCalls, 1);
-  assert.deepEqual(exits, [0]);
-  assert.equal(processRef.listenerCount('SIGTERM'), 0);
-  assert.equal(processRef.listenerCount('SIGINT'), 0);
-  assert.equal(timers.size, 0);
-  assert.match(logs.join('\n'), /SIGTERM received/);
-  assert.match(logs.join('\n'), /drained cleanly/);
-});
-
-test('registerGracefulShutdown exits nonzero when drain fails or times out', () => {
-  const closeErrorProcess = new EventEmitter();
-  const closeErrorExits = [];
-  const closeErrorServer = new EventEmitter();
-  closeErrorServer.close = (callback) => callback(new Error('close failed'));
-
-  __test__.registerGracefulShutdown(closeErrorServer, {
-    processRef: closeErrorProcess,
-    logger: { log() {}, error() {} },
-    exit: (code) => closeErrorExits.push(code),
-    setTimeoutFn: () => ({ unref() {} }),
-    clearTimeoutFn: () => {},
-  });
-  closeErrorProcess.emit('SIGINT');
-  assert.deepEqual(closeErrorExits, [1]);
-  assert.equal(closeErrorProcess.listenerCount('SIGINT'), 0);
-
-  const timeoutProcess = new EventEmitter();
-  const timeoutExits = [];
-  let timeoutCallback;
-  const hangingServer = new EventEmitter();
-  hangingServer.close = () => {};
-
-  __test__.registerGracefulShutdown(hangingServer, {
-    gracePeriodMs: 1,
-    processRef: timeoutProcess,
-    logger: { log() {}, error() {} },
-    exit: (code) => timeoutExits.push(code),
-    setTimeoutFn: (callback) => {
-      timeoutCallback = callback;
-      return { unref() {} };
-    },
-    clearTimeoutFn: () => {},
-  });
-  timeoutProcess.emit('SIGTERM');
-  timeoutCallback();
-  assert.deepEqual(timeoutExits, [1]);
-  assert.equal(timeoutProcess.listenerCount('SIGTERM'), 0);
 });
 
 test('protected endpoints accept x-api-key as an alternate auth header', async () => {


### PR DESCRIPTION
## Summary\n- reverts the runtime graceful-shutdown cleanup from #2262 after Railway production verification showed that build could leave the service without a healthy running container\n- keeps the Codex plugin instruction/publish fix from #2264 intact\n- adds a patch changeset documenting the revert\n\n## Verification\n- node --test tests/api-server.test.js tests/deployment.test.js tests/adapters.test.js tests/changeset-check.test.js\n- node --test tests/changeset-check.test.js\n- Production rollback verified: /health 200 on build a34e7a621e5cd926942755a0e6cc313e789232e4\n