### PR TITLE
fix(landing): replace broken 90-second demo link with honest CTA

### DIFF
--- a/.changeset/landing-demo-cta-honesty.md
+++ b/.changeset/landing-demo-cta-honesty.md
@@ -1,0 +1,12 @@
+---
+"thumbgate": patch
+---
+
+fix(landing): replace broken 90-second demo link with honest CTA
+
+The hero "Watch the 90-second demo" anchor on `/` pointed to `#demo`,
+which scrolled to a section that no longer hosts a video — the link
+landed visitors on an empty placeholder. Replace with an honest CTA
+that directs to a real, available surface so the landing-page promise
+matches what's actually there. Companion E2E coverage updated in
+`tests/e2e/index-page-clickability.spec.js`.

--- a/public/index.html
+++ b/public/index.html
@@ -721,7 +721,7 @@ __GA_BOOTSTRAP__
       </div>
       <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-gpt-page btn-install-hero" title="Click to copy: npx thumbgate init">Install Free CLI</a>
       <a href="#workflow-sprint-intake" onclick="try{posthog.capture('hero_sprint_click',{cta:'sprint_intake'})}catch(_){};sendFirstPartyTelemetry('hero_sprint_intake_started',{ctaId:'hero_workflow_sprint',ctaPlacement:'hero',offer:'workflow_sprint'});" class="btn-pro-page hero-pro">Talk to me — Workflow Hardening Sprint →</a>
-      <a href="#demo" onclick="try{posthog.capture('hero_demo_click',{cta:'watch_demo'})}catch(_){};sendFirstPartyTelemetry('hero_demo_clicked',{ctaId:'hero_watch_demo',ctaPlacement:'hero'});" class="btn-free" style="font-size:15px;padding:14px 22px;">▶ Watch the 90-second demo</a>
+      <a href="#demo" onclick="try{posthog.capture('hero_demo_click',{cta:'see_enforcement'})}catch(_){};sendFirstPartyTelemetry('hero_demo_clicked',{ctaId:'hero_see_enforcement',ctaPlacement:'hero'});" class="btn-free" style="font-size:15px;padding:14px 22px;">See the enforcement in action</a>
     </div>
 
     <div class="hero-trust-bar">

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -51,9 +51,9 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await expect(page).toHaveURL(/#workflow-sprint-intake$/);
   });
 
-  test('clicking "Watch the 90-second demo" anchors to #demo', async ({ page }) => {
+  test('clicking "See the enforcement in action" anchors to #demo', async ({ page }) => {
     await page.goto('/');
-    await page.locator('a.btn-free', { hasText: /Watch the 90-second demo/ }).first().click();
+    await page.locator('a.btn-free', { hasText: /See the enforcement in action/ }).first().click();
     await expect(page).toHaveURL(/#demo$/);
   });
 


### PR DESCRIPTION
## Summary

- The hero "Watch the 90-second demo" button promised a video that doesn't exist — it scrolled to static feature cards, breaking trust with potential customers
- Replaced with "See the enforcement in action" which honestly describes the #demo section content
- Updated E2E test to match new button text

## Test plan

- [ ] `npx playwright test tests/e2e/index-page-clickability.spec.js` — updated test passes
- [ ] Visual: hero CTA no longer promises a video

🤖 Generated with [Claude Code](https://claude.com/claude-code)