### PR TITLE
fix(site): audit and fix broken links across 45 files

### DIFF
--- a/.changeset/broken-links-audit.md
+++ b/.changeset/broken-links-audit.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+fix(site): broken link audit — correct llm-context.md paths in 43 HTML files, fix dead pricing anchor, add 404 catch-all, add /go/team /go/checkout /go/trial shortlinks

--- a/public/codex-plugin.html
+++ b/public/codex-plugin.html
@@ -12,7 +12,7 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://thumbgate-production.up.railway.app/codex-plugin">
 <link rel="canonical" href="https://thumbgate-production.up.railway.app/codex-plugin">
-<link rel="llm-context" href="/public/llm-context.md" type="text/markdown">
+<link rel="llm-context" href="/llm-context.md" type="text/markdown">
 
 <script type="application/ld+json">
 {

--- a/public/compare/agentix-labs.html
+++ b/public/compare/agentix-labs.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/compare/agentix-labs" />
   <link rel="canonical" href="https://thumbgate.ai/compare/agentix-labs" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/png" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/compare/fallow.html
+++ b/public/compare/fallow.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/compare/fallow" />
   <link rel="canonical" href="https://thumbgate.ai/compare/fallow" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/compare/heidi.html
+++ b/public/compare/heidi.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/compare/heidi" />
   <link rel="canonical" href="https://thumbgate.ai/compare/heidi" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/png" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/compare/mem0.html
+++ b/public/compare/mem0.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/compare/mem0" />
   <link rel="canonical" href="https://thumbgate.ai/compare/mem0" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/compare/speclock.html
+++ b/public/compare/speclock.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/compare/speclock" />
   <link rel="canonical" href="https://thumbgate.ai/compare/speclock" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/agent-harness-optimization.html
+++ b/public/guides/agent-harness-optimization.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/agent-harness-optimization" />
   <link rel="canonical" href="https://thumbgate.ai/guides/agent-harness-optimization" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/ai-agent-governance-sprint.html
+++ b/public/guides/ai-agent-governance-sprint.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/ai-agent-governance-sprint" />
   <link rel="canonical" href="https://thumbgate.ai/guides/ai-agent-governance-sprint" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/ai-agent-workflow-migration-checklist.html
+++ b/public/guides/ai-agent-workflow-migration-checklist.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/ai-agent-workflow-migration-checklist" />
   <link rel="canonical" href="https://thumbgate.ai/guides/ai-agent-workflow-migration-checklist" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/ai-deployment-readiness.html
+++ b/public/guides/ai-deployment-readiness.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/ai-deployment-readiness" />
   <link rel="canonical" href="https://thumbgate.ai/guides/ai-deployment-readiness" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/ai-search-topical-presence.html
+++ b/public/guides/ai-search-topical-presence.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/ai-search-topical-presence" />
   <link rel="canonical" href="https://thumbgate.ai/guides/ai-search-topical-presence" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/autoresearch-agent-safety.html
+++ b/public/guides/autoresearch-agent-safety.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/autoresearch-agent-safety" />
   <link rel="canonical" href="https://thumbgate.ai/guides/autoresearch-agent-safety" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/background-agent-governance.html
+++ b/public/guides/background-agent-governance.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/background-agent-governance" />
   <link rel="canonical" href="https://thumbgate.ai/guides/background-agent-governance" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/best-tools-stop-ai-agents-breaking-production.html
+++ b/public/guides/best-tools-stop-ai-agents-breaking-production.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/best-tools-stop-ai-agents-breaking-production" />
   <link rel="canonical" href="https://thumbgate.ai/guides/best-tools-stop-ai-agents-breaking-production" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/browser-automation-safety.html
+++ b/public/guides/browser-automation-safety.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/browser-automation-safety" />
   <link rel="canonical" href="https://thumbgate.ai/guides/browser-automation-safety" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/chatgpt-ads-trust.html
+++ b/public/guides/chatgpt-ads-trust.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/chatgpt-ads-trust" />
   <link rel="canonical" href="https://thumbgate.ai/guides/chatgpt-ads-trust" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/claude-code-feedback.html
+++ b/public/guides/claude-code-feedback.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/claude-code-feedback" />
   <link rel="canonical" href="https://thumbgate.ai/guides/claude-code-feedback" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/claude-code-prevent-repeated-mistakes.html
+++ b/public/guides/claude-code-prevent-repeated-mistakes.html
@@ -12,7 +12,7 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://thumbgate-production.up.railway.app/guides/claude-code-prevent-repeated-mistakes">
 <link rel="canonical" href="https://thumbgate-production.up.railway.app/guides/claude-code-prevent-repeated-mistakes">
-<link rel="llm-context" href="/public/llm-context.md" type="text/markdown">
+<link rel="llm-context" href="/llm-context.md" type="text/markdown">
 
 <script type="application/ld+json">
 {

--- a/public/guides/claude-code-skills-guardrails.html
+++ b/public/guides/claude-code-skills-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/claude-code-skills-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/claude-code-skills-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/claude-desktop.html
+++ b/public/guides/claude-desktop.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/claude-desktop" />
   <link rel="canonical" href="https://thumbgate.ai/guides/claude-desktop" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/code-knowledge-graph-guardrails.html
+++ b/public/guides/code-knowledge-graph-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/code-knowledge-graph-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/code-knowledge-graph-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/codex-cli-guardrails.html
+++ b/public/guides/codex-cli-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/codex-cli-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/codex-cli-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/cursor-agent-guardrails.html
+++ b/public/guides/cursor-agent-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/cursor-agent-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/cursor-agent-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/cursor-prevent-repeated-mistakes.html
+++ b/public/guides/cursor-prevent-repeated-mistakes.html
@@ -12,7 +12,7 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://thumbgate-production.up.railway.app/guides/cursor-prevent-repeated-mistakes">
 <link rel="canonical" href="https://thumbgate-production.up.railway.app/guides/cursor-prevent-repeated-mistakes">
-<link rel="llm-context" href="/public/llm-context.md" type="text/markdown">
+<link rel="llm-context" href="/llm-context.md" type="text/markdown">
 
 <script type="application/ld+json">
 {

--- a/public/guides/deepseek-v4-runtime-guardrails.html
+++ b/public/guides/deepseek-v4-runtime-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/deepseek-v4-runtime-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/deepseek-v4-runtime-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/developer-machine-supply-chain-guardrails.html
+++ b/public/guides/developer-machine-supply-chain-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/developer-machine-supply-chain-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/developer-machine-supply-chain-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/gcp-mcp-guardrails.html
+++ b/public/guides/gcp-mcp-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/gcp-mcp-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/gcp-mcp-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/gemini-cli-feedback-memory.html
+++ b/public/guides/gemini-cli-feedback-memory.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/gemini-cli-feedback-memory" />
   <link rel="canonical" href="https://thumbgate.ai/guides/gemini-cli-feedback-memory" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/gpt-5-5-model-evaluation.html
+++ b/public/guides/gpt-5-5-model-evaluation.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/gpt-5-5-model-evaluation" />
   <link rel="canonical" href="https://thumbgate.ai/guides/gpt-5-5-model-evaluation" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/internal-ai-engineering-stack-guardrails.html
+++ b/public/guides/internal-ai-engineering-stack-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/internal-ai-engineering-stack-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/internal-ai-engineering-stack-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/long-running-agent-context-management.html
+++ b/public/guides/long-running-agent-context-management.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/long-running-agent-context-management" />
   <link rel="canonical" href="https://thumbgate.ai/guides/long-running-agent-context-management" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/multica-thumbgate-setup.html
+++ b/public/guides/multica-thumbgate-setup.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/multica-thumbgate-setup" />
   <link rel="canonical" href="https://thumbgate.ai/guides/multica-thumbgate-setup" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/native-messaging-host-security.html
+++ b/public/guides/native-messaging-host-security.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/native-messaging-host-security" />
   <link rel="canonical" href="https://thumbgate.ai/guides/native-messaging-host-security" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/pre-action-checks.html
+++ b/public/guides/pre-action-checks.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/pre-action-checks" />
   <link rel="canonical" href="https://thumbgate.ai/guides/pre-action-checks" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/prompt-tricks-to-workflow-rules.html
+++ b/public/guides/prompt-tricks-to-workflow-rules.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/prompt-tricks-to-workflow-rules" />
   <link rel="canonical" href="https://thumbgate.ai/guides/prompt-tricks-to-workflow-rules" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/proxy-pointer-rag-guardrails.html
+++ b/public/guides/proxy-pointer-rag-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/proxy-pointer-rag-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/proxy-pointer-rag-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/rag-precision-tuning-guardrails.html
+++ b/public/guides/rag-precision-tuning-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/rag-precision-tuning-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/rag-precision-tuning-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/reasoning-compression-guardrails.html
+++ b/public/guides/reasoning-compression-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/reasoning-compression-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/reasoning-compression-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/relational-knowledge-ai-recommendations.html
+++ b/public/guides/relational-knowledge-ai-recommendations.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/relational-knowledge-ai-recommendations" />
   <link rel="canonical" href="https://thumbgate.ai/guides/relational-knowledge-ai-recommendations" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/roo-code-alternative-cline.html
+++ b/public/guides/roo-code-alternative-cline.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/roo-code-alternative-cline" />
   <link rel="canonical" href="https://thumbgate.ai/guides/roo-code-alternative-cline" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/semantic-programmatic-seo-guardrails.html
+++ b/public/guides/semantic-programmatic-seo-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/semantic-programmatic-seo-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/semantic-programmatic-seo-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/seo-agent-skills-guardrails.html
+++ b/public/guides/seo-agent-skills-guardrails.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/seo-agent-skills-guardrails" />
   <link rel="canonical" href="https://thumbgate.ai/guides/seo-agent-skills-guardrails" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/guides/stop-repeated-ai-agent-mistakes.html
+++ b/public/guides/stop-repeated-ai-agent-mistakes.html
@@ -10,7 +10,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes" />
   <link rel="canonical" href="https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes" />
-  <link rel="llm-context" href="/public/llm-context.md" type="text/markdown" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
   <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
   <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
   <meta property="og:image" content="/og.png" />

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -213,7 +213,7 @@ __GA_BOOTSTRAP__
   <div class="container">
     <a href="/" class="nav-logo">ThumbGate</a>
     <div class="nav-links">
-      <a href="/#features">Features</a>
+      <a href="/#how-it-works">Features</a>
       <a href="/pricing" style="color:var(--text);">Pricing</a>
       <a href="/guide">Guide</a>
       <a href="/dashboard">Dashboard</a>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -429,6 +429,46 @@ const TRACKED_LINK_TARGETS = Object.freeze({
       plan_id: 'team',
     },
   },
+  // Aliases: /go/team → same as /go/teams, /go/checkout → same as /go/pro,
+  // /go/trial → install guide (trial starts on init)
+  team: {
+    path: '/#workflow-sprint-intake',
+    ctaId: 'go_team',
+    ctaPlacement: 'link_router',
+    eventType: 'team_intake_started',
+    defaults: {
+      utm_source: 'website',
+      utm_medium: 'link_router',
+      utm_campaign: 'team_intake',
+      plan_id: 'team',
+    },
+  },
+  checkout: {
+    path: '/checkout/pro',
+    ctaId: 'go_checkout',
+    ctaPlacement: 'link_router',
+    eventType: 'cta_click',
+    defaults: {
+      utm_source: 'website',
+      utm_medium: 'link_router',
+      utm_campaign: 'pro_upgrade',
+      plan_id: 'pro',
+      billing_cycle: 'monthly',
+    },
+    allowCustomerEmail: true,
+  },
+  trial: {
+    path: '/guide',
+    ctaId: 'go_trial',
+    ctaPlacement: 'link_router',
+    eventType: 'trial_start_click',
+    defaults: {
+      utm_source: 'website',
+      utm_medium: 'link_router',
+      utm_campaign: 'trial_start',
+      plan_id: 'free_trial',
+    },
+  },
   install: {
     path: '/guide',
     ctaId: 'go_install',
@@ -757,7 +797,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Inspect prevention_rules after repeats.',
       ],
       installCommand: 'npx thumbgate init',
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
     {
@@ -784,7 +824,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Evaluate NDCG@10 on visual hard negatives.',
         'Require artifact links before using retrieved evidence in claims.',
       ],
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
     {
@@ -798,7 +838,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Compact feedback context with anchors for proof-critical lessons.',
         'Record estimated token savings next to the workflow evidence.',
       ],
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       footprintUrl: buildPublicUrl(hostedConfig, '/.well-known/mcp/footprint.json'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
@@ -813,7 +853,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Require baseline evals before adding autonomy or subagents.',
         'Classify tool risk before allowing writes, money movement, production changes, or outbound actions.',
       ],
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
     {
@@ -827,7 +867,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Grade goal inference separately from intervention timing.',
         'Block multi-app proactive writes until rollback and orchestration evidence exists.',
       ],
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
     {
@@ -841,7 +881,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Map every proxy metric to the real user objective.',
         'Require holdout or regression proof before treating benchmark gains as product gains.',
       ],
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
     {
@@ -855,7 +895,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Reproduce locally before claiming a fix.',
         'Open one focused PR with tests, proof, and transparent ThumbGate context only when relevant.',
       ],
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
     {
@@ -869,7 +909,7 @@ function getMcpSkillManifests(hostedConfig) {
         'Route self-serve intent to the guide and team pain to Workflow Hardening Sprint intake.',
         'Block unsupported ad and landing-page claims before spend scales.',
       ],
-      contextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      contextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
       proofUrl: VERIFICATION_EVIDENCE_URL,
     },
   ];
@@ -1003,7 +1043,7 @@ function getMcpDiscoveryManifest(hostedConfig) {
     footprint: getContextFootprintReport(hostedConfig),
     proof: {
       verificationEvidenceUrl: VERIFICATION_EVIDENCE_URL,
-      llmContextUrl: buildPublicUrl(hostedConfig, '/public/llm-context.md'),
+      llmContextUrl: buildPublicUrl(hostedConfig, '/llm-context.md'),
     },
   };
 }
@@ -4663,7 +4703,7 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname === '/checkout/pro') {
       if (isHeadRequest) {
-        sendText(res, 200, '', {}, {
+        sendHtml(res, 200, '', {}, {
           headOnly: true,
         });
         return;
@@ -6320,6 +6360,14 @@ async function addContext(){
           detail: err.message || 'An unexpected error occurred.',
         }, getPublicBillingHeaders(requestedTraceId));
       }
+      return;
+    }
+
+    // Catch non-API GET requests that didn't match any public page route above.
+    // Without this, /about, /docs, /demo etc. fall through to the API auth gate
+    // and return a raw JSON 401 instead of a user-friendly 404.
+    if (isGetLikeRequest && !pathname.startsWith('/v1/') && !pathname.startsWith('/api/')) {
+      sendHtml(res, 404, `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Page Not Found — ThumbGate</title><style>body{background:#0a0a0a;color:#e2e8f0;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}main{text-align:center;padding:2rem}h1{font-size:4rem;margin:0;color:#22d3ee}p{font-size:1.1rem;color:#94a3b8;margin:1rem 0}a{color:#22d3ee;text-decoration:underline}</style></head><body><main><h1>404</h1><p>This page doesn't exist.</p><p><a href="/">Back to ThumbGate</a></p></main></body></html>`);
       return;
     }
 

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -29,10 +29,10 @@ test.describe('/pricing clickability — full CTA coverage', () => {
     await page.waitForURL(/\/$/);
   });
 
-  test('nav: "Features" anchors to /#features', async ({ page }) => {
+  test('nav: "Features" anchors to /#how-it-works', async ({ page }) => {
     await page.goto('/pricing');
-    await page.locator('nav a[href="/#features"]').first().click();
-    await page.waitForURL(/\/#features$/);
+    await page.locator('nav a[href="/#how-it-works"]').first().click();
+    await page.waitForURL(/\/#how-it-works$/);
   });
 
   test('nav: "Guide" navigates to /guide', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fixed `llm-context.md` href path in 43 HTML files (`/public/llm-context.md` → `/llm-context.md`)
- Fixed dead `/#features` anchor in pricing.html → `/#how-it-works`
- Fixed checkout/pro HEAD handler content-type (`sendText` → `sendHtml`)
- Added 3 new tracked shortlinks: `/go/team`, `/go/checkout`, `/go/trial` with UTM attribution
- Added 404 HTML catch-all for non-API GET requests (previously returned raw API auth JSON)
- Fixed 9 MCP manifest entries with wrong `llm-context.md` paths in `server.js`

## Test plan
- [x] `landing-page-claims.test.js` — 23/23 pass
- [x] Pre-commit hooks all pass (parity, version sync, claims)
- [x] Pre-push guards pass (npm pack dry-run, internal link validation, regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)