### PR TITLE
fix(api): /health tiers failures so a buildSha gap can't kill the container

### DIFF
--- a/.changeset/health-buildsha-resilience.md
+++ b/.changeset/health-buildsha-resilience.md
@@ -1,0 +1,28 @@
+---
+"thumbgate": patch
+---
+
+fix(api): /health no longer kills the container over a missing buildSha
+
+The /health endpoint previously returned HTTP 503 if any of three checks
+failed — including a missing `BUILD_METADATA.buildSha`. Railway treats
+503 as a healthcheck failure → sends SIGTERM → container exits →
+restart-policy budget exhausts → outage.
+
+This exact failure mode took prod down 2026-05-21 18:21Z → 19:30Z
+(~70 min) after the THUMBGATE_BUILD_SHA env var was cleaned up earlier
+in the day. A telemetry gap is not a service outage; the container still
+serves requests fine when buildSha is empty.
+
+Tiered failure classification:
+- **service-failing** (feedback dir unwritable, hosted-config appOrigin
+  missing) → HTTP 503 + status: 'failing'. Container should be replaced.
+- **telemetry-degraded** (buildSha missing) → HTTP 200 + status: 'degraded'
+  + `degraded: true` flag. Container stays alive; monitors see the gap.
+
+Every check now carries a `severity` field so downstream monitors can
+distinguish the two classes. Response shape is backwards-compatible
+(adds `degraded` and `severity` fields; existing consumers ignore them).
+
+Regression test pins the new behavior: a missing build-metadata file
+must return 200 (not 503) and must set status='degraded'.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5229,40 +5229,57 @@ async function addContext(){
       // was down, when feedback-dir was unwritable, when env was misconfigured.
       // The fix is shallow but meaningful: probe each critical subsystem and
       // surface failures with HTTP 503 + a per-check breakdown.
+      // Tiered failure classification — not all degradations should kill the
+      // container. A *service-failing* check (feedback dir unwritable,
+      // appOrigin missing) returns 503 → Railway's healthcheck fails → SIGTERM
+      // → restart loop → outage (this exact failure mode took prod down
+      // 2026-05-21 18:21Z → 19:30Z when BUILD_METADATA.buildSha came up empty
+      // after a Railway env-var cleanup). A *telemetry-degraded* check (missing
+      // buildSha) returns 200 with `degraded: true` so observability stays
+      // visible but Railway doesn't kill an otherwise-healthy container over
+      // a SHA gap.
       const checks = {};
-      let allOk = true;
+      let failing = false;     // any service-failing check → 503
+      let degraded = false;    // any telemetry-degraded check → 200 + flag
 
       // Check 1: feedback dir exists and is writable.
+      // SERVICE-FAILING — if we can't write feedback, the API can't function.
       try {
         const { FEEDBACK_DIR } = getFeedbackPaths();
         fs.accessSync(FEEDBACK_DIR, fs.constants.W_OK);
         checks.feedbackDir = { ok: true };
       } catch (err) {
-        checks.feedbackDir = { ok: false, error: err?.code || 'inaccessible' };
-        allOk = false;
+        checks.feedbackDir = { ok: false, error: err?.code || 'inaccessible', severity: 'failing' };
+        failing = true;
       }
 
       // Check 2: hosted config resolves the canonical app origin.
-      // If appOrigin is missing/empty, redirects + checkout flow break silently.
+      // SERVICE-FAILING — if appOrigin is missing/empty, redirects + checkout
+      // flow break silently.
       if (hostedConfig?.appOrigin) {
         checks.hostedConfig = { ok: true };
       } else {
-        checks.hostedConfig = { ok: false, error: 'missing_appOrigin' };
-        allOk = false;
+        checks.hostedConfig = { ok: false, error: 'missing_appOrigin', severity: 'failing' };
+        failing = true;
       }
 
-      // Check 3: build metadata loaded. If BUILD_METADATA.buildSha is empty,
-      // Railway didn't inject the deploy SHA — observability is degraded.
+      // Check 3: build metadata loaded.
+      // TELEMETRY-DEGRADED — observability gap, not a runtime outage. The
+      // container still serves requests fine; we just can't tag responses with
+      // the deployed SHA. Surfaces the gap to monitors via `degraded: true`
+      // without triggering Railway's SIGTERM-on-503 loop.
       if (BUILD_METADATA?.buildSha) {
         checks.buildMetadata = { ok: true };
       } else {
-        checks.buildMetadata = { ok: false, error: 'missing_buildSha' };
-        allOk = false;
+        checks.buildMetadata = { ok: false, error: 'missing_buildSha', severity: 'degraded' };
+        degraded = true;
       }
 
-      const statusCode = allOk ? 200 : 503;
+      const statusCode = failing ? 503 : 200;
+      const status = failing ? 'failing' : (degraded ? 'degraded' : 'ok');
       sendJson(res, statusCode, {
-        status: allOk ? 'ok' : 'degraded',
+        status,
+        degraded: degraded || failing,
         version: pkg.version,
         buildSha: BUILD_METADATA.buildSha,
         uptime: process.uptime(),

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -150,7 +150,7 @@ test('/health surfaces a per-check breakdown (no longer always-green theater)', 
   assert.equal(body.checks.buildMetadata.ok, true);
 });
 
-test('/health returns degraded when feedback dir is not writable', async () => {
+test('/health returns 503 failing when feedback dir is not writable (service-failing severity)', async () => {
   const originalAccessSync = fs.accessSync;
   fs.accessSync = (target, mode) => {
     if (target === tmpFeedbackDir && mode === fs.constants.W_OK) {
@@ -165,14 +165,56 @@ test('/health returns degraded when feedback dir is not writable', async () => {
     const res = await fetch(apiUrl('/health'), { headers: authHeader });
     assert.equal(res.status, 503);
     const body = await res.json();
-    assert.equal(body.status, 'degraded');
-    assert.deepEqual(body.checks.feedbackDir, { ok: false, error: 'EACCES' });
+    assert.equal(body.status, 'failing');
+    assert.equal(body.degraded, true);
+    assert.equal(body.checks.feedbackDir.ok, false);
+    assert.equal(body.checks.feedbackDir.error, 'EACCES');
+    assert.equal(body.checks.feedbackDir.severity, 'failing');
   } finally {
     fs.accessSync = originalAccessSync;
   }
 });
 
-test('/health returns degraded when build metadata is missing', async () => {
+test('/health returns 200 degraded (not 503) when build metadata is missing', async () => {
+  // Regression for 2026-05-21 outage (18:21Z → 19:30Z): when BUILD_METADATA.buildSha
+  // was empty, /health returned 503 → Railway healthcheck failed → SIGTERM →
+  // restart loop → 70-min prod outage. A missing buildSha is an OBSERVABILITY
+  // gap (can't tag responses with the deployed SHA), not a service failure —
+  // the API still handles requests fine. It must return 200 with degraded=true.
+  const originalMetadataPath = process.env.THUMBGATE_BUILD_METADATA_PATH;
+  const missingMetadataPath = path.join(tmpFeedbackDir, 'missing-build-metadata-degraded.json');
+  let isolatedHandle;
+
+  process.env.THUMBGATE_BUILD_METADATA_PATH = missingMetadataPath;
+  delete require.cache[apiServerModulePath];
+  const isolatedServerModule = require('../src/api/server');
+
+  try {
+    isolatedHandle = await isolatedServerModule.startServer({ port: 0, host: '127.0.0.1' });
+    const isolatedOrigin = `http://localhost:${isolatedHandle.port}`;
+    const res = await fetch(new URL('/health', isolatedOrigin), { headers: authHeader });
+    assert.equal(res.status, 200, 'telemetry gap must NOT return 503 — that triggers Railway SIGTERM');
+    const body = await res.json();
+    assert.equal(body.status, 'degraded');
+    assert.equal(body.degraded, true);
+    assert.equal(body.checks.buildMetadata.ok, false);
+    assert.equal(body.checks.buildMetadata.error, 'missing_buildSha');
+    assert.equal(body.checks.buildMetadata.severity, 'degraded');
+    // Critical: other checks still pass — only the telemetry one is degraded.
+    assert.equal(body.checks.feedbackDir.ok, true);
+    assert.equal(body.checks.hostedConfig.ok, true);
+  } finally {
+    if (isolatedHandle) {
+      await new Promise((resolve) => isolatedHandle.server.close(resolve));
+    }
+    if (originalMetadataPath === undefined) delete process.env.THUMBGATE_BUILD_METADATA_PATH;
+    else process.env.THUMBGATE_BUILD_METADATA_PATH = originalMetadataPath;
+    delete require.cache[apiServerModulePath];
+    require('../src/api/server');
+  }
+});
+
+test('/health legacy test: build-metadata-missing path no longer returns 503', async () => {
   const originalMetadataPath = process.env.THUMBGATE_BUILD_METADATA_PATH;
   const missingMetadataPath = path.join(tmpFeedbackDir, 'missing-build-metadata.json');
   let isolatedHandle;
@@ -185,10 +227,12 @@ test('/health returns degraded when build metadata is missing', async () => {
     isolatedHandle = await isolatedServerModule.startServer({ port: 0, host: '127.0.0.1' });
     const isolatedOrigin = `http://localhost:${isolatedHandle.port}`;
     const res = await fetch(new URL('/health', isolatedOrigin), { headers: authHeader });
-    assert.equal(res.status, 503);
+    // Was 503 before the 2026-05-21 fix; now 200 because telemetry gap !== service failure.
+    assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.status, 'degraded');
-    assert.deepEqual(body.checks.buildMetadata, { ok: false, error: 'missing_buildSha' });
+    assert.equal(body.checks.buildMetadata.ok, false);
+    assert.equal(body.checks.buildMetadata.error, 'missing_buildSha');
   } finally {
     if (isolatedHandle) {
       await new Promise((resolve) => isolatedHandle.server.close(resolve));


### PR DESCRIPTION
Surgical post-mortem fix for the 2026-05-21 70-min outage. /health used to return 503 when BUILD_METADATA.buildSha was missing → Railway healthcheck fail → SIGTERM → restart loop → outage.

Tiered failure classification:
- **service-failing** (feedback dir unwritable, appOrigin missing) → 503 + status='failing'. Container should be replaced.
- **telemetry-degraded** (buildSha missing) → 200 + status='degraded' + degraded=true. Container stays alive; monitors see the gap.

Backwards-compatible response shape. New regression test pins the contract. 131 api-server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)