### PR TITLE
feat(ul): silent-failure clustering on by default (was opt-in)

### DIFF
--- a/.changeset/silent-failure-cluster-default-on.md
+++ b/.changeset/silent-failure-cluster-default-on.md
@@ -1,0 +1,29 @@
+---
+"thumbgate": minor
+---
+
+feat(ul): silent-failure clustering is now ON by default (was opt-in)
+
+The silent-failure clustering candidate source shipped behind
+`THUMBGATE_SILENT_FAILURE_CLUSTERING=1` in PR #2285. The whole point of
+that work was to cover the case where users don't manually give
+thumbs-down on failed tool calls — but leaving it opt-in meant the
+users who needed it most (the ones who never set environment variables)
+never got the benefit.
+
+Flipped to default-ON. Opt out via:
+- `THUMBGATE_SILENT_FAILURE_CLUSTERING=0` (or `false` / `off` / `no`)
+- `NODE_ENV=test` (auto-opted-out so test runs stay deterministic)
+
+Back-compat: users who already set `THUMBGATE_SILENT_FAILURE_CLUSTERING=1`
+remain enabled (no-op for them).
+
+Bounded-risk rationale: silent-failure candidates flow through the
+existing `meta-agent-loop.js` fp-rate eval — they cannot auto-promote
+to real gates without passing the same precision/recall thresholds as
+LLM-generated candidates. Turning the candidate funnel on by default
+expands what the eval considers; it does not bypass any guardrail.
+
+6 new tests in `tests/silent-failure-cluster.test.js` cover default-on,
+explicit opt-out, explicit opt-in back-compat, and NODE_ENV=test
+precedence. All 37 tests pass locally.

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recal
 - [Agent Workflow Contract](WORKFLOW.md) — the agent-run contract for all ThumbGate operations
 - [Ready for Agent Intake](https://github.com/IgorGanapolsky/ThumbGate/issues/new?template=ready-for-agent.yml) — ready-for-agent intake template
 - [SEO Guide: Claude Code Guardrails](docs/learn/claude-code-guardrails.md)
-- [Unsupervised Learning Signals](docs/UL.md) — silent-failure clustering (experimental, behind `THUMBGATE_SILENT_FAILURE_CLUSTERING=1`; only useful on workspaces with ≥ 50 tool calls/day)
+- [Unsupervised Learning Signals](docs/UL.md) — silent-failure clustering (**on by default** as of 2026-05-21; opt out via `THUMBGATE_SILENT_FAILURE_CLUSTERING=0`; only meaningfully active on workspaces with ≥ 50 tool calls/day)
 - [ThumbGate-Core](https://github.com/IgorGanapolsky/ThumbGate-Core) — private core for hosted overlays, ranking, policy synthesis, billing intelligence, and org/team workflows
 
 ---

--- a/docs/UL.md
+++ b/docs/UL.md
@@ -7,9 +7,15 @@ silently recovers, the user moves on, the signal is lost. The unsupervised
 learning surface below mines those silent failures so they can re-enter the
 existing gate-promotion pipeline.
 
-## Silent-failure clustering (experimental)
+## Silent-failure clustering (default-on as of 2026-05-21)
 
-**Flag**: `THUMBGATE_SILENT_FAILURE_CLUSTERING=1` (off by default)
+**Status**: ON by default. The opt-in flag from PR #2285 was flipped to
+opt-out in PR #2289 — the whole point of the feature is to help users who
+don't manually thumbs-down, so leaving it opt-in defeated the purpose.
+
+**Opt out**: set `THUMBGATE_SILENT_FAILURE_CLUSTERING=0` (also accepts
+`false`, `off`, `no`) or run with `NODE_ENV=test`. Back-compat: anyone
+who had `=1` set before the flip stays enabled — no-op for them.
 
 **Module**: `scripts/silent-failure-cluster.js`
 

--- a/public/agents-cost-savings.html
+++ b/public/agents-cost-savings.html
@@ -106,6 +106,7 @@
       <tr><td>Allocate spend to teams / features</td><td>✅</td><td>Per-gate breakdown via <code>byGate</code></td></tr>
       <tr><td>Stop a known-bad tool call before it hits the model</td><td>❌</td><td>✅ — PreToolUse gate fires, no API call made</td></tr>
       <tr><td>Promote a one-off failure into a permanent gate</td><td>❌</td><td>✅ — feedback loop + lesson DB</td></tr>
+      <tr><td>Surface gate candidates from <em>silent</em> failures (where no human ever gave thumbs-down)</td><td>❌</td><td>✅ — unsupervised silent-failure clustering, on by default</td></tr>
       <tr><td>Print conservative $ saved per day</td><td>❌</td><td>✅ — <code>thumbgate cost</code></td></tr>
       <tr><td>K8s pod-level allocation, finance-grade reporting</td><td>✅ (that's their core)</td><td>❌ (not our layer)</td></tr>
     </tbody>
@@ -117,6 +118,7 @@
     <li><strong>Every block is one fewer round trip.</strong> A blocked tool call doesn't reach the model. There's no "ThumbGate intercepted but the request still cost you" — the agent's tool-call execution is replaced with the gate's verdict, and the agent's next reasoning step takes the verdict as context instead of the failed result.</li>
     <li><strong>The avoided retry loop is the bulk of the saving.</strong> Failed tool calls don't just cost the call — they cost the model's next reasoning turn (which sees the failure and tries again), and often a third turn (which tries a different approach). Conservative 2k input + 600 output assumes one retry; in practice it's often more.</li>
     <li><strong>The numbers come from your local <code>gate-stats.json</code>.</strong> Not from a marketing model, not from "what enterprises like you saved." Your machine, your gates, your blocks.</li>
+    <li><strong>You don't have to give thumbs-down for the system to learn.</strong> ThumbGate's unsupervised <em>silent-failure clustering</em> runs by default — it mines your conversation logs for tool calls that failed (non-zero exit code or matched error patterns) but never got an explicit thumbs-down, clusters them by tool + argument shape, and surfaces them as gate candidates. The same false-positive-rate guardrail that vets human-feedback candidates vets these. Lazy users still get the savings. Opt out with <code>THUMBGATE_SILENT_FAILURE_CLUSTERING=0</code> if you want HITL-only.</li>
   </ol>
 
   <h2>Get the number on your machine</h2>

--- a/scripts/meta-agent-loop.js
+++ b/scripts/meta-agent-loop.js
@@ -385,10 +385,9 @@ async function runMetaAgentLoop({ dryRun = false, verbose = false } = {}) {
   // are lazy and never give thumbs-down — keeping it opt-in meant the users
   // who need it most never got the benefit.
   let silentFailureStats = null;
-  const { isSilentFailureClusteringEnabled } = require('./silent-failure-cluster');
+  const { isSilentFailureClusteringEnabled, generateSilentFailureCandidates } = require('./silent-failure-cluster');
   if (isSilentFailureClusteringEnabled()) {
     try {
-      const { generateSilentFailureCandidates } = require('./silent-failure-cluster');
       const sfResult = generateSilentFailureCandidates({ feedbackLogPath });
       silentFailureStats = sfResult.stats;
       if (sfResult.candidates && sfResult.candidates.length > 0) {

--- a/scripts/meta-agent-loop.js
+++ b/scripts/meta-agent-loop.js
@@ -377,11 +377,16 @@ async function runMetaAgentLoop({ dryRun = false, verbose = false } = {}) {
   // measurement (silentFailureDerivedGates vs user-feedback-derived) is possible.
   candidates = candidates.map((c) => (c.origin ? c : { ...c, origin: 'user-feedback' }));
 
-  // Step 3b: Silent-failure clustering — behind THUMBGATE_SILENT_FAILURE_CLUSTERING=1.
-  // Candidates flow through the SAME scoring / fp-rate eval below; we do not
-  // bypass any guardrail. Off by default to preserve existing behavior.
+  // Step 3b: Silent-failure clustering — DEFAULT-ON as of 2026-05-21
+  // (flipped from opt-in by PR #2289). Opt out via
+  // THUMBGATE_SILENT_FAILURE_CLUSTERING=0 (or NODE_ENV=test). Candidates flow
+  // through the SAME scoring / fp-rate eval below; we do not bypass any
+  // guardrail. The point of this clustering is to cover the case where users
+  // are lazy and never give thumbs-down — keeping it opt-in meant the users
+  // who need it most never got the benefit.
   let silentFailureStats = null;
-  if (process.env.THUMBGATE_SILENT_FAILURE_CLUSTERING === '1') {
+  const { isSilentFailureClusteringEnabled } = require('./silent-failure-cluster');
+  if (isSilentFailureClusteringEnabled()) {
     try {
       const { generateSilentFailureCandidates } = require('./silent-failure-cluster');
       const sfResult = generateSilentFailureCandidates({ feedbackLogPath });

--- a/scripts/silent-failure-cluster.js
+++ b/scripts/silent-failure-cluster.js
@@ -4,7 +4,14 @@
 /**
  * Silent-Failure Clustering — Unsupervised candidate source for the meta-agent loop
  *
- * Off by default. Enabled with: THUMBGATE_SILENT_FAILURE_CLUSTERING=1
+ * Default-ON since 2026-05-21. Opt-out with: THUMBGATE_SILENT_FAILURE_CLUSTERING=0
+ * (or set NODE_ENV=test to skip in test runs). Was opt-in for the initial
+ * landing of PR #2285; flipped to default-on because the entire point is to
+ * cover the case where users never give thumbs-down — keeping it opt-in
+ * means lazy users (the ones who need it most) never benefit. Bounded risk:
+ * candidates still flow through meta-agent-loop's existing fp-rate eval, so
+ * a noisy cluster can't auto-promote to a real gate without passing the
+ * same precision/recall thresholds as LLM-generated candidates.
  *
  * Problem: ThumbGate's HITL loop only learns from explicit thumbs-down. Tool calls
  * that fail without user feedback (exit_code != 0, regex-matched error in output,
@@ -460,9 +467,20 @@ function generateSilentFailureCandidates(opts = {}) {
 // CLI
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve the enabled state. Default ON. Explicit "0" or "false" opts out;
+ * NODE_ENV=test also opts out to keep test runs deterministic.
+ */
+function isSilentFailureClusteringEnabled(env = process.env) {
+  if (env.NODE_ENV === 'test') return false;
+  const raw = env.THUMBGATE_SILENT_FAILURE_CLUSTERING;
+  if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'no') return false;
+  return true;
+}
+
 async function main() {
-  if (process.env.THUMBGATE_SILENT_FAILURE_CLUSTERING !== '1') {
-    process.stdout.write('silent-failure-cluster: disabled (set THUMBGATE_SILENT_FAILURE_CLUSTERING=1 to enable)\n');
+  if (!isSilentFailureClusteringEnabled()) {
+    process.stdout.write('silent-failure-cluster: disabled (THUMBGATE_SILENT_FAILURE_CLUSTERING=0 or NODE_ENV=test)\n');
     return;
   }
 
@@ -492,6 +510,7 @@ if (require.main === module) {
 
 module.exports = {
   generateSilentFailureCandidates,
+  isSilentFailureClusteringEnabled,
   // exported for testing
   redactSecrets,
   normalizePaths,

--- a/scripts/silent-failure-cluster.js
+++ b/scripts/silent-failure-cluster.js
@@ -473,7 +473,7 @@ function generateSilentFailureCandidates(opts = {}) {
  */
 function isSilentFailureClusteringEnabled(env = process.env) {
   if (env.NODE_ENV === 'test') return false;
-  const raw = env.THUMBGATE_SILENT_FAILURE_CLUSTERING;
+  const raw = (env.THUMBGATE_SILENT_FAILURE_CLUSTERING || '').toLowerCase();
   if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'no') return false;
   return true;
 }

--- a/tests/silent-failure-cluster.test.js
+++ b/tests/silent-failure-cluster.test.js
@@ -450,3 +450,35 @@ test('normalizeForSignature — redaction happens before path replacement', () =
   const out = normalizeForSignature('sk-ant-0000000000000000000000000000000000');
   assert.match(out, /\[REDACTED\]/);
 });
+
+// ---------------------------------------------------------------------------
+// Default-on enablement (PR #2289 flip)
+// ---------------------------------------------------------------------------
+
+const { isSilentFailureClusteringEnabled } = require('../scripts/silent-failure-cluster');
+
+test('isSilentFailureClusteringEnabled — default ON when env is empty', () => {
+  assert.equal(isSilentFailureClusteringEnabled({}), true);
+});
+
+test('isSilentFailureClusteringEnabled — explicit "0" opts out', () => {
+  assert.equal(isSilentFailureClusteringEnabled({ THUMBGATE_SILENT_FAILURE_CLUSTERING: '0' }), false);
+});
+
+test('isSilentFailureClusteringEnabled — "false"/"off"/"no" also opt out (forgiving syntax)', () => {
+  for (const v of ['false', 'off', 'no']) {
+    assert.equal(isSilentFailureClusteringEnabled({ THUMBGATE_SILENT_FAILURE_CLUSTERING: v }), false, `expected ${v} to opt out`);
+  }
+});
+
+test('isSilentFailureClusteringEnabled — explicit "1" keeps it enabled (back-compat for users who already set the old opt-in)', () => {
+  assert.equal(isSilentFailureClusteringEnabled({ THUMBGATE_SILENT_FAILURE_CLUSTERING: '1' }), true);
+});
+
+test('isSilentFailureClusteringEnabled — NODE_ENV=test opts out (deterministic test runs)', () => {
+  assert.equal(isSilentFailureClusteringEnabled({ NODE_ENV: 'test' }), false);
+});
+
+test('isSilentFailureClusteringEnabled — NODE_ENV=test wins even over explicit "1"', () => {
+  assert.equal(isSilentFailureClusteringEnabled({ NODE_ENV: 'test', THUMBGATE_SILENT_FAILURE_CLUSTERING: '1' }), false);
+});


### PR DESCRIPTION
Flips the THUMBGATE_SILENT_FAILURE_CLUSTERING flag from opt-in to opt-out. The whole point of the silent-failure clustering feature (shipped in #2285) is helping users who DON'T manually give thumbs-down — keeping it opt-in meant those users never benefited.

## Behavior

- **Default**: ON
- **Opt-out**: `THUMBGATE_SILENT_FAILURE_CLUSTERING=0` (also accepts `false`/`off`/`no`) or `NODE_ENV=test`
- **Back-compat**: users who already set `=1` stay enabled (no-op)

## Why bounded risk

Silent-failure candidates flow through the SAME `meta-agent-loop.js` fp-rate eval as LLM-generated candidates. They cannot auto-promote to real gates without passing the precision/recall thresholds. Turning the funnel on by default expands what the eval considers; it does not bypass any guardrail.

## Files

- `scripts/silent-failure-cluster.js` — new `isSilentFailureClusteringEnabled()` helper, exported
- `scripts/meta-agent-loop.js` — use the helper, update comments
- `tests/silent-failure-cluster.test.js` — 6 new tests (default-on, opt-out variants, back-compat, NODE_ENV=test precedence)
- `.changeset/silent-failure-cluster-default-on.md` — minor bump

37 tests pass locally (31 existing + 6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)