### PR TITLE
fix(package): ship silent failure clustering runtime

### DIFF
--- a/.changeset/chatgpt-actions-observability.md
+++ b/.changeset/chatgpt-actions-observability.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add first-party telemetry counters for ThumbGate GPT Action calls so ChatGPT usage can be measured separately from GPT link opens.

--- a/.changeset/self-healing-check-package.md
+++ b/.changeset/self-healing-check-package.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Ship the self-healing health-check runtime in the npm package so `thumbgate self-heal` works from published installs.

--- a/.changeset/silent-failure-cluster-package.md
+++ b/.changeset/silent-failure-cluster-package.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Ship `scripts/silent-failure-cluster.js` in the npm package so the experimental `THUMBGATE_SILENT_FAILURE_CLUSTERING=1` meta-agent lane works from published installs, not only source checkouts.

--- a/adapters/chatgpt/openapi.yaml
+++ b/adapters/chatgpt/openapi.yaml
@@ -72,6 +72,11 @@ components:
           description: Optional domain tags. If omitted, ThumbGate infers one from the feedback text before promotion.
         skill:
           type: string
+        source:
+          type: string
+          enum: [chatgpt_gpt]
+          default: chatgpt_gpt
+          description: Attribution marker for ThumbGate analytics. The published ThumbGate GPT should send `chatgpt_gpt` so owner dashboards can distinguish GPT Action calls from local API calls.
     IntentPlanRequest:
       type: object
       required: [intentId]
@@ -880,6 +885,11 @@ paths:
                 toolName:
                   type: string
                   description: Tool name is optional when provider-native tool call payload is supplied.
+                source:
+                  type: string
+                  enum: [chatgpt_gpt]
+                  default: chatgpt_gpt
+                  description: Attribution marker for ThumbGate analytics. The published ThumbGate GPT should send `chatgpt_gpt` so owner dashboards can distinguish GPT Action calls from local API calls.
                 provider:
                   type: string
                 model:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -72,6 +72,11 @@ components:
           description: Optional domain tags. If omitted, ThumbGate infers one from the feedback text before promotion.
         skill:
           type: string
+        source:
+          type: string
+          enum: [chatgpt_gpt]
+          default: chatgpt_gpt
+          description: Attribution marker for ThumbGate analytics. The published ThumbGate GPT should send `chatgpt_gpt` so owner dashboards can distinguish GPT Action calls from local API calls.
     IntentPlanRequest:
       type: object
       required: [intentId]
@@ -880,6 +885,11 @@ paths:
                 toolName:
                   type: string
                   description: Tool name is optional when provider-native tool call payload is supplied.
+                source:
+                  type: string
+                  enum: [chatgpt_gpt]
+                  default: chatgpt_gpt
+                  description: Attribution marker for ThumbGate analytics. The published ThumbGate GPT should send `chatgpt_gpt` so owner dashboards can distinguish GPT Action calls from local API calls.
                 provider:
                   type: string
                 model:

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "scripts/security-scanner.js",
     "scripts/self-distill-agent.js",
     "scripts/self-heal.js",
+    "scripts/self-healing-check.js",
     "scripts/semantic-dedup.js",
     "scripts/semantic-layer.js",
     "scripts/seo-gsd.js",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "scripts/semantic-layer.js",
     "scripts/seo-gsd.js",
     "scripts/settings-hierarchy.js",
+    "scripts/silent-failure-cluster.js",
     "scripts/single-use-credential-gate.js",
     "scripts/skill-generator.js",
     "scripts/skill-rag-router.js",

--- a/scripts/telemetry-analytics.js
+++ b/scripts/telemetry-analytics.js
@@ -313,6 +313,12 @@ function sanitizeTelemetryPayload(payload = {}, headers = {}) {
     pipelineStatus: pickFirstText(raw.pipelineStatus, raw.workflowSprintStatus, raw.status),
     reasonCode,
     reasonDetail: pickFirstText(raw.reasonDetail, raw.reasonText, raw.otherReason, raw.notes),
+    integration: pickFirstText(raw.integration, raw.actionIntegration),
+    actionOperation: pickFirstText(raw.actionOperation, raw.operationId),
+    endpoint: pickFirstText(raw.endpoint, raw.apiPath),
+    decisionMode: pickFirstText(raw.decisionMode, raw.executionMode),
+    actionStatus: pickFirstText(raw.actionStatus, raw.status),
+    accepted: raw.accepted === undefined || raw.accepted === null ? null : Boolean(raw.accepted),
     pricingInterest: pickFirstText(raw.pricingInterest, raw.interestLevel),
     seoQuery: pickFirstText(raw.seoQuery, raw.query),
     seoSurface: pickFirstText(raw.seoSurface, raw.searchSurface, raw.surface),
@@ -526,6 +532,12 @@ function getTelemetrySummary(feedbackDir, options = {}) {
   let exitEngagementMsCount = 0;
   let exitScrollPercentTotal = 0;
   let exitScrollPercentCount = 0;
+  let chatgptActionCalls = 0;
+  let chatgptActionAccepted = 0;
+  const chatgptActionsByOperation = {};
+  const chatgptActionsByEndpoint = {};
+  const chatgptActionsByStatus = {};
+  const chatgptActionsByDecisionMode = {};
 
   for (const entry of events) {
     incrementCounter(byClientType, entry.clientType || entry.client || 'unknown');
@@ -714,6 +726,18 @@ function getTelemetrySummary(feedbackDir, options = {}) {
       }
     }
 
+    if (
+      String(entry.eventType || entry.event || '').startsWith('chatgpt_action_') ||
+      entry.integration === 'chatgpt_gpt'
+    ) {
+      chatgptActionCalls += 1;
+      if (entry.accepted === true) chatgptActionAccepted += 1;
+      incrementCounter(chatgptActionsByOperation, entry.actionOperation);
+      incrementCounter(chatgptActionsByEndpoint, entry.endpoint);
+      incrementCounter(chatgptActionsByStatus, entry.actionStatus);
+      incrementCounter(chatgptActionsByDecisionMode, entry.decisionMode);
+    }
+
     if ((entry.clientType || entry.client) === 'cli') {
       if (entry.installId) cliInstalls.add(entry.installId);
       incrementCounter(cliByPlatform, entry.platform);
@@ -770,6 +794,7 @@ function getTelemetrySummary(feedbackDir, options = {}) {
       landingViews: pageViews,
       installCopies,
       gptOpens,
+      gptActionCalls: chatgptActionCalls,
       checkoutStarts,
       checkoutInterstitialViews,
       checkoutInterstitialClicks,
@@ -777,6 +802,7 @@ function getTelemetrySummary(feedbackDir, options = {}) {
       proConversions,
       landingToInstallCopyRate: safeRate(installCopies, pageViews),
       landingToGptOpenRate: safeRate(gptOpens, pageViews),
+      gptOpenToActionRate: safeRate(chatgptActionCalls, gptOpens),
       landingToCheckoutRate: safeRate(checkoutStarts, pageViews),
       checkoutInterstitialClickRate: safeRate(checkoutInterstitialClicks, checkoutInterstitialViews),
       checkoutInterstitialProConfirmRate: safeRate(checkoutInterstitialProConfirms, checkoutInterstitialViews),
@@ -834,6 +860,17 @@ function getTelemetrySummary(feedbackDir, options = {}) {
       initPings: byEventType.cli_init || 0,
       byPlatform: cliByPlatform,
       byVersion: cliByVersion,
+    },
+    chatgpt: {
+      gptOpens,
+      actionCalls: chatgptActionCalls,
+      acceptedActionCalls: chatgptActionAccepted,
+      openToActionRate: safeRate(chatgptActionCalls, gptOpens),
+      acceptedActionRate: safeRate(chatgptActionAccepted, chatgptActionCalls),
+      byOperation: chatgptActionsByOperation,
+      byEndpoint: chatgptActionsByEndpoint,
+      byStatus: chatgptActionsByStatus,
+      byDecisionMode: chatgptActionsByDecisionMode,
     },
     marketing: {
       pageViewsBySource,
@@ -929,6 +966,7 @@ function getTelemetryAnalytics(feedbackDir, options = {}) {
     byClientType: summary.byClientType,
     byEventType: summary.byEventType,
     conversionFunnel: summary.conversionFunnel,
+    chatgpt: summary.chatgpt,
     visitors: {
       totalEvents: summary.web.totalEvents,
       uniqueVisitors: summary.web.uniqueVisitors,

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1867,6 +1867,19 @@ function appendBestEffortTelemetry(feedbackDir, payload, headers, context) {
   }
 }
 
+function inferActionIntegration(body = {}, headers = {}) {
+  const explicit = pickFirstText(body.integration, body.source, body.actionIntegration, body.provider);
+  const userAgent = String(headers['user-agent'] || '').toLowerCase();
+  if (/chatgpt|gpt[_-]?actions?|openai/.test(String(explicit || '').toLowerCase()) || /chatgpt|openai/.test(userAgent)) {
+    return 'chatgpt_gpt';
+  }
+  return explicit || 'api';
+}
+
+function chatgptActionEventType(integration, suffix) {
+  return integration === 'chatgpt_gpt' ? `chatgpt_action_${suffix}` : `api_action_${suffix}`;
+}
+
 function getPublicOrigin(req) {
   const proto = String(req.headers['x-forwarded-proto'] || '').split(',')[0].trim() || 'http';
   const host = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim() || 'localhost';
@@ -7019,6 +7032,18 @@ async function addContext(){
           tags: extractTags(body.tags),
           skill: body.skill,
         });
+        const actionIntegration = inferActionIntegration(body, req.headers);
+        appendBestEffortTelemetry(requestFeedbackDir, {
+          eventType: chatgptActionEventType(actionIntegration, 'capture_feedback'),
+          clientType: 'api',
+          source: actionIntegration,
+          integration: actionIntegration,
+          actionOperation: 'captureFeedback',
+          endpoint: '/v1/feedback/capture',
+          actionStatus: result.accepted ? 'accepted' : 'clarification_required',
+          accepted: Boolean(result.accepted),
+          failureCode: result.accepted ? null : 'clarification_required',
+        }, req.headers, 'api_action_capture_feedback');
         if (result?.accepted) {
           // Fan out to any connected dashboard clients so they re-render
           // without polling. Non-sensitive summary only (no chat history,
@@ -7829,6 +7854,18 @@ async function addContext(){
         });
         report.actionId = evaluation.actionId;
         if (report.decisionControl) report.decisionControl.actionId = evaluation.actionId;
+        const actionIntegration = inferActionIntegration(body, req.headers);
+        appendBestEffortTelemetry(requestFeedbackDir, {
+          eventType: chatgptActionEventType(actionIntegration, 'evaluate_decision'),
+          clientType: 'api',
+          source: actionIntegration,
+          integration: actionIntegration,
+          actionOperation: 'evaluateDecision',
+          endpoint: '/v1/decisions/evaluate',
+          actionStatus: 'accepted',
+          accepted: true,
+          decisionMode: report.decisionControl && report.decisionControl.executionMode,
+        }, req.headers, 'api_action_evaluate_decision');
         sendJson(res, 200, report);
         return;
       }

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -117,6 +117,7 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     'scripts/feedback-loop.js',
     'scripts/gates-engine.js',
     'scripts/hf-papers.js',
+    'scripts/self-healing-check.js',
     'scripts/silent-failure-cluster.js',
     'scripts/statusline.sh',
     'scripts/statusline-meta.js',
@@ -265,9 +266,12 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // meta-agent-loop.js requires it when THUMBGATE_SILENT_FAILURE_CLUSTERING=1;
   // without this file, published installs silently lose the experimental
   // unsupervised-learning lane even though source-checkout tests pass.
+  // Bumped 263 → 264 (2026-05-22) to ship scripts/self-healing-check.js.
+  // bin/cli.js runs it before scripts/self-heal.js for `thumbgate self-heal`;
+  // without this file, published installs fail with a missing-module error.
   assert.ok(
-    manifest.fileCount <= 263,
-    `npm package should stay <= 263 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 264,
+    `npm package should stay <= 264 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing
@@ -352,9 +356,12 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // the Dell+OpenAI Codex Enterprise landing page (~14 KB). Stacked on top of
   // the auto-context-packs ratchet from earlier the same day; the bump gives
   // one normal-PR headroom buffer before the next ratchet review.
+  // Bumped 3.80 MB -> 3.82 MB (2026-05-22) for scripts/self-healing-check.js
+  // (~5 KB), which `thumbgate self-heal` invokes before self-heal.js in
+  // published installs. Observed unpacked size is ~3.806 MB.
   assert.ok(
-    manifest.unpackedSize <= 3_800_000,
-    `npm package should stay <= 3.80 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 3_820_000,
+    `npm package should stay <= 3.82 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -117,6 +117,7 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     'scripts/feedback-loop.js',
     'scripts/gates-engine.js',
     'scripts/hf-papers.js',
+    'scripts/silent-failure-cluster.js',
     'scripts/statusline.sh',
     'scripts/statusline-meta.js',
     'scripts/tool-registry.js',
@@ -260,9 +261,13 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // (Matt Beekhuizen demo on 2026-05-28). Sister-bumped from
   // public-bundle-ratchet + public-core-boundary; all three stay in lockstep.
   // (changeset: ai-malpractice-prevention-landing.md)
+  // Bumped 262 → 263 (2026-05-22) to ship scripts/silent-failure-cluster.js.
+  // meta-agent-loop.js requires it when THUMBGATE_SILENT_FAILURE_CLUSTERING=1;
+  // without this file, published installs silently lose the experimental
+  // unsupervised-learning lane even though source-checkout tests pass.
   assert.ok(
-    manifest.fileCount <= 262,
-    `npm package should stay <= 262 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 263,
+    `npm package should stay <= 263 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -55,7 +55,10 @@ const path = require('node:path');
 //            landing page built for the warm Greenberg Traurig lead
 //            (Matt Beekhuizen demo 2026-05-28).
 //            (changeset: ai-malpractice-prevention-landing.md)
-const BASELINE_FILE_COUNT = 262;
+// 262 → 263: scripts/silent-failure-cluster.js added so the experimental
+//            THUMBGATE_SILENT_FAILURE_CLUSTERING=1 lane works from npm, not
+//            only from source checkouts.
+const BASELINE_FILE_COUNT = 263;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -58,7 +58,9 @@ const path = require('node:path');
 // 262 → 263: scripts/silent-failure-cluster.js added so the experimental
 //            THUMBGATE_SILENT_FAILURE_CLUSTERING=1 lane works from npm, not
 //            only from source checkouts.
-const BASELINE_FILE_COUNT = 263;
+// 263 → 264: scripts/self-healing-check.js added so `thumbgate self-heal`
+//            works from npm installs instead of failing before self-heal.js.
+const BASELINE_FILE_COUNT = 264;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -111,8 +111,11 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // stay in lockstep.
   // Bumped 261 → 262 (2026-05-21) to ship public/ai-malpractice-prevention.html
   // — legal-vertical landing page (changeset: ai-malpractice-prevention-landing.md).
+  // Bumped 262 → 263 (2026-05-22) to ship scripts/silent-failure-cluster.js:
+  // meta-agent-loop.js imports it when THUMBGATE_SILENT_FAILURE_CLUSTERING=1,
+  // so omitting it breaks the published experimental unsupervised track.
   const files = npmPackFiles();
-  const CEILING = 262;
+  const CEILING = 263;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -114,8 +114,11 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // Bumped 262 → 263 (2026-05-22) to ship scripts/silent-failure-cluster.js:
   // meta-agent-loop.js imports it when THUMBGATE_SILENT_FAILURE_CLUSTERING=1,
   // so omitting it breaks the published experimental unsupervised track.
+  // Bumped 263 → 264 (2026-05-22) to ship scripts/self-healing-check.js:
+  // `thumbgate self-heal` invokes it before scripts/self-heal.js, so omitting
+  // it breaks published installs even though source-checkout tests pass.
   const files = npmPackFiles();
-  const CEILING = 263;
+  const CEILING = 264;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +

--- a/tests/telemetry-analytics.test.js
+++ b/tests/telemetry-analytics.test.js
@@ -758,6 +758,51 @@ test('getTelemetryAnalytics exposes the first-party marketing conversion funnel'
   assert.equal(analytics.recent[0].eventType, 'checkout_paid_confirmed');
 });
 
+test('getTelemetryAnalytics summarizes ChatGPT GPT Action usage separately from GPT opens', () => {
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'chatgpt_gpt_open',
+    clientType: 'web',
+    source: 'website',
+    ctaId: 'go_gpt',
+    linkSlug: 'gpt',
+    page: '/go/gpt',
+  });
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'chatgpt_action_capture_feedback',
+    clientType: 'api',
+    source: 'chatgpt_gpt',
+    integration: 'chatgpt_gpt',
+    actionOperation: 'captureFeedback',
+    endpoint: '/v1/feedback/capture',
+    actionStatus: 'accepted',
+    accepted: true,
+  });
+  appendTelemetryEvent(tmpDir, {
+    eventType: 'chatgpt_action_evaluate_decision',
+    clientType: 'api',
+    source: 'chatgpt_gpt',
+    integration: 'chatgpt_gpt',
+    actionOperation: 'evaluateDecision',
+    endpoint: '/v1/decisions/evaluate',
+    actionStatus: 'accepted',
+    decisionMode: 'checkpoint_required',
+    accepted: true,
+  });
+
+  const analytics = getTelemetryAnalytics(tmpDir);
+
+  assert.equal(analytics.conversionFunnel.gptOpens, 1);
+  assert.equal(analytics.conversionFunnel.gptActionCalls, 2);
+  assert.equal(analytics.conversionFunnel.gptOpenToActionRate, 2);
+  assert.equal(analytics.chatgpt.actionCalls, 2);
+  assert.equal(analytics.chatgpt.acceptedActionCalls, 2);
+  assert.equal(analytics.chatgpt.acceptedActionRate, 1);
+  assert.equal(analytics.chatgpt.byOperation.captureFeedback, 1);
+  assert.equal(analytics.chatgpt.byOperation.evaluateDecision, 1);
+  assert.equal(analytics.chatgpt.byEndpoint['/v1/feedback/capture'], 1);
+  assert.equal(analytics.chatgpt.byDecisionMode.checkpoint_required, 1);
+});
+
 test('getTelemetryAnalytics summarizes reddit community and offer performance', () => {
   appendTelemetryEvent(tmpDir, {
     eventType: 'landing_page_view',


### PR DESCRIPTION
## What changed
- Adds `scripts/silent-failure-cluster.js` to the public npm package allowlist.
- Updates package-boundary and public-bundle ratchet tests from 261 to 262 files with the reason documented.
- Adds a patch changeset so the fix can publish.

## Why
`meta-agent-loop.js` requires `./silent-failure-cluster` when `THUMBGATE_SILENT_FAILURE_CLUSTERING=1`. Source-checkout tests passed, but `npm pack --dry-run` showed the module was missing from the published package, so the experimental unsupervised-learning lane could fail in npm installs.

## Verification
- `node --test tests/silent-failure-cluster.test.js tests/package-boundary.test.js tests/public-bundle-ratchet.test.js tests/changeset-check.test.js`
- `npm run test:meta-agent`
- `npm pack --dry-run --json` confirmed `scripts/meta-agent-loop.js` and `scripts/silent-failure-cluster.js` both ship.
- pre-commit and pre-push guards passed.

----
## Summary by Gitar

- **Package distribution:**
  - Added `scripts/self-healing-check.js` to the npm package allowlist in `package.json`.
  - Updated ratchet tests across `package-boundary.test.js`, `public-bundle-ratchet.test.js`, and `public-core-boundary.test.js` to accommodate the new file, increasing file count thresholds from 263 to 264.
- **Observability:**
  - Increased unpacked package size limit from 3.80 MB to 3.82 MB in `package-boundary.test.js` to account for the new health-check script.
- **Changeset:**
  - Added a patch changeset to ensure `self-healing-check` is included in the next release.

<sub>This will update automatically on new commits.</sub>