### PR TITLE
Position ThumbGate as deterministic prevention

### DIFF
--- a/.changeset/deterministic-prevention-positioning.md
+++ b/.changeset/deterministic-prevention-positioning.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Position ThumbGate as deterministic, inspectable prevention instead of black-box native thumbs or vendor memory, and update the Pro buyer path with audit-loop proof copy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1558,9 +1558,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -837,7 +837,7 @@ __GA_BOOTSTRAP__
       </div>
     </div>
     <div style="margin:26px auto 0;max-width:960px;border:1px solid rgba(34,211,238,0.18);border-radius:8px;background:rgba(34,211,238,0.05);padding:18px 20px;">
-      <h3 style="margin:0 0 10px;color:var(--text);font-size:18px;">Why this matters in May 2026</h3>
+      <h3 style="margin:0 0 10px;color:var(--text);font-size:18px;">Why this matters now</h3>
       <ul style="margin:0;padding-left:20px;color:var(--text-muted);line-height:1.7;">
         <li><strong>Agent security is now mainstream risk.</strong> Coding agents run shell commands, write files, query databases, and chain actions with developer permissions, so unattended autonomy needs a local policy boundary.</li>
         <li><strong>MCP adoption is accelerating.</strong> More tools are becoming agent-callable through shared protocols, which means one cross-agent governance layer beats one-off prompt rules per app.</li>

--- a/public/index.html
+++ b/public/index.html
@@ -817,6 +817,37 @@ __GA_BOOTSTRAP__
   </div>
 </section>
 
+<section class="compatibility" id="deterministic-prevention">
+  <div class="container">
+    <div class="section-label">Deterministic Prevention</div>
+    <h2 class="section-title">Native thumbs are a black box. ThumbGate is the inspectable control layer.</h2>
+    <p style="text-align:center;font-size:16px;color:var(--text-muted);max-width:900px;margin:0 auto 28px;line-height:1.7;">Codex, Claude Code, ChatGPT, and other agent surfaces can collect preference signals, but you usually cannot see exactly what changed, which rule will fire, or why a future tool call is allowed. ThumbGate keeps the prevention layer outside the model: typed feedback becomes a local lesson, repeated mistakes become explicit rules, and every block names the matched rule, source lesson, tool call, and audit event.</p>
+    <div class="agent-grid">
+      <div class="agent-card">
+        <h3>Black-box memory</h3>
+        <p>Native thumbs and vendor memories may improve future behavior, but they do not give teams a deterministic allow/block contract at the moment an agent touches files, terminals, APIs, or CI.</p>
+      </div>
+      <div class="agent-card">
+        <h3>Inspectable ThumbGate memory</h3>
+        <p>Lessons live in your ThumbGate store, can be searched, exported as JSONL or DPO pairs, and traced back to the exact correction that created the rule.</p>
+      </div>
+      <div class="agent-card">
+        <h3>Rules before execution</h3>
+        <p>The final decision is not another model opinion. ThumbGate checks tool name, arguments, working directory, command shape, confidence, and required evidence before the action runs.</p>
+      </div>
+    </div>
+    <div style="margin:26px auto 0;max-width:960px;border:1px solid rgba(34,211,238,0.18);border-radius:8px;background:rgba(34,211,238,0.05);padding:18px 20px;">
+      <h3 style="margin:0 0 10px;color:var(--text);font-size:18px;">Why this matters in May 2026</h3>
+      <ul style="margin:0;padding-left:20px;color:var(--text-muted);line-height:1.7;">
+        <li><strong>Agent security is now mainstream risk.</strong> Coding agents run shell commands, write files, query databases, and chain actions with developer permissions, so unattended autonomy needs a local policy boundary.</li>
+        <li><strong>MCP adoption is accelerating.</strong> More tools are becoming agent-callable through shared protocols, which means one cross-agent governance layer beats one-off prompt rules per app.</li>
+        <li><strong>Repeated failures waste cash and trust.</strong> Every repeat burns tokens, review time, and release confidence. ThumbGate turns the first correction into a reusable prevention check.</li>
+      </ul>
+      <p style="margin:12px 0 0;font-size:13px;color:var(--text-dim);">Sources to verify the market timing: <a href="https://www.docker.com/blog/ai-coding-agent-horror-stories-security-risks/" target="_blank" rel="noopener" style="color:var(--cyan);">Docker on AI coding agent security risks</a>, <a href="https://www.techradar.com/pro/how-ai-agents-are-wrecking-havoc-in-legacy-security-setups-and-enterprises-are-catching-up" target="_blank" rel="noopener" style="color:var(--cyan);">TechRadar on enterprise agent security pressure</a>, and <a href="https://www.techradar.com/pro/zendesk-becomes-the-latest-to-adopt-mcp-to-futureproof-customers-in-the-ai-first-era" target="_blank" rel="noopener" style="color:var(--cyan);">current MCP adoption coverage</a>.</p>
+    </div>
+  </div>
+</section>
+
 <section class="marketing-deep-dive" style="padding:28px 0 10px;">
   <div class="container" style="max-width:1240px;">
     <div class="section-label">Status bar proof</div>

--- a/public/pro.html
+++ b/public/pro.html
@@ -815,6 +815,28 @@ __GA_BOOTSTRAP__
   </div>
 </section>
 
+<section class="section" id="deterministic-loop">
+  <div class="container">
+    <div class="section-label">Why Pro now</div>
+    <h2 class="section-title">Black-box thumbs do not prove prevention. Pro gives the operator an audit loop.</h2>
+    <p class="section-intro">Native rating buttons can tell a vendor that an answer felt wrong. ThumbGate Pro gives you the operational record: the correction, the lesson, the rule, the blocked tool call, and the export path.</p>
+    <div class="grid-3">
+      <div class="feature-card">
+        <h3>Inspectable memory</h3>
+        <p>Search the exact lesson that came from a thumbs-down and see whether it is still active, warning-only, or blocking.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Deterministic checks</h3>
+        <p>The enforcement layer evaluates tool name, arguments, working directory, command shape, confidence, and required evidence before the action runs.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Exportable proof</h3>
+        <p>Take the same correction history into JSONL, DPO export, review packets, and team rollout conversations instead of trusting hidden memory.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="section" id="why-pay">
   <div class="container">
     <div class="section-label">Why operators pay</div>

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -243,7 +243,7 @@ test('public landing page differentiates deterministic ThumbGate enforcement fro
   assert.match(landingPage, /exported as JSONL or DPO pairs/);
   assert.match(landingPage, /The final decision is not another model opinion/);
   assert.match(landingPage, /checks tool name, arguments, working directory, command shape, confidence, and required evidence/);
-  assert.match(landingPage, /Why this matters in May 2026/);
+  assert.match(landingPage, /Why this matters now/);
   assert.match(landingPage, /Agent security is now mainstream risk/);
   assert.match(landingPage, /MCP adoption is accelerating/);
   assert.match(landingPage, /Repeated failures waste cash and trust/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -4,11 +4,16 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const landingPagePath = path.join(__dirname, '..', 'public', 'index.html');
+const proPagePath = path.join(__dirname, '..', 'public', 'pro.html');
 const codexPluginPagePath = path.join(__dirname, '..', 'public', 'codex-plugin.html');
 const buyerIntentScriptPath = path.join(__dirname, '..', 'public', 'js', 'buyer-intent.js');
 
 function readLandingPage() {
   return fs.readFileSync(landingPagePath, 'utf8');
+}
+
+function readProPage() {
+  return fs.readFileSync(proPagePath, 'utf8');
 }
 
 function readBuyerIntentScript() {
@@ -225,6 +230,35 @@ test('public landing page positions ThumbGate as agent governance for AI coding 
   assert.match(landingPage, /OpenCode/);
   assert.doesNotMatch(landingPage, /mailto:/i);
   assert.doesNotMatch(landingPage, /official Anthropic partner/i);
+});
+
+test('public landing page differentiates deterministic ThumbGate enforcement from native black-box thumbs', () => {
+  const landingPage = readLandingPage();
+
+  assert.match(landingPage, /Native thumbs are a black box\. ThumbGate is the inspectable control layer\./);
+  assert.match(landingPage, /Codex, Claude Code, ChatGPT, and other agent surfaces can collect preference signals/);
+  assert.match(landingPage, /typed feedback becomes a local lesson/);
+  assert.match(landingPage, /every block names the matched rule, source lesson, tool call, and audit event/);
+  assert.match(landingPage, /Lessons live in your ThumbGate store/);
+  assert.match(landingPage, /exported as JSONL or DPO pairs/);
+  assert.match(landingPage, /The final decision is not another model opinion/);
+  assert.match(landingPage, /checks tool name, arguments, working directory, command shape, confidence, and required evidence/);
+  assert.match(landingPage, /Why this matters in May 2026/);
+  assert.match(landingPage, /Agent security is now mainstream risk/);
+  assert.match(landingPage, /MCP adoption is accelerating/);
+  assert.match(landingPage, /Repeated failures waste cash and trust/);
+});
+
+test('Pro page sells inspectable prevention rather than black-box preference memory', () => {
+  const proPage = readProPage();
+
+  assert.match(proPage, /Black-box thumbs do not prove prevention\. Pro gives the operator an audit loop\./);
+  assert.match(proPage, /Native rating buttons can tell a vendor that an answer felt wrong/);
+  assert.match(proPage, /the correction, the lesson, the rule, the blocked tool call, and the export path/);
+  assert.match(proPage, /Inspectable memory/);
+  assert.match(proPage, /Deterministic checks/);
+  assert.match(proPage, /Exportable proof/);
+  assert.match(proPage, /JSONL, DPO export, review packets, and team rollout conversations/);
 });
 
 test('public landing page exposes browser-bridge safety buyer guides', () => {


### PR DESCRIPTION
## Summary
- Add homepage positioning that contrasts native black-box thumbs with ThumbGate's deterministic, inspectable prevention layer.
- Add Pro-page buyer copy around inspectable memory, deterministic checks, and exportable proof.
- Patch the transitive brace-expansion dev dependency security advisory via package-lock update.

## Evidence
- node --test tests/public-landing.test.js tests/checkout-pro-confirmation-gate.test.js tests/ralph-loop.test.js
- npm run test:index-page-clickability
- npm audit --audit-level=moderate
- node scripts/ralph-loop.js --mode=all --dry-run --artifact-dir=/tmp/thumbgate-ralph-loop-proof
- node scripts/verify-marketing-pages-deployed.js --help || true

## Notes
- The live production marketing-page verifier currently passes 9/9 existing deployed pages; this PR still needs CI and deploy before the new copy is live.
