### PR TITLE
Add CLI conversion receipts

### DIFF
--- a/.changeset/cli-conversion-receipts.md
+++ b/.changeset/cli-conversion-receipts.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add CLI value receipts after feedback capture and stats so installers see stored proof, next proof commands, and tracked Pro or Team upgrade paths at the moment value is created.

--- a/.changeset/legal-ai-pilot-conservative-positioning.md
+++ b/.changeset/legal-ai-pilot-conservative-positioning.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Sharpen the legal AI pilot page for law-firm innovation and risk buyers with conservative pre-execution-control positioning, preloaded ground-truth pilot inputs, and a 25-minute walkthrough CTA.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -939,6 +939,17 @@ function capture() {
       }
     }
     console.log('');
+    try {
+      const { buildCaptureReceipt } = require(path.join(PKG_ROOT, 'scripts', 'commercial-offer'));
+      console.log(buildCaptureReceipt({
+        signal: normalized,
+        feedbackId: ev.id,
+        memoryId: mem.id,
+        actionType: ev.actionType,
+      }));
+    } catch (_) {
+      // Receipt is a conversion aid, not part of feedback persistence.
+    }
     proNudge();
   } else {
     if (args.json) {
@@ -1021,6 +1032,13 @@ function stats() {
     console.log('  Solo side lane: npx thumbgate pro');
   } else {
     console.log('\n✅ System is currently high-reliability. No immediate revenue loss detected.');
+  }
+  try {
+    const { buildStatsReceipt } = require(path.join(PKG_ROOT, 'scripts', 'commercial-offer'));
+    const receipt = buildStatsReceipt(payload);
+    if (receipt) console.log(receipt);
+  } catch (_) {
+    // Keep stats resilient if the receipt helper is unavailable in old installs.
   }
   proNudge();
 }

--- a/package.json
+++ b/package.json
@@ -638,7 +638,7 @@
     "test:high-roi": "node --test tests/high-roi.test.js tests/model-candidates.test.js tests/autonomous-workflow.test.js tests/high-roi-agent-workflows.test.js tests/interaction-model.test.js tests/interaction-model-e2e.test.js tests/code-graph-guardrails.test.js tests/proxy-pointer-rag-guardrails.test.js tests/rag-precision-guardrails.test.js tests/ai-engineering-stack-guardrails.test.js tests/long-running-agent-context-guardrails.test.js tests/reasoning-efficiency-guardrails.test.js tests/deepseek-v4-runtime-guardrails.test.js tests/upstream-contribution-engine.test.js tests/proactive-agent-eval-guardrails.test.js tests/reward-hacking-guardrails.test.js tests/chatgpt-ads-readiness-pack.test.js tests/oss-pr-opportunity-scout.test.js tests/agent-design-governance.test.js tests/gemini-embedding-policy.test.js tests/openclaw-agent-governance-kit.test.js",
     "test:public-static-assets": "node --test tests/public-static-assets.test.js",
     "test:token-savings": "node --test tests/token-savings.test.js",
-    "test:cost-cli": "node --test tests/cost-cli.test.js",
+    "test:cost-cli": "node --test tests/cost-cli.test.js tests/conversion-receipt.test.js",
     "test:numbers-page": "node --test tests/numbers-page.test.js",
     "test:workflow-gate-checkpoint": "node --test tests/workflow-gate-checkpoint.test.js tests/autonomous-workflow.test.js",
     "workflow:autonomous": "node scripts/autonomous-workflow.js",

--- a/public/ai-malpractice-prevention.html
+++ b/public/ai-malpractice-prevention.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>AI Intake Risk Controls for Law Firms - ThumbGate</title>
+<title>Pre-Execution Controls for Legal AI Agents - ThumbGate</title>
 <script defer data-domain="thumbgate-production.up.railway.app" src="https://plausible.io/js/script.js"></script>
-<meta name="description" content="Pre-action controls for law-firm AI intake agents: reduce unauthorized-practice, conflict-check, confidentiality, and audit-trail risk before an agent sends a response or calls a tool.">
-<meta property="og:title" content="AI Intake Risk Controls for Law Firms">
-<meta property="og:description" content="ThumbGate adds pre-action guardrails, firm-approved ground truth, and audit trails to legal AI intake workflows. Built for law-firm innovation, risk, and pricing teams.">
+<meta name="description" content="Pre-execution controls for law-firm AI agents: block unauthorized advice, conflict-check failures, privilege leaks, and unapproved model calls before an agent acts.">
+<meta property="og:title" content="Pre-Execution Controls for Legal AI Agents">
+<meta property="og:description" content="ThumbGate preloads firm-approved ground truth, checks legal AI actions before execution, and records audit evidence for law-firm innovation, risk, and pricing teams.">
 <meta property="og:type" content="article">
 <meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
 <link rel="canonical" href="https://thumbgate-production.up.railway.app/ai-malpractice-prevention">
@@ -15,10 +15,10 @@
 {
   "@context": "https://schema.org",
   "@type": "TechArticle",
-  "headline": "AI Intake Risk Controls for Law Firms",
-  "description": "ThumbGate is a pre-action control layer for law-firm AI intake workflows. It can preload firm-approved ground truth, evaluate proposed agent actions before execution, and produce audit evidence for human review.",
+  "headline": "Pre-Execution Controls for Legal AI Agents",
+  "description": "ThumbGate is a pre-execution control layer for law-firm AI intake workflows. It can preload firm-approved ground truth, evaluate proposed agent actions before execution, and produce audit evidence for human review.",
   "datePublished": "2026-05-21",
-  "dateModified": "2026-05-22",
+  "dateModified": "2026-05-25",
   "author": { "@type": "Person", "name": "Igor Ganapolsky", "url": "https://github.com/IgorGanapolsky" },
   "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate-production.up.railway.app" },
   "about": [
@@ -132,6 +132,22 @@
   }
   .proof strong { display: block; color: var(--text); font-size: 0.94rem; }
   .proof span { color: var(--muted); font-size: 0.85rem; }
+  .trust-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.7rem;
+    margin: 1.2rem 0 0;
+    max-width: 920px;
+  }
+  .trust-item {
+    border: 1px solid rgba(98, 164, 255, 0.24);
+    border-radius: 8px;
+    background: rgba(98, 164, 255, 0.07);
+    padding: 0.72rem;
+    color: var(--soft);
+    font-size: 0.82rem;
+    font-weight: 750;
+  }
   .control-flow {
     border: 1px solid #343a46;
     background: #101318;
@@ -234,7 +250,7 @@
     border-top: 1px solid var(--line);
   }
   @media (max-width: 880px) {
-    .hero, .grid, .two, .proof-row { grid-template-columns: 1fr; }
+    .hero, .grid, .two, .proof-row, .trust-strip { grid-template-columns: 1fr; }
     .hero { min-height: auto; padding-top: 2.4rem; }
     nav { position: static; }
   }
@@ -280,16 +296,22 @@
   <header class="hero">
     <div>
       <span class="eyebrow">Pre-read for law-firm AI governance pilots</span>
-      <h1>Let AI intake move faster without letting it give legal advice, skip conflicts, or leak privileged data.</h1>
-      <p class="lead">ThumbGate adds a pre-action control layer around legal AI agents. It loads firm-approved rules before launch, checks proposed agent actions before execution, and leaves an audit trail a risk committee can review.</p>
+      <h1>Pre-execution controls for legal AI agents.</h1>
+      <p class="lead">Block unauthorized advice, conflict-check failures, privilege leaks, and unapproved model calls before an intake agent replies, fetches records, schedules a meeting, or sends data outside the firm's approved boundary.</p>
       <div class="hero-actions">
-        <a class="cta" href="mailto:iganapolsky@gmail.com?subject=ThumbGate%20legal%20AI%20pilot%20walkthrough&amp;body=Hi%20Igor%2C%0A%0AWe%27d%20like%20to%20review%20the%20ThumbGate%20legal%20AI%20intake%20pilot.%20Please%20send%20the%20meeting%20invite%20and%20demo%20materials.%0A%0ABest%2C">Request the pilot walkthrough</a>
+        <a class="cta" href="mailto:iganapolsky@gmail.com?subject=ThumbGate%2025-minute%20legal%20AI%20pilot%20walkthrough&amp;body=Hi%20Igor%2C%0A%0AWe%27d%20like%20to%20review%20the%2025-minute%20ThumbGate%20legal%20AI%20intake%20pilot.%20Please%20send%20the%20meeting%20invite%20and%20demo%20materials.%0A%0ABest%2C">Book a 25-minute pilot walkthrough</a>
         <a class="ghost" href="#demo">View the 25-minute demo plan</a>
       </div>
       <div class="proof-row" aria-label="Key proof points">
         <div class="proof"><strong>Preloaded controls</strong><span>Firm policy, approved disclaimers, adverse-party lists, routing rules, and model endpoint allowlists.</span></div>
         <div class="proof"><strong>Pre-action checks</strong><span>Controls run before the agent replies, fetches records, schedules intake, or calls an external model.</span></div>
         <div class="proof"><strong>Reviewable evidence</strong><span>Every block, warning, override, and handoff becomes a structured audit event.</span></div>
+      </div>
+      <div class="trust-strip" aria-label="Trust and deployment assumptions">
+        <div class="trust-item">Local-first enforcement option</div>
+        <div class="trust-item">Works around Azure OpenAI, Claude, Gemini, and internal tools</div>
+        <div class="trust-item">ABA Formal Opinion 512 mapped to reviewable controls</div>
+        <div class="trust-item">No guaranteed-malpractice-prevention claim</div>
       </div>
     </div>
 
@@ -351,6 +373,28 @@
     </section>
 
     <section>
+      <h2>Yes, the pilot can start with preloaded ground truth.</h2>
+      <p class="section-lead">The first pilot should not ask the model to discover the firm's risk posture. ThumbGate should load the approved rule pack before the first intake simulation, then prove that the agent is physically stopped when a proposed action violates that pack.</p>
+      <div class="grid">
+        <div class="card">
+          <span class="tag green">Inputs</span>
+          <h3>Firm-approved source material</h3>
+          <p>Disclaimers, intake scripts, escalation rules, practice-area boundaries, jurisdiction notes, model endpoint policy, retention rules, and reviewer roles.</p>
+        </div>
+        <div class="card">
+          <span class="tag amber">Fixtures</span>
+          <h3>Adverse-party and matter examples</h3>
+          <p>A synthetic adverse-party list and red-team intake transcripts let the demo show conflict stops without exposing privileged or client data.</p>
+        </div>
+        <div class="card">
+          <span class="tag blue">Outputs</span>
+          <h3>Deterministic control evidence</h3>
+          <p>Each demo decision shows the matched rule, proposed action, allowed or blocked outcome, reviewer path, timestamp, and exportable audit record.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
       <h2>Three failure modes the pilot should control.</h2>
       <div class="grid">
         <div class="card">
@@ -394,6 +438,22 @@
           </ul>
         </div>
       </div>
+      <div class="two grid" style="margin-top:1rem;">
+        <div class="card">
+          <h3>Suggested agenda</h3>
+          <ul>
+            <li>3 minutes: confirm the target workflow and risk owners.</li>
+            <li>7 minutes: show blocked unauthorized-advice and conflict examples.</li>
+            <li>7 minutes: show preloaded ground truth and audit evidence.</li>
+            <li>5 minutes: discuss deployment boundary, data handling, and reviewer roles.</li>
+            <li>3 minutes: agree on pilot inputs and next step.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Recommended ask</h3>
+          <p>Ask for one practice-area workflow, one approved disclaimer, one synthetic adverse-party fixture, one security contact, and permission to build a no-client-data pilot pack.</p>
+        </div>
+      </div>
     </section>
 
     <section>
@@ -416,7 +476,7 @@
         <h2>Recommended 30-day pilot.</h2>
         <p>Start narrow: one intake channel, one practice-area workflow, one adverse-party fixture, one approved-model routing policy, and one audit export format.</p>
         <p>Deliverables: preloaded rule pack, demo agent, screenshot set, 60-second walkthrough clip, security data-flow note, pilot metrics, and a go/no-go rollout recommendation.</p>
-        <p><a class="cta" href="mailto:iganapolsky@gmail.com?subject=ThumbGate%20legal%20AI%20pilot%20walkthrough&amp;body=Hi%20Igor%2C%0A%0AWe%27d%20like%20to%20review%20the%20ThumbGate%20legal%20AI%20intake%20pilot.%20Please%20send%20the%20meeting%20invite%20and%20demo%20materials.%0A%0ABest%2C">Request the pilot walkthrough</a></p>
+        <p><a class="cta" href="mailto:iganapolsky@gmail.com?subject=ThumbGate%2025-minute%20legal%20AI%20pilot%20walkthrough&amp;body=Hi%20Igor%2C%0A%0AWe%27d%20like%20to%20review%20the%2025-minute%20ThumbGate%20legal%20AI%20intake%20pilot.%20Please%20send%20the%20meeting%20invite%20and%20demo%20materials.%0A%0ABest%2C">Book a 25-minute pilot walkthrough</a></p>
       </div>
     </section>
   </main>

--- a/scripts/commercial-offer.js
+++ b/scripts/commercial-offer.js
@@ -35,6 +35,75 @@ function normalizeSeatCount(value, fallback = TEAM_MIN_SEATS) {
   return Math.max(TEAM_MIN_SEATS, Math.round(parsed));
 }
 
+function trackedProUrl(source = 'cli_receipt', content = 'value_receipt') {
+  try {
+    const url = new URL(PRO_MONTHLY_PAYMENT_LINK);
+    url.searchParams.set('utm_source', source);
+    url.searchParams.set('utm_medium', 'cli');
+    url.searchParams.set('utm_campaign', 'pro_conversion');
+    url.searchParams.set('utm_content', content);
+    return url.toString();
+  } catch (_) {
+    return PRO_MONTHLY_PAYMENT_LINK;
+  }
+}
+
+function pluralize(count, singular, plural = `${singular}s`) {
+  return Number(count) === 1 ? singular : plural;
+}
+
+function buildCaptureReceipt({ signal, feedbackId, memoryId, actionType } = {}) {
+  const normalizedSignal = String(signal || '').toUpperCase() || 'UNKNOWN';
+  const lines = [
+    '',
+    'Value receipt',
+    '─'.repeat(50),
+    `  Stored proof   : ${normalizedSignal} feedback${feedbackId ? ` (${feedbackId})` : ''}`,
+    memoryId ? `  Local memory   : ${memoryId}` : '  Local memory   : saved locally',
+    actionType ? `  Rule pressure  : ${actionType}` : '  Rule pressure  : available for promotion',
+    '  Next proof     : npx thumbgate stats',
+    '  Cost proof     : npx thumbgate cost',
+    '',
+    `  Solo Pro       : ${PRO_PRICE_LABEL} for dashboard, search, exports, sync`,
+    `  Upgrade        : ${trackedProUrl('cli_capture_receipt', actionType || normalizedSignal.toLowerCase())}`,
+    `  Team path      : ${TEAM_PRICE_LABEL}; start with one repeated workflow failure`,
+    '                   https://thumbgate.ai/#workflow-sprint-intake',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function buildStatsReceipt(stats = {}) {
+  const negatives = Number(stats.negatives || stats.totalNegative || 0);
+  const blocked = Number(stats.gatesBlocked || stats.blocked || 0);
+  const warned = Number(stats.gatesWarned || stats.warned || 0);
+  const gates = Number(stats.totalGates || 0);
+  const autoPromoted = Number(stats.autoPromotedGates || 0);
+  const hasFriction = negatives > 0 || blocked > 0 || warned > 0 || gates > 0;
+  if (!hasFriction) return '';
+
+  const interventions = blocked + warned;
+  const lines = [
+    '',
+    'Paid-intent next step',
+    '─'.repeat(50),
+  ];
+  if (interventions > 0) {
+    lines.push(`  Proof already seen : ${interventions} gate ${pluralize(interventions, 'intervention')}`);
+  }
+  if (gates > 0) {
+    lines.push(`  Active prevention  : ${gates} ${pluralize(gates, 'gate')} (${autoPromoted} auto-promoted)`);
+  }
+  if (negatives > 0) {
+    lines.push(`  Failure pressure   : ${negatives} negative ${pluralize(negatives, 'signal')}`);
+  }
+  lines.push('  Show the buyer     : npx thumbgate cost');
+  lines.push(`  Solo Pro           : ${trackedProUrl('cli_stats_receipt', 'proof_seen')}`);
+  lines.push('  Team workflow      : https://thumbgate.ai/#workflow-sprint-intake');
+  lines.push('');
+  return lines.join('\n');
+}
+
 module.exports = {
   PRO_MONTHLY_PAYMENT_LINK,
   PRO_ANNUAL_PAYMENT_LINK,
@@ -51,4 +120,7 @@ module.exports = {
   normalizePlanId,
   normalizeBillingCycle,
   normalizeSeatCount,
+  buildCaptureReceipt,
+  buildStatsReceipt,
+  trackedProUrl,
 };

--- a/tests/conversion-receipt.test.js
+++ b/tests/conversion-receipt.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildCaptureReceipt,
+  buildStatsReceipt,
+  trackedProUrl,
+} = require('../scripts/commercial-offer');
+
+test('trackedProUrl adds CLI conversion attribution without losing the canonical route', () => {
+  const url = new URL(trackedProUrl('cli_test', 'receipt_test'));
+  assert.equal(url.hostname, 'thumbgate.ai');
+  assert.equal(url.pathname, '/go/pro');
+  assert.equal(url.searchParams.get('utm_source'), 'cli_test');
+  assert.equal(url.searchParams.get('utm_medium'), 'cli');
+  assert.equal(url.searchParams.get('utm_campaign'), 'pro_conversion');
+  assert.equal(url.searchParams.get('utm_content'), 'receipt_test');
+});
+
+test('buildCaptureReceipt turns a saved thumbs signal into a paid-intent next step', () => {
+  const receipt = buildCaptureReceipt({
+    signal: 'down',
+    feedbackId: 'fb_123',
+    memoryId: 'mem_456',
+    actionType: 'block',
+  });
+
+  assert.match(receipt, /Value receipt/);
+  assert.match(receipt, /Stored proof\s*:\s*DOWN feedback \(fb_123\)/);
+  assert.match(receipt, /Local memory\s*:\s*mem_456/);
+  assert.match(receipt, /npx thumbgate stats/);
+  assert.match(receipt, /npx thumbgate cost/);
+  assert.match(receipt, /utm_source=cli_capture_receipt/);
+  assert.match(receipt, /utm_campaign=pro_conversion/);
+  assert.match(receipt, /workflow-sprint-intake/);
+});
+
+test('buildStatsReceipt stays quiet when there is no proof or failure pressure', () => {
+  assert.equal(buildStatsReceipt({ negatives: 0, gatesBlocked: 0, gatesWarned: 0, totalGates: 0 }), '');
+});
+
+test('buildStatsReceipt routes proven friction to Pro and Team surfaces', () => {
+  const receipt = buildStatsReceipt({
+    negatives: 3,
+    gatesBlocked: 8,
+    gatesWarned: 2,
+    totalGates: 5,
+    autoPromotedGates: 2,
+  });
+
+  assert.match(receipt, /Paid-intent next step/);
+  assert.match(receipt, /10 gate interventions/);
+  assert.match(receipt, /5 gates \(2 auto-promoted\)/);
+  assert.match(receipt, /3 negative signals/);
+  assert.match(receipt, /npx thumbgate cost/);
+  assert.match(receipt, /utm_source=cli_stats_receipt/);
+  assert.match(receipt, /workflow-sprint-intake/);
+});

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -300,6 +300,11 @@ test('GET /ai-malpractice-prevention serves the legal-vertical landing HTML', as
     assert.match(body, /privilege/i);
     assert.match(body, /conflict/i);
     assert.match(body, /ABA Formal Op/i);
+    assert.match(body, /Pre-execution controls for legal AI agents/i);
+    assert.match(body, /Book a 25-minute pilot walkthrough/i);
+    assert.match(body, /preloaded ground truth/i);
+    assert.match(body, /Local-first enforcement option/i);
+    assert.match(body, /No guaranteed-malpractice-prevention claim/i);
   }
 });
 


### PR DESCRIPTION
## Summary\n- add value receipts after feedback capture so users see stored proof, next proof commands, and tracked Pro/Team paths\n- add paid-intent receipt in stats when there is real failure or gate pressure\n- keep npm bundle file count flat by folding helper logic into existing commercial offer module\n\n## Verification\n- node --test tests/conversion-receipt.test.js tests/cost-cli.test.js tests/cli-trial-and-help.test.js tests/package-boundary.test.js tests/public-bundle-ratchet.test.js tests/public-package-parity.test.js\n- npm run test:cost-cli\n- npm audit --audit-level=moderate\n- npm pack --dry-run --json\n- CLI smoke: capture output contains Value receipt, stats/cost next steps, and tracked Pro URL

----
## Summary by Gitar

- **Legal AI pilot page:**
  - Refined `ai-malpractice-prevention.html` to emphasize pre-execution controls and added a trust-strip for deployment assumptions.
  - Added a new section for pilot ground-truth inputs and a recommended 30-day pilot agenda.
- **Content refinement:**
  - Updated the pilot walkthrough CTA to a 25-minute demo request and added coverage in `public-static-assets.test.js`.
  - Added `legal-ai-pilot-conservative-positioning.md` to document the positioning shift.

<sub>This will update automatically on new commits.</sub>