### PR TITLE
Version ThumbGate 1.23.1

### DIFF
--- a/.changeset/cli-conversion-receipts.md
+++ b/.changeset/cli-conversion-receipts.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add CLI value receipts after feedback capture and stats so installers see stored proof, next proof commands, and tracked Pro or Team upgrade paths at the moment value is created.

--- a/.changeset/deterministic-prevention-positioning.md
+++ b/.changeset/deterministic-prevention-positioning.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Position ThumbGate as deterministic, inspectable prevention instead of black-box native thumbs or vendor memory, and update the Pro buyer path with audit-loop proof copy.

--- a/.changeset/legal-ai-control-flow-asset.md
+++ b/.changeset/legal-ai-control-flow-asset.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Tighten the law-firm AI intake pilot page with a visual control-flow asset and add the route to post-deploy marketing verification.

--- a/.changeset/legal-ai-pilot-conservative-positioning.md
+++ b/.changeset/legal-ai-pilot-conservative-positioning.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Sharpen the legal AI pilot page for law-firm innovation and risk buyers with conservative pre-execution-control positioning, preloaded ground-truth pilot inputs, and a 25-minute walkthrough CTA.

--- a/.changeset/legal-ai-pilot-page.md
+++ b/.changeset/legal-ai-pilot-page.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Sharpen the law-firm AI intake pilot page with safer buyer-facing governance language, preloaded rule-pack positioning, demo storyboard, and meeting agenda for enterprise legal innovation review.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.23.0",
+      "version": "1.23.1",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.23.0"
+    "version": "1.23.1"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.23.1
+
+### Patch Changes
+
+- [#2313](https://github.com/IgorGanapolsky/ThumbGate/pull/2313) [`6c2647d`](https://github.com/IgorGanapolsky/ThumbGate/commit/6c2647dbc93d9f4c6823e0debd759f7c2e1ce02b) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Add CLI value receipts after feedback capture and stats so installers see stored proof, next proof commands, and tracked Pro or Team upgrade paths at the moment value is created.
+
+- [#2297](https://github.com/IgorGanapolsky/ThumbGate/pull/2297) [`a127dc6`](https://github.com/IgorGanapolsky/ThumbGate/commit/a127dc6df11589ecf2bc7ed23ece618ac1d1f566) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Position ThumbGate as deterministic, inspectable prevention instead of black-box native thumbs or vendor memory, and update the Pro buyer path with audit-loop proof copy.
+
+- [#2296](https://github.com/IgorGanapolsky/ThumbGate/pull/2296) [`6da4d87`](https://github.com/IgorGanapolsky/ThumbGate/commit/6da4d876708f01b0009fcc4ec4a3255ce431e177) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Tighten the law-firm AI intake pilot page with a visual control-flow asset and add the route to post-deploy marketing verification.
+
+- [#2313](https://github.com/IgorGanapolsky/ThumbGate/pull/2313) [`6c2647d`](https://github.com/IgorGanapolsky/ThumbGate/commit/6c2647dbc93d9f4c6823e0debd759f7c2e1ce02b) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Sharpen the legal AI pilot page for law-firm innovation and risk buyers with conservative pre-execution-control positioning, preloaded ground-truth pilot inputs, and a 25-minute walkthrough CTA.
+
+- [#2295](https://github.com/IgorGanapolsky/ThumbGate/pull/2295) [`ce44ea6`](https://github.com/IgorGanapolsky/ThumbGate/commit/ce44ea60db4e6421dd83c50effd347982d95c7e1) Thanks [@IgorGanapolsky](https://github.com/IgorGanapolsky)! - Sharpen the law-firm AI intake pilot page with safer buyer-facing governance language, preloaded rule-pack positioning, demo storyboard, and meeting agenda for enterprise legal innovation review.
+
 ## 1.23.0
 
 ### Minor Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.23.0 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.23.1 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.23.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.23.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.23.0", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.23.1", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -216,7 +216,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.23.0' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.23.1' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.23.0",
+        "thumbgate@1.23.1",
         "thumbgate",
         "serve"
       ],

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.23.0 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.23.1 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.23.0 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.23.1 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1562,7 +1562,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.23.0 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.23.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2779,7 +2779,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.23.0 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.23.1 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.23.0`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.23.1`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/marketing/codex-marketplace-revenue-pack.json
+++ b/docs/marketing/codex-marketplace-revenue-pack.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T18:11:09.125Z",
+  "generatedAt": "2026-05-25T20:11:57.326Z",
   "channel": "Codex",
   "objective": "Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and qualified workflow sprint conversations.",
   "canonicalIdentity": {
@@ -29,7 +29,7 @@
       "key": "standalone_bundle",
       "name": "Standalone bundle download",
       "url": "https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip",
-      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.23.0/thumbgate-codex-plugin-v1.23.0.zip",
+      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.23.1/thumbgate-codex-plugin-v1.23.1.zip",
       "supportUrl": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/README.md",
       "evidenceSource": "plugins/codex-profile/README.md",
       "operatorUse": "Portable plugin path for buyers who want a direct asset instead of a repo checkout.",

--- a/docs/marketing/codex-marketplace-revenue-pack.md
+++ b/docs/marketing/codex-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Operator Revenue Pack
 
-Updated: 2026-05-22T18:11:09.125Z
+Updated: 2026-05-25T20:11:57.326Z
 
 This is a sales operator artifact. It is not proof of installs, revenue, or marketplace approval by itself.
 
@@ -26,7 +26,7 @@ Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and 
 
 ### Standalone bundle download
 - URL: https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip
-- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.23.0/thumbgate-codex-plugin-v1.23.0.zip
+- Versioned URL: https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.23.1/thumbgate-codex-plugin-v1.23.1.zip
 - Operator use: Portable plugin path for buyers who want a direct asset instead of a repo checkout.
 - Buyer signal: Warm buyers ready to install now if the runtime, update policy, and proof links are explicit.
 - Evidence source: plugins/codex-profile/README.md

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.23.0 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.23.1 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.23.0", "serve"],
+      "args": ["-y", "thumbgate@1.23.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.23.0", "serve"],
+      "args": ["-y", "thumbgate@1.23.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.23.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.23.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.23.0
+1.23.1
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.23.0"
+version: "1.23.1"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 33 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate-production.up.railway.app",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.23.0",
+        "thumbgate@1.23.1",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "author": {
     "name": "Igor Ganapolsky"
   },

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.23.0", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.23.1", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Pre-action checks for AI coding agents in VS Code, Open VSX-compatible IDEs, and Antigravity-style VS Code forks.",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate-production.up.railway.app/og.png">
-<meta name="thumbgate-version" content="1.23.0">
+<meta name="thumbgate-version" content="1.23.1">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
@@ -1523,7 +1523,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.23.0</span>
+    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.23.1</span>
   </div>
 </footer>
 

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.23.0",
+  "softwareVersion": "1.23.1",
   "url": "https://thumbgate-production.up.railway.app/numbers",
   "dateModified": "2026-05-07",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-05-07 · Version 1.23.0</div>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.23.1</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.23.0",
+  "version": "1.23.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- consume pending changesets for the legal AI pilot positioning and CLI conversion receipt work
- bump ThumbGate and synced plugin/runtime manifests to 1.23.1
- add 1.23.1 changelog entries for the shipped buyer-facing and CLI conversion changes

## Verification
- npm run test:sync-version
- npm run changeset:check
- node --test tests/conversion-receipt.test.js tests/cost-cli.test.js tests/public-static-assets.test.js tests/package-boundary.test.js tests/public-bundle-ratchet.test.js tests/public-package-parity.test.js
- npm pack --dry-run --json -> thumbgate-1.23.1.tgz, entryCount 264
- npm audit --audit-level=moderate
- git diff --check