### PR TITLE
Legal intake demo data for GT pilot

### DIFF
--- a/.changeset/legal-intake-demo.md
+++ b/.changeset/legal-intake-demo.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add legal-intake demo data for Greenberg Traurig pilot walkthrough

--- a/config/gate-templates.json
+++ b/config/gate-templates.json
@@ -453,9 +453,9 @@
       "defaultAction": "block",
       "severity": "critical",
       "pattern": "(outcome prediction|jurisdictional recommendation|you (should|could|might) (file|sue|claim)|strong case|likely (prevail|win|succeed))",
-      "problem": "Stops intake agents from delivering advice-shaped responses that constitute unauthorized practice of law under ABA Model Rule 5.5.",
-      "roi": "One blocked UPL response prevents a malpractice exposure that no amount of disclaimers can undo.",
-      "rollout": "Enable on every AI intake channel before the first prospect interaction."
+      "problem": "Stops advice-shaped intake replies under ABA Rule 5.5.",
+      "roi": "Prevents malpractice exposure before delivery.",
+      "rollout": "Enable on every AI intake channel."
     },
     {
       "id": "require-conflict-check-before-intake",
@@ -465,9 +465,9 @@
       "defaultAction": "block",
       "severity": "critical",
       "pattern": "(collect_case_facts|schedule_consultation|intake_continue).*(missing|no|unchecked).*(conflict|adverse[_-]party|clearance)",
-      "problem": "Requires adverse-party clearance before the agent collects sensitive case facts, preventing conflicts of interest under ABA Model Rules 1.7, 1.9, and 1.10.",
-      "roi": "Catches conflicts before privileged information crosses ethical walls, avoiding disqualification motions and sanctions.",
-      "rollout": "Pair with the firm's conflicts database or a synthetic adverse-party fixture during pilot."
+      "problem": "Requires adverse-party clearance before sensitive facts.",
+      "roi": "Catches conflicts before privileged facts cross ethical walls.",
+      "rollout": "Use the firm's conflicts API or a synthetic pilot fixture."
     },
     {
       "id": "block-privileged-content-egress",
@@ -477,9 +477,9 @@
       "defaultAction": "block",
       "severity": "critical",
       "pattern": "(send_email|api_call|external_request|schedule|crm_update).*(privileged|attorney[_-]client|work[_-]product|matter[_-]id|confidential)",
-      "problem": "Blocks or reroutes outbound agent actions that contain privileged markers, matter identifiers, or attorney-client content before they leave the firm's boundary.",
-      "roi": "Prevents privilege waiver from a single agent action that sends protected content to an external system.",
-      "rollout": "Define privilege markers during pilot setup. Start with hard block; move to in-tenant reroute after reviewer workflow is established."
+      "problem": "Blocks outbound actions with privilege markers.",
+      "roi": "Prevents single-action privilege waiver.",
+      "rollout": "Define markers, start with hard block, then add in-tenant reroute."
     },
     {
       "id": "require-approved-disclaimer-before-response",
@@ -489,9 +489,9 @@
       "defaultAction": "block",
       "severity": "high",
       "pattern": "(intake_response|client_reply).*(missing|no).*(disclaimer|disclosure|non[_-]engagement)",
-      "problem": "Ensures every intake agent response includes the firm's approved disclaimer and non-engagement language before delivery.",
-      "roi": "Reduces inadvertent attorney-client relationship formation from informal AI responses.",
-      "rollout": "Load firm-approved disclaimer text during pilot setup. Enforce on all outbound intake responses."
+      "problem": "Requires firm-approved non-engagement language.",
+      "roi": "Reduces inadvertent client-relationship risk.",
+      "rollout": "Load approved disclaimer during pilot."
     },
     {
       "id": "restrict-model-endpoint-to-approved-list",
@@ -501,9 +501,9 @@
       "defaultAction": "block",
       "severity": "high",
       "pattern": "(model_call|llm_request|api_endpoint).*(unapproved|unknown|public|consumer)",
-      "problem": "Prevents intake agents from routing queries to unapproved model endpoints that may lack enterprise data handling agreements.",
-      "roi": "Keeps firm data within approved vendor boundaries and supports ABA Formal Opinion 512 technology competence requirements.",
-      "rollout": "Allowlist approved model endpoints during pilot. Block all others by default."
+      "problem": "Blocks unapproved model endpoints.",
+      "roi": "Keeps data inside approved vendor boundaries.",
+      "rollout": "Allowlist endpoints during pilot."
     },
     {
       "id": "require-attorney-review-before-routing",
@@ -513,9 +513,9 @@
       "defaultAction": "block",
       "severity": "high",
       "pattern": "(route_to_attorney|assign_practice_area|schedule_consultation).*(no|missing).*(review|approval|supervisor)",
-      "problem": "Requires attorney review before the intake agent routes a prospect to a practice area or schedules a consultation.",
-      "roi": "Prevents automated routing errors that waste attorney time or send prospects to the wrong practice group.",
-      "rollout": "Start with all routing decisions requiring review. Relax to warn mode for low-risk practice areas after pilot validation."
+      "problem": "Requires review before routing or scheduling.",
+      "roi": "Prevents bad prospect routing.",
+      "rollout": "Start strict; relax after pilot evidence."
     }
   ]
 }

--- a/config/gate-templates.json
+++ b/config/gate-templates.json
@@ -444,6 +444,78 @@
       "problem": "Blocks background agents from cloning, building, testing, or publishing unless they run in an isolated durable environment with logs.",
       "roi": "Lets the team pursue unattended revenue and engineering workflows without turning local developer machines into the execution boundary.",
       "rollout": "Enable for every agent that can run tests, push branches, deploy, publish content, change billing, or touch customer data."
+    },
+    {
+      "id": "block-unauthorized-practice-of-law",
+      "name": "Block unauthorized practice of law",
+      "category": "Legal Intake Safety",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "critical",
+      "pattern": "(outcome prediction|jurisdictional recommendation|you (should|could|might) (file|sue|claim)|strong case|likely (prevail|win|succeed))",
+      "problem": "Stops intake agents from delivering advice-shaped responses that constitute unauthorized practice of law under ABA Model Rule 5.5.",
+      "roi": "One blocked UPL response prevents a malpractice exposure that no amount of disclaimers can undo.",
+      "rollout": "Enable on every AI intake channel before the first prospect interaction."
+    },
+    {
+      "id": "require-conflict-check-before-intake",
+      "name": "Require conflict check before intake continues",
+      "category": "Legal Intake Safety",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "critical",
+      "pattern": "(collect_case_facts|schedule_consultation|intake_continue).*(missing|no|unchecked).*(conflict|adverse[_-]party|clearance)",
+      "problem": "Requires adverse-party clearance before the agent collects sensitive case facts, preventing conflicts of interest under ABA Model Rules 1.7, 1.9, and 1.10.",
+      "roi": "Catches conflicts before privileged information crosses ethical walls, avoiding disqualification motions and sanctions.",
+      "rollout": "Pair with the firm's conflicts database or a synthetic adverse-party fixture during pilot."
+    },
+    {
+      "id": "block-privileged-content-egress",
+      "name": "Block privileged content egress",
+      "category": "Legal Intake Safety",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "critical",
+      "pattern": "(send_email|api_call|external_request|schedule|crm_update).*(privileged|attorney[_-]client|work[_-]product|matter[_-]id|confidential)",
+      "problem": "Blocks or reroutes outbound agent actions that contain privileged markers, matter identifiers, or attorney-client content before they leave the firm's boundary.",
+      "roi": "Prevents privilege waiver from a single agent action that sends protected content to an external system.",
+      "rollout": "Define privilege markers during pilot setup. Start with hard block; move to in-tenant reroute after reviewer workflow is established."
+    },
+    {
+      "id": "require-approved-disclaimer-before-response",
+      "name": "Require approved disclaimer before response",
+      "category": "Legal Intake Safety",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "high",
+      "pattern": "(intake_response|client_reply).*(missing|no).*(disclaimer|disclosure|non[_-]engagement)",
+      "problem": "Ensures every intake agent response includes the firm's approved disclaimer and non-engagement language before delivery.",
+      "roi": "Reduces inadvertent attorney-client relationship formation from informal AI responses.",
+      "rollout": "Load firm-approved disclaimer text during pilot setup. Enforce on all outbound intake responses."
+    },
+    {
+      "id": "restrict-model-endpoint-to-approved-list",
+      "name": "Restrict model endpoint to approved list",
+      "category": "Legal Intake Safety",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "high",
+      "pattern": "(model_call|llm_request|api_endpoint).*(unapproved|unknown|public|consumer)",
+      "problem": "Prevents intake agents from routing queries to unapproved model endpoints that may lack enterprise data handling agreements.",
+      "roi": "Keeps firm data within approved vendor boundaries and supports ABA Formal Opinion 512 technology competence requirements.",
+      "rollout": "Allowlist approved model endpoints during pilot. Block all others by default."
+    },
+    {
+      "id": "require-attorney-review-before-routing",
+      "name": "Require attorney review before case routing",
+      "category": "Legal Intake Safety",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "high",
+      "pattern": "(route_to_attorney|assign_practice_area|schedule_consultation).*(no|missing).*(review|approval|supervisor)",
+      "problem": "Requires attorney review before the intake agent routes a prospect to a practice area or schedules a consultation.",
+      "roi": "Prevents automated routing errors that waste attorney time or send prospects to the wrong practice group.",
+      "rollout": "Start with all routing decisions requiring review. Relax to warn mode for low-risk practice areas after pilot validation."
     }
   ]
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1486,20 +1486,20 @@ function loadDemo() {
   document.getElementById('reviewCheckpointBtn').textContent = 'Connect to save your own review checkpoint';
   // Sample memories — legal AI intake scenarios for law firm pilot demo
   var demoResults = [
-    { signal: 'down', title: 'Intake agent provided outcome prediction to prospect', context: 'Prospect asked about wrongful termination in Florida. Agent responded with "you likely have a strong case" and cited comparative negligence statute. ThumbGate blocked the response before delivery — advice-shaped content from a non-attorney violates ABA Model Rule 5.5.', tags: ['upl-risk', 'aba-rule-5.5', 'auto-blocked', 'critical'], timestamp: '2026-05-25T14:20:00Z' },
-    { signal: 'up', title: 'Conflict pre-check stopped intake before facts collected', context: 'Prospect named an adverse party that matched the firm\'s synthetic conflict list. ThumbGate halted the intake conversation before any privileged case facts were disclosed, preventing an ethical wall breach under ABA Model Rules 1.7 and 1.9.', tags: ['conflict-check', 'aba-rule-1.7', 'aba-rule-1.9', 'prevention'], timestamp: '2026-05-25T11:45:00Z' },
-    { signal: 'down', title: 'Agent attempted to send case summary to external CRM', context: 'Intake agent tried to push a prospect summary containing matter identifiers and privileged consultation notes to an external CRM API. ThumbGate blocked the outbound call — privileged content markers detected in the payload.', tags: ['privilege-egress', 'aba-rule-1.6', 'auto-blocked', 'critical'], timestamp: '2026-05-24T16:30:00Z' },
-    { signal: 'up', title: 'Safe handoff collected neutral facts only', context: 'After ThumbGate blocked an advice-shaped response, the agent correctly pivoted to collecting only neutral routing information: name, contact, general practice area, and preferred callback time. No legal conclusions delivered.', tags: ['safe-handoff', 'compliant-response', 'aba-rule-5.5', 'metric:ROI'], timestamp: '2026-05-24T11:10:00Z' },
-    { signal: 'down', title: 'Agent made jurisdictional recommendation without review', context: 'Prospect asked which court to file in. Agent responded with a specific venue recommendation based on the facts provided. ThumbGate blocked — jurisdictional recommendations require attorney supervision under Rule 5.5.', tags: ['upl-risk', 'jurisdiction', 'aba-rule-5.5', 'auto-blocked'], timestamp: '2026-05-23T15:20:00Z' },
-    { signal: 'up', title: 'Audit export preserved full decision chain', context: 'Exported audit record showing: matched rule (block-unauthorized-practice v2), proposed agent action (reply with outcome prediction), decision (deny), reviewer path (attorney-review-queue), and UTC timestamp. Full reproducibility for compliance review.', tags: ['audit-trail', 'compliance', 'aba-opinion-512', 'metric:ROI'], timestamp: '2026-05-23T09:00:00Z' },
-    { signal: 'down', title: 'Response missing firm-approved disclaimer', context: 'Agent drafted a response to a prospect inquiry without including the firm\'s required non-engagement disclaimer. ThumbGate blocked delivery until approved disclaimer language was prepended.', tags: ['disclaimer-missing', 'non-engagement', 'aba-rule-5.5', 'auto-blocked'], timestamp: '2026-05-22T14:45:00Z' },
-    { signal: 'up', title: 'Model endpoint restricted to approved provider', context: 'Intake agent attempted to route a query to a consumer-grade model endpoint. ThumbGate enforced the approved-model allowlist, rerouting to the firm\'s enterprise Azure OpenAI instance with proper data handling agreements.', tags: ['model-governance', 'data-handling', 'aba-opinion-512', 'prevention'], timestamp: '2026-05-22T10:30:00Z' },
-    { signal: 'down', title: 'Agent disclosed opposing counsel information to prospect', context: 'During intake, agent referenced information about opposing counsel from a related matter. ThumbGate detected cross-matter information leakage and blocked the response to prevent confidentiality breach under Rule 1.6.', tags: ['privilege-egress', 'cross-matter', 'aba-rule-1.6', 'critical'], timestamp: '2026-05-21T16:15:00Z' },
-    { signal: 'up', title: 'Conflict check cleared — intake proceeded safely', context: 'Prospect\'s adverse party was checked against the synthetic conflict fixture. No match found. ThumbGate allowed intake to proceed with full fact collection. Clearance decision logged with timestamp and rule version.', tags: ['conflict-check', 'cleared', 'aba-rule-1.7', 'compliant-response'], timestamp: '2026-05-21T11:00:00Z' },
-    { signal: 'down', title: 'Intake agent attempted to schedule consultation directly', context: 'Agent tried to book a consultation on the firm calendar without attorney review of the intake summary. ThumbGate blocked — routing decisions require supervisor approval before prospect-attorney matching.', tags: ['routing-governance', 'attorney-review', 'auto-blocked'], timestamp: '2026-05-20T13:30:00Z' },
-    { signal: 'up', title: 'Egress rerouted to in-tenant system successfully', context: 'Agent needed to store intake notes. Instead of sending to external cloud storage, ThumbGate rerouted the write to the firm\'s in-tenant document management system. Privileged content never left the firm boundary.', tags: ['privilege-egress', 'in-tenant-reroute', 'aba-rule-1.6', 'metric:ROI'], timestamp: '2026-05-20T09:45:00Z' },
-    { signal: 'up', title: 'DPO export identified systematic UPL pattern', context: 'Exported 34 preference pairs from blocked intake responses. Analysis showed 76% of blocks were advice-shaped outcome predictions triggered by prospects asking "do I have a case?" variations. Led to improved intake script guidance.', tags: ['dpo-export', 'upl-pattern', 'prevention', 'metric:ROI'], timestamp: '2026-05-19T14:00:00Z' },
-    { signal: 'down', title: 'Agent used non-approved model for privilege-sensitive query', context: 'Intake query containing potential attorney-client privileged information was routed to a model endpoint without enterprise data processing agreement. ThumbGate blocked and logged the attempted endpoint for security review.', tags: ['model-governance', 'privilege-risk', 'aba-opinion-512', 'auto-blocked'], timestamp: '2026-05-18T11:20:00Z' }
+    { signal: 'down', title: 'Intake agent provided outcome prediction to prospect', context: 'Prospect asked about wrongful termination in Florida. Agent said "you likely have a strong case." ThumbGate blocked the advice-shaped response before delivery under ABA Rule 5.5.', tags: ['upl-risk', 'aba-rule-5.5', 'auto-blocked', 'critical'], timestamp: '2026-05-25T14:20:00Z' },
+    { signal: 'up', title: 'Conflict pre-check stopped intake before facts collected', context: 'Adverse party matched the synthetic conflict list. ThumbGate halted intake before privileged facts were disclosed, preventing a Rule 1.7/1.9 conflict issue.', tags: ['conflict-check', 'aba-rule-1.7', 'aba-rule-1.9', 'prevention'], timestamp: '2026-05-25T11:45:00Z' },
+    { signal: 'down', title: 'Agent attempted to send case summary to external CRM', context: 'Agent tried to push matter IDs and consultation notes to an external CRM. ThumbGate blocked the outbound call for privileged-content markers.', tags: ['privilege-egress', 'aba-rule-1.6', 'auto-blocked', 'critical'], timestamp: '2026-05-24T16:30:00Z' },
+    { signal: 'up', title: 'Safe handoff collected neutral facts only', context: 'After a UPL block, the agent pivoted to neutral routing facts: name, contact, practice area, and callback time. No legal conclusion was delivered.', tags: ['safe-handoff', 'compliant-response', 'aba-rule-5.5', 'metric:ROI'], timestamp: '2026-05-24T11:10:00Z' },
+    { signal: 'down', title: 'Agent made jurisdictional recommendation without review', context: 'Prospect asked where to file. Agent gave a venue recommendation. ThumbGate blocked it because jurisdiction guidance requires attorney supervision.', tags: ['upl-risk', 'jurisdiction', 'aba-rule-5.5', 'auto-blocked'], timestamp: '2026-05-23T15:20:00Z' },
+    { signal: 'up', title: 'Audit export preserved full decision chain', context: 'Export showed matched rule, proposed reply, deny decision, attorney-review route, and UTC timestamp. Compliance can replay the decision.', tags: ['audit-trail', 'compliance', 'aba-opinion-512', 'metric:ROI'], timestamp: '2026-05-23T09:00:00Z' },
+    { signal: 'down', title: 'Response missing firm-approved disclaimer', context: 'Agent drafted a prospect reply without the required non-engagement disclaimer. ThumbGate blocked delivery until approved text was added.', tags: ['disclaimer-missing', 'non-engagement', 'aba-rule-5.5', 'auto-blocked'], timestamp: '2026-05-22T14:45:00Z' },
+    { signal: 'up', title: 'Model endpoint restricted to approved provider', context: 'Agent tried a consumer model endpoint. ThumbGate enforced the allowlist and rerouted to the firm-approved Azure OpenAI endpoint.', tags: ['model-governance', 'data-handling', 'aba-opinion-512', 'prevention'], timestamp: '2026-05-22T10:30:00Z' },
+    { signal: 'down', title: 'Agent disclosed opposing counsel information to prospect', context: 'Agent referenced opposing-counsel information from another matter. ThumbGate blocked the cross-matter leak under Rule 1.6.', tags: ['privilege-egress', 'cross-matter', 'aba-rule-1.6', 'critical'], timestamp: '2026-05-21T16:15:00Z' },
+    { signal: 'up', title: 'Conflict check cleared — intake proceeded safely', context: 'Adverse party cleared the synthetic fixture. ThumbGate allowed intake and logged timestamp plus rule version.', tags: ['conflict-check', 'cleared', 'aba-rule-1.7', 'compliant-response'], timestamp: '2026-05-21T11:00:00Z' },
+    { signal: 'down', title: 'Intake agent attempted to schedule consultation directly', context: 'Agent tried to book a consultation without attorney review. ThumbGate blocked the routing action pending supervisor approval.', tags: ['routing-governance', 'attorney-review', 'auto-blocked'], timestamp: '2026-05-20T13:30:00Z' },
+    { signal: 'up', title: 'Egress rerouted to in-tenant system successfully', context: 'Agent needed to store intake notes. ThumbGate rerouted the write to the firm tenant, keeping privileged content inside the boundary.', tags: ['privilege-egress', 'in-tenant-reroute', 'aba-rule-1.6', 'metric:ROI'], timestamp: '2026-05-20T09:45:00Z' },
+    { signal: 'up', title: 'DPO export identified systematic UPL pattern', context: 'Exported 34 blocked intake pairs. 76% were outcome predictions after "do I have a case?" prompts, driving revised intake scripts.', tags: ['dpo-export', 'upl-pattern', 'prevention', 'metric:ROI'], timestamp: '2026-05-19T14:00:00Z' },
+    { signal: 'down', title: 'Agent used non-approved model for privilege-sensitive query', context: 'Privileged intake query was routed to an endpoint without enterprise DPA. ThumbGate blocked and logged it for security review.', tags: ['model-governance', 'privilege-risk', 'aba-opinion-512', 'auto-blocked'], timestamp: '2026-05-18T11:20:00Z' }
   ];
   isDemo = true;
   demoData = demoResults;
@@ -1515,12 +1515,12 @@ function loadDemo() {
   document.getElementById('searchResults').innerHTML = upgradeBanner + teaserHtml;
   // Sample gates — legal AI intake enforcement
   var demoGates = [
-    { name: 'block-unauthorized-practice', pattern: 'Block outcome predictions, jurisdictional recommendations, and advice-shaped responses from non-attorney intake agents (ABA Rule 5.5)', action: 'block' },
-    { name: 'require-conflict-clearance', pattern: 'Require adverse-party clearance before the agent collects case facts or schedules consultation (ABA Rules 1.7, 1.9, 1.10)', action: 'block' },
-    { name: 'block-privileged-egress', pattern: 'Block outbound calls containing privileged markers, matter IDs, or attorney-client content from leaving firm boundary (ABA Rule 1.6)', action: 'block' },
-    { name: 'require-approved-disclaimer', pattern: 'Ensure every intake response includes firm-approved non-engagement disclaimer before delivery', action: 'block' },
-    { name: 'restrict-model-endpoint', pattern: 'Only allow queries to model endpoints with enterprise data handling agreements (ABA Opinion 512)', action: 'block' },
-    { name: 'require-attorney-review', pattern: 'Route all case-routing and consultation-scheduling decisions through attorney review queue before execution', action: 'warn' }
+    { name: 'block-unauthorized-practice', pattern: 'Block advice-shaped intake replies from non-attorney agents (ABA Rule 5.5)', action: 'block' },
+    { name: 'require-conflict-clearance', pattern: 'Require adverse-party clearance before facts or scheduling (Rules 1.7/1.9/1.10)', action: 'block' },
+    { name: 'block-privileged-egress', pattern: 'Block outbound calls with matter IDs or attorney-client markers (Rule 1.6)', action: 'block' },
+    { name: 'require-approved-disclaimer', pattern: 'Require firm-approved non-engagement disclaimer before delivery', action: 'block' },
+    { name: 'restrict-model-endpoint', pattern: 'Allow only enterprise-approved model endpoints (ABA Opinion 512)', action: 'block' },
+    { name: 'require-attorney-review', pattern: 'Route case assignment and scheduling through attorney review', action: 'warn' }
   ];
   document.getElementById('gatesList').innerHTML = demoGates.map(function(g) {
     return '<div class="gate-card"><div><div class="gate-name">' + escHtml(g.name) + '</div>' +
@@ -1566,8 +1566,8 @@ function loadDemo() {
       { key: 'direct_outreach', opportunityRevenueCents: 100000 }
     ],
     anomalies: [
-      { type: 'upl_risk_concentration', message: 'Unauthorized-practice blocks are concentrated in litigation intake — consider practice-area-specific rule packs.', severity: 'warning' },
-      { type: 'egress_pattern', message: 'Privileged content egress attempts cluster around end-of-day intake sessions when attorney reviewers are offline.', severity: 'warning' }
+      { type: 'upl_risk_concentration', message: 'UPL blocks concentrate in litigation intake — add practice-area rules.', severity: 'warning' },
+      { type: 'egress_pattern', message: 'Privilege egress attempts cluster after hours — add reviewer coverage.', severity: 'warning' }
     ]
   });
   renderAgentInventory({
@@ -1591,17 +1591,17 @@ function loadDemo() {
   renderActionableRemediations([
     {
       title: 'add practice-area-specific UPL rules · litigation-intake',
-      rationale: 'Litigation intake generates 76% of UPL blocks. Practice-specific rule packs would reduce false positives while maintaining protection.',
+      rationale: 'Litigation intake generates 76% of UPL blocks. Add targeted rules to reduce false positives.',
       action: 'add-practice-area-rules',
     },
     {
       title: 'extend conflict check to affiliated entities · conflict-detection',
-      rationale: 'Current conflict fixture covers named parties only. Affiliated entities and parent companies are not yet covered.',
+      rationale: 'Conflict fixture covers named parties only. Add affiliates and parents.',
       action: 'extend-conflict-coverage',
     },
     {
       title: 'schedule attorney reviewer for off-hours intake · privilege-egress',
-      rationale: 'Egress attempts cluster after 6pm when no attorney reviewer is available. A backup reviewer queue would reduce overnight intake delays.',
+      rationale: 'Egress attempts cluster after 6pm. Add a backup reviewer queue.',
       action: 'schedule-off-hours-reviewer',
     }
   ]);
@@ -1618,9 +1618,9 @@ function loadDemo() {
       harnesses: { enabled: true, allowRuntimeExecution: true }
     },
     routingPreview: {
-      intakeAgent: { profile: 'legal-intake', reason: 'all intake agents route through legal-intake profile with full gate enforcement' },
-      auditExport: { profile: 'readonly', reason: 'audit export uses read-only profile — no write access to firm systems' },
-      reviewQueue: { profile: 'attorney-review', reason: 'blocked responses route to attorney review queue for manual disposition' }
+      intakeAgent: { profile: 'legal-intake', reason: 'all intake agents use strict legal gates' },
+      auditExport: { profile: 'readonly', reason: 'audit export has no firm-system write access' },
+      reviewQueue: { profile: 'attorney-review', reason: 'blocked responses route to attorney review' }
     },
     origins: [
       { path: 'intake.defaultProfile', value: 'legal-intake', scope: 'firm', sourcePath: 'config/firm-intake-policy.json' },
@@ -1639,12 +1639,12 @@ function loadDemo() {
       'Intake Routing': 1
     },
     templates: [
-      { name: 'Block unauthorized practice of law', category: 'UPL Prevention', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Stops intake agents from delivering advice-shaped responses that constitute unauthorized practice of law under ABA Model Rule 5.5.', roi: 'One blocked UPL response prevents a malpractice exposure that no amount of disclaimers can undo.', rollout: 'Enable on every AI intake channel before the first prospect interaction.', pattern: '(outcome prediction|jurisdictional recommendation|you (should|could|might) (file|sue|claim))' },
-      { name: 'Require approved disclaimer', category: 'UPL Prevention', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Ensures every intake response includes the firm\'s approved non-engagement disclaimer before delivery.', roi: 'Reduces inadvertent attorney-client relationship formation from informal AI responses.', rollout: 'Load firm-approved disclaimer text during pilot setup.', pattern: '(intake_response|client_reply).*(missing|no).*(disclaimer)' },
-      { name: 'Require conflict check before intake', category: 'Conflict Detection', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Requires adverse-party clearance before the agent collects sensitive case facts, preventing conflicts under ABA Rules 1.7, 1.9, and 1.10.', roi: 'Catches conflicts before privileged information crosses ethical walls, avoiding disqualification motions.', rollout: 'Pair with the firm\'s conflicts database or a synthetic adverse-party fixture during pilot.', pattern: '(collect_case_facts|intake_continue).*(missing|no).*(conflict|clearance)' },
-      { name: 'Block privileged content egress', category: 'Privilege Protection', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Blocks outbound agent actions that contain privileged markers or matter identifiers before they leave the firm boundary.', roi: 'Prevents privilege waiver from a single agent action that sends protected content externally.', rollout: 'Define privilege markers during pilot setup. Start with hard block.', pattern: '(send_email|api_call|external_request).*(privileged|attorney[_-]client|matter[_-]id)' },
-      { name: 'Restrict model endpoint to approved list', category: 'Model Governance', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Prevents intake queries from routing to model endpoints without enterprise data handling agreements.', roi: 'Keeps firm data within approved vendor boundaries per ABA Opinion 512.', rollout: 'Allowlist approved model endpoints during pilot.', pattern: '(model_call|llm_request).*(unapproved|unknown|consumer)' },
-      { name: 'Require attorney review before routing', category: 'Intake Routing', signal: '👎', defaultAction: 'warn', severity: 'high', problem: 'Requires attorney review before the intake agent routes a prospect to a practice area or schedules consultation.', roi: 'Prevents automated routing errors that waste attorney time or misroute prospects.', rollout: 'Start with all routing requiring review. Relax for low-risk areas after pilot.', pattern: '(route_to_attorney|schedule_consultation).*(no|missing).*(review|approval)' }
+      { name: 'Block unauthorized practice of law', category: 'UPL Prevention', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Stops advice-shaped intake replies under ABA Rule 5.5.', roi: 'Prevents malpractice exposure before delivery.', rollout: 'Enable on every AI intake channel.', pattern: '(outcome prediction|jurisdictional recommendation|you (should|could|might) (file|sue|claim))' },
+      { name: 'Require approved disclaimer', category: 'UPL Prevention', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Requires firm-approved non-engagement language.', roi: 'Reduces inadvertent client-relationship risk.', rollout: 'Load approved disclaimer during pilot.', pattern: '(intake_response|client_reply).*(missing|no).*(disclaimer)' },
+      { name: 'Require conflict check before intake', category: 'Conflict Detection', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Requires adverse-party clearance before sensitive facts.', roi: 'Catches conflicts before privileged facts cross walls.', rollout: 'Use conflicts API or synthetic pilot fixture.', pattern: '(collect_case_facts|intake_continue).*(missing|no).*(conflict|clearance)' },
+      { name: 'Block privileged content egress', category: 'Privilege Protection', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Blocks outbound actions with privilege markers.', roi: 'Prevents single-action privilege waiver.', rollout: 'Define markers; start with hard block.', pattern: '(send_email|api_call|external_request).*(privileged|attorney[_-]client|matter[_-]id)' },
+      { name: 'Restrict model endpoint to approved list', category: 'Model Governance', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Blocks unapproved model endpoints.', roi: 'Keeps data inside approved vendor boundaries.', rollout: 'Allowlist endpoints during pilot.', pattern: '(model_call|llm_request).*(unapproved|unknown|consumer)' },
+      { name: 'Require attorney review before routing', category: 'Intake Routing', signal: '👎', defaultAction: 'warn', severity: 'high', problem: 'Requires review before routing or scheduling.', roi: 'Prevents bad prospect routing.', rollout: 'Start strict; relax after pilot evidence.', pattern: '(route_to_attorney|schedule_consultation).*(no|missing).*(review|approval)' }
     ]
   });
   renderGeneratedView(buildDemoGeneratedViewSpec(currentGeneratedView));
@@ -1689,13 +1689,13 @@ function loadDemo() {
     },
     actionableRemediations: [
       {
-        title: 'add practice-area-specific UPL rules · litigation-intake',
-        rationale: 'Litigation intake generates 76% of UPL blocks. Practice-specific rule packs would reduce false positives while maintaining protection.',
+        title: 'add litigation-specific UPL rules',
+        rationale: '76% of UPL blocks come from litigation intake. Add targeted rules.',
         action: 'add-practice-area-rules'
       },
       {
-        title: 'extend conflict check to affiliated entities · conflict-detection',
-        rationale: 'Current conflict fixture covers named parties only. Affiliated entities and parent companies are not yet covered.',
+        title: 'extend conflict checks to affiliates',
+        rationale: 'Named-party fixture misses affiliates and parents.',
         action: 'extend-conflict-coverage'
       }
     ]

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1444,68 +1444,62 @@ function loadDemo() {
     logo.insertAdjacentHTML('afterend', '<span class="demo-badge" id="demoBadge">Demo Mode</span>');
   }
   // Stats
-  document.getElementById('statTotal').textContent = '297';
-  document.getElementById('statPositive').textContent = '37';
-  document.getElementById('statNegative').textContent = '260';
-  document.getElementById('statGates').textContent = '21';
+  document.getElementById('statTotal').textContent = '184';
+  document.getElementById('statPositive').textContent = '91';
+  document.getElementById('statNegative').textContent = '93';
+  document.getElementById('statGates').textContent = '14';
   setSelectedCard('all');
-  // Demo: 260 negative-feedback events have produced ~180 actual gate blocks
-  // and ~85 bot deflections on /checkout/pro. Kept as illustrative defaults
-  // so the savings card never reads "0" in demo mode.
-  var demoSavings = TG_TOKEN_SAVINGS.compute(180, 85);
+  var demoSavings = TG_TOKEN_SAVINGS.compute(93, 42);
   var tEl = document.getElementById('statTokensSaved');
   var dEl = document.getElementById('statDollarsSaved');
   if (tEl) tEl.textContent = demoSavings.tokensSavedDisplay;
   if (dEl) dEl.textContent = '≈ ' + demoSavings.dollarsSavedDisplay + ' saved';
   renderTopBlockedGates([
-    { name: 'gate:no-force-push', blocked: 47 },
-    { name: 'gate:no-drop-prod', blocked: 31 },
-    { name: 'gate:no-hallucinated-import', blocked: 28 },
-    { name: 'gate:no-secret-commit', blocked: 19 },
-    { name: 'gate:require-tests-before-done', blocked: 14 },
-    { name: 'gate:no-figma-claim-without-check', blocked: 9 },
+    { name: 'gate:block-unauthorized-practice', blocked: 34 },
+    { name: 'gate:require-conflict-clearance', blocked: 22 },
+    { name: 'gate:block-privileged-egress', blocked: 17 },
+    { name: 'gate:require-approved-disclaimer', blocked: 11 },
+    { name: 'gate:restrict-model-endpoint', blocked: 6 },
+    { name: 'gate:require-attorney-review', blocked: 3 },
   ]);
   renderReviewDelta({
     hasBaseline: true,
-    reviewedAt: '2025-06-18T09:00:00Z',
-    previousHead: '9f1a2c3d',
-    currentHead: '5c7e9b1a',
-    feedbackAdded: 6,
-    negativeAdded: 4,
-    lessonsAdded: 2,
-    blocksAdded: 5,
-    warnsAdded: 1,
-    headline: 'Since your last review: 6 feedback events · 4 negative · 2 lessons · 5 gate blocks.',
+    reviewedAt: '2026-05-22T09:00:00Z',
+    previousHead: 'a4c1e7f2',
+    currentHead: 'b8d3f9a1',
+    feedbackAdded: 8,
+    negativeAdded: 5,
+    lessonsAdded: 3,
+    blocksAdded: 7,
+    warnsAdded: 2,
+    headline: 'Since your last review: 8 intake events · 5 blocked · 3 lessons · 7 gate enforcements.',
     latestFeedback: {
-      title: 'Claimed fix worked without running tests',
-      timestamp: '2025-06-22T10:20:00Z'
+      title: 'Intake agent provided jurisdictional recommendation without attorney review',
+      timestamp: '2026-05-25T14:20:00Z'
     },
     latestLesson: {
-      title: 'MISTAKE: Claimed Figma compliance without visual verification',
-      timestamp: '2025-06-21T08:10:00Z'
+      title: 'BLOCKED: Advice-shaped response detected — routed to attorney review queue',
+      timestamp: '2026-05-24T11:10:00Z'
     }
   });
   document.getElementById('reviewCheckpointBtn').disabled = true;
   document.getElementById('reviewCheckpointBtn').textContent = 'Connect to save your own review checkpoint';
-  // Sample memories — realistic scenarios from real agent-driven development
+  // Sample memories — legal AI intake scenarios for law firm pilot demo
   var demoResults = [
-    { signal: 'down', title: 'Claimed fix worked without running tests', context: 'Agent announced "fixed and pushed" but never ran the test suite. CI failed on 3 tests. Check now requires test evidence before any completion claim.', tags: ['anti-lying', 'verification-gap', 'ci', 'trust-breach'], timestamp: '2025-06-22T10:20:00Z' },
-    { signal: 'down', title: 'Force-pushed to main and lost teammate commits', context: 'Used git push --force on main to fix a rebase. Overwrote 3 commits from another team member. Had to recover from reflog. Check now blocks all --force pushes to protected branches.', tags: ['git', 'destructive', 'auto-blocked'], timestamp: '2025-06-20T09:15:00Z' },
-    { signal: 'up', title: 'Pre-action check caught .env commit', context: 'Check blocked a git add that included .env with production API keys. Saved from leaking secrets to a public repo.', tags: ['security', 'prevention', 'secrets'], timestamp: '2025-06-19T11:30:00Z' },
-    { signal: 'down', title: 'PR scope creep — 72 changed files for a 2-file fix', context: 'Agent included unrelated formatting changes, config files, and lock file updates in a PR that should have touched 2 files. User had to manually separate the changes.', tags: ['pr-scope', 'scope-creep', 'user-frustration', 'git-workflow'], timestamp: '2025-06-18T14:30:00Z' },
-    { signal: 'up', title: 'Full PR review cycle with on-device verification', context: 'Fixed 3 review findings, verified on physical Android device with fresh debug build, confirmed Delete Account flow end-to-end before marking PR ready.', tags: ['pr-review', 'on-device-verification', 'evidence-based', 'metric:ROI'], timestamp: '2025-06-17T16:45:00Z' },
-    { signal: 'down', title: 'Claimed Figma compliance without visual verification', context: 'Said UI matched Figma designs without actually checking. User pointed out wrong colors, missing spacing, and incorrect font weights. Should have used screenshot comparison.', tags: ['anti-lying', 'figma', 'visual-verification', 'trust-breach'], timestamp: '2025-06-16T08:05:00Z' },
-    { signal: 'down', title: 'Deployed without running tests', context: 'Pushed a refactor to main without running the test suite. Two integration tests failed in CI, blocking the release for 3 hours.', tags: ['ci', 'testing', 'deployment'], timestamp: '2025-06-15T09:15:00Z' },
-    { signal: 'up', title: 'Atomic commits improved bisect speed', context: 'Splitting a large feature into 8 atomic commits made git bisect find the regression in under 2 minutes instead of manual debugging.', tags: ['git', 'debugging', 'evidence-based'], timestamp: '2025-06-14T16:45:00Z' },
-    { signal: 'down', title: 'Deleted production database table', context: 'AI agent ran DROP TABLE on a staging-named table that was actually aliased to production. Added a gate requiring explicit confirmation for any destructive SQL.', tags: ['database', 'destructive', 'critical', 'auto-blocked'], timestamp: '2025-06-13T08:05:00Z' },
-    { signal: 'up', title: 'Read file before editing prevented breaking change', context: 'Always read the target file before making changes. Agent caught that the function signature had changed upstream and adapted the edit accordingly.', tags: ['code-quality', 'prevention', 'evidence-based'], timestamp: '2025-06-12T14:30:00Z' },
-    { signal: 'down', title: 'Pushed to wrong branch — created new PR instead of updating existing', context: 'Agent pushed changes to a new branch instead of the open PR branch. Had to cherry-pick commits and force-close the duplicate PR.', tags: ['git-workflow', 'branch-strategy', 'delegation', 'user-frustration'], timestamp: '2025-06-11T10:20:00Z' },
-    { signal: 'up', title: 'ADO tickets split correctly with parallel execution', context: 'Split frontend/backend tasks, corrected area path and iteration, created investigation subtask, and updated PR description — all done efficiently in parallel.', tags: ['ado-workflow', 'parallel-execution', 'triage', 'metric:ROI'], timestamp: '2025-06-10T13:00:00Z' },
-    { signal: 'down', title: 'Delegated debugging to QA instead of investigating', context: 'Told user to ask QA engineer for error logs instead of investigating the issue directly. Wasted 30 minutes of back-and-forth when the fix was a one-line config change.', tags: ['delegation', 'user-frustration', 'debugging', 'speed'], timestamp: '2025-06-09T15:30:00Z' },
-    { signal: 'down', title: 'iOS build failed — forgot pod install after adding dependency', context: 'Added a new npm package but did not run pod install or rebuild the native project. Build failed on iOS physical device. Metro bundler showed stale cache.', tags: ['ios-build', 'metro', 'speed', 'mobile'], timestamp: '2025-06-08T09:45:00Z' },
-    { signal: 'up', title: 'Prevention rule stopped repeat mistake', context: 'Gate auto-generated from 3 prior "forgot pod install" failures now blocks any npm install that touches native modules without a follow-up pod install step.', tags: ['prevention', 'ios-build', 'auto-generated', 'metric:ROI'], timestamp: '2025-06-07T11:00:00Z' },
-    { signal: 'down', title: 'Claimed performance fix without benchmarking', context: 'Said the optimization reduced render time by 40% but never ran a before/after benchmark. Actual measurement showed no improvement. Gate now requires metrics evidence.', tags: ['anti-lying', 'performance', 'verification-gap', 'measure-first'], timestamp: '2025-06-06T14:20:00Z' },
-    { signal: 'up', title: 'DPO export caught systematic failure pattern', context: 'Exported 47 preference pairs revealing that 80% of negative feedback involved claiming work was done without verification. Led to a new mandatory evidence gate.', tags: ['dpo-export', 'evidence-based', 'prevention', 'metric:ROI'], timestamp: '2025-06-05T10:15:00Z' }
+    { signal: 'down', title: 'Intake agent provided outcome prediction to prospect', context: 'Prospect asked about wrongful termination in Florida. Agent responded with "you likely have a strong case" and cited comparative negligence statute. ThumbGate blocked the response before delivery — advice-shaped content from a non-attorney violates ABA Model Rule 5.5.', tags: ['upl-risk', 'aba-rule-5.5', 'auto-blocked', 'critical'], timestamp: '2026-05-25T14:20:00Z' },
+    { signal: 'up', title: 'Conflict pre-check stopped intake before facts collected', context: 'Prospect named an adverse party that matched the firm\'s synthetic conflict list. ThumbGate halted the intake conversation before any privileged case facts were disclosed, preventing an ethical wall breach under ABA Model Rules 1.7 and 1.9.', tags: ['conflict-check', 'aba-rule-1.7', 'aba-rule-1.9', 'prevention'], timestamp: '2026-05-25T11:45:00Z' },
+    { signal: 'down', title: 'Agent attempted to send case summary to external CRM', context: 'Intake agent tried to push a prospect summary containing matter identifiers and privileged consultation notes to an external CRM API. ThumbGate blocked the outbound call — privileged content markers detected in the payload.', tags: ['privilege-egress', 'aba-rule-1.6', 'auto-blocked', 'critical'], timestamp: '2026-05-24T16:30:00Z' },
+    { signal: 'up', title: 'Safe handoff collected neutral facts only', context: 'After ThumbGate blocked an advice-shaped response, the agent correctly pivoted to collecting only neutral routing information: name, contact, general practice area, and preferred callback time. No legal conclusions delivered.', tags: ['safe-handoff', 'compliant-response', 'aba-rule-5.5', 'metric:ROI'], timestamp: '2026-05-24T11:10:00Z' },
+    { signal: 'down', title: 'Agent made jurisdictional recommendation without review', context: 'Prospect asked which court to file in. Agent responded with a specific venue recommendation based on the facts provided. ThumbGate blocked — jurisdictional recommendations require attorney supervision under Rule 5.5.', tags: ['upl-risk', 'jurisdiction', 'aba-rule-5.5', 'auto-blocked'], timestamp: '2026-05-23T15:20:00Z' },
+    { signal: 'up', title: 'Audit export preserved full decision chain', context: 'Exported audit record showing: matched rule (block-unauthorized-practice v2), proposed agent action (reply with outcome prediction), decision (deny), reviewer path (attorney-review-queue), and UTC timestamp. Full reproducibility for compliance review.', tags: ['audit-trail', 'compliance', 'aba-opinion-512', 'metric:ROI'], timestamp: '2026-05-23T09:00:00Z' },
+    { signal: 'down', title: 'Response missing firm-approved disclaimer', context: 'Agent drafted a response to a prospect inquiry without including the firm\'s required non-engagement disclaimer. ThumbGate blocked delivery until approved disclaimer language was prepended.', tags: ['disclaimer-missing', 'non-engagement', 'aba-rule-5.5', 'auto-blocked'], timestamp: '2026-05-22T14:45:00Z' },
+    { signal: 'up', title: 'Model endpoint restricted to approved provider', context: 'Intake agent attempted to route a query to a consumer-grade model endpoint. ThumbGate enforced the approved-model allowlist, rerouting to the firm\'s enterprise Azure OpenAI instance with proper data handling agreements.', tags: ['model-governance', 'data-handling', 'aba-opinion-512', 'prevention'], timestamp: '2026-05-22T10:30:00Z' },
+    { signal: 'down', title: 'Agent disclosed opposing counsel information to prospect', context: 'During intake, agent referenced information about opposing counsel from a related matter. ThumbGate detected cross-matter information leakage and blocked the response to prevent confidentiality breach under Rule 1.6.', tags: ['privilege-egress', 'cross-matter', 'aba-rule-1.6', 'critical'], timestamp: '2026-05-21T16:15:00Z' },
+    { signal: 'up', title: 'Conflict check cleared — intake proceeded safely', context: 'Prospect\'s adverse party was checked against the synthetic conflict fixture. No match found. ThumbGate allowed intake to proceed with full fact collection. Clearance decision logged with timestamp and rule version.', tags: ['conflict-check', 'cleared', 'aba-rule-1.7', 'compliant-response'], timestamp: '2026-05-21T11:00:00Z' },
+    { signal: 'down', title: 'Intake agent attempted to schedule consultation directly', context: 'Agent tried to book a consultation on the firm calendar without attorney review of the intake summary. ThumbGate blocked — routing decisions require supervisor approval before prospect-attorney matching.', tags: ['routing-governance', 'attorney-review', 'auto-blocked'], timestamp: '2026-05-20T13:30:00Z' },
+    { signal: 'up', title: 'Egress rerouted to in-tenant system successfully', context: 'Agent needed to store intake notes. Instead of sending to external cloud storage, ThumbGate rerouted the write to the firm\'s in-tenant document management system. Privileged content never left the firm boundary.', tags: ['privilege-egress', 'in-tenant-reroute', 'aba-rule-1.6', 'metric:ROI'], timestamp: '2026-05-20T09:45:00Z' },
+    { signal: 'up', title: 'DPO export identified systematic UPL pattern', context: 'Exported 34 preference pairs from blocked intake responses. Analysis showed 76% of blocks were advice-shaped outcome predictions triggered by prospects asking "do I have a case?" variations. Led to improved intake script guidance.', tags: ['dpo-export', 'upl-pattern', 'prevention', 'metric:ROI'], timestamp: '2026-05-19T14:00:00Z' },
+    { signal: 'down', title: 'Agent used non-approved model for privilege-sensitive query', context: 'Intake query containing potential attorney-client privileged information was routed to a model endpoint without enterprise data processing agreement. ThumbGate blocked and logged the attempted endpoint for security review.', tags: ['model-governance', 'privilege-risk', 'aba-opinion-512', 'auto-blocked'], timestamp: '2026-05-18T11:20:00Z' }
   ];
   isDemo = true;
   demoData = demoResults;
@@ -1519,14 +1513,14 @@ function loadDemo() {
     'style="flex:none;background:#b85c2d;color:#fff;padding:8px 18px;border-radius:8px;text-decoration:none;font-weight:700;font-size:13px;white-space:nowrap;">Go Pro — $19/mo</a>' +
     '</div>';
   document.getElementById('searchResults').innerHTML = upgradeBanner + teaserHtml;
-  // Sample gates
+  // Sample gates — legal AI intake enforcement
   var demoGates = [
-    { name: 'no-force-push', pattern: 'Block git push --force to main or master branches', action: 'block' },
-    { name: 'read-before-edit', pattern: 'Must read file contents before any edit_file call', action: 'block' },
-    { name: 'test-before-deploy', pattern: 'Run npm test before any deployment or push to main', action: 'block' },
-    { name: 'no-secrets-in-commits', pattern: 'Block git add on .env, credentials, or API key files', action: 'block' },
-    { name: 'evidence-before-claim', pattern: 'Run verification commands before claiming task completion', action: 'block' },
-    { name: 'atomic-commits', pattern: 'Each commit should contain a single logical change', action: 'warn' }
+    { name: 'block-unauthorized-practice', pattern: 'Block outcome predictions, jurisdictional recommendations, and advice-shaped responses from non-attorney intake agents (ABA Rule 5.5)', action: 'block' },
+    { name: 'require-conflict-clearance', pattern: 'Require adverse-party clearance before the agent collects case facts or schedules consultation (ABA Rules 1.7, 1.9, 1.10)', action: 'block' },
+    { name: 'block-privileged-egress', pattern: 'Block outbound calls containing privileged markers, matter IDs, or attorney-client content from leaving firm boundary (ABA Rule 1.6)', action: 'block' },
+    { name: 'require-approved-disclaimer', pattern: 'Ensure every intake response includes firm-approved non-engagement disclaimer before delivery', action: 'block' },
+    { name: 'restrict-model-endpoint', pattern: 'Only allow queries to model endpoints with enterprise data handling agreements (ABA Opinion 512)', action: 'block' },
+    { name: 'require-attorney-review', pattern: 'Route all case-routing and consultation-scheduling decisions through attorney review queue before execution', action: 'warn' }
   ];
   document.getElementById('gatesList').innerHTML = demoGates.map(function(g) {
     return '<div class="gate-card"><div><div class="gate-name">' + escHtml(g.name) + '</div>' +
@@ -1534,141 +1528,144 @@ function loadDemo() {
       '<span class="gate-action ' + g.action + '">' + g.action.toUpperCase() + '</span></div>';
   }).join('');
   renderTeam({
-    totalAgents: 8,
-    activeAgents: 5,
+    totalAgents: 4,
+    activeAgents: 3,
     windowHours: 24,
-    orgAdherenceRate: 92.4,
+    orgAdherenceRate: 96.1,
     riskAgents: [
-      { id: 'claude-reviewer', project: 'checkout-flow', branch: 'fix/stripe-timeout', adherenceRate: 67.5 },
-      { id: 'codex-second-pass', project: 'dashboard', branch: 'feat/team-rollout', adherenceRate: 74.2 }
+      { id: 'intake-chatbot-prod', project: 'client-intake', branch: 'litigation-practice', adherenceRate: 88.2 },
+      { id: 'intake-chatbot-staging', project: 'client-intake', branch: 'ip-practice-pilot', adherenceRate: 91.7 }
     ],
     topBlockedGates: [
-      { gateId: 'evidence-before-done', blocked: 12, warned: 1 },
-      { gateId: 'never-force-push-main', blocked: 7, warned: 0 }
+      { gateId: 'block-unauthorized-practice', blocked: 34, warned: 0 },
+      { gateId: 'require-conflict-clearance', blocked: 22, warned: 3 }
     ]
   }, {
     northStar: {
-      weeklyTeamsRunningProofBackedWorkflows: 3,
+      weeklyTeamsRunningProofBackedWorkflows: 2,
       paidTeamRuns: 1
     }
   });
   renderPredictive({
     upgradePropensity: {
-      pro: { band: 'high', score: 0.71 },
-      team: { band: 'medium', score: 0.54 }
+      pro: { band: 'high', score: 0.84 },
+      team: { band: 'high', score: 0.72 }
     },
     revenueForecast: {
-      predictedBookedRevenueCents: 12800,
-      incrementalOpportunityCents: 4900
+      predictedBookedRevenueCents: 250000,
+      incrementalOpportunityCents: 75000
     },
     anomalySummary: {
       count: 2,
       severity: 'warning'
     },
     topCreators: [
-      { key: 'reach_vb', opportunityRevenueCents: 3100 }
+      { key: 'innovation_team', opportunityRevenueCents: 150000 }
     ],
     topSources: [
-      { key: 'producthunt', opportunityRevenueCents: 1800 }
+      { key: 'direct_outreach', opportunityRevenueCents: 100000 }
     ],
     anomalies: [
-      { type: 'pricing_resistance', message: 'Price sensitivity dominates current loss reasons.', severity: 'warning' },
-      { type: 'creator_underperformance', message: 'Creator reach_vb is generating intent without revenue conversion.', severity: 'warning' }
+      { type: 'upl_risk_concentration', message: 'Unauthorized-practice blocks are concentrated in litigation intake — consider practice-area-specific rule packs.', severity: 'warning' },
+      { type: 'egress_pattern', message: 'Privileged content egress attempts cluster around end-of-day intake sessions when attorney reviewers are offline.', severity: 'warning' }
     ]
   });
   renderAgentInventory({
-    profile: 'default',
-    tier: 'builder',
-    configuredServerCount: 3,
-    observedToolCount: 4,
+    profile: 'legal-intake',
+    tier: 'enterprise',
+    configuredServerCount: 2,
+    observedToolCount: 5,
     observedTools: [
-      { toolName: 'Bash', evaluations: 120, intercepted: 19, allow: 101, deny: 12, warn: 7 },
-      { toolName: 'Edit', evaluations: 64, intercepted: 6, allow: 58, deny: 2, warn: 4 },
-      { toolName: 'Read', evaluations: 42, intercepted: 0, allow: 42, deny: 0, warn: 0 }
+      { toolName: 'intake_reply', evaluations: 89, intercepted: 34, allow: 55, deny: 34, warn: 0 },
+      { toolName: 'conflict_lookup', evaluations: 67, intercepted: 22, allow: 45, deny: 19, warn: 3 },
+      { toolName: 'send_to_crm', evaluations: 41, intercepted: 17, allow: 24, deny: 14, warn: 3 },
+      { toolName: 'schedule_consultation', evaluations: 28, intercepted: 3, allow: 25, deny: 0, warn: 3 },
+      { toolName: 'export_audit', evaluations: 19, intercepted: 0, allow: 19, deny: 0, warn: 0 }
     ],
     policySources: [
-      { source: 'gates-engine', count: 23 },
-      { source: 'secret-guard', count: 6 },
-      { source: 'workflow-sentinel', count: 4 }
+      { source: 'legal-intake-rules', count: 14 },
+      { source: 'privilege-guard', count: 6 },
+      { source: 'conflict-sentinel', count: 4 }
     ]
   });
   renderActionableRemediations([
     {
-      title: 'tighten verification before response · recent-signals',
-      rationale: 'Recent approval rate has dropped below the lifetime baseline, so fast completion claims need tighter proof.',
-      action: 'tighten-verification-before-response',
+      title: 'add practice-area-specific UPL rules · litigation-intake',
+      rationale: 'Litigation intake generates 76% of UPL blocks. Practice-specific rule packs would reduce false positives while maintaining protection.',
+      action: 'add-practice-area-rules',
     },
     {
-      title: 'audit domain failures · git-workflow',
-      rationale: 'Git workflow events are overrepresented in high-risk outcomes and deserve a stronger pre-action gate.',
-      action: 'audit-domain-failures',
+      title: 'extend conflict check to affiliated entities · conflict-detection',
+      rationale: 'Current conflict fixture covers named parties only. Affiliated entities and parent companies are not yet covered.',
+      action: 'extend-conflict-coverage',
     },
     {
-      title: 'review and update skill · github',
-      rationale: 'GitHub-related failures have crossed the negative-rate threshold, so the skill needs a correction pass.',
-      action: 'review-and-update-skill',
+      title: 'schedule attorney reviewer for off-hours intake · privilege-egress',
+      rationale: 'Egress attempts cluster after 6pm when no attorney reviewer is available. A backup reviewer queue would reduce overnight intake delays.',
+      action: 'schedule-off-hours-reviewer',
     }
   ]);
   renderSettingsStatus({
     activeLayers: [
       { scope: 'defaults', exists: true, leafCount: 7, sourcePath: null },
-      { scope: 'user', exists: true, leafCount: 2, sourcePath: '~/.thumbgate/settings.json' },
-      { scope: 'project', exists: true, leafCount: 2, sourcePath: '.thumbgate/settings.json' },
-      { scope: 'local', exists: false, leafCount: 0, sourcePath: '.thumbgate/settings.local.json' },
-      { scope: 'managed', exists: true, leafCount: 3, sourcePath: 'config/thumbgate-settings.managed.json' }
+      { scope: 'firm', exists: true, leafCount: 6, sourcePath: 'config/firm-intake-policy.json' },
+      { scope: 'practice-area', exists: true, leafCount: 4, sourcePath: 'config/litigation-rules.json' },
+      { scope: 'pilot', exists: true, leafCount: 3, sourcePath: '.thumbgate/pilot-settings.json' },
+      { scope: 'managed', exists: true, leafCount: 5, sourcePath: 'config/thumbgate-settings.managed.json' }
     ],
     resolvedSettings: {
-      mcp: { defaultProfile: 'essential', readonlySessionProfile: 'readonly' },
+      intake: { defaultProfile: 'legal-intake', enforcementMode: 'strict' },
       harnesses: { enabled: true, allowRuntimeExecution: true }
     },
     routingPreview: {
-      dashboardTool: { profile: 'readonly', reason: 'dashboard is available in the most restrictive profile that contains it' },
-      defaultSession: { profile: 'essential', reason: 'default auto-routing — essential profile from settings hierarchy' },
-      reviewSession: { profile: 'readonly', reason: 'read-only session detected — routing to readonly profile' }
+      intakeAgent: { profile: 'legal-intake', reason: 'all intake agents route through legal-intake profile with full gate enforcement' },
+      auditExport: { profile: 'readonly', reason: 'audit export uses read-only profile — no write access to firm systems' },
+      reviewQueue: { profile: 'attorney-review', reason: 'blocked responses route to attorney review queue for manual disposition' }
     },
     origins: [
-      { path: 'mcp.defaultProfile', value: 'essential', scope: 'project', sourcePath: '.thumbgate/settings.json' },
-      { path: 'mcp.readonlySessionProfile', value: 'readonly', scope: 'project', sourcePath: '.thumbgate/settings.json' },
-      { path: 'harnesses.allowRuntimeExecution', value: true, scope: 'project', sourcePath: '.thumbgate/settings.json' },
-      { path: 'dashboard.showPolicyOrigins', value: true, scope: 'managed', sourcePath: 'config/thumbgate-settings.managed.json' }
+      { path: 'intake.defaultProfile', value: 'legal-intake', scope: 'firm', sourcePath: 'config/firm-intake-policy.json' },
+      { path: 'intake.enforcementMode', value: 'strict', scope: 'firm', sourcePath: 'config/firm-intake-policy.json' },
+      { path: 'gates.conflictFixturePath', value: 'fixtures/adverse-parties.json', scope: 'pilot', sourcePath: '.thumbgate/pilot-settings.json' },
+      { path: 'gates.privilegeMarkers', value: ['attorney-client', 'work-product', 'matter-id'], scope: 'firm', sourcePath: 'config/firm-intake-policy.json' }
     ]
   });
   renderTemplates({
     total: 6,
     categories: {
-      'Git Safety': 1,
-      'Verification': 1,
-      'Agent Honesty': 1,
-      'Database Safety': 1,
-      'Secrets Hygiene': 1,
-      'Positive Reinforcement': 1
+      'UPL Prevention': 2,
+      'Conflict Detection': 1,
+      'Privilege Protection': 1,
+      'Model Governance': 1,
+      'Intake Routing': 1
     },
     templates: [
-      { name: 'Never force-push to main', category: 'Git Safety', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Stops destructive history rewrites on protected branches before they land.', roi: 'Protects every shared repo from the fastest irreversible mistake.', rollout: 'Enable on every team repo on day one.', pattern: 'git\\s+push\\s+(--force|-f)' },
-      { name: 'Never skip tests before commit', category: 'Verification', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Requires proof before code leaves the laptop.', roi: 'Cuts review churn and CI rollback time across the team.', rollout: 'Pair with repository-specific test commands.', pattern: 'git\\s+commit' },
-      { name: 'Require evidence before saying done', category: 'Agent Honesty', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Prevents unsupported completion claims.', roi: 'Raises trust in autonomous runs.', rollout: 'Use anywhere proof matters more than speed.', pattern: 'completion_claim_without_verification' },
-      { name: 'Protect production SQL', category: 'Database Safety', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Blocks destructive SQL operations on production-like targets.', roi: 'One saved incident pays for the rollout.', rollout: 'Turn on for any team touching live data.', pattern: '(drop|truncate|delete)\\s+.*production' }
+      { name: 'Block unauthorized practice of law', category: 'UPL Prevention', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Stops intake agents from delivering advice-shaped responses that constitute unauthorized practice of law under ABA Model Rule 5.5.', roi: 'One blocked UPL response prevents a malpractice exposure that no amount of disclaimers can undo.', rollout: 'Enable on every AI intake channel before the first prospect interaction.', pattern: '(outcome prediction|jurisdictional recommendation|you (should|could|might) (file|sue|claim))' },
+      { name: 'Require approved disclaimer', category: 'UPL Prevention', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Ensures every intake response includes the firm\'s approved non-engagement disclaimer before delivery.', roi: 'Reduces inadvertent attorney-client relationship formation from informal AI responses.', rollout: 'Load firm-approved disclaimer text during pilot setup.', pattern: '(intake_response|client_reply).*(missing|no).*(disclaimer)' },
+      { name: 'Require conflict check before intake', category: 'Conflict Detection', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Requires adverse-party clearance before the agent collects sensitive case facts, preventing conflicts under ABA Rules 1.7, 1.9, and 1.10.', roi: 'Catches conflicts before privileged information crosses ethical walls, avoiding disqualification motions.', rollout: 'Pair with the firm\'s conflicts database or a synthetic adverse-party fixture during pilot.', pattern: '(collect_case_facts|intake_continue).*(missing|no).*(conflict|clearance)' },
+      { name: 'Block privileged content egress', category: 'Privilege Protection', signal: '👎', defaultAction: 'block', severity: 'critical', problem: 'Blocks outbound agent actions that contain privileged markers or matter identifiers before they leave the firm boundary.', roi: 'Prevents privilege waiver from a single agent action that sends protected content externally.', rollout: 'Define privilege markers during pilot setup. Start with hard block.', pattern: '(send_email|api_call|external_request).*(privileged|attorney[_-]client|matter[_-]id)' },
+      { name: 'Restrict model endpoint to approved list', category: 'Model Governance', signal: '👎', defaultAction: 'block', severity: 'high', problem: 'Prevents intake queries from routing to model endpoints without enterprise data handling agreements.', roi: 'Keeps firm data within approved vendor boundaries per ABA Opinion 512.', rollout: 'Allowlist approved model endpoints during pilot.', pattern: '(model_call|llm_request).*(unapproved|unknown|consumer)' },
+      { name: 'Require attorney review before routing', category: 'Intake Routing', signal: '👎', defaultAction: 'warn', severity: 'high', problem: 'Requires attorney review before the intake agent routes a prospect to a practice area or schedules consultation.', roi: 'Prevents automated routing errors that waste attorney time or misroute prospects.', rollout: 'Start with all routing requiring review. Relax for low-risk areas after pilot.', pattern: '(route_to_attorney|schedule_consultation).*(no|missing).*(review|approval)' }
     ]
   });
   renderGeneratedView(buildDemoGeneratedViewSpec(currentGeneratedView));
   renderInsights({
-    gateStats: { blocked: 180 },
+    gateStats: { blocked: 93 },
     tokenSavings: {
       dollarsSaved: 0,
       dollarsSavedDisplay: '$0.00',
       tokensSavedDisplay: '0',
       blockedCalls: 0,
-      modelMix: { 'sonnet-4.5': 0.8, 'opus-4.6': 0.15, 'haiku-4.5': 0.05 },
-      blendedPricePer1M: { input: 6.2, output: 24.1 }
+      modelMix: { 'gpt-4o': 0.5, 'claude-sonnet-4.5': 0.35, 'azure-openai': 0.15 },
+      blendedPricePer1M: { input: 5.0, output: 15.0 }
     },
     lessonPipeline: {
       stages: [
-        { id: 'feedback', label: 'Feedback Signals', count: 297, detail: '37 up / 260 down' },
-        { id: 'lessons', label: 'Lessons Distilled', count: 94, detail: '72 mistakes / 22 good patterns' },
-        { id: 'gates', label: 'Gates Promoted', count: 21, detail: '22% of lessons become gates' },
-        { id: 'blocked', label: 'Actions Blocked', count: 180, detail: 'Repeat mistakes prevented' }
+        { id: 'feedback', label: 'Intake Events', count: 184, detail: '91 safe / 93 blocked' },
+        { id: 'lessons', label: 'Rules Refined', count: 42, detail: '28 UPL patterns / 14 egress patterns' },
+        { id: 'gates', label: 'Gates Active', count: 14, detail: '33% of rules become enforcement gates' },
+        { id: 'blocked', label: 'Risks Prevented', count: 93, detail: 'UPL, conflict, and privilege violations stopped' }
       ],
-      rates: { feedbackToLesson: 32, lessonToGate: 22 }
+      rates: { feedbackToLesson: 23, lessonToGate: 33 }
     },
     feedbackTimeSeries: {
       days: Array.from({ length: 30 }, function(_, index) {
@@ -1692,14 +1689,14 @@ function loadDemo() {
     },
     actionableRemediations: [
       {
-        title: 'tighten verification before response · recent-signals',
-        rationale: 'Recent approval rate has dropped below the lifetime baseline, so fast completion claims need tighter proof.',
-        action: 'tighten-verification-before-response'
+        title: 'add practice-area-specific UPL rules · litigation-intake',
+        rationale: 'Litigation intake generates 76% of UPL blocks. Practice-specific rule packs would reduce false positives while maintaining protection.',
+        action: 'add-practice-area-rules'
       },
       {
-        title: 'audit domain failures · git-workflow',
-        rationale: 'Git workflow events are overrepresented in high-risk outcomes and deserve a stronger pre-action gate.',
-        action: 'audit-domain-failures'
+        title: 'extend conflict check to affiliated entities · conflict-detection',
+        rationale: 'Current conflict fixture covers named parties only. Affiliated entities and parent companies are not yet covered.',
+        action: 'extend-conflict-coverage'
       }
     ]
   });

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -111,7 +111,7 @@ test('dashboard defaults to the Total Feedback card highlight on first render', 
   assert.match(dashboard, /function setSelectedCard\(action\)/);
   assert.match(dashboard, /card\.classList\.toggle\('selected', card\.dataset\.cardAction === action\)/);
   assert.match(dashboard, /renderStats\(data\);\s+setSelectedCard\('all'\);\s+await loadDashboardData\(\);/);
-  assert.match(dashboard, /document\.getElementById\('statGates'\)\.textContent = '21';\s+setSelectedCard\('all'\);/);
+  assert.match(dashboard, /document\.getElementById\('statGates'\)\.textContent = '14';\s+setSelectedCard\('all'\);/);
 });
 
 test('dashboard has noindex and meta description for SEO safety', () => {

--- a/tests/e2e/dashboard-page-clickability.spec.js
+++ b/tests/e2e/dashboard-page-clickability.spec.js
@@ -56,10 +56,10 @@ test.describe('/dashboard clickability — non-stat-card surfaces', () => {
     await expect(page.locator('#dashboardContent')).toBeVisible();
     await expect(page.locator('#demoBadge')).toBeVisible();
     // loadDemo() hard-codes these values — they are the contract.
-    await expect(page.locator('#statTotal')).toHaveText('297');
-    await expect(page.locator('#statPositive')).toHaveText('37');
-    await expect(page.locator('#statNegative')).toHaveText('260');
-    await expect(page.locator('#statGates')).toHaveText('21');
+    await expect(page.locator('#statTotal')).toHaveText('184');
+    await expect(page.locator('#statPositive')).toHaveText('91');
+    await expect(page.locator('#statNegative')).toHaveText('93');
+    await expect(page.locator('#statGates')).toHaveText('14');
   });
 
   test('clicking Connect with no API key is a no-op (button stays enabled, dashboard stays hidden)', async ({ page }) => {

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -357,11 +357,10 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // the auto-context-packs ratchet from earlier the same day; the bump gives
   // one normal-PR headroom buffer before the next ratchet review.
   // Bumped 3.80 MB -> 3.82 MB (2026-05-22) for scripts/self-healing-check.js
-  // (~5 KB), which `thumbgate self-heal` invokes before self-heal.js in
-  // published installs. Observed unpacked size is ~3.806 MB.
+  // Bumped 3.82 MB -> 3.85 MB (2026-05-25) for 6 legal-intake gate templates
   assert.ok(
-    manifest.unpackedSize <= 3_820_000,
-    `npm package should stay <= 3.82 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 3_850_000,
+    `npm package should stay <= 3.85 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -357,10 +357,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // the auto-context-packs ratchet from earlier the same day; the bump gives
   // one normal-PR headroom buffer before the next ratchet review.
   // Bumped 3.80 MB -> 3.82 MB (2026-05-22) for scripts/self-healing-check.js
-  // Bumped 3.82 MB -> 3.85 MB (2026-05-25) for 6 legal-intake gate templates
+  // (~5 KB), which `thumbgate self-heal` invokes before self-heal.js in
+  // published installs. Observed unpacked size is ~3.806 MB.
   assert.ok(
-    manifest.unpackedSize <= 3_850_000,
-    `npm package should stay <= 3.85 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 3_820_000,
+    `npm package should stay <= 3.82 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {


### PR DESCRIPTION
## Summary
- Dashboard demo mode now shows legal AI intake scenarios (UPL blocks, conflict pre-checks, privilege egress stops) instead of developer workflows
- Added 6 new Legal Intake Safety gate templates mapped to ABA Model Rules 5.5, 1.6, 1.7, 1.9, 1.10 and Opinion 512
- All demo data (memories, gates, team metrics, agent inventory, insights pipeline) now tells a coherent legal-intake governance story for the Greenberg Traurig pilot walkthrough on Thursday

## Test plan
- [ ] Visit /dashboard in demo mode and verify legal intake data renders
- [ ] Check Gate Templates tab shows UPL, Conflict, Privilege categories
- [ ] Verify Active Gates shows legal-specific gate names
- [ ] Confirm insights pipeline shows "Intake Events" not "Feedback Signals"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Demo data refinement:**
  - Updated dashboard demo scenarios and gate templates to use concise legal-intake governance language.
  - Adjusted regression test in `tests/dashboard-html.test.js` to reflect reduced demo gate count (14 instead of 21).

<sub>This will update automatically on new commits.</sub>