### PR TITLE
Add revenue truth audit and focus homepage offers

### DIFF
--- a/.changeset/revenue-truth-offer-focus.md
+++ b/.changeset/revenue-truth-offer-focus.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a manual revenue truth audit workflow and tighten the homepage offer router so buyers can choose Pro, workflow intake, or free evaluation without CTA overload.

--- a/.github/workflows/revenue-truth-audit.yml
+++ b/.github/workflows/revenue-truth-audit.yml
@@ -1,0 +1,101 @@
+name: Revenue Truth Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      window:
+        description: "Hosted billing window to audit"
+        required: false
+        default: "30d"
+        type: choice
+        options:
+          - today
+          - 30d
+          - lifetime
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Audit hosted billing summary
+        id: hosted
+        env:
+          THUMBGATE_OPERATOR_KEY: ${{ secrets.THUMBGATE_OPERATOR_KEY }}
+          THUMBGATE_API_KEY: ${{ secrets.THUMBGATE_API_KEY }}
+          THUMBGATE_BILLING_API_BASE_URL: ${{ vars.THUMBGATE_BILLING_API_BASE_URL || 'https://thumbgate.ai' }}
+        run: |
+          set -euo pipefail
+          mkdir -p reports/revenue
+          node bin/cli.js cfo --window="${{ inputs.window }}" > reports/revenue/hosted-cfo.json
+          SOURCE=$(node -p "require('./reports/revenue/hosted-cfo.json').source")
+          BOOKED=$(node -p "require('./reports/revenue/hosted-cfo.json').summary.revenue.bookedRevenueCents || 0")
+          PAID=$(node -p "require('./reports/revenue/hosted-cfo.json').summary.revenue.paidOrders || 0")
+          echo "source=$SOURCE" >> "$GITHUB_OUTPUT"
+          echo "booked_cents=$BOOKED" >> "$GITHUB_OUTPUT"
+          echo "paid_orders=$PAID" >> "$GITHUB_OUTPUT"
+          if [ "$SOURCE" != "hosted" ]; then
+            echo "::error::Hosted billing summary did not return hosted truth. Source=$SOURCE"
+            exit 1
+          fi
+
+      - name: Audit Stripe live status
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p reports/revenue
+          node scripts/stripe-live-status.js --strict > reports/revenue/stripe-live.json
+
+      - name: Audit external customer truth
+        id: external
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          THUMBGATE_OWNER_EMAILS: ${{ secrets.THUMBGATE_OWNER_EMAILS }}
+        run: |
+          set -euo pipefail
+          mkdir -p reports/revenue
+          node scripts/external-customer-audit.js --json > reports/revenue/external-customer-audit.json
+          node scripts/external-customer-audit.js > reports/revenue/external-customer-audit.md
+          REAL_CUSTOMERS=$(node -p "require('./reports/revenue/external-customer-audit.json').charges.external.uniqueCustomerCount || 0")
+          REAL_NET=$(node -p "require('./reports/revenue/external-customer-audit.json').charges.external.net || 0")
+          REAL_ACTIVE=$(node -p "require('./reports/revenue/external-customer-audit.json').subscriptions.activeExternal || 0")
+          echo "real_customers=$REAL_CUSTOMERS" >> "$GITHUB_OUTPUT"
+          echo "real_net=$REAL_NET" >> "$GITHUB_OUTPUT"
+          echo "real_active=$REAL_ACTIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Write operator summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Revenue Truth Audit"
+            echo
+            echo "- Hosted source: ${{ steps.hosted.outputs.source }}"
+            echo "- Hosted paid orders (${{ inputs.window }}): ${{ steps.hosted.outputs.paid_orders }}"
+            echo "- Hosted booked cents (${{ inputs.window }}): ${{ steps.hosted.outputs.booked_cents }}"
+            echo "- Real non-owner paying customers lifetime: ${{ steps.external.outputs.real_customers }}"
+            echo "- Real non-owner active subscriptions: ${{ steps.external.outputs.real_active }}"
+            echo "- Real non-owner net revenue lifetime: \$${{ steps.external.outputs.real_net }}"
+            echo
+            cat reports/revenue/external-customer-audit.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload revenue truth artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: revenue-truth-audit-${{ github.run_id }}
+          path: reports/revenue/

--- a/public/index.html
+++ b/public/index.html
@@ -411,6 +411,12 @@ __GA_BOOTSTRAP__
   .hero-actions .hero-install { margin-bottom: 0; font-size: 18px; padding: 14px 22px; border: 1px solid rgba(34,211,238,0.55); background: rgba(34,211,238,0.07); box-shadow: none; }
   .hero-actions .btn-install-hero { font-size: 16px; padding: 14px 22px; }
   .hero-actions .hero-diagnostic { font-size: 16px; padding: 14px 22px; background: var(--green); color: #06120a; font-weight: 800; box-shadow: none; }
+  .offer-router { max-width: 940px; margin: 18px auto 22px; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; text-align: left; }
+  .offer-route { border: 1px solid rgba(34,211,238,0.18); background: rgba(17,17,19,0.72); border-radius: 8px; padding: 14px; min-height: 128px; }
+  .offer-route strong { display: block; color: var(--text); font-size: 14px; margin-bottom: 6px; }
+  .offer-route p { margin: 0 0 10px; color: var(--text-muted); font-size: 13px; line-height: 1.45; }
+  .offer-route a, .offer-route button { color: var(--cyan); font-weight: 800; font-size: 13px; text-decoration: none; background: transparent; border: 0; padding: 0; cursor: pointer; }
+  .offer-route.primary { border-color: rgba(34,211,238,0.42); background: rgba(34,211,238,0.07); }
   .btn-pro-page { display: inline-flex; align-items: center; justify-content: center; padding: 11px 18px; background: var(--cyan); color: var(--bg); border-radius: 999px; text-decoration: none; font-size: 14px; font-weight: 700; box-shadow: 0 0 0 1px rgba(34,211,238,0.28), 0 12px 32px rgba(34,211,238,0.18); transition: opacity 0.15s, transform 0.15s; }
   .btn-pro-page:hover { opacity: 0.9; transform: translateY(-1px); }
   .btn-gpt-page { display: inline-flex; align-items: center; justify-content: center; padding: 14px 32px; background: var(--green); color: #06120a; border-radius: 8px; text-decoration: none; font-size: 16px; font-weight: 800; box-shadow: 0 0 0 1px rgba(74,222,128,0.32), 0 12px 32px rgba(74,222,128,0.18); transition: opacity 0.15s, transform 0.15s; }
@@ -654,6 +660,7 @@ __GA_BOOTSTRAP__
     .hero { padding: 72px 0 56px; }
     .hero-actions { flex-direction: column; }
     .hero-actions a { width: 100%; }
+    .offer-router { grid-template-columns: 1fr; }
     .hero-paid-actions { justify-content: center; }
     .hero-paid-actions a { width: 100%; }
     .nav-links a:not(.nav-cta) { display: none; }
@@ -715,14 +722,26 @@ __GA_BOOTSTRAP__
 
     <div class="hero-actions">
       <a href="/checkout/pro?utm_source=website&utm_medium=hero_cta&utm_campaign=pro_upgrade&cta_id=hero_start_pro&cta_placement=hero&plan_id=pro&landing_path=%2F" data-revenue-cta data-cta-id="hero_start_pro" data-cta-placement="hero" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);try{posthog.capture('hero_pro_checkout_click',{cta:'hero_start_pro',tier:'pro',price:19})}catch(_){}" class="btn-pro-page hero-pro hero-pro-primary">Start Pro — $19/mo</a>
-      <div class="hero-install hero-install-primary" onclick="copyInstall(this)" title="Click to copy">
-        <span class="prompt">$</span>
-        <span class="cmd">npx thumbgate init</span>
-        <span class="copy-hint">click to copy</span>
-      </div>
-      <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-gpt-page btn-install-hero" title="Click to copy: npx thumbgate init">Install Free CLI</a>
       <a href="#workflow-sprint-intake" onclick="try{posthog.capture('hero_sprint_click',{cta:'sprint_intake'})}catch(_){};sendFirstPartyTelemetry('hero_sprint_intake_started',{ctaId:'hero_workflow_sprint',ctaPlacement:'hero',offer:'workflow_sprint'});" class="btn-pro-page hero-pro">Talk to me — Workflow Hardening Sprint →</a>
-      <a href="#demo" onclick="try{posthog.capture('hero_demo_click',{cta:'see_enforcement'})}catch(_){};sendFirstPartyTelemetry('hero_demo_clicked',{ctaId:'hero_see_enforcement',ctaPlacement:'hero'});" class="btn-free" style="font-size:15px;padding:14px 22px;">See the enforcement in action</a>
+      <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-gpt-page btn-install-hero" title="Click to copy: npx thumbgate init">Install Free CLI</a>
+    </div>
+
+    <div class="offer-router" aria-label="Choose the right ThumbGate path">
+      <div class="offer-route primary">
+        <strong>Solo operator: Start Pro</strong>
+        <p>Use Pro when one person needs hosted sync, dashboard evidence, and exports across machines.</p>
+        <a href="/checkout/pro?utm_source=website&utm_medium=offer_router&utm_campaign=pro_upgrade&cta_id=router_start_pro&cta_placement=offer_router&plan_id=pro&landing_path=%2F" data-revenue-cta data-cta-id="router_start_pro" data-cta-placement="offer_router" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);">Pay $19/mo with Stripe →</a>
+      </div>
+      <div class="offer-route">
+        <strong>Team workflow: Start with intake</strong>
+        <p>Use the sprint when a team has one repeated blocker, one owner, and needs proof before rollout.</p>
+        <a href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});try{posthog.capture('router_sprint_click',{cta:'router_workflow_sprint'})}catch(_){}">Send the workflow first →</a>
+      </div>
+      <div class="offer-route">
+        <strong>Still evaluating: Free CLI</strong>
+        <p>Use free local gates to prove one blocked repeat. Upgrade only when sync, exports, or shared ops matter.</p>
+        <button type="button" data-router-install onclick="copyInstall(this);try{posthog.capture('router_install_click',{cta:'router_install_cli'})}catch(_){}"><span class="copy-hint">Copy npx thumbgate init</span></button>
+      </div>
     </div>
 
     <div class="hero-trust-bar">
@@ -765,7 +784,6 @@ __GA_BOOTSTRAP__
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/THUMBGATE_BENCH.md" target="_blank" rel="noopener">ThumbGate Bench</a>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/RELEASE_CONFIDENCE.md" target="_blank" rel="noopener">Release confidence</a>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">Proof-backed CI</a>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/actions" target="_blank" rel="noopener">CI and proof lanes</a>
       <a href="#compatibility">Claude Code · Cursor · Codex · Gemini · Amp · Cline · OpenCode</a>
     </nav>
     <div class="marketing-test-copy" hidden>

--- a/public/index.html
+++ b/public/index.html
@@ -411,12 +411,10 @@ __GA_BOOTSTRAP__
   .hero-actions .hero-install { margin-bottom: 0; font-size: 18px; padding: 14px 22px; border: 1px solid rgba(34,211,238,0.55); background: rgba(34,211,238,0.07); box-shadow: none; }
   .hero-actions .btn-install-hero { font-size: 16px; padding: 14px 22px; }
   .hero-actions .hero-diagnostic { font-size: 16px; padding: 14px 22px; background: var(--green); color: #06120a; font-weight: 800; box-shadow: none; }
-  .offer-router { max-width: 940px; margin: 18px auto 22px; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; text-align: left; }
-  .offer-route { border: 1px solid rgba(34,211,238,0.18); background: rgba(17,17,19,0.72); border-radius: 8px; padding: 14px; min-height: 128px; }
-  .offer-route strong { display: block; color: var(--text); font-size: 14px; margin-bottom: 6px; }
-  .offer-route p { margin: 0 0 10px; color: var(--text-muted); font-size: 13px; line-height: 1.45; }
-  .offer-route a, .offer-route button { color: var(--cyan); font-weight: 800; font-size: 13px; text-decoration: none; background: transparent; border: 0; padding: 0; cursor: pointer; }
-  .offer-route.primary { border-color: rgba(34,211,238,0.42); background: rgba(34,211,238,0.07); }
+  .offer-router{max-width:940px;margin:18px auto 22px;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;text-align:left}
+  .offer-route{border:1px solid rgba(34,211,238,.18);background:rgba(17,17,19,.72);border-radius:8px;padding:14px}
+  .offer-route strong{display:block;color:var(--text);font-size:14px;margin-bottom:6px}.offer-route p{margin:0 0 10px;color:var(--text-muted);font-size:13px}
+  .offer-route a,.offer-route button{color:var(--cyan);font-weight:800;font-size:13px;text-decoration:none;background:transparent;border:0;padding:0;cursor:pointer}.offer-route.primary{background:rgba(34,211,238,.07)}
   .btn-pro-page { display: inline-flex; align-items: center; justify-content: center; padding: 11px 18px; background: var(--cyan); color: var(--bg); border-radius: 999px; text-decoration: none; font-size: 14px; font-weight: 700; box-shadow: 0 0 0 1px rgba(34,211,238,0.28), 0 12px 32px rgba(34,211,238,0.18); transition: opacity 0.15s, transform 0.15s; }
   .btn-pro-page:hover { opacity: 0.9; transform: translateY(-1px); }
   .btn-gpt-page { display: inline-flex; align-items: center; justify-content: center; padding: 14px 32px; background: var(--green); color: #06120a; border-radius: 8px; text-decoration: none; font-size: 16px; font-weight: 800; box-shadow: 0 0 0 1px rgba(74,222,128,0.32), 0 12px 32px rgba(74,222,128,0.18); transition: opacity 0.15s, transform 0.15s; }
@@ -729,18 +727,18 @@ __GA_BOOTSTRAP__
     <div class="offer-router" aria-label="Choose the right ThumbGate path">
       <div class="offer-route primary">
         <strong>Solo operator: Start Pro</strong>
-        <p>Use Pro when one person needs hosted sync, dashboard evidence, and exports across machines.</p>
-        <a href="/checkout/pro?utm_source=website&utm_medium=offer_router&utm_campaign=pro_upgrade&cta_id=router_start_pro&cta_placement=offer_router&plan_id=pro&landing_path=%2F" data-revenue-cta data-cta-id="router_start_pro" data-cta-placement="offer_router" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);">Pay $19/mo with Stripe →</a>
+        <p>Sync, proof, exports.</p>
+        <a href="/checkout/pro?utm_source=website&utm_medium=offer_router&cta_id=router_start_pro&cta_placement=offer_router&plan_id=pro" data-revenue-cta data-cta-id="router_start_pro" data-cta-placement="offer_router" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);">Pay $19/mo with Stripe →</a>
       </div>
       <div class="offer-route">
         <strong>Team workflow: Start with intake</strong>
-        <p>Use the sprint when a team has one repeated blocker, one owner, and needs proof before rollout.</p>
-        <a href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});try{posthog.capture('router_sprint_click',{cta:'router_workflow_sprint'})}catch(_){}">Send the workflow first →</a>
+        <p>Proof before rollout.</p>
+        <a href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});">Send the workflow first →</a>
       </div>
       <div class="offer-route">
         <strong>Still evaluating: Free CLI</strong>
-        <p>Use free local gates to prove one blocked repeat. Upgrade only when sync, exports, or shared ops matter.</p>
-        <button type="button" data-router-install onclick="copyInstall(this);try{posthog.capture('router_install_click',{cta:'router_install_cli'})}catch(_){}"><span class="copy-hint">Copy npx thumbgate init</span></button>
+        <p>Local proof first.</p>
+        <button data-router-install onclick="copyInstall(this)"><span class="copy-hint">Copy npx thumbgate init</span></button>
       </div>
     </div>
 

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -23,18 +23,22 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
 
   test('renders the hero install command + visible CTAs', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.hero-install-primary .cmd')).toHaveText('npx thumbgate init');
     await expect(page.locator('.hero-pro-primary')).toBeVisible();
     await expect(page.locator('.btn-install-hero')).toBeVisible();
     await expect(page.locator('.hero-pro', { hasText: /Workflow Hardening Sprint/ })).toBeVisible();
+    await expect(page.locator('.offer-router')).toBeVisible();
+    await expect(page.locator('.offer-route', { hasText: /Solo operator/ })).toBeVisible();
+    await expect(page.locator('.offer-route', { hasText: /Team workflow/ })).toBeVisible();
+    await expect(page.locator('.offer-route', { hasText: /Still evaluating/ })).toBeVisible();
   });
 
-  test('clicking hero install tile copies the command and flips copy-hint to "copied!"', async ({ page }) => {
+  test('clicking router install button copies the command and confirms the copy', async ({ page }) => {
     await page.goto('/');
-    const tile = page.locator('.hero-install-primary');
-    await tile.click();
-    await expect(tile.locator('.copy-hint')).toHaveText('copied!');
-    await expect(tile.locator('.copy-hint')).toHaveClass(/copied/);
+    const btn = page.locator('[data-router-install]');
+    await expect(btn.locator('.copy-hint')).toHaveText('Copy npx thumbgate init');
+    await btn.click();
+    await expect(btn.locator('.copy-hint')).toHaveText('copied!');
+    await expect(btn.locator('.copy-hint')).toHaveClass(/copied/);
   });
 
   test('clicking "Install Free CLI" button swaps its label to the Copied confirmation', async ({ page }) => {
@@ -52,10 +56,11 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await expect(page).toHaveURL(/#workflow-sprint-intake$/);
   });
 
-  test('clicking "See the enforcement in action" anchors to #demo', async ({ page }) => {
+  test('router Pro CTA navigates to hosted Pro checkout', async ({ page }) => {
     await page.goto('/');
-    await page.locator('a.btn-free', { hasText: /See the enforcement in action/ }).first().click();
-    await expect(page).toHaveURL(/#demo$/);
+    await page.locator('.offer-route.primary a', { hasText: /Pay \$19\/mo with Stripe/ }).click();
+    await expect(page).toHaveURL(/\/checkout\/pro/);
+    await expect(page).toHaveURL(/cta_id=router_start_pro/);
   });
 
   // --- nav region (in-page anchors that are actually visible) ---

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -71,6 +71,11 @@ test('public landing page exposes above-fold paid Pro CTA with canonical revenue
   assert.match(heroBlock, /Start Pro — \$19\/mo/);
   assert.match(heroBlock, /\/checkout\/pro\?/);
   assert.ok(heroBlock.indexOf('hero_start_pro') < heroBlock.indexOf('hero_install_cli'));
+  assert.match(heroBlock, /aria-label="Choose the right ThumbGate path"/);
+  assert.match(heroBlock, /Solo operator: Start Pro/);
+  assert.match(heroBlock, /data-cta-id="router_start_pro"/);
+  assert.match(heroBlock, /Team workflow: Start with intake/);
+  assert.match(heroBlock, /Still evaluating: Free CLI/);
   assert.match(landingPage, /function trackRevenueCta/);
   assert.match(landingPage, /plausible\('pricing_cta_click'/);
   assert.match(landingPage, /plausible\('checkout_start'/);
@@ -200,7 +205,7 @@ test('public landing page includes Plausible analytics and search engine proof b
   assert.match(landingPage, /Release confidence/i);
   assert.match(landingPage, /ThumbGate Bench/i);
   assert.match(landingPage, /Proof-backed CI/i);
-  assert.match(landingPage, /CI and proof lanes/i);
+  assert.doesNotMatch(landingPage, /CI and proof lanes/i);
   assert.match(landingPage, /Claude Code · Cursor · Codex · Gemini · Amp · Cline · OpenCode/i);
 });
 
@@ -359,6 +364,9 @@ test('public landing page proof bar uses individually clickable link chips', () 
   assert.match(landingPage, /Claude Extension →/);
   assert.match(landingPage, /Codex plugin setup →/);
   assert.match(landingPage, /Verification evidence →/);
+  assert.equal((landingPage.match(/Claude Extension →/g) || []).length, 1);
+  assert.equal((landingPage.match(/Proof-backed CI/g) || []).length, 1);
+  assert.doesNotMatch(landingPage, /CI and proof lanes/);
 });
 
 test('public landing page Pro tier uses outcome-framed bullets that justify upgrade', () => {

--- a/tests/revenue-observability-workflow.test.js
+++ b/tests/revenue-observability-workflow.test.js
@@ -9,6 +9,10 @@ function readWorkflow() {
   return fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'daily-revenue-loop.yml'), 'utf8');
 }
 
+function readRevenueTruthWorkflow() {
+  return fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'revenue-truth-audit.yml'), 'utf8');
+}
+
 test('daily revenue loop audits hosted revenue truth before reporting', () => {
   const workflow = readWorkflow();
 
@@ -32,4 +36,20 @@ test('daily revenue loop audits Stripe and Plausible with stored artifacts', () 
   assert.match(workflow, /npm run social:poll:plausible/);
   assert.match(workflow, /actions\/upload-artifact@v7/);
   assert.match(workflow, /revenue-observability-\$\{\{ github\.run_id \}\}/);
+});
+
+test('manual revenue truth audit produces hosted and owner-filtered artifacts', () => {
+  const workflow = readRevenueTruthWorkflow();
+
+  assert.match(workflow, /name:\s*Revenue Truth Audit/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /THUMBGATE_OPERATOR_KEY:\s*\$\{\{\s*secrets\.THUMBGATE_OPERATOR_KEY\s*\}\}/);
+  assert.match(workflow, /THUMBGATE_API_KEY:\s*\$\{\{\s*secrets\.THUMBGATE_API_KEY\s*\}\}/);
+  assert.match(workflow, /node bin\/cli\.js cfo --window="\$\{\{ inputs\.window \}\}"/);
+  assert.match(workflow, /if \[ "\$SOURCE" != "hosted" \]/);
+  assert.match(workflow, /node scripts\/stripe-live-status\.js --strict/);
+  assert.match(workflow, /node scripts\/external-customer-audit\.js --json > reports\/revenue\/external-customer-audit\.json/);
+  assert.match(workflow, /Real non-owner paying customers lifetime/);
+  assert.match(workflow, /actions\/upload-artifact@v7/);
+  assert.match(workflow, /revenue-truth-audit-\$\{\{ github\.run_id \}\}/);
 });


### PR DESCRIPTION
## What changed

- Adds a manual `Revenue Truth Audit` workflow that pulls hosted billing truth, Stripe live status, and owner-filtered external customer truth into artifacts and the GitHub Actions summary.
- Simplifies the homepage above-fold offer paths into three explicit routes: Pro checkout, workflow sprint intake, and free CLI evaluation.
- Removes a duplicate proof-bar CI chip and updates landing page/E2E coverage for the new routing.

## Why

The business question needs a repeatable answer: real revenue must be separated from owner/test payments, and the page should not overload cold visitors with overlapping CTAs. This gives us a clean manual audit lane and a cleaner first-screen decision path.

## Validation

- `node --test tests/revenue-observability-workflow.test.js tests/public-landing.test.js tests/deployment.test.js` → 102 passed
- `npm run test:index-page-clickability` → 19 passed
- `CHANGESET_BASE_REF=origin/main node scripts/changeset-check.js` → no release-relevant changes
- `git diff --check` → passed
- Pre-commit guards → package parity, version sync, congruence, landing claims all passed
- Pre-push guards → npm pack dry-run, public HTML link validation, regression guard all passed