### PR TITLE
Cap noncritical scheduled GitHub Actions

### DIFF
--- a/.github/workflows/daily-revenue-loop.yml
+++ b/.github/workflows/daily-revenue-loop.yml
@@ -1,8 +1,6 @@
 name: Daily Revenue Loop
 
 on:
-  schedule:
-    - cron: '0 13 * * *'  # 9am ET (1pm UTC)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/gtm-autonomous-loop.yml
+++ b/.github/workflows/gtm-autonomous-loop.yml
@@ -1,8 +1,6 @@
 name: Always-On GTM Acquisition Loop
 
 on:
-  schedule:
-    - cron: '0 9 * * *' # Daily at 9am UTC (was hourly — saves ~23 runs/day)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/instagram-autopilot.yml
+++ b/.github/workflows/instagram-autopilot.yml
@@ -16,8 +16,6 @@ name: Instagram Autopilot
 # a safe no-op rather than a double-post.
 
 on:
-  schedule:
-    - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:
       image_only:

--- a/.github/workflows/marketing-autopilot.yml
+++ b/.github/workflows/marketing-autopilot.yml
@@ -1,6 +1,8 @@
 name: Marketing Autopilot
 
-# Text content autopilot — fires every 4 hours.
+# Manual-only cost governor: scheduled content autopilot burned GitHub-hosted
+# Actions minutes without clear revenue attribution. Keep operator dispatch;
+# move recurring loops to local/Railway/runner compute before re-enabling.
 # Posts text/image content to LinkedIn, Threads, Bluesky, and Instagram.
 # YouTube remains video-only via the video autopilot.
 # Posts to Reddit via the configured OAuth publisher.
@@ -10,8 +12,6 @@ name: Marketing Autopilot
 # X_* secrets and scripts/post-to-x*.* helpers have been retired.
 
 on:
-  schedule:
-    - cron: '15 */4 * * *'   # every 4 hours, offset from video-autopilot
   workflow_dispatch:
     inputs:
       action:

--- a/.github/workflows/medium-weekly-visibility.yml
+++ b/.github/workflows/medium-weekly-visibility.yml
@@ -5,8 +5,6 @@ name: Medium Weekly Visibility
 # Medium URL in docs/marketing/medium/published.csv after visible publish.
 
 on:
-  schedule:
-    - cron: '30 13 * * 1' # Mondays 09:30 America/New_York during daylight time
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/perplexity-command-center.yml
+++ b/.github/workflows/perplexity-command-center.yml
@@ -1,8 +1,6 @@
 name: Perplexity Command Center
 
 on:
-  schedule:
-    - cron: '30 12 * * *'
   workflow_dispatch:
     inputs:
       command:

--- a/.github/workflows/ralph-loop.yml
+++ b/.github/workflows/ralph-loop.yml
@@ -1,7 +1,7 @@
 name: Ralph Loop Audience Engagement
 
 # Ralph Mode is the always-on acquisition loop:
-# - hourly audience sensing and reply monitoring
+# - operator-triggered audience sensing and reply monitoring
 # - cache-backed state so CI does not forget handled replies
 # - Reddit remains draft-only; LinkedIn replies pass the social quality gate
 # - Bluesky can auto-publish a bounded set of safe replies: no URLs, no sales
@@ -10,8 +10,6 @@ name: Ralph Loop Audience Engagement
 # - X/Twitter was retired from distribution 2026-04-20.
 
 on:
-  schedule:
-    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       mode:

--- a/.github/workflows/ralph-mode.yml
+++ b/.github/workflows/ralph-mode.yml
@@ -1,13 +1,11 @@
 name: Ralph Mode - 24/7 Engagement Loop
 
 # Ralph Mode handles outbound campaign posts and GitHub/dev.to outreach.
-# Ralph Loop Audience Engagement handles hourly reply sensing, analytics, and
+# Ralph Loop Audience Engagement handles operator-triggered reply sensing, analytics, and
 # draft-safe audience replies. Keep both lanes stateful so CI does not repeat
 # the same contact or forget previous engagement.
 
 on:
-  schedule:
-    - cron: '0 */2 * * *'  # Every 2 hours
   workflow_dispatch: {}      # Manual trigger
 
 permissions:

--- a/.github/workflows/self-healing-auto-fix.yml
+++ b/.github/workflows/self-healing-auto-fix.yml
@@ -1,8 +1,6 @@
 name: Self-Healing Auto-Fix
 
 on:
-  schedule:
-    - cron: '30 */12 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/self-healing-monitor.yml
+++ b/.github/workflows/self-healing-monitor.yml
@@ -1,8 +1,6 @@
 name: Self-Healing Monitor
 
 on:
-  schedule:
-    - cron: '0 8 * * *' # Daily at 8am UTC (was every 6h — saves 3 runs/day)
   workflow_dispatch:
     inputs:
       heal:

--- a/.github/workflows/social-analytics-poll.yml
+++ b/.github/workflows/social-analytics-poll.yml
@@ -5,8 +5,6 @@ name: Social Analytics Poll
 # Each poller is self-skipping when its required env vars are absent.
 
 on:
-  schedule:
-    - cron: '0 6 * * *'   # Daily at 06:00 UTC
   workflow_dispatch:
     inputs:
       verbose:

--- a/.github/workflows/social-analytics.yml
+++ b/.github/workflows/social-analytics.yml
@@ -1,9 +1,6 @@
 name: Social Analytics Pipeline
 
 on:
-  schedule:
-    - cron: '0 10 * * *'    # Daily at 10am UTC (was every 6h — saves 3 runs/day)
-    - cron: '0 9 * * 1'     # Weekly digest: Monday 9am UTC
   workflow_dispatch:
     inputs:
       digest_only:

--- a/.github/workflows/social-engagement-hourly.yml
+++ b/.github/workflows/social-engagement-hourly.yml
@@ -8,9 +8,6 @@ name: Social Engagement (Smart Schedule)
 # - Reddit: reply-only, no auto-posting (ban risk)
 
 on:
-  schedule:
-    # Post once daily at 2pm UTC (10am EST — peak dev engagement)
-    - cron: '0 14 * * *'
   workflow_dispatch:
     inputs:
       action:

--- a/.github/workflows/upstream-contribution-discovery.yml
+++ b/.github/workflows/upstream-contribution-discovery.yml
@@ -1,8 +1,6 @@
 name: Upstream Contribution Discovery
 
 on:
-  schedule:
-    - cron: '17 14 * * 1,4'
   workflow_dispatch:
     inputs:
       live:

--- a/.github/workflows/video-autopilot.yml
+++ b/.github/workflows/video-autopilot.yml
@@ -1,9 +1,9 @@
 name: Video Autopilot
 
-# Fires every 4 hours, but scheduled runs are gated off by default. The
-# workflow can still generate dry-runs, but paid Zernio publishing requires an
-# explicit workflow input or repo variable because low-engagement duplicate
-# posts were burning attention without revenue.
+# Manual-only cost governor: scheduled video generation burned GitHub-hosted
+# Actions minutes without producing revenue. Keep this workflow available for
+# explicit operator runs; move recurring media loops to local/Railway/runner
+# compute before re-enabling automation.
 #
 # Content rotation: 6 templates picked by least-recently-used order in
 # the marketing DB — never double-posts the same template within 7 days.
@@ -16,8 +16,6 @@ name: Video Autopilot
 # The CI run is a no-op (skips all platforms) if cooldowns haven't expired.
 
 on:
-  schedule:
-    - cron: '0 */4 * * *'   # every 4 hours, all days
   workflow_dispatch:
     inputs:
       template:

--- a/.github/workflows/weekly-social-post.yml
+++ b/.github/workflows/weekly-social-post.yml
@@ -5,8 +5,6 @@ name: Weekly Social Post
 # publishing requires workflow opt-in or THUMBGATE_ENABLE_ZERNIO_WEEKLY_SOCIAL=1.
 
 on:
-  schedule:
-    - cron: '0 14 * * 1'   # Every Monday at 14:00 UTC (9am ET — prime posting time)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/tests/ci-cd-hygiene-audit.test.js
+++ b/tests/ci-cd-hygiene-audit.test.js
@@ -2,6 +2,8 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
   parseArgs,
   ageInDays,
@@ -11,6 +13,21 @@ const {
   buildReport,
   renderMarkdown,
 } = require('../scripts/ci-cd-hygiene-audit');
+
+const PROJECT_ROOT = path.join(__dirname, '..');
+
+test('GitHub Actions schedules stay limited to security maintenance', () => {
+  const workflowsDir = path.join(PROJECT_ROOT, '.github', 'workflows');
+  const allowedScheduledWorkflows = new Set(['codeql.yml']);
+  const offenders = fs.readdirSync(workflowsDir)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .filter((name) => {
+      const body = fs.readFileSync(path.join(workflowsDir, name), 'utf8');
+      return /^\s{2}schedule:\s*$/m.test(body) && !allowedScheduledWorkflows.has(name);
+    });
+
+  assert.deepEqual(offenders, [], 'noncritical recurring loops must run outside GitHub-hosted Actions or via workflow_dispatch');
+});
 
 test('parseArgs reads --json, --strict, --repo flags', () => {
   assert.equal(parseArgs(['--json']).json, true);

--- a/tests/perplexity-command-center.test.js
+++ b/tests/perplexity-command-center.test.js
@@ -178,13 +178,14 @@ test('buildMcpConfig returns official Perplexity MCP install commands', () => {
   assert.equal(config.mcpServers.perplexity.env.PERPLEXITY_API_KEY, '${PERPLEXITY_API_KEY}');
 });
 
-test('Perplexity command-center workflow is scheduled, secret-backed, and artifact-only', () => {
+test('Perplexity command-center workflow is manual, secret-backed, and artifact-only', () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, '..', '.github', 'workflows', 'perplexity-command-center.yml'),
     'utf8'
   );
 
-  assert.match(workflow, /cron: '30 12 \* \* \*'/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /^\s*schedule:/m);
   assert.match(workflow, /PERPLEXITY_API_KEY:\s*\$\{\{\s*secrets\.PERPLEXITY_API_KEY\s*\}\}/);
   assert.match(workflow, /node scripts\/perplexity-command-center\.js "\$COMMAND"/);
   assert.match(workflow, /--allow-chat-fallback/);

--- a/tests/ralph-loop.test.js
+++ b/tests/ralph-loop.test.js
@@ -228,7 +228,7 @@ test('runRalphLoop writes machine-readable evidence and keeps state paths explic
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-test('Ralph workflows are scheduled, stateful, and split outbound from reply engagement', () => {
+test('Ralph workflows are manual, stateful, and split outbound from reply engagement', () => {
   const workflowsDir = path.join(PROJECT_ROOT, '.github', 'workflows');
   const ralph = fs.readFileSync(path.join(workflowsDir, 'ralph-loop.yml'), 'utf8');
   const ralphMode = fs.readFileSync(path.join(workflowsDir, 'ralph-mode.yml'), 'utf8');
@@ -236,7 +236,8 @@ test('Ralph workflows are scheduled, stateful, and split outbound from reply eng
   const socialEngagement = fs.readFileSync(path.join(workflowsDir, 'social-engagement-hourly.yml'), 'utf8');
 
   assert.match(ralph, /name: Ralph Loop Audience Engagement/);
-  assert.match(ralph, /cron: '17 \* \* \* \*'/);
+  assert.match(ralph, /workflow_dispatch:/);
+  assert.doesNotMatch(ralph, /^\s*schedule:/m);
   assert.match(ralph, /actions\/cache\/restore@v[45]/);
   assert.match(ralph, /actions\/cache\/save@v[45]/);
   assert.match(ralph, /node scripts\/ralph-loop\.js --mode="\$MODE"/);
@@ -250,7 +251,8 @@ test('Ralph workflows are scheduled, stateful, and split outbound from reply eng
   assert.match(ralph, /THUMBGATE_BLUESKY_PUBLISH_LIMIT/);
   assert.match(ralph, /scripts\/social-reply-monitor-bluesky\.js/);
   assert.match(ralphMode, /name: Ralph Mode - 24\/7 Engagement Loop/);
-  assert.match(ralphMode, /cron: '0 \*\/2 \* \* \*'/);
+  assert.match(ralphMode, /workflow_dispatch:/);
+  assert.doesNotMatch(ralphMode, /^\s*schedule:/m);
   assert.match(ralphMode, /actions\/cache\/restore@v[45]/);
   assert.match(ralphMode, /actions\/cache\/save@v[45]/);
   assert.match(ralphMode, /\.thumbgate\/ralph-state\.json/);
@@ -258,5 +260,6 @@ test('Ralph workflows are scheduled, stateful, and split outbound from reply eng
   assert.match(replyMonitor, /bluesky/);
   assert.match(replyMonitor, /scripts\/social-reply-monitor-bluesky\.js/);
   assert.doesNotMatch(replyMonitor, /^\s*schedule:/m);
+  assert.doesNotMatch(socialEngagement, /^\s*schedule:/m);
   assert.doesNotMatch(socialEngagement, /0 9,13,17,21 \* \* \*/);
 });


### PR DESCRIPTION
## Summary
- disables noncritical scheduled GitHub Actions loops so they are manual-only via workflow_dispatch
- leaves PR CI, deploy gates, CodeQL/security, release publishing, and explicit production/revenue checks available
- adds a regression test that allows only CodeQL to keep a cron schedule

## Evidence
- remaining cron inventory: only `.github/workflows/codeql.yml`
- `node --test tests/ci-cd-hygiene-audit.test.js tests/ralph-loop.test.js tests/perplexity-command-center.test.js tests/deployment.test.js`
- `git diff --check`
- pre-commit guards passed
- pre-push guards passed: npm pack dry-run, public HTML links, regression guard

## Cost rationale
May 2026 Actions burn is dominated by recurring automation loops, not critical PR/deploy work. This PR caps that waste before increasing shared Actions budget.