### PR TITLE
ci(cost): strip no-op cron from video-autopilot + instagram-autopilot

### DIFF
--- a/.changeset/cap-actions-burn-v1.md
+++ b/.changeset/cap-actions-burn-v1.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+ci: strip cron schedules from video-autopilot and instagram-autopilot
+
+Both workflows already gated their publishing path off by default (low-engagement output) but kept firing on schedule (video every 4h = 180+ runs/month, instagram daily). Every run was a no-op that still booted Node, npm-installed, and burned the runner. Removing the `schedule:` trigger keeps the `workflow_dispatch` entry point so a manual run is still available, but stops the no-op burn.
+
+Re-add the schedule when there is a proven content cadence that justifies the CI minutes.

--- a/.github/workflows/instagram-autopilot.yml
+++ b/.github/workflows/instagram-autopilot.yml
@@ -1,8 +1,11 @@
 name: Instagram Autopilot
 
-# Generates a ThumbGate Instagram static card once per day, but scheduled
-# publishing is off by default. Screenshots showed repeated low-engagement
-# cards, so Zernio publishing must be explicitly re-enabled after proof.
+# Manual-dispatch only as of 2026-05-26. The cron previously fired daily at
+# 13:00 UTC but scheduled publishing was off by default (low-engagement
+# cards observed in screenshots), so every run cost CI minutes for a no-op.
+# Re-add the schedule only after Zernio publishing is explicitly re-enabled
+# and post engagement justifies the burn.
+#
 # Complements video-autopilot.yml (which posts Reels) by covering the
 # Instagram feed with image content as well.
 #
@@ -10,14 +13,11 @@ name: Instagram Autopilot
 #   ZERNIO_API_KEY
 #   (Zernio must have an Instagram account connected under the same profile)
 #
-# Cadence: every 24h at 13:00 UTC (09:00 ET — peak engagement window).
 # Dedup: publishers/zernio.js enforces a 24h content-hash window via the
-# marketing DB, so a manual dispatch immediately after a scheduled run is
-# a safe no-op rather than a double-post.
+# marketing DB, so back-to-back manual dispatches are a safe no-op rather
+# than a double-post.
 
 on:
-  schedule:
-    - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:
       image_only:

--- a/.github/workflows/video-autopilot.yml
+++ b/.github/workflows/video-autopilot.yml
@@ -1,9 +1,10 @@
 name: Video Autopilot
 
-# Fires every 4 hours, but scheduled runs are gated off by default. The
-# workflow can still generate dry-runs, but paid Zernio publishing requires an
-# explicit workflow input or repo variable because low-engagement duplicate
-# posts were burning attention without revenue.
+# Manual-dispatch only as of 2026-05-26. The cron previously fired every 4
+# hours (180+ runs/month) but every run was a no-op because per-platform
+# cooldowns and the "publishing off by default" gate meant nothing actually
+# shipped. Re-add the schedule only after a proven content cadence justifies
+# the burn.
 #
 # Content rotation: 6 templates picked by least-recently-used order in
 # the marketing DB — never double-posts the same template within 7 days.
@@ -12,12 +13,8 @@ name: Video Autopilot
 #   TikTok:    24 h (one distinct experiment/day)
 #   Instagram: 24 h (one Reel/day)
 #   YouTube:  12 h  (up to 2 Shorts/day)
-#
-# The CI run is a no-op (skips all platforms) if cooldowns haven't expired.
 
 on:
-  schedule:
-    - cron: '0 */4 * * *'   # every 4 hours, all days
   workflow_dispatch:
     inputs:
       template:


### PR DESCRIPTION
Closing as duplicate — main already has the cron-strip applied to both `video-autopilot.yml` and `instagram-autopilot.yml` via a parallel commit. The two workflows on `main` (HEAD) are already in `workflow_dispatch:`-only state with the same intent. CEO's comment-header wording ("Manual-only cost governor… move recurring media loops to local/Railway/runner compute before re-enabling automation") is the better framing and is the version that landed.

No follow-up needed — the cost-cap step is already in place.

The other active-cron candidates I flagged for follow-up are still worth a conversation:
- `gtm-autonomous-loop`
- `daily-revenue-loop`
- `perplexity-command-center`
- `self-healing-auto-fix`
- `self-healing-monitor`

Ready to strip any of those next on request.