### PR TITLE
feat(site): serve /llms.txt for LLM-search visibility (Perplexity/ChatGPT/Claude/Gemini/Grok)

### DIFF
--- a/.changeset/llms-txt-geo.md
+++ b/.changeset/llms-txt-geo.md
@@ -1,0 +1,13 @@
+---
+"thumbgate": patch
+---
+
+site: serve `/llms.txt` (llmstxt.org spec) for LLM-search visibility
+
+Adds the canonical `/llms.txt` manifest at the site root so Perplexity, ChatGPT, Claude, Gemini, and Grok crawlers get a clean markdown index of what ThumbGate is and which canonical URLs to fetch. The existing `/llm-context.md` (29 KB single-file dump) stays — `llms.txt` is the short table-of-contents that points at it.
+
+- Adds `public/llms.txt` (~50 lines): one-line summary + section links to the legal AI page, agent manager, FinOps, pricing, guide, compatibility matrix, dashboard.
+- Adds GET handler in `src/api/server.js` (mirrors the `/llm-context.md` handler).
+- Adds regression test in `tests/api-server.test.js` asserting 200 + `text/markdown` + content.
+
+`/robots.txt` already explicitly allows GPTBot, ClaudeBot, PerplexityBot, anthropic-ai, Google-Extended — this is the missing surface those crawlers look for first.

--- a/.changeset/llms-txt-geo.md
+++ b/.changeset/llms-txt-geo.md
@@ -2,12 +2,15 @@
 "thumbgate": patch
 ---
 
-site: serve `/llms.txt` (llmstxt.org spec) for LLM-search visibility
+site: serve `/llms.txt` (llmstxt.org spec) for LLM-search visibility + fix systemic CI flake
 
-Adds the canonical `/llms.txt` manifest at the site root so Perplexity, ChatGPT, Claude, Gemini, and Grok crawlers get a clean markdown index of what ThumbGate is and which canonical URLs to fetch. The existing `/llm-context.md` (29 KB single-file dump) stays — `llms.txt` is the short table-of-contents that points at it.
+**Two bundled fixes:**
 
-- Adds `public/llms.txt` (~50 lines): one-line summary + section links to the legal AI page, agent manager, FinOps, pricing, guide, compatibility matrix, dashboard.
-- Adds GET handler in `src/api/server.js` (mirrors the `/llm-context.md` handler).
-- Adds regression test in `tests/api-server.test.js` asserting 200 + `text/markdown` + content.
+1. **`/llms.txt`**: AI search engines (Perplexity, ChatGPT, Claude, Gemini, Grok) look for the canonical `/llms.txt` manifest at the site root per the [llmstxt.org](https://llmstxt.org) spec. Currently 404. This PR ships the file + server route.
+   - `public/llms.txt` (~50 lines): one-line summary + section links to canonical URLs.
+   - `src/api/server.js`: GET handler mirroring the existing `/llm-context.md` handler.
+   - `tests/api-server.test.js`: regression test for the route.
 
-`/robots.txt` already explicitly allows GPTBot, ClaudeBot, PerplexityBot, anthropic-ai, Google-Extended — this is the missing surface those crawlers look for first.
+2. **CI broker-audit test fragility**: `tests/api-server.test.js`'s `/broker-audit returns 500…` test was using rename-and-restore (`fs.renameSync` to `.swap-<pid>` then back). When the test process was SIGTERM'd (which happens routinely under timeout in CI sandboxes), the asset file stayed renamed and every subsequent CI run on every PR failed with ENOENT until someone manually restored it. Replaced with in-memory swap (`readFileSync` → `unlinkSync` → `writeFileSync(saved)`); the saved content lives in process memory so a crash leaves only a missing file that `git restore` recovers.
+
+`/robots.txt` already explicitly allows GPTBot, ClaudeBot, PerplexityBot, anthropic-ai, Google-Extended.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,41 @@
+# ThumbGate
+
+> Infrastructure firewall for AI coding agents. Captures thumbs-up/down feedback, promotes confirmed mistakes to prevention rules, and blocks known-bad tool calls via PreToolUse hooks before the agent acts on code, money, or customer systems.
+
+ThumbGate sits between an AI agent (Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, Claude Desktop) and its tools. Deterministic pattern-matching gates run on every PreToolUse event — no LLM on the enforcement path, no extra latency. Local-first by default; hosted sync, shared rules, and team dashboards are paid.
+
+Stack: Node.js >= 18.18.0 · SQLite + FTS5 lesson database · Thompson Sampling for rule promotion · LanceDB vector store · ContextFS context assembly.
+
+## What ThumbGate is for
+
+- [Pre-Execution Controls for Legal AI Agents](https://thumbgate-production.up.railway.app/ai-malpractice-prevention): Block unauthorized practice of law (UPL), conflict-check failures, and privilege leaks before an intake bot acts. Includes live interactive simulators for the UPL, Conflict, and Egress gates.
+- [Agent Manager](https://thumbgate-production.up.railway.app/agent-manager): Inventory of every AI agent in your environment with active checks, hit rates, and risk classification.
+- [FinOps for Agents](https://thumbgate-production.up.railway.app/agents-cost-savings): Track and cap LLM spend per agent, per workflow, per matter.
+- [Federal AI Governance](https://thumbgate-production.up.railway.app/federal): Pre-execution controls aligned to NIST AI RMF + OMB M-24-10 for agency AI agent rollouts.
+- [Codex Enterprise integration](https://thumbgate-production.up.railway.app/codex-enterprise): Drop-in PreToolUse layer for OpenAI×Dell Codex Enterprise deployments.
+
+## How to install
+
+- Free CLI: `npx thumbgate init`. 10 feedback captures/day, 3 active prevention rules, 5 built-in checks, local PreToolUse blocking, MCP integrations for Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, Claude Desktop.
+- [Pricing](https://thumbgate-production.up.railway.app/pricing): Pro $19/mo for hosted sync + adapter matrix + dashboard + DPO export. Team $49/seat (min 3) for workflow hardening sprint + shared lesson DB.
+
+## Reference
+
+- [Guide](https://thumbgate-production.up.railway.app/guide): How the gate engine, lesson DB, and prevention-rule loop work end-to-end.
+- [Compatibility matrix](https://thumbgate-production.up.railway.app/compare): What's supported across Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode.
+- [Dashboard](https://thumbgate-production.up.railway.app/dashboard): Gate hit rates, agent inventory, remediations, token-savings telemetry.
+- [Learn](https://thumbgate-production.up.railway.app/learn): Background-agent control layer, deterministic prevention vs probabilistic alignment, lessons learned in production.
+- [LLM context document](https://thumbgate-production.up.railway.app/llm-context.md): Single-file declarative content for AI retrieval.
+
+## Source code
+
+- npm package: `thumbgate` — MIT licensed, local-first, no telemetry without explicit opt-in (`THUMBGATE_NO_TELEMETRY=1` to disable usage pings entirely).
+- GitHub: https://github.com/IgorGanapolsky/ThumbGate
+- Compatible with Claude Code (CLI + Desktop extension), Cursor, OpenAI Codex CLI, Google Gemini CLI, Sourcegraph Amp, Cline, OpenCode.
+
+## Optional
+
+- [Pro details](https://thumbgate-production.up.railway.app/pro): Hosted sync + DPO export + dashboard.
+- [Numbers page](https://thumbgate-production.up.railway.app/numbers): Token-savings telemetry, gate-firing rates.
+- [Lessons](https://thumbgate-production.up.railway.app/lessons): Public learnings from gate-blocked agent mistakes.
+- [Blog](https://thumbgate-production.up.railway.app/blog): Long-form writing on agent governance, prevention rules, and the AI-malpractice problem.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5217,7 +5217,8 @@ async function addContext(){
       let toolName = encodedToolName;
       try {
         toolName = decodeURIComponent(encodedToolName);
-      } catch (_err) {
+      } catch (err) {
+        console.error('mcp/tools/* decode failed:', err?.message);
         sendJson(res, 400, {
           error: 'invalid_tool_name',
           toolIndexUrl: buildPublicUrl(hostedConfig, '/.well-known/mcp/tools.json'),

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -4165,6 +4165,25 @@ function createApiServer() {
       return;
     }
 
+    // /llms.txt — llmstxt.org standard index for LLM crawlers (Perplexity,
+    // ChatGPT, Claude, Gemini, Grok). Short markdown manifest with the
+    // canonical URLs an LLM should fetch to learn what ThumbGate is.
+    if (isGetLikeRequest && pathname === '/llms.txt') {
+      const llmsTxtPath = path.resolve(__dirname, '../../public/llms.txt');
+      try {
+        const content = fs.readFileSync(llmsTxtPath, 'utf8');
+        sendText(res, 200, content, {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          'X-Robots-Tag': 'all',
+        }, {
+          headOnly: isHeadRequest,
+        });
+      } catch (_err) {
+        sendJson(res, 404, { error: 'Not found' });
+      }
+      return;
+    }
+
     // Quick feedback capture via GET — for statusline clickable links
     if (isGetLikeRequest && pathname === '/feedback/quick') {
       const signal = parsed.searchParams.get('signal');

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -4178,7 +4178,8 @@ function createApiServer() {
         }, {
           headOnly: isHeadRequest,
         });
-      } catch (_err) {
+      } catch (err) {
+        console.error('llms.txt read failed:', err?.message);
         sendJson(res, 404, { error: 'Not found' });
       }
       return;

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1451,6 +1451,23 @@ test('/llms.txt serves the llmstxt.org manifest for LLM crawlers', async () => {
   assert.match(body, /## /);
 });
 
+test('/llms.txt returns 404 when the manifest file is missing', async () => {
+  // Covers the catch branch of the /llms.txt handler (SonarCloud
+  // new_coverage gate). Uses the same in-memory swap pattern as the
+  // broker-audit missing-asset test so a SIGTERM cannot leave an orphan.
+  const assetPath = path.resolve(__dirname, '..', 'public', 'llms.txt');
+  const savedContent = fs.readFileSync(assetPath);
+  fs.unlinkSync(assetPath);
+  try {
+    const res = await fetch(apiUrl('/llms.txt'));
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'Not found');
+  } finally {
+    fs.writeFileSync(assetPath, savedContent);
+  }
+});
+
 test('provisioning endpoint works', async () => {
   const res = await fetch(apiUrl('/v1/billing/provision'), {
     method: 'POST',

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1453,18 +1453,27 @@ test('/llms.txt serves the llmstxt.org manifest for LLM crawlers', async () => {
 
 test('/llms.txt returns 404 when the manifest file is missing', async () => {
   // Covers the catch branch of the /llms.txt handler (SonarCloud
-  // new_coverage gate). Uses the same in-memory swap pattern as the
-  // broker-audit missing-asset test so a SIGTERM cannot leave an orphan.
-  const assetPath = path.resolve(__dirname, '..', 'public', 'llms.txt');
-  const savedContent = fs.readFileSync(assetPath);
-  fs.unlinkSync(assetPath);
+  // new_coverage gate). Truly SIGTERM-safe — we monkey-patch
+  // fs.readFileSync to throw ENOENT only for llms.txt paths; the real
+  // file on disk is never touched. Restoring the patch in finally is
+  // best-effort but a process death leaves only an in-memory module
+  // state that next test run rebuilds from scratch.
+  const originalReadFileSync = fs.readFileSync;
+  fs.readFileSync = function patched(p, ...args) {
+    if (typeof p === 'string' && p.endsWith('/public/llms.txt')) {
+      const err = new Error(`ENOENT: no such file or directory, open '${p}'`);
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return originalReadFileSync.call(this, p, ...args);
+  };
   try {
     const res = await fetch(apiUrl('/llms.txt'));
     assert.equal(res.status, 404);
     const body = await res.json();
     assert.equal(body.error, 'Not found');
   } finally {
-    fs.writeFileSync(assetPath, savedContent);
+    fs.readFileSync = originalReadFileSync;
   }
 });
 
@@ -4045,22 +4054,27 @@ test('/broker-audit returns 500 problem-json when static asset is missing', asyn
   // Exercises the catch branch of the /broker-audit handler so the read
   // failure path is covered (Sonar new_coverage gate).
   //
-  // Uses in-memory swap (read -> unlink -> restore from buffer) instead of
-  // rename-and-restore. The rename approach left orphaned .swap-<pid> files
-  // when the test process was SIGTERM'd, which then made every subsequent
-  // CI run on every PR fail with ENOENT until someone manually restored the
-  // asset. In-memory swap survives a crash: git already tracks the file, so
-  // `git restore assets/static/broker-audit.html` recovers immediately.
-  const assetPath = path.resolve(__dirname, '..', 'assets', 'static', 'broker-audit.html');
-  const savedContent = fs.readFileSync(assetPath);
-  fs.unlinkSync(assetPath);
+  // Truly SIGTERM-safe: we monkey-patch fs.readFileSync to throw ENOENT
+  // only for the broker-audit asset path. The real file on disk is never
+  // touched, so a crashed test run cannot leave the asset in a deleted
+  // state. Previous rename-and-restore approach orphaned .swap-<pid> files
+  // when SIGTERM'd, breaking every subsequent CI run on every PR.
+  const originalReadFileSync = fs.readFileSync;
+  fs.readFileSync = function patched(p, ...args) {
+    if (typeof p === 'string' && p.endsWith('/assets/static/broker-audit.html')) {
+      const err = new Error(`ENOENT: no such file or directory, open '${p}'`);
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return originalReadFileSync.call(this, p, ...args);
+  };
   try {
     const res = await fetch(apiUrl('/broker-audit'));
     assert.equal(res.status, 500);
     const body = await res.json();
     assert.equal(body.error, 'broker-audit page unavailable');
   } finally {
-    fs.writeFileSync(assetPath, savedContent);
+    fs.readFileSync = originalReadFileSync;
   }
 });
 

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1441,6 +1441,16 @@ test('robots and sitemap endpoints publish crawl metadata for the canonical app 
   assert.match(sitemapBody, /<priority>0\.8<\/priority>/);
 });
 
+test('/llms.txt serves the llmstxt.org manifest for LLM crawlers', async () => {
+  const res = await fetch(apiUrl('/llms.txt'));
+  assert.equal(res.status, 200);
+  assert.match(String(res.headers.get('content-type')), /text\/markdown/);
+  const body = await res.text();
+  assert.match(body, /^# ThumbGate/);
+  assert.match(body, /Infrastructure firewall for AI coding agents/);
+  assert.match(body, /## /);
+});
+
 test('provisioning endpoint works', async () => {
   const res = await fetch(apiUrl('/v1/billing/provision'), {
     method: 'POST',

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -4027,16 +4027,23 @@ test('/broker-audit serves the public landing page with telemetry script', async
 test('/broker-audit returns 500 problem-json when static asset is missing', async () => {
   // Exercises the catch branch of the /broker-audit handler so the read
   // failure path is covered (Sonar new_coverage gate).
+  //
+  // Uses in-memory swap (read -> unlink -> restore from buffer) instead of
+  // rename-and-restore. The rename approach left orphaned .swap-<pid> files
+  // when the test process was SIGTERM'd, which then made every subsequent
+  // CI run on every PR fail with ENOENT until someone manually restored the
+  // asset. In-memory swap survives a crash: git already tracks the file, so
+  // `git restore assets/static/broker-audit.html` recovers immediately.
   const assetPath = path.resolve(__dirname, '..', 'assets', 'static', 'broker-audit.html');
-  const backupPath = `${assetPath}.swap-${process.pid}`;
-  fs.renameSync(assetPath, backupPath);
+  const savedContent = fs.readFileSync(assetPath);
+  fs.unlinkSync(assetPath);
   try {
     const res = await fetch(apiUrl('/broker-audit'));
     assert.equal(res.status, 500);
     const body = await res.json();
     assert.equal(body.error, 'broker-audit page unavailable');
   } finally {
-    fs.renameSync(backupPath, assetPath);
+    fs.writeFileSync(assetPath, savedContent);
   }
 });
 

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -361,9 +361,14 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // published installs. Observed unpacked size is ~3.806 MB.
   // Bumped 3.84 MB -> 3.85 MB (2026-05-26) after injecting Plausible/PostHog/GA4
   // scripts into the checkout interstitial page in server.js.
+  // Bumped 3.85 MB -> 3.90 MB (2026-05-27) after the GT live gate simulators
+  // (#2330) added ~138 lines to public/ai-malpractice-prevention.html and the
+  // /llms.txt + broker-audit-test-stability fix (#2333) added the route
+  // handler + larger comments. Observed unpacked size is ~3.862 MB; margin
+  // stays narrow at ~38 KB.
   assert.ok(
-    manifest.unpackedSize <= 3_850_000,
-    `npm package should stay <= 3.85 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 3_900_000,
+    `npm package should stay <= 3.90 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {


### PR DESCRIPTION
## Why

The CEO asked: "How do LLMs (Perplexity, Gemini, ChatGPT, Claude, Grok) find us? Are we optimized for their search?"

Audit found:
- ✅ `/robots.txt` explicitly allows GPTBot, ClaudeBot, PerplexityBot, anthropic-ai, Google-Extended, Googlebot, Bingbot.
- ✅ `/sitemap.xml` present.
- ✅ `/llm-context.md` present (29 KB single-file dump).
- ✅ schema.org `TechArticle` structured data on key pages.
- ❌ **`/llms.txt` returns 404.** This is the canonical surface AI crawlers look for FIRST per the [llmstxt.org](https://llmstxt.org) spec.

This PR ships the missing piece.

## What

- **`public/llms.txt`** (~50 lines): short markdown manifest per llmstxt.org spec — H1 + one-line summary + section links to canonical URLs (legal AI page, agent manager, FinOps, pricing, guide, compatibility matrix, dashboard, llm-context.md, GitHub).
- **`src/api/server.js`**: GET handler mirroring the existing `/llm-context.md` handler. Returns `text/markdown; charset=utf-8`, `X-Robots-Tag: all`.
- **`tests/api-server.test.js`**: regression test asserting 200 + content-type + content.
- **`.changeset/llms-txt-geo.md`**: patch entry.

## Verification

```bash
node --test tests/api-server.test.js  # passes locally
curl -s https://thumbgate-production.up.railway.app/llms.txt  # currently 404
```

After merge + Railway rebuild, the same curl should return the manifest with `text/markdown` content-type. Perplexity, Claude, ChatGPT, and Gemini crawlers will pick it up on their next index pass.

## Out of scope (deferred)

- `/llms-full.txt`: optional richer dump (the existing `/llm-context.md` already covers this role).
- Active LLM-citation measurement: `scripts/ai-search-visibility.js` already exists but needs `PERPLEXITY_API_KEY` to run. Tracked separately.

https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd)_

----
## Summary by Gitar

- **Error handling:**
  - Added error logging for `mcp/tools/*` decoding failures in `src/api/server.js` to improve debugging and SonarCloud compliance.
- **Test reliability:**
  - Improved test robustness by replacing destructive `fs.unlinkSync` operations with `fs.readFileSync` monkey-patching in `tests/api-server.test.js`.
  - Eliminated risk of orphaned files during CI SIGTERM events, ensuring consistent state for `broker-audit` and `/llms.txt` error handling tests.
- **Test maintenance:**
  - Bumped npm package unpacked size limit in `tests/package-boundary.test.js` from `3.85 MB` to `3.90 MB`.
  - Adjusted boundary threshold to accommodate recent `public/ai-malpractice-prevention.html` additions and new `/llms.txt` handler code.

<sub>This will update automatically on new commits.</sub>