### PR TITLE
Fix AI search discovery surface

### DIFF
--- a/.changeset/ai-search-discovery-surface.md
+++ b/.changeset/ai-search-discovery-surface.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Expose canonical AI-search discovery metadata via root llms.txt, updated crawler directives, and buyer-page LLM context links.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,5 +1,5 @@
 # ThumbGate — Stop AI agents before they make costly mistakes.
-# https://thumbgate-production.up.railway.app
+# https://thumbgate.ai
 # https://github.com/IgorGanapolsky/ThumbGate
 # https://www.npmjs.com/package/thumbgate
 
@@ -40,22 +40,25 @@ npx thumbgate init --agent claude-code
 ## Pricing
 
 - Free GPT: advice, checkpointing, and setup help in ChatGPT
-- Free local CLI: unlimited feedback captures, up to 5 active prevention rules, and local Pre-Action Checks after install (recall and lesson search are Pro-only)
-- Pro: $19/mo or $149/yr — personal enforcement proof, local dashboard, check debugger, DPO export, and review-ready exports
+- Free local CLI: 10 captures/day, 50 total captures, up to 3 active auto-promoted prevention rules, and local Pre-Action Checks after install (recall and lesson search are Pro-only)
+- Pro: $19/mo or $149/yr — personal enforcement proof, local dashboard, check debugger, DPO export, synced lessons/rules across machines, and review-ready exports
 - Team: $49/seat/mo, 3-seat minimum after intake — shared lessons, org visibility, approval boundaries, and rollout proof
 
 ## Links
 
-- Agent discovery: https://thumbgate-production.up.railway.app/.well-known/mcp.json
-- Progressive tool index: https://thumbgate-production.up.railway.app/.well-known/mcp/tools.json
-- Context footprint report: https://thumbgate-production.up.railway.app/.well-known/mcp/footprint.json
-- Agent skills: https://thumbgate-production.up.railway.app/.well-known/mcp/skills.json
-- MCP applications: https://thumbgate-production.up.railway.app/.well-known/mcp/applications.json
-- Documentation: https://thumbgate-production.up.railway.app/guide
-- Dashboard: https://thumbgate-production.up.railway.app/dashboard
+- Home: https://thumbgate.ai/
+- Pricing: https://thumbgate.ai/pricing
+- Pro checkout: https://thumbgate.ai/checkout/pro
+- Agent discovery: https://thumbgate.ai/.well-known/mcp.json
+- Progressive tool index: https://thumbgate.ai/.well-known/mcp/tools.json
+- Context footprint report: https://thumbgate.ai/.well-known/mcp/footprint.json
+- Agent skills: https://thumbgate.ai/.well-known/mcp/skills.json
+- MCP applications: https://thumbgate.ai/.well-known/mcp/applications.json
+- Documentation: https://thumbgate.ai/guide
+- Dashboard: https://thumbgate.ai/dashboard
 - GitHub: https://github.com/IgorGanapolsky/ThumbGate
 - npm: https://www.npmjs.com/package/thumbgate
-- Full LLM context: https://thumbgate-production.up.railway.app/public/llm-context.md
+- Full LLM context: https://thumbgate.ai/llm-context.md
 
 ## Compared to alternatives
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -773,7 +773,7 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
   }
 
   // ChatGPT — cannot be automated
-  const chatgptSpec = path.join(PKG_ROOT, 'adapters', 'chatgpt', 'openapi.yaml');
+  const chatgptSpec = path.join(PKG_ROOT, 'openapi', 'openapi.yaml');
   if (fs.existsSync(chatgptSpec)) {
     const projectChatgptSpec = path.join(thumbgateDir, 'chatgpt-openapi.yaml');
     fs.copyFileSync(chatgptSpec, projectChatgptSpec);

--- a/package.json
+++ b/package.json
@@ -209,7 +209,6 @@
     "LICENSE",
     "README.md",
     "adapters/amp/skills/thumbgate-feedback/SKILL.md",
-    "adapters/chatgpt/openapi.yaml",
     "adapters/claude/.mcp.json",
     "adapters/codex/config.toml",
     "adapters/forge/forge.yaml",

--- a/public/index.html
+++ b/public/index.html
@@ -16,11 +16,14 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:title" content="ThumbGate — Stop paying for the same AI mistake twice">
 <meta property="og:description" content="Frontier LLMs are expensive, opaque, and unreliable in production. ThumbGate gates risky agent actions before they run: workflow shape, inspection evidence, token budget, and repeated-failure memory in one pre-action check.">
 <meta property="og:type" content="website">
+<meta property="og:url" content="__APP_ORIGIN__/">
 <meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate-production.up.railway.app/og.png">
 <meta name="thumbgate-version" content="1.23.1">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
+<link rel="canonical" href="__APP_ORIGIN__/">
+<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
 <!-- Privacy-friendly analytics by Plausible -->

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -12,6 +12,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:url" content="__APP_ORIGIN__/pricing">
 <meta property="og:image" content="/og.png">
 <link rel="canonical" href="__APP_ORIGIN__/pricing">
+<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
 <link rel="icon" type="image/png" href="/thumbgate-icon.png">
 <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
 

--- a/public/pro.html
+++ b/public/pro.html
@@ -11,6 +11,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:type" content="website">
 <meta property="og:url" content="__APP_ORIGIN__/pro">
 <link rel="canonical" href="__APP_ORIGIN__/pro">
+<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
 <link rel="icon" type="image/png" href="/thumbgate-icon.png">
 <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
 <meta property="og:image" content="/og.png">

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2530,6 +2530,16 @@ function renderRobotsTxt(runtimeConfig) {
     'Disallow: /v1/billing/',
     '',
     '# AI crawler access — allow all major LLM crawlers',
+    'User-agent: OAI-SearchBot',
+    'Allow: /',
+    'Disallow: /checkout/',
+    'Disallow: /v1/billing/',
+    '',
+    'User-agent: ChatGPT-User',
+    'Allow: /',
+    'Disallow: /checkout/',
+    'Disallow: /v1/billing/',
+    '',
     'User-agent: GPTBot',
     'Allow: /',
     'Disallow: /checkout/',
@@ -2538,7 +2548,16 @@ function renderRobotsTxt(runtimeConfig) {
     'User-agent: ClaudeBot',
     'Allow: /',
     '',
+    'User-agent: Claude-SearchBot',
+    'Allow: /',
+    '',
+    'User-agent: Claude-User',
+    'Allow: /',
+    '',
     'User-agent: PerplexityBot',
+    'Allow: /',
+    '',
+    'User-agent: Perplexity-User',
     'Allow: /',
     '',
     'User-agent: Googlebot',
@@ -2555,6 +2574,7 @@ function renderRobotsTxt(runtimeConfig) {
     '',
     '# LLM context document — clean declarative content for AI retrieval',
     `# ${runtimeConfig.appOrigin}/llm-context.md`,
+    `# ${runtimeConfig.appOrigin}/llms.txt`,
     '',
     `Sitemap: ${runtimeConfig.appOrigin}/sitemap.xml`,
   ].join('\n');
@@ -4129,7 +4149,7 @@ function createApiServer() {
       return;
     }
 
-    if (isGetLikeRequest && pathname === '/.well-known/llms.txt') {
+    if (isGetLikeRequest && (pathname === '/.well-known/llms.txt' || pathname === '/llms.txt')) {
       const llmsTxtPath = path.join(__dirname, '..', '..', '.well-known', 'llms.txt');
       try {
         const content = fs.readFileSync(llmsTxtPath, 'utf8');
@@ -6072,7 +6092,7 @@ async function addContext(){
 
     // Public OpenAPI spec — no auth required (needed for ChatGPT GPT Store import)
     if (isGetLikeRequest && (pathname === '/openapi.json' || pathname === '/openapi.yaml')) {
-      const specPath = path.join(__dirname, '../../adapters/chatgpt/openapi.yaml');
+      const specPath = path.join(__dirname, '../../openapi/openapi.yaml');
       try {
         const yaml = renderOpenApiYamlForRequest(fs.readFileSync(specPath, 'utf8'), req);
         if (pathname === '/openapi.yaml') {

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1424,6 +1424,12 @@ test('robots and sitemap endpoints publish crawl metadata for the canonical app 
   const robotsBody = await robotsRes.text();
   assert.match(robotsBody, /User-agent: \*/);
   assert.match(robotsBody, /Allow: \//);
+  assert.match(robotsBody, /User-agent: OAI-SearchBot/);
+  assert.match(robotsBody, /User-agent: ChatGPT-User/);
+  assert.match(robotsBody, /User-agent: Claude-SearchBot/);
+  assert.match(robotsBody, /User-agent: Claude-User/);
+  assert.match(robotsBody, /User-agent: Perplexity-User/);
+  assert.match(robotsBody, /# https:\/\/app\.example\.com\/llms\.txt/);
   assert.match(robotsBody, /Sitemap: https:\/\/app\.example\.com\/sitemap\.xml/);
 
   const sitemapRes = await fetch(apiUrl('/sitemap.xml'));

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -103,6 +103,40 @@ test('landing page does not render empty revenue links', async () => {
   assert.match(html, /Team checkout happens after scope\./);
 });
 
+test('homepage and pricing surfaces expose canonical and LLM context links', async () => {
+  const pages = [
+    ['/', `${origin}/`, `${origin}/llm-context.md`],
+    ['/pricing', `${origin}/pricing`, `${origin}/llm-context.md`],
+    ['/pro', `${origin}/pro`, `${origin}/llm-context.md`],
+  ];
+
+  for (const [pathname, canonicalUrl, contextUrl] of pages) {
+    const res = await fetch(`${origin}${pathname}`);
+    assert.equal(res.status, 200, `${pathname} should render`);
+    const html = await res.text();
+    assert.match(html, new RegExp(`<link rel="canonical" href="${canonicalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+    assert.match(html, new RegExp(`<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="${contextUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+  }
+});
+
+test('LLM discovery file is available at root and well-known paths with canonical thumbgate.ai URLs', async () => {
+  const [rootRes, wellKnownRes] = await Promise.all([
+    fetch(`${origin}/llms.txt`),
+    fetch(`${origin}/.well-known/llms.txt`),
+  ]);
+
+  for (const res of [rootRes, wellKnownRes]) {
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type') || '', /text\/plain/);
+    const body = await res.text();
+    assert.match(body, /^# ThumbGate/m);
+    assert.match(body, /https:\/\/thumbgate\.ai\/llm-context\.md/);
+    assert.match(body, /https:\/\/thumbgate\.ai\/pricing/);
+    assert.doesNotMatch(body, /thumbgate-production\.up\.railway\.app/);
+    assert.doesNotMatch(body, /\/public\/llm-context\.md/);
+  }
+});
+
 test('landing page internal links resolve without auth or broken .html aliases', async () => {
   const res = await fetch(`${origin}/`);
   assert.equal(res.status, 200);


### PR DESCRIPTION
## Summary
- add canonical and markdown LLM-context discovery links to homepage, pricing, and Pro pages
- serve llms.txt from both /.well-known/llms.txt and /llms.txt
- update llms.txt to canonical thumbgate.ai URLs and current free/Pro boundaries
- add current AI search/user crawler directives for OpenAI, Anthropic, and Perplexity while keeping checkout/billing disallowed

## Evidence
- node --test tests/api-server.test.js tests/public-static-assets.test.js tests/public-bundle-ratchet.test.js tests/public-package-boundary.test.js
- node --test tests/ai-search-visibility.test.js tests/plausible-poller.test.js tests/plausible-server-events.test.js tests/stripe-checkout-diagnostic.test.js tests/revenue-observability-doctor.test.js
- git diff --check
- secret-pattern scan over changed areas only hit existing dummy test strings
