### PR TITLE
Fix hosted OpenAPI runtime path

### DIFF
--- a/.changeset/openapi-runtime-fallback.md
+++ b/.changeset/openapi-runtime-fallback.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix hosted OpenAPI spec delivery by copying the canonical OpenAPI directory into the runtime image and keeping source-checkout fallback paths.

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ COPY assets/ ./assets/
 COPY src/ ./src/
 COPY config/ ./config/
 COPY adapters/ ./adapters/
+COPY openapi/ ./openapi/
 COPY public/ ./public/
 COPY .well-known/ ./.well-known/
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -773,8 +773,11 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
   }
 
   // ChatGPT — cannot be automated
-  const chatgptSpec = path.join(PKG_ROOT, 'openapi', 'openapi.yaml');
-  if (fs.existsSync(chatgptSpec)) {
+  const chatgptSpec = [
+    path.join(PKG_ROOT, 'openapi', 'openapi.yaml'),
+    path.join(PKG_ROOT, 'adapters', 'chatgpt', 'openapi.yaml'),
+  ].find((candidate) => fs.existsSync(candidate));
+  if (chatgptSpec) {
     const projectChatgptSpec = path.join(thumbgateDir, 'chatgpt-openapi.yaml');
     fs.copyFileSync(chatgptSpec, projectChatgptSpec);
     console.log(`  ChatGPT: import ${path.relative(CWD, projectChatgptSpec)} in GPT Builder > Actions`);

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -6092,7 +6092,19 @@ async function addContext(){
 
     // Public OpenAPI spec — no auth required (needed for ChatGPT GPT Store import)
     if (isGetLikeRequest && (pathname === '/openapi.json' || pathname === '/openapi.yaml')) {
-      const specPath = path.join(__dirname, '../../openapi/openapi.yaml');
+      const specPath = [
+        path.join(__dirname, '../../openapi/openapi.yaml'),
+        path.join(__dirname, '../../adapters/chatgpt/openapi.yaml'),
+      ].find((candidate) => fs.existsSync(candidate));
+      if (!specPath) {
+        sendProblem(res, {
+          type: PROBLEM_TYPES.NOT_FOUND,
+          title: 'Not Found',
+          status: 404,
+          detail: 'OpenAPI spec not found.',
+        });
+        return;
+      }
       try {
         const yaml = renderOpenApiYamlForRequest(fs.readFileSync(specPath, 'utf8'), req);
         if (pathname === '/openapi.yaml') {

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -222,6 +222,12 @@ test('runtime Docker image installs git for operational integrity checks', () =>
   assert.match(dockerfile, /apt-get install[^\n]*\bgit\b/);
 });
 
+test('runtime Docker image copies the canonical OpenAPI spec used by hosted GPT Actions import', () => {
+  const dockerfile = fs.readFileSync(path.join(PROJECT_ROOT, 'Dockerfile'), 'utf8');
+
+  assert.match(dockerfile, /COPY openapi\/ \.\/openapi\//);
+});
+
 test('Deploy to Railway workflow is the single authoritative Railway deploy lane', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'deploy-railway.yml'), 'utf8');
 


### PR DESCRIPTION
## Summary
- copy the canonical openapi/ directory into the Railway Docker runtime image
- keep hosted /openapi.yaml resilient with a fallback to adapters/chatgpt/openapi.yaml
- keep CLI ChatGPT spec copy resilient across source checkouts and packaged installs
- add a Dockerfile regression test for the hosted GPT Actions import spec

## Evidence
- node --test tests/deployment.test.js tests/api-server.test.js tests/package-boundary.test.js tests/cli.test.js
- npm pack --dry-run --json => 263 files, 3,814,637 unpacked bytes, canonical openapi included, duplicate adapter openapi excluded
- git diff --check

## Production context
Post-deploy verification for #2334 proved /llms.txt and crawler metadata are live, but /openapi.yaml returned 404 because Dockerfile did not copy openapi/. This PR fixes that runtime image gap.
