### PR TITLE
feat(site): /compare/claude-code-hooks — head-to-head page targeting the #1 buyer query

### DIFF
--- a/.changeset/compare-claude-code-hooks.md
+++ b/.changeset/compare-claude-code-hooks.md
@@ -1,0 +1,13 @@
+---
+"thumbgate": patch
+---
+
+site: head-to-head comparison page `/compare/claude-code-hooks`
+
+karanb192/claude-code-hooks currently ranks #1 on the buyer query "Claude Code safety pre-tool-use hooks npm package" — the exact query an npm/GitHub user searches before they discover ThumbGate. This PR ships a fair, fact-based comparison page that explains the scope difference (their local shell scripts vs our hosted sync + adapter matrix + dashboard) and links honestly to their repo.
+
+- `public/compare/claude-code-hooks.html`: full comparison page in the same style as the existing `/compare/heidi`, `/compare/mem0`, `/compare/speclock` pages. TechArticle + FAQPage schema.org markup so Perplexity/ChatGPT/Claude/Gemini can cite it. Honest framing — credits karanb192 explicitly and recommends installing both for the seed library.
+- `src/api/server.js`: sitemap entry added at priority 0.85.
+- `tests/public-static-assets.test.js`: regression tests for the route + sitemap inclusion.
+
+Targets the third-party listicle gap identified in the LLM-search visibility audit: ThumbGate is currently absent from every "best AI agent safety tools" comparison that LLMs retrieve from. Owning the head-to-head against the top-ranking competitor is the lowest-cost way to surface in those answers.

--- a/public/compare/claude-code-hooks.html
+++ b/public/compare/claude-code-hooks.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ThumbGate vs claude-code-hooks | Hosted Sync vs Local Shell Scripts</title>
+  <meta name="description" content="karanb192/claude-code-hooks is a hand-curated bash hook collection you copy-paste into ~/.claude. ThumbGate is the same idea plus a hosted lesson DB, adapter matrix across 8 agent runtimes, and a dashboard you don't self-host. Honest head-to-head." />
+  <meta property="og:title" content="ThumbGate vs claude-code-hooks | Hosted Sync vs Local Shell Scripts" />
+  <meta property="og:description" content="claude-code-hooks is great if you want to babysit shell scripts on one laptop. ThumbGate is what you want when the same rule has to fire across every machine and every agent your team uses." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://thumbgate.ai/compare/claude-code-hooks" />
+  <link rel="canonical" href="https://thumbgate.ai/compare/claude-code-hooks" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
+  <link rel="icon" type="image/png" href="/thumbgate-icon.png" />
+  <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
+  <meta property="og:image" content="/og.png" />
+  <style>
+    :root { --bg: #0a0a0b; --bg-raised: #111113; --bg-card: #161618; --line: #222225; --text: #e8e8ec; --muted: #8b8b96; --cyan: #22d3ee; --green: #4ade80; --amber: #fbbf24; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--text); line-height: 1.65; }
+    a { color: var(--cyan); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .container { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+    .topbar { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(12px); background: rgba(10, 10, 11, 0.88); border-bottom: 1px solid var(--line); }
+    .topbar .container { display: flex; justify-content: space-between; align-items: center; padding-top: 14px; padding-bottom: 14px; }
+    .brand { font-weight: 700; color: var(--text); display: inline-flex; align-items: center; gap: 8px; text-decoration: none; }
+    .brand .logo-mark { width: 28px; height: 28px; display: block; }
+    .hero { padding: 72px 0 32px; }
+    .eyebrow { display: inline-flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; border: 1px solid rgba(34, 211, 238, 0.22); background: rgba(34, 211, 238, 0.1); color: var(--cyan); text-transform: uppercase; letter-spacing: 0.08em; font-size: 12px; font-weight: 700; }
+    h1 { font-size: clamp(34px, 5vw, 56px); line-height: 1.06; letter-spacing: -0.04em; margin: 16px 0; max-width: 820px; }
+    .hero p { max-width: 760px; color: var(--muted); font-size: 18px; }
+    .grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr); gap: 24px; padding-bottom: 72px; }
+    .card, .detail-section, .sidebar-card { background: var(--bg-card); border: 1px solid var(--line); border-radius: 16px; }
+    .card { padding: 24px; }
+    .detail-section { padding: 24px; margin-bottom: 18px; }
+    .detail-section h2 { margin: 0 0 12px; font-size: 24px; letter-spacing: -0.03em; }
+    .detail-section p, .detail-section li, .sidebar-card p { color: var(--muted); }
+    .detail-section ul, .card ul { padding-left: 18px; color: var(--muted); }
+    .comparison-table { width: 100%; border-collapse: collapse; margin-top: 16px; font-size: 14px; }
+    .comparison-table th, .comparison-table td { border: 1px solid var(--line); padding: 12px; text-align: left; vertical-align: top; }
+    .comparison-table th { background: var(--bg-raised); color: var(--cyan); }
+    .pill-row { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 24px; }
+    .pill { border: 1px solid var(--line); background: var(--bg-raised); border-radius: 999px; padding: 10px 14px; font-size: 14px; font-weight: 650; }
+    .pill.good { color: #b8f7c8; border-color: rgba(74, 222, 128, 0.28); background: rgba(74, 222, 128, 0.1); }
+    .pill.warn { color: #ffe2a4; border-color: rgba(251, 191, 36, 0.28); background: rgba(251, 191, 36, 0.1); }
+    .sidebar { display: flex; flex-direction: column; gap: 18px; }
+    .sidebar-card { padding: 20px; }
+    .sidebar-card:first-child { position: sticky; top: 84px; max-height: calc(100vh - 104px); overflow-y: auto; -webkit-overflow-scrolling: touch; }
+    .cta-button { display: inline-flex; align-items: center; justify-content: center; margin-top: 18px; padding: 12px 16px; border-radius: 10px; background: var(--cyan); color: #071116; font-weight: 700; text-decoration: none; }
+    .related-card { display: block; padding: 14px; border-radius: 12px; border: 1px solid var(--line); background: var(--bg-raised); margin-top: 12px; color: var(--text); }
+    .related-label { display: block; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 4px; }
+    .faq-item { border-top: 1px solid var(--line); padding: 14px 0; }
+    .faq-item summary { cursor: pointer; font-weight: 600; }
+    .faq-item p { color: var(--muted); }
+    @media (max-width: 860px) { .grid { grid-template-columns: 1fr; } .sidebar-card:first-child { position: static; max-height: none; overflow: visible; } }
+  </style>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "ThumbGate vs claude-code-hooks",
+  "description": "karanb192/claude-code-hooks is a copy-paste bash hook collection for one laptop. ThumbGate is the same enforcement model plus hosted lesson sync, an adapter matrix across 8 agent runtimes, and a dashboard. Side-by-side comparison.",
+  "about": ["thumbgate vs claude-code-hooks", "AI coding agent safety hooks", "PreToolUse hook comparison", "Claude Code shell hooks"],
+  "url": "https://thumbgate.ai/compare/claude-code-hooks",
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
+  "mainEntityOfPage": "https://thumbgate.ai/compare/claude-code-hooks"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is claude-code-hooks a direct ThumbGate competitor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Same category, different scope. karanb192/claude-code-hooks is a curated GitHub repository of bash scripts you copy into ~/.claude/hooks and edit by hand. ThumbGate ships the same PreToolUse enforcement model as a runtime engine plus hosted lesson sync across machines, a maintained adapter matrix for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and Claude Desktop, and a dashboard you don't self-host. If you only run one agent on one laptop and you like bash, claude-code-hooks is great. If the same rule has to fire across multiple machines, multiple agents, or multiple teammates, that's where ThumbGate fits."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use both?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. claude-code-hooks runs at the Claude Code hooks layer; ThumbGate's runtime runs at the same PreToolUse boundary but is agent-agnostic and persists lessons across reinstalls. They don't fight each other. The most common pattern is: borrow a few well-written hooks from claude-code-hooks for ideas, then let ThumbGate generalize them across every agent runtime you use."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does ThumbGate Pro add that the free tier and claude-code-hooks don't?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Hosted lesson sync (the same rule fires on your laptop and your CI runner without you re-copying scripts), the managed adapter matrix (when Claude Code, Cursor, or Codex ship a breaking change to their hook API, that's our problem not yours), a dashboard with gate hit rates and agent inventory, DPO/HuggingFace export for fine-tuning, and 24x7 ops. claude-code-hooks doesn't aim to do any of that on purpose — its scope is intentionally local-only."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is ThumbGate's local CLI free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. npx thumbgate init gives you the runtime, 10 feedback captures per day, 3 active prevention rules, 5 built-in checks, and PreToolUse blocking across all supported agents. MIT licensed. Pro at $19/mo unlocks unlimited captures, unlimited rules, sync, dashboard, and exports."
+      }
+    }
+  ]
+}
+  </script>
+</head>
+<body>
+  <div class="topbar">
+    <div class="container">
+      <a class="brand" href="/"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence</a>
+    </div>
+  </div>
+
+  <section class="hero">
+    <div class="container">
+      <span class="eyebrow">ThumbGate vs claude-code-hooks</span>
+      <h1>Copy-paste hooks on one laptop, or the same enforcement model across every agent and machine.</h1>
+      <p><strong>claude-code-hooks</strong> (by <a href="https://github.com/karanb192/claude-code-hooks" target="_blank" rel="noopener">karanb192</a>) is a hand-curated collection of bash hooks you drop into <code>~/.claude/hooks</code>. It's a great free starting point. <strong>ThumbGate</strong> ships the same PreToolUse enforcement idea, but as a runtime that learns from your feedback, syncs lessons across machines, and works across Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and Claude Desktop without you maintaining shell scripts.</p>
+      <div class="pill-row">
+        <span class="pill">Both free at base tier</span>
+        <span class="pill">Both PreToolUse-based</span>
+        <span class="pill">Both local-first by default</span>
+        <span class="pill good">Different scopes</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="container grid">
+    <main>
+      <article class="detail-section">
+        <h2>Side-by-side feature comparison</h2>
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>Capability</th>
+              <th>claude-code-hooks</th>
+              <th>ThumbGate</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Distribution</td>
+              <td>GitHub repo of shell scripts; copy-paste into <code>~/.claude/hooks</code></td>
+              <td>npm package: <code>npx thumbgate init</code> wires hooks across every supported agent</td>
+            </tr>
+            <tr>
+              <td>Agents supported</td>
+              <td>Claude Code only (uses Claude Code's native hooks API)</td>
+              <td>Claude Code, Cursor, OpenAI Codex CLI, Google Gemini CLI, Sourcegraph Amp, Cline, OpenCode, Claude Desktop (via MCP)</td>
+            </tr>
+            <tr>
+              <td>Rule format</td>
+              <td>Hand-written bash scripts (deny-lists, regex matchers)</td>
+              <td>Auto-promoted from operator feedback through Thompson Sampling; precision/recall gated before any rule activates</td>
+            </tr>
+            <tr>
+              <td>Cross-machine sync</td>
+              <td>Manual: copy the repo to each machine you use</td>
+              <td>Pro tier: hosted lesson sync, so the same rule fires on laptop, CI, and teammate machines</td>
+            </tr>
+            <tr>
+              <td>Adapter maintenance</td>
+              <td>You maintain it as Claude Code's hook API changes</td>
+              <td>Maintained adapter matrix — when an agent runtime ships a breaking change, we update the adapter</td>
+            </tr>
+            <tr>
+              <td>Dashboard</td>
+              <td>None (file-based logs)</td>
+              <td>Hit rates, gate inventory, agent activity, DPO export, hosted at <a href="/dashboard">/dashboard</a></td>
+            </tr>
+            <tr>
+              <td>Telemetry / training data export</td>
+              <td>None</td>
+              <td>DPO preference pairs, HuggingFace dataset export, Databricks-friendly JSONL</td>
+            </tr>
+            <tr>
+              <td>License</td>
+              <td>MIT</td>
+              <td>MIT (npm package); Pro/Team are hosted services</td>
+            </tr>
+            <tr>
+              <td>Cost</td>
+              <td>$0 forever</td>
+              <td>$0 local CLI; $19/mo Pro for sync + dashboard; $49/seat/mo Team (min 3) for workflow hardening sprint</td>
+            </tr>
+          </tbody>
+        </table>
+      </article>
+
+      <article class="detail-section">
+        <h2>Pick claude-code-hooks if</h2>
+        <ul>
+          <li>You use Claude Code on one laptop and you're happy editing bash by hand.</li>
+          <li>You want every line of enforcement visible in a shell script you can grep through in 30 seconds.</li>
+          <li>You don't need the same rule to fire on a teammate's machine or on CI.</li>
+          <li>You haven't yet hit the "I've copied these hooks to my third laptop, this is getting silly" moment.</li>
+        </ul>
+        <p>karanb192's repo is a legitimately great resource and the answers it provides for the basic blocklist questions are the right ones. We link to it from our docs. There's nothing about it that we're trying to disparage — it's just scoped to a smaller problem than what ThumbGate solves.</p>
+      </article>
+
+      <article class="detail-section">
+        <h2>Pick ThumbGate if</h2>
+        <ul>
+          <li>You use more than one AI coding agent and you want the same rule to fire across all of them.</li>
+          <li>You don't want to babysit shell scripts when Claude Code, Cursor, or Codex ship a breaking change to their hook API.</li>
+          <li>You want lessons to auto-promote from operator feedback instead of writing every rule by hand.</li>
+          <li>You want a dashboard, exports, and the ability to share enforced rules across a team.</li>
+          <li>You're a law firm, finance team, or other regulated org that needs an audit trail of every blocked action.</li>
+        </ul>
+      </article>
+
+      <article class="detail-section">
+        <h2>Can I use both?</h2>
+        <p>Yes. claude-code-hooks runs at Claude Code's native hooks layer. ThumbGate runs at the same PreToolUse boundary but is agent-agnostic and persists lessons across reinstalls and machines. They don't conflict. The most common dual-use pattern: borrow well-written hook ideas from claude-code-hooks (their <code>block-dangerous-commands</code> and <code>protect-secrets</code> sets are good seed material), let ThumbGate generalize those patterns into prevention rules that fire across every agent runtime you use.</p>
+      </article>
+
+      <article class="detail-section">
+        <h2>FAQ</h2>
+        <details class="faq-item" open>
+          <summary>Is claude-code-hooks a direct ThumbGate competitor?</summary>
+          <p>Same category, different scope. claude-code-hooks is a copy-paste bash hook collection for one laptop running Claude Code. ThumbGate is the same PreToolUse enforcement model packaged as a runtime engine with hosted sync, a multi-agent adapter matrix, and a dashboard. If you only need a few static rules on one machine, claude-code-hooks is fine. If you need the same rule to fire across machines, agents, or teammates, that's where ThumbGate fits.</p>
+        </details>
+        <details class="faq-item">
+          <summary>Is ThumbGate's free CLI as capable as claude-code-hooks?</summary>
+          <p>For the basic blocklist use case, comparable. ThumbGate's free tier ships 5 built-in checks plus the feedback loop and PreToolUse hook across 8 agent runtimes. claude-code-hooks ships more pre-written bash scripts you can install on day one. If you want to start with curated hand-written rules, install both — start with claude-code-hooks for the seed library, run ThumbGate alongside it to learn from your thumbs-down reactions.</p>
+        </details>
+        <details class="faq-item">
+          <summary>What does ThumbGate Pro add over both the free tier and claude-code-hooks?</summary>
+          <p>Hosted lesson sync, the maintained adapter matrix, the dashboard, DPO and HuggingFace export, and 24x7 ops on the rule engine. Pro is $19/mo. Team at $49/seat/mo (min 3) adds shared lesson DB and the Workflow Hardening Sprint engagement.</p>
+        </details>
+        <details class="faq-item">
+          <summary>Where do I start?</summary>
+          <p>If you want the smallest possible install: <code>npx thumbgate init</code>. If you want a curated set of hand-written hook examples to read: <a href="https://github.com/karanb192/claude-code-hooks" target="_blank" rel="noopener">karanb192/claude-code-hooks</a>. The two are complementary.</p>
+        </details>
+      </article>
+    </main>
+
+    <aside class="sidebar">
+      <div class="sidebar-card">
+        <h3 style="margin: 0 0 8px;">Install ThumbGate free</h3>
+        <p>10 captures/day, 3 active rules, PreToolUse blocking across Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, Claude Desktop.</p>
+        <pre style="background: var(--bg-raised); border: 1px solid var(--line); border-radius: 8px; padding: 12px; font-size: 13px; overflow: auto;">npx thumbgate init</pre>
+        <a class="cta-button" href="/pricing">See Pro vs Team pricing →</a>
+        <p style="font-size: 12px; margin-top: 16px;">MIT licensed. No telemetry without explicit opt-in. <code>THUMBGATE_NO_TELEMETRY=1</code> to disable.</p>
+      </div>
+
+      <div class="sidebar-card">
+        <span class="related-label">Related comparisons</span>
+        <a class="related-card" href="/compare/heidi">
+          <strong>ThumbGate vs HEIDI</strong><br>
+          <span style="color: var(--muted); font-size: 13px;">Agent behavior enforcement vs dependency CVE scanning</span>
+        </a>
+        <a class="related-card" href="/compare/mem0">
+          <strong>ThumbGate vs Mem0</strong><br>
+          <span style="color: var(--muted); font-size: 13px;">Enforcement gates vs long-term agent memory</span>
+        </a>
+        <a class="related-card" href="/compare/speclock">
+          <strong>ThumbGate vs SpecLock</strong><br>
+          <span style="color: var(--muted); font-size: 13px;">Runtime PreToolUse vs spec-pinned contracts</span>
+        </a>
+      </div>
+
+      <div class="sidebar-card">
+        <span class="related-label">Sources</span>
+        <p style="font-size: 13px;">Comparison data from <a href="https://github.com/karanb192/claude-code-hooks" target="_blank" rel="noopener">karanb192/claude-code-hooks README</a> (MIT license, public repo) and ThumbGate's <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">VERIFICATION_EVIDENCE.md</a>. If anything here misrepresents claude-code-hooks, open an issue at <a href="https://github.com/IgorGanapolsky/ThumbGate/issues" target="_blank" rel="noopener">our repo</a> and we'll correct it.</p>
+      </div>
+    </aside>
+  </div>
+</body>
+</html>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2591,6 +2591,7 @@ function renderSitemapXml(runtimeConfig) {
     { path: '/agents-cost-savings', changefreq: 'weekly', priority: '0.85' },
     { path: '/ai-malpractice-prevention', changefreq: 'weekly', priority: '0.9' },
     { path: '/learn/background-agent-control-layer', changefreq: 'weekly', priority: '0.85' },
+    { path: '/compare/claude-code-hooks', changefreq: 'weekly', priority: '0.85' },
     ...THUMBGATE_SEO_SITEMAP_ENTRIES,
   ];
   return [

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -368,3 +368,31 @@ test('GET /sitemap.xml includes background-agent control layer at priority 0.85'
   assert.ok(entry, 'background-agent-control-layer <url> block must exist');
   assert.match(entry[0], /<priority>0\.85<\/priority>/);
 });
+
+test('GET /compare/claude-code-hooks serves the hand-written comparison page', async () => {
+  const res = await fetch(`${origin}/compare/claude-code-hooks`);
+  assert.equal(res.status, 200);
+  assert.match(String(res.headers.get('content-type')), /text\/html/);
+  const html = await res.text();
+  // Title + canonical positioning
+  assert.match(html, /ThumbGate vs claude-code-hooks/);
+  assert.match(html, /Hosted Sync vs Local Shell Scripts/);
+  // FAQ schema + structured data must be present for LLM citation
+  assert.match(html, /"@type":\s*"FAQPage"/);
+  assert.match(html, /"@type":\s*"TechArticle"/);
+  // Honest framing — must link to karanb192's repo
+  assert.match(html, /github\.com\/karanb192\/claude-code-hooks/);
+  // Comparison table must surface the key differentiation rows
+  assert.match(html, /Agents supported/);
+  assert.match(html, /Cross-machine sync/);
+  assert.match(html, /Adapter maintenance/);
+});
+
+test('GET /sitemap.xml includes the claude-code-hooks comparison page', async () => {
+  const res = await fetch(`${origin}/sitemap.xml`);
+  assert.equal(res.status, 200);
+  const xml = await res.text();
+  const entry = xml.match(/<url>\s*<loc>[^<]*\/compare\/claude-code-hooks<\/loc>[\s\S]*?<\/url>/);
+  assert.ok(entry, 'compare/claude-code-hooks <url> block must exist');
+  assert.match(entry[0], /<priority>0\.85<\/priority>/);
+});


### PR DESCRIPTION
## Why (your strict diagnosis, acted on)

You wrote: *"the bigger issue is traffic plus conversion from npm/GitHub users into a paid hosted need… LLM discovery still depends on crawling, citations, backlinks, and third-party mentions."*

Visibility audit on 2026-05-27 confirmed: **karanb192/claude-code-hooks ranks #1** on the query `"Claude Code safety pre-tool-use hooks npm package"` (verified via WebSearch). ThumbGate is **not in the top 10**. Every "best AI agent safety tools" listicle that LLMs retrieve from cites Lakera, Aim, Zenity, Pipelock, LlamaFirewall, karanb192/claude-code-hooks, @constellos/claude-code-kit — never us.

The lowest-cost first move that an LLM can actually surface: **own the direct head-to-head against the top-ranking competitor.**

## What

- `public/compare/claude-code-hooks.html` (274 lines, ~10 KB): comparison page in the existing `/compare/heidi`-`/compare/mem0`-`/compare/speclock` style.
  - `TechArticle` + `FAQPage` schema.org structured data so Perplexity / ChatGPT / Claude / Gemini can cite individual Q&As.
  - 9-row side-by-side feature table (distribution, agents, rules, sync, adapter, dashboard, exports, license, cost).
  - Honest framing: credits karanb192 explicitly, recommends installing both, links to their repo.
  - Three CTAs: `npx thumbgate init` (free), pricing page (Pro/Team), three related comparison pages.
- `src/api/server.js`: sitemap entry at priority 0.85.
- `tests/public-static-assets.test.js`: two regression tests — route serves expected content, sitemap includes the URL.

## Verification

- `node --test tests/public-static-assets.test.js`: **28/28 pass** including the two new tests.
- `npm pack --dry-run`: 3.8 MB unpacked, 263 files — under the 3.90 MB ratchet ceiling, no new files in the tarball (`public/compare/` is on the forbidden-prefix list, intentionally server-only).
- Pre-commit guards green: package parity, version sync, claim hygiene.
- Pre-push guards green: link validation, regression suite.

## Expected impact

- Surfaces on "thumbgate vs claude-code-hooks" branded query (immediate).
- Surfaces on "Claude Code safety hooks" and "best AI agent PreToolUse tools" queries once LLM crawlers pick up the FAQ schema (typically 7-21 days).
- Provides an organic citation surface that listicle authors can copy from when adding ThumbGate to their lists.

## Note on PR #2333

Your `/llms.txt` PR (#2334) and OpenAPI runtime fallback (#2335) already shipped what my PR #2333 was trying to add — closing #2333 separately as duplicate.

https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd)_