### PR TITLE
Fix revenue funnel observability, moat limits, and AI discovery

### DIFF
--- a/.changeset/revenue-funnel-moat-ai-search.md
+++ b/.changeset/revenue-funnel-moat-ai-search.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Tighten free-to-paid conversion boundaries, add first-party visitor journey summaries to the operator telemetry export, and strengthen AI-search discovery metadata.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "thumbgate",
       "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-      "longDescription": "ThumbGate is a tripwire, not a memory layer. When you thumbs-down an agent action — a force-push that overwrote a teammate's commit, a destructive SQL drop, a refactor you already rejected — ThumbGate captures the pattern, distills a one-sentence lesson, and installs it as a PreToolUse block. The next time the agent reaches for the same tool call shape, the hook fires before execution and Claude sees your own words back as the reason.\n\nThe enforcement lives in the hook, not in the model's context, so the agent cannot bypass it by forgetting, by being prompted around it, or by switching sessions. Same rule works in Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, and OpenCode.\n\n33 pre-action checks shipped (force-push, destructive SQL, mass-delete, npm publish from wrong branch, deploy without verification). Budget enforcement (action count + time limits) prevents runaway agent sessions. NIST / SOC2 / OWASP / CWE compliance tags on every rule for enterprise teams. DPO training-pair export for teams running their own fine-tunes.\n\nFree tier: unlimited local rules, fully offline. Pro ($19/mo): cloud sync across team, dashboard, audit export.",
+      "longDescription": "ThumbGate is a tripwire, not a memory layer. When you thumbs-down an agent action — a force-push that overwrote a teammate's commit, a destructive SQL drop, a refactor you already rejected — ThumbGate captures the pattern, distills a one-sentence lesson, and installs it as a PreToolUse block. The next time the agent reaches for the same tool call shape, the hook fires before execution and Claude sees your own words back as the reason.\n\nThe enforcement lives in the hook, not in the model's context, so the agent cannot bypass it by forgetting, by being prompted around it, or by switching sessions. Same rule works in Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, and OpenCode.\n\n33 pre-action checks shipped (force-push, destructive SQL, mass-delete, npm publish from wrong branch, deploy without verification). Budget enforcement (action count + time limits) prevents runaway agent sessions. NIST / SOC2 / OWASP / CWE compliance tags on every rule for enterprise teams. DPO training-pair export for teams running their own fine-tunes.\n\nFree tier: 5 feedback captures/day, 25 total captures, 3 active auto-promoted prevention rules, fully offline. Pro ($19/mo): hosted sync across machines and agent runtimes, dashboard, audit export.",
       "source": {
         "source": "npm",
         "package": "thumbgate"
@@ -20,7 +20,7 @@
         "email": "ig5973700@gmail.com",
         "url": "https://thumbgate.ai"
       },
-      "homepage": "https://thumbgate-production.up.railway.app",
+      "homepage": "https://thumbgate.ai",
       "repository": "https://github.com/IgorGanapolsky/ThumbGate",
       "license": "MIT",
       "category": "developer-tools",
@@ -60,7 +60,7 @@
       "installCommand": "/plugin install thumbgate@claude-plugins-official",
       "metadata": {
         "author": "Igor Ganapolsky",
-        "homepage": "https://thumbgate-production.up.railway.app",
+        "homepage": "https://thumbgate.ai",
         "license": "MIT",
         "keywords": [
           "guardrails",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "ig5973700@gmail.com",
     "url": "https://thumbgate.ai"
   },
-  "homepage": "https://thumbgate-production.up.railway.app",
+  "homepage": "https://thumbgate.ai",
   "repository": "https://github.com/IgorGanapolsky/ThumbGate",
   "license": "MIT",
   "category": "developer-tools",

--- a/.github/github-app-manifest.json
+++ b/.github/github-app-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "ThumbGate",
   "description": "Human-in-the-loop enforcement for AI coding agents with pre-action checks that block repeated mistakes.",
-  "url": "https://thumbgate-production.up.railway.app",
+  "url": "https://thumbgate.ai",
   "hook_attributes": {
     "url": "https://thumbgate-production.up.railway.app/webhooks/github",
     "active": true

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -40,7 +40,7 @@ npx thumbgate init --agent claude-code
 ## Pricing
 
 - Free GPT: advice, checkpointing, and setup help in ChatGPT
-- Free local CLI: 10 captures/day, 50 total captures, up to 3 active auto-promoted prevention rules, and local Pre-Action Checks after install (recall and lesson search are Pro-only)
+- Free local CLI: 5 captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and local Pre-Action Checks after install (recall and lesson search are Pro-only)
 - Pro: $19/mo or $149/yr — personal enforcement proof, local dashboard, check debugger, DPO export, synced lessons/rules across machines, and review-ready exports
 - Team: $49/seat/mo, 3-seat minimum after intake — shared lessons, org visibility, approval boundaries, and rollout proof
 

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -2,14 +2,14 @@
   "name": "thumbgate",
   "version": "1.23.1",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
-  "homepage": "https://thumbgate-production.up.railway.app",
+  "homepage": "https://thumbgate.ai",
   "transport": "stdio",
   "discovery": {
-    "manifestUrl": "https://thumbgate-production.up.railway.app/.well-known/mcp.json",
-    "toolIndexUrl": "https://thumbgate-production.up.railway.app/.well-known/mcp/tools.json",
-    "toolSchemaUrlTemplate": "https://thumbgate-production.up.railway.app/.well-known/mcp/tools/{name}.json",
-    "footprintUrl": "https://thumbgate-production.up.railway.app/.well-known/mcp/footprint.json",
-    "skillsUrl": "https://thumbgate-production.up.railway.app/.well-known/mcp/skills.json",
-    "applicationsUrl": "https://thumbgate-production.up.railway.app/.well-known/mcp/applications.json"
+    "manifestUrl": "https://thumbgate.ai/.well-known/mcp.json",
+    "toolIndexUrl": "https://thumbgate.ai/.well-known/mcp/tools.json",
+    "toolSchemaUrlTemplate": "https://thumbgate.ai/.well-known/mcp/tools/{name}.json",
+    "footprintUrl": "https://thumbgate.ai/.well-known/mcp/footprint.json",
+    "skillsUrl": "https://thumbgate.ai/.well-known/mcp/skills.json",
+    "applicationsUrl": "https://thumbgate.ai/.well-known/mcp/applications.json"
   }
 }

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ npx thumbgate init   # auto-detects your agent, wires hooks, 30 seconds
 
 Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and any MCP-compatible agent.
 
-**Free:** 10 feedback captures/day (50 total captures), 3 active auto-promoted prevention rules, all MCP integrations, local-first.
-**[Pro — $19/mo or $149/yr](https://thumbgate-production.up.railway.app/checkout/pro?utm_source=github&utm_medium=readme):** no limits on captures or rules, history-aware lessons, feedback sessions, hosted dashboard, DPO export.
+**Free:** 5 feedback captures/day (25 total captures), 3 active auto-promoted prevention rules, all MCP integrations, local-first.
+**[Pro — $19/mo or $149/yr](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme):** no limits on captures or rules, history-aware lessons, feedback sessions, hosted dashboard, DPO export.
 **Team — $49/seat/mo:** shared lesson DB, org dashboard, approval boundaries.
 
 [![CI](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml)
@@ -48,7 +48,7 @@ Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and 
 
 Watch the force-push scenario: agent tries to `git push --force`, one thumbs-down, next session it's blocked — zero tokens spent on the repeat.
 
-[**▶ Watch the 90-second demo**](https://thumbgate-production.up.railway.app/#demo?utm_source=github&utm_medium=readme&utm_campaign=demo_video) · [Script](docs/marketing/demo-video-script.md) · [ElevenLabs narration: `npm run demo:voiceover`](scripts/generate-demo-voiceover.js)
+[**▶ Watch the 90-second demo**](https://thumbgate.ai/#demo?utm_source=github&utm_medium=readme&utm_campaign=demo_video) · [Script](docs/marketing/demo-video-script.md) · [ElevenLabs narration: `npm run demo:voiceover`](scripts/generate-demo-voiceover.js)
 
 <!-- Video embed lives on the landing page and YouTube. Script + voiceover automation ship with the repo so anyone can re-record. -->
 
@@ -58,7 +58,7 @@ Watch the force-push scenario: agent tries to `git push --force`, one thumbs-dow
 
 If someone is not already bought into ThumbGate, do not lead with architecture. Lead with one repeated mistake.
 
-1. **Show the pain:** open the **[ThumbGate GPT](https://thumbgate-production.up.railway.app/go/gpt?utm_source=github&utm_medium=readme&utm_campaign=first_dollar_activation&cta_id=readme_first_dollar_open_gpt&cta_placement=readme_first_dollar)** and paste the bad answer, risky command, deploy, PR action, or agent plan before it runs again.
+1. **Show the pain:** open the **[ThumbGate GPT](https://thumbgate.ai/go/gpt?utm_source=github&utm_medium=readme&utm_campaign=first_dollar_activation&cta_id=readme_first_dollar_open_gpt&cta_placement=readme_first_dollar)** and paste the bad answer, risky command, deploy, PR action, or agent plan before it runs again.
 2. **Capture the lesson:** type `thumbs down:` or `thumbs up:` with one concrete sentence. Native ChatGPT rating buttons are not the ThumbGate capture path; typed feedback is.
 3. **Enforce the repeat:** run `npx thumbgate init` where the agent executes so the lesson can become one of your Pre-Action Checks instead of another reminder.
 4. **Upgrade only after proof:** Solo Pro is for the dashboard, DPO export, proof-ready evidence, and higher capture limits after one real blocked repeat. Team starts with the Workflow Hardening Sprint around one repeated failure, one owner, and one proof review.
@@ -216,7 +216,7 @@ Claude renders the live ThumbGate footer today. `npx thumbgate init --agent code
 
 Open the Codex plugin install page or download the standalone bundle from GitHub Releases. The Codex launcher resolves `thumbgate@latest` when MCP and hooks start, so published npm fixes reach active Codex installs without hand-editing `~/.codex/config.toml`.
 
-1. Install page: [thumbgate-production.up.railway.app/codex-plugin](https://thumbgate-production.up.railway.app/codex-plugin)
+1. Install page: [thumbgate.ai/codex-plugin](https://thumbgate.ai/codex-plugin)
 2. Direct zip: [thumbgate-codex-plugin.zip](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip)
 3. Follow: [plugins/codex-profile/INSTALL.md](plugins/codex-profile/INSTALL.md)
 
@@ -266,7 +266,7 @@ ThumbGate sells three concrete outcomes:
 - **Healthcare** — Prevent AI agents from providing medical diagnoses, enforce HIPAA-compliant data routing, require clinician review before patient-facing content
 - **Audit trail** — Every gate decision (block, allow, reroute) is preserved with rule version, timestamp, and reviewer path for compliance review
 
-[See the legal-intake demo →](https://thumbgate-production.up.railway.app/dashboard)
+[See the legal-intake demo →](https://thumbgate.ai/dashboard)
 
 ---
 
@@ -308,7 +308,7 @@ npx thumbgate bench --programbench-smoke  # include cleanroom whole-repo proof l
 | | Free | Pro ($19/mo) | Team ($49/seat/mo) | Enterprise |
 |---|---|---|---|---|
 | Local CLI + enforced checks | ✅ | ✅ | ✅ | ✅ |
-| Feedback captures | 10/day, 50 total | Unlimited | Unlimited | Unlimited |
+| Feedback captures | 5/day, 25 total | Unlimited | Unlimited | Unlimited |
 | Auto-promoted prevention rules | 3 active | Unlimited | Unlimited | Unlimited |
 | MCP agent integrations | All | All | All | All |
 | Personal dashboard | — | ✅ | ✅ | ✅ |
@@ -322,17 +322,17 @@ npx thumbgate bench --programbench-smoke  # include cleanroom whole-repo proof l
 | Compliance audit export | — | — | — | ✅ |
 | Dedicated onboarding + SLA | — | — | — | ✅ |
 
-The free tier gives you 10 feedback captures/day, 50 total captures, and up to 3 active auto-promoted prevention rules — enough to prove value without replacing Pro for daily operators. MCP integrations for all agents (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode) ship free.
+The free tier gives you 5 feedback captures/day, 25 total captures, and up to 3 active auto-promoted prevention rules — enough to prove value without replacing Pro for daily operators. MCP integrations for all agents (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode) ship free.
 
 Pro ($19/mo or $149/yr) removes the capture/rule caps and adds history-aware lesson recall, lesson search, DPO export, hosted sync, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement across the org. Enterprise adds regulatory gate templates (legal intake, financial compliance, healthcare), custom policy layers scoped to firm/practice-area, compliance audit export, and dedicated onboarding with SLA.
 
-**Best first paid motion for teams:** the **Workflow Hardening Sprint** — qualify one repeated failure before committing to a full rollout. **[Start intake →](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=team_rollout#workflow-sprint-intake)**
+**Best first paid motion for teams:** the **Workflow Hardening Sprint** — qualify one repeated failure before committing to a full rollout. **[Start intake →](https://thumbgate.ai/?utm_source=github&utm_medium=readme&utm_campaign=team_rollout#workflow-sprint-intake)**
 
 **Best first technical motion:** install the CLI-first and let `init` wire hooks for the agent you already use.
 
-**Paid path for individual operators:** [ThumbGate Pro](https://thumbgate-production.up.railway.app/checkout/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page) is the self-serve side lane for a personal dashboard and export-ready evidence.
+**Paid path for individual operators:** [ThumbGate Pro](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme&utm_campaign=pro_page) is the self-serve side lane for a personal dashboard and export-ready evidence.
 
-**[Start free](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme)** · **[See Pro](https://thumbgate-production.up.railway.app/checkout/pro?utm_source=github&utm_medium=readme)** · **[Team Sprint intake](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme#workflow-sprint-intake)**
+**[Start free](https://thumbgate.ai/?utm_source=github&utm_medium=readme)** · **[See Pro](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme)** · **[Team Sprint intake](https://thumbgate.ai/?utm_source=github&utm_medium=readme#workflow-sprint-intake)**
 
 ---
 
@@ -425,17 +425,17 @@ Every Changeset is tied to the exact `main` merge commit and generates Verificat
 
 ---
 
-**Popular buyer questions:** **[AI search topical presence](https://thumbgate-production.up.railway.app/guides/ai-search-topical-presence?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Relational knowledge and AI recommendations](https://thumbgate-production.up.railway.app/guides/relational-knowledge-ai-recommendations?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Background agent governance](https://thumbgate-production.up.railway.app/guides/background-agent-governance?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[GPT-5.5 model evaluation](https://thumbgate-production.up.railway.app/guides/gpt-5-5-model-evaluation?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Stop repeated AI agent mistakes](https://thumbgate-production.up.railway.app/guides/stop-repeated-ai-agent-mistakes?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Browser automation safety](https://thumbgate-production.up.railway.app/guides/browser-automation-safety?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Native messaging host security](https://thumbgate-production.up.railway.app/guides/native-messaging-host-security?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Autoresearch agent safety](https://thumbgate-production.up.railway.app/guides/autoresearch-agent-safety?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Cursor guardrails](https://thumbgate-production.up.railway.app/guides/cursor-agent-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Codex CLI guardrails](https://thumbgate-production.up.railway.app/guides/codex-cli-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Gemini CLI memory + enforcement](https://thumbgate-production.up.railway.app/guides/gemini-cli-feedback-memory?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Google Cloud MCP guardrails](https://thumbgate-production.up.railway.app/guides/gcp-mcp-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Roo Code alternative: migrate to Cline](https://thumbgate-production.up.railway.app/guides/roo-code-alternative-cline?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)**
+**Popular buyer questions:** **[AI search topical presence](https://thumbgate.ai/guides/ai-search-topical-presence?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Relational knowledge and AI recommendations](https://thumbgate.ai/guides/relational-knowledge-ai-recommendations?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Background agent governance](https://thumbgate.ai/guides/background-agent-governance?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[GPT-5.5 model evaluation](https://thumbgate.ai/guides/gpt-5-5-model-evaluation?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Stop repeated AI agent mistakes](https://thumbgate.ai/guides/stop-repeated-ai-agent-mistakes?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Browser automation safety](https://thumbgate.ai/guides/browser-automation-safety?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Native messaging host security](https://thumbgate.ai/guides/native-messaging-host-security?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Autoresearch agent safety](https://thumbgate.ai/guides/autoresearch-agent-safety?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Cursor guardrails](https://thumbgate.ai/guides/cursor-agent-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Codex CLI guardrails](https://thumbgate.ai/guides/codex-cli-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Gemini CLI memory + enforcement](https://thumbgate.ai/guides/gemini-cli-feedback-memory?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Google Cloud MCP guardrails](https://thumbgate.ai/guides/gcp-mcp-guardrails?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)** · **[Roo Code alternative: migrate to Cline](https://thumbgate.ai/guides/roo-code-alternative-cline?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions)**
 
-**[Workflow Hardening Sprint](https://thumbgate-production.up.railway.app/?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake)** · **[Live Dashboard](https://thumbgate-production.up.railway.app/dashboard?utm_source=github&utm_medium=readme&utm_campaign=top_cta)**
+**[Workflow Hardening Sprint](https://thumbgate.ai/?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake)** · **[Live Dashboard](https://thumbgate.ai/dashboard?utm_source=github&utm_medium=readme&utm_campaign=top_cta)**
 
 ---
 
 ## Integrations
 
-- **[Open ThumbGate GPT](https://thumbgate-production.up.railway.app/go/gpt?utm_source=github&utm_medium=readme&utm_campaign=readme_gpt)** — ThumbGate GPT: start here. Paste agent actions, get advice + checkpointing. No, users do not have to keep chatting inside the ThumbGate GPT to use ThumbGate — the hard enforcement layer still runs where the work happens.
+- **[Open ThumbGate GPT](https://thumbgate.ai/go/gpt?utm_source=github&utm_medium=readme&utm_campaign=readme_gpt)** — ThumbGate GPT: start here. Paste agent actions, get advice + checkpointing. No, users do not have to keep chatting inside the ThumbGate GPT to use ThumbGate — the hard enforcement layer still runs where the work happens.
 - **[Claude Desktop Extension](https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb)** — One-click install for Claude Desktop
-- **[Codex Plugin](https://thumbgate-production.up.railway.app/codex-plugin)** — Auto-updating standalone bundle and install page for Codex CLI
+- **[Codex Plugin](https://thumbgate.ai/codex-plugin)** — Auto-updating standalone bundle and install page for Codex CLI
 - **[VS Code / Open VSX Extension](plugins/vscode-extension/README.md)** — Marketplace-ready MCP provider and `.vscode/mcp.json` fallback for VS Code-compatible IDEs
 - **[Antigravity-compatible VSIX](plugins/antigravity-extension/INSTALL.md)** — Open VSX/direct VSIX install path while Antigravity-specific marketplace support is still unproven
 - **[JetBrains Plugin Scaffold](plugins/jetbrains-plugin/README.md)** — IntelliJ/PyCharm Marketplace path for the same `thumbgate@latest` runtime
@@ -474,7 +474,7 @@ Those are suggestions the agent can ignore. ThumbGate checks are enforced — th
 If it supports MCP or pre-action hooks, yes. Claude Code, Claude Desktop, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode all work out of the box.
 
 **Is it free?**
-The free tier gives you 10 feedback captures/day, 50 total captures, and up to 3 active auto-promoted prevention rules. MCP integrations ship free for every agent.
+The free tier gives you 5 feedback captures/day, 25 total captures, and up to 3 active auto-promoted prevention rules. MCP integrations ship free for every agent.
 
 Pro ($19/mo or $149/yr) removes the capture/rule caps and adds history-aware lesson recall, lesson search, hosted sync, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement.
 
@@ -482,7 +482,7 @@ Pro ($19/mo or $149/yr) removes the capture/rule caps and adds history-aware les
 
 ## Docs
 
-- [**ThumbGate for Federal Agencies**](docs/FEDERAL.md) — pilot-ready posture, NIST 800-53 control mapping, OMB M-24-10 / EO 14110 alignment, ThumbGate-Core gov deployment mode, public/Core boundary invariants. Landing page: [thumbgate.ai/federal](https://thumbgate-production.up.railway.app/federal).
+- [**ThumbGate for Federal Agencies**](docs/FEDERAL.md) — pilot-ready posture, NIST 800-53 control mapping, OMB M-24-10 / EO 14110 alignment, ThumbGate-Core gov deployment mode, public/Core boundary invariants. Landing page: [thumbgate.ai/federal](https://thumbgate.ai/federal).
 - [First Dollar Playbook](docs/FIRST_DOLLAR_PLAYBOOK.md) — turning one painful workflow into the next booked pilot
 - [Commercial Truth](docs/COMMERCIAL_TRUTH.md) — pricing, claims, what we don't say
 - [Goal Contracts](docs/GOAL_CONTRACTS.md) — evidence-before-done contracts for multi-agent handoffs

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -50,7 +50,7 @@ const COMMAND = process.argv[2];
 const CWD = process.cwd();
 const PKG_ROOT = path.join(__dirname, '..');
 
-const PRO_URL = 'https://thumbgate-production.up.railway.app';
+const PRO_URL = 'https://thumbgate.ai';
 const PRO_CHECKOUT_URL = PRO_MONTHLY_PAYMENT_LINK;
 const TRIAL_DAYS = 14;
 
@@ -94,7 +94,7 @@ function upgradeNudge() {
   const pricingUrl = pricingUrlFor('cli_upgrade_nudge', COMMAND || 'general');
   process.stderr.write(
     '\n  Team rollout: start with the Workflow Hardening Sprint\n' +
-    '  https://thumbgate-production.up.railway.app/#workflow-sprint-intake\n' +
+    '  https://thumbgate.ai/#workflow-sprint-intake\n' +
     `\n  Solo side lane: Pro — ${PRO_PRICE_LABEL}\n` +
     '  Keeps lessons, rules, and the dashboard synced across machines and agent runtimes.\n' +
     `  ${pricingUrl}\n\n`
@@ -154,7 +154,7 @@ function telemetryPing(installId) {
     timestamp: new Date().toISOString(),
   };
   appendLocalTelemetry(payloadObject);
-  const apiUrl = process.env.THUMBGATE_API_URL || 'https://thumbgate-production.up.railway.app';
+  const apiUrl = process.env.THUMBGATE_API_URL || 'https://thumbgate.ai';
   const payload = JSON.stringify(payloadObject);
   try {
     const url = new URL('/v1/telemetry/ping', apiUrl);
@@ -207,7 +207,7 @@ function printInitConversionPrompt(email) {
   const checkoutUrl = checkoutUrlFor('cli_init', email ? 'init_email' : 'init_no_email');
   console.log('');
   console.log('  ┌──────────────────────────────────────────────────────────┐');
-  console.log(`  │  14-day Pro trial active through ${trialDeadlineLabel()}.              │`);
+  console.log(`  │  7-day Pro trial active through ${trialDeadlineLabel()}.               │`);
   console.log('  │  Pro keeps lessons/rules/dashboard synced everywhere.   │');
   console.log('  │  Add onboarding: npx thumbgate init --email you@company.com │');
   console.log(`  │  Upgrade: ${checkoutUrl}`);
@@ -954,7 +954,7 @@ function capture() {
       const pct = Math.round((capLimit.used / capLimit.limit) * 100);
       console.log(`  Usage       : ${capLimit.used}/${capLimit.limit} captures today (${pct}%)`);
       if (capLimit.remaining <= 1) {
-        console.log(`  ⚠️  Free tier limit reached. Upgrade to Pro for unlimited: https://thumbgate-production.up.railway.app/pro`);
+        console.log(`  ⚠️  Free tier limit reached. Upgrade to Pro for unlimited: https://thumbgate.ai/pro`);
       }
     }
     console.log('');
@@ -1047,7 +1047,7 @@ function stats() {
     console.log(`  Estimated Operational Loss: $${payload.revenueAtRisk}`);
     console.log('  Action Required: Run "npx thumbgate rules" to generate guardrails.');
     console.log('  Strategic Recommendation: if this is a shared workflow problem, start the Workflow Hardening Sprint.');
-    console.log('  Team intake: https://thumbgate-production.up.railway.app/#workflow-sprint-intake');
+    console.log('  Team intake: https://thumbgate.ai/#workflow-sprint-intake');
     console.log('  Solo side lane: npx thumbgate pro');
   } else {
     console.log('\n✅ System is currently high-reliability. No immediate revenue loss detected.');
@@ -1164,7 +1164,7 @@ function pro() {
   } = require(path.join(PKG_ROOT, 'scripts', 'pro-local-dashboard'));
 
   function printProInfo() {
-    const hostedUrl = 'https://thumbgate-production.up.railway.app';
+    const hostedUrl = 'https://thumbgate.ai';
     const truthUrl = 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/COMMERCIAL_TRUTH.md';
     console.log('\nThumbGate Pro — Local Dashboard');
     console.log('─'.repeat(50));
@@ -2132,7 +2132,7 @@ function backgroundGovernance() {
   console.log('  - Run --check before dispatching an unattended PR job.');
   console.log('  - Route protected branches and large blast-radius jobs to human review.');
   console.log('  - Convert CI failures into thumbs-down lessons so repeats become Pre-Action Checks.');
-  console.log('\nGuide: https://thumbgate-production.up.railway.app/guides/background-agent-governance\n');
+  console.log('\nGuide: https://thumbgate.ai/guides/background-agent-governance\n');
 }
 
 function optimize() {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -52,7 +52,10 @@ const PKG_ROOT = path.join(__dirname, '..');
 
 const PRO_URL = 'https://thumbgate.ai';
 const PRO_CHECKOUT_URL = PRO_MONTHLY_PAYMENT_LINK;
-const TRIAL_DAYS = 14;
+// Mirrors scripts/rate-limiter.js TRIAL_DAYS — must stay in sync. Gitar
+// caught a 14-vs-7 mismatch on PR #2337 (banner said "7-day trial" but
+// the date label was computed 14 days out).
+const TRIAL_DAYS = 7;
 
 function checkoutUrlFor(source, content) {
   try {

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -26,17 +26,17 @@ const DASHBOARD_URL = 'https://thumbgate.ai/dashboard?utm_source=npm&utm_medium=
 
 process.stderr.write(`
   ╭─────────────────────────────────────────────────────╮
-  │  ThumbGate installed — 14-day Pro trial is live.    │
+  │  ThumbGate installed — 7-day Pro trial is live.     │
   │                                                     │
   │  Start now:  npx thumbgate init                     │
   │  Updates:    npx thumbgate subscribe you@company.com│
   │                                                     │
-  │  Free after trial: 3 rules, 10 captures/day.       │
+  │  Free after trial: 3 rules, 5 captures/day.        │
   │  Pro ($19/mo): unlimited everything.                │
   ╰─────────────────────────────────────────────────────╯
 
   Trial unlocks: unlimited rules, lesson search, DPO export,
-  hosted dashboard. After 14 days, free tier limits apply.
+  hosted dashboard. After 7 days, free tier limits apply.
   Subscribe for the 5-min setup guide + weekly tips:
   npx thumbgate subscribe you@company.com
 

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -1,7 +1,7 @@
 {
   "repo": "IgorGanapolsky/ThumbGate",
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
-  "homepageUrl": "https://thumbgate-production.up.railway.app",
+  "homepageUrl": "https://thumbgate.ai",
   "githubDescription": "Agent governance for ThumbGate: 👍/👎 become Pre-Action Checks that block repeat mistakes before code, money, or customer systems change.",
   "metaDescription": "Stop paying for the same AI mistake twice. ThumbGate is machine-speed pre-action defense for AI coding agents and vibe coding workflows: 👍 thumbs up and 👎 thumbs down become history-aware lessons, shared lessons and org visibility, actionable remediations, agent surface inventory, and Pre-Action Checks that block repeat mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
   "topics": [

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -23,7 +23,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 
 ### Free (local, `npx thumbgate serve`)
 
-- 10 feedback captures/day, 50 total captures
+- 5 feedback captures/day, 25 total captures
 - Up to 3 active auto-promoted prevention rules
 - No recall or lesson search
 - No exports (DPO, Databricks, HuggingFace)

--- a/docs/X_AUTOMATION_REPORT.md
+++ b/docs/X_AUTOMATION_REPORT.md
@@ -15,14 +15,14 @@ This is an operator planning report, not proof that posts were sent or that impr
 Use these as starting points in high-intent threads where the pain is already visible:
 
 ### Target: MCP context drift
-> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate.ai/#workflow-sprint-intake
 
 ### Target: Claude amnesia
-> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate.ai/#workflow-sprint-intake
 
 ### Target: AI agent repetition
-> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate.ai/#workflow-sprint-intake
 
 ### Target: Agentic feedback loop
-> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate-production.up.railway.app/#workflow-sprint-intake
+> I ran into this too. The problem usually is not the model, it is one workflow repeating the same mistake. I have been treating it as workflow hardening with recall, gates, and proof instead of more orchestration: https://thumbgate.ai/#workflow-sprint-intake
 

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -1135,7 +1135,7 @@
             <p style='margin:0 0 8px;font-size:15px;color:var(--muted);font-style:italic;'>CLI-first local enforcement for a solo developer proving the need.</p>
             <div class='price'>$0 <small>/ forever</small></div>
             <ul>
-              <li>10 feedback captures/day, 50 total captures</li>
+              <li>5 feedback captures/day, 25 total captures</li>
               <li>Up to 3 active auto-promoted prevention rules</li>
               <li>5 built-in checks</li>
               <li>No recall or lesson search</li>

--- a/docs/marketing/email-nurture-sequence.md
+++ b/docs/marketing/email-nurture-sequence.md
@@ -164,9 +164,9 @@ If ThumbGate has saved you from a repeated mistake, we'd genuinely love to hear 
 
 **Body:**
 
-You've been using ThumbGate for two weeks. By now you likely know whether the local loop is catching real mistakes.
+You've been using ThumbGate for one week. By now you likely know whether the local loop is catching real mistakes.
 
-Free tier gives you 10 feedback captures/day, 50 total captures, and 3 active prevention rules, but keeps recall, lesson search, the dashboard, hosted sync, and DPO exports behind Pro. If you've leaned on ThumbGate for two weeks, the next step is the dashboard and unlimited rules.
+Free tier gives you 5 feedback captures/day, 25 total captures, and 3 active prevention rules, but keeps recall, lesson search, the dashboard, hosted sync, and DPO exports behind Pro. If you've leaned on ThumbGate for one week, the next step is the dashboard and unlimited rules.
 
 ThumbGate Pro removes the limit and adds:
 

--- a/docs/marketing/pricing-comparison.md
+++ b/docs/marketing/pricing-comparison.md
@@ -2,7 +2,7 @@
 
 | Feature | Free | Pro ($19/mo or $149/yr) |
 |---------|------|--------------|
-| Feedback capture | 10/day, 50 total | Unlimited |
+| Feedback capture | 5/day, 25 total | Unlimited |
 | Recall + lesson search | No | Yes |
 | Prevention rules | Up to 3 active | Unlimited |
 | 5 built-in checks | Yes | Yes |

--- a/docs/marketing/product-hunt-launch-kit.md
+++ b/docs/marketing/product-hunt-launch-kit.md
@@ -60,7 +60,7 @@ I'm here all day — ask me anything.
 
 Happy launch day! A few things to know before you try it:
 
-The free tier gives you the local loop: 10 feedback captures/day, 50 total captures, up to 3 active auto-promoted prevention rules, and local enforcement via PreToolUse hooks. No cloud account, no credit card.
+The free tier gives you the local loop: 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and local enforcement via PreToolUse hooks. No cloud account, no credit card.
 
 Pro ($19/mo) adds the personal local dashboard, DPO export pairs for downstream fine-tuning, and a check debugger to trace exactly why a rule fired.
 

--- a/docs/marketing/readme-hero-update.md
+++ b/docs/marketing/readme-hero-update.md
@@ -28,7 +28,7 @@ ThumbGate remembers what went wrong and blocks it before it happens again. One t
 npx thumbgate init   # auto-detects your agent, wires hooks, 30 seconds
 ```
 
-Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and any MCP-compatible agent. Free tier: 10 captures/day, 50 total captures, and 3 active prevention rules. [Pro: $19/mo](https://thumbgate-production.up.railway.app/checkout/pro?utm_source=github&utm_medium=readme) — unlimited captures/rules, hosted sync, dashboard, DPO export.
+Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and any MCP-compatible agent. Free tier: 5 captures/day, 25 total captures, and 3 active prevention rules. [Pro: $19/mo](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme) — unlimited captures/rules, hosted sync, dashboard, DPO export.
 
 [![CI](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/thumbgate)](https://www.npmjs.com/package/thumbgate)

--- a/docs/marketing/show-hn.md
+++ b/docs/marketing/show-hn.md
@@ -54,7 +54,7 @@ It speaks MCP stdio, so it plugs into Claude Code, Claude Desktop,
 Cursor, Codex CLI, Gemini CLI, Amp, OpenCode — anything that speaks the
 protocol. One correction in Claude Code also protects your Cursor session.
 
-Free tier: 10 captures/day, 50 total captures, 3 active auto-promoted rules. Enough to prove
+Free tier: 5 captures/day, 25 total captures, 3 active auto-promoted rules. Enough to prove
 ThumbGate in your own workflow. Pro is $19/mo or $149/yr for unlimited rules + a
 local dashboard showing tokens-saved since install (Sonnet-blended
 estimate, conservative). Team is $49/seat/mo for a shared hosted

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "version": "1.23.1",
   "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 33 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
-  "homepage": "https://thumbgate-production.up.railway.app",
+  "homepage": "https://thumbgate.ai",
   "repository": {
     "type": "git",
     "url": "https://github.com/IgorGanapolsky/ThumbGate.git"
@@ -198,6 +198,7 @@
     "scripts/verification-loop.js",
     "scripts/verifier-scoring.js",
     "scripts/verify-marketing-pages-deployed.js",
+    "scripts/visitor-journey.js",
     "scripts/workflow-runs.js",
     "scripts/workflow-sentinel.js",
     "scripts/workspace-agent-routines.js",

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"
   },
-  "homepage": "https://thumbgate-production.up.railway.app",
+  "homepage": "https://thumbgate.ai",
   "repository": "https://github.com/IgorGanapolsky/ThumbGate",
   "license": "MIT",
   "keywords": [

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"
   },
-  "homepage": "https://thumbgate-production.up.railway.app",
+  "homepage": "https://thumbgate.ai",
   "repository": "https://github.com/IgorGanapolsky/ThumbGate",
   "license": "MIT",
   "keywords": [

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -7,7 +7,7 @@
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"
   },
-  "homepage": "https://thumbgate-production.up.railway.app",
+  "homepage": "https://thumbgate.ai",
   "repository": "https://github.com/IgorGanapolsky/ThumbGate",
   "license": "MIT",
   "keywords": [
@@ -29,7 +29,10 @@
     "longDescription": "Adds ThumbGate's pre-action gates, domain skill packs (Stripe, Railway, DB), hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP reliability memory to Cursor workflows.",
     "developerName": "Igor Ganapolsky",
     "category": "Developer Tools",
-    "capabilities": ["Interactive", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
     "websiteURL": "https://thumbgate-production.up.railway.app",
     "privacyPolicyURL": "https://thumbgate-production.up.railway.app/privacy",
     "termsOfServiceURL": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/LICENSE",

--- a/public/agent-manager.html
+++ b/public/agent-manager.html
@@ -9,8 +9,8 @@
 <meta property="og:title" content="ThumbGate for the Agent Manager">
 <meta property="og:description" content="The role Anthropic named — Agent Manager — owns CLAUDE.md, the plugin marketplace, permissions, and which skills ship. ThumbGate is the runtime underneath all of that.">
 <meta property="og:type" content="article">
-<meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/agent-manager">
+<meta property="og:image" content="https://thumbgate.ai/og.png">
+<link rel="canonical" href="https://thumbgate.ai/agent-manager">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -20,7 +20,7 @@
   "datePublished": "2026-05-19",
   "dateModified": "2026-05-19",
   "author": { "@type": "Person", "name": "Igor Ganapolsky", "url": "https://github.com/IgorGanapolsky" },
-  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate-production.up.railway.app" },
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
   "about": [
     { "@type": "Thing", "name": "Agent Manager" },
     { "@type": "Thing", "name": "Claude Code rollout" },

--- a/public/agents-cost-savings.html
+++ b/public/agents-cost-savings.html
@@ -9,8 +9,8 @@
 <meta property="og:title" content="FinOps for AI Agents — Prevention, Not Reporting">
 <meta property="og:description" content="Cost dashboards tell you what your agents wasted last week. ThumbGate's PreToolUse gates stop the wasted tool calls before they fire — and `thumbgate cost` shows you the dollar amount.">
 <meta property="og:type" content="article">
-<meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/agents-cost-savings">
+<meta property="og:image" content="https://thumbgate.ai/og.png">
+<link rel="canonical" href="https://thumbgate.ai/agents-cost-savings">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -20,7 +20,7 @@
   "datePublished": "2026-05-21",
   "dateModified": "2026-05-21",
   "author": { "@type": "Person", "name": "Igor Ganapolsky", "url": "https://github.com/IgorGanapolsky" },
-  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate-production.up.railway.app" },
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
   "about": [
     { "@type": "Thing", "name": "FinOps for AI" },
     { "@type": "Thing", "name": "Agent Cost Optimization" },

--- a/public/ai-malpractice-prevention.html
+++ b/public/ai-malpractice-prevention.html
@@ -9,8 +9,8 @@
 <meta property="og:title" content="Pre-Execution Controls for Legal AI Agents">
 <meta property="og:description" content="ThumbGate preloads firm-approved ground truth, checks legal AI actions before execution, and records audit evidence for law-firm innovation, risk, and pricing teams.">
 <meta property="og:type" content="article">
-<meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/ai-malpractice-prevention">
+<meta property="og:image" content="https://thumbgate.ai/og.png">
+<link rel="canonical" href="https://thumbgate.ai/ai-malpractice-prevention">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -20,7 +20,7 @@
   "datePublished": "2026-05-21",
   "dateModified": "2026-05-25",
   "author": { "@type": "Person", "name": "Igor Ganapolsky", "url": "https://github.com/IgorGanapolsky" },
-  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate-production.up.railway.app" },
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
   "about": [
     { "@type": "Thing", "name": "Legal AI Governance" },
     { "@type": "Thing", "name": "Unauthorized Practice of Law" },

--- a/public/blog.html
+++ b/public/blog.html
@@ -11,7 +11,7 @@
     />
     <link
       rel="canonical"
-      href="https://thumbgate-production.up.railway.app/blog"
+      href="https://thumbgate.ai/blog"
     />
     <meta
       property="og:title"
@@ -24,14 +24,14 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:url"
-      content="https://thumbgate-production.up.railway.app/blog"
+      content="https://thumbgate.ai/blog"
     />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "Blog",
         "name": "ThumbGate Blog",
-        "url": "https://thumbgate-production.up.railway.app/blog",
+        "url": "https://thumbgate.ai/blog",
         "publisher": { "@type": "Organization", "name": "ThumbGate" },
         "blogPost": [
           {

--- a/public/codex-enterprise.html
+++ b/public/codex-enterprise.html
@@ -9,8 +9,8 @@
 <meta property="og:title" content="ThumbGate for Codex in the Enterprise">
 <meta property="og:description" content="Dell-distributed or self-hosted, Codex agents repeat the same mistakes. ThumbGate is the governance layer underneath — capture, promote, audit.">
 <meta property="og:type" content="article">
-<meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/codex-enterprise">
+<meta property="og:image" content="https://thumbgate.ai/og.png">
+<link rel="canonical" href="https://thumbgate.ai/codex-enterprise">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -20,7 +20,7 @@
   "datePublished": "2026-05-20",
   "dateModified": "2026-05-20",
   "author": { "@type": "Person", "name": "Igor Ganapolsky", "url": "https://github.com/IgorGanapolsky" },
-  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate-production.up.railway.app" },
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
   "about": [
     { "@type": "Thing", "name": "OpenAI Codex" },
     { "@type": "Thing", "name": "Dell Codex Enterprise" },

--- a/public/codex-plugin.html
+++ b/public/codex-plugin.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="ThumbGate for Codex">
 <meta property="og:description" content="Auto-updating MCP and hook launcher for Codex. One install, then ThumbGate resolves the latest npm runtime when Codex starts.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/codex-plugin">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/codex-plugin">
+<meta property="og:url" content="https://thumbgate.ai/codex-plugin">
+<link rel="canonical" href="https://thumbgate.ai/codex-plugin">
 <link rel="llm-context" href="/llm-context.md" type="text/markdown">
 
 <script type="application/ld+json">
@@ -22,9 +22,9 @@
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "macOS, Linux, Windows with Node.js",
   "description": "ThumbGate for Codex installs an MCP server and hook launcher that resolves thumbgate@latest at startup, captures thumbs-up/down feedback, and enforces Pre-Action Checks before risky agent actions run.",
-  "url": "https://thumbgate-production.up.railway.app/codex-plugin",
+  "url": "https://thumbgate.ai/codex-plugin",
   "downloadUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip",
-  "installUrl": "https://thumbgate-production.up.railway.app/codex-plugin",
+  "installUrl": "https://thumbgate.ai/codex-plugin",
   "license": "https://opensource.org/licenses/MIT",
   "dateModified": "2026-04-20",
   "creator": {

--- a/public/compare.html
+++ b/public/compare.html
@@ -11,8 +11,8 @@
 <meta property="og:title" content="Best Pre-Action Check Tools for AI Coding Agents (2026 Comparison)">
 <meta property="og:description" content="Compare pre-action check tools that prevent AI coding agents from making costly mistakes. ThumbGate vs manual review vs post-hoc fixes.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/compare">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/compare">
+<meta property="og:url" content="https://thumbgate.ai/compare">
+<link rel="canonical" href="https://thumbgate.ai/compare">
 
 <script type="application/ld+json">
 {
@@ -28,11 +28,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-08",
   "dateModified": "2026-04-08",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/compare"
+  "mainEntityOfPage": "https://thumbgate.ai/compare"
 }
 </script>
 
@@ -62,7 +62,7 @@
       "name": "Is ThumbGate free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate has a free tier that includes local enforcement with 10 feedback captures/day, 50 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard."
+        "text": "ThumbGate has a free tier that includes local enforcement with 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard."
       }
     },
     {
@@ -311,7 +311,7 @@
 
 <div class="card">
   <h3>Is ThumbGate free?</h3>
-  <p>ThumbGate has a free tier that includes local enforcement with 10 feedback captures/day, 50 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard.</p>
+  <p>ThumbGate has a free tier that includes local enforcement with 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard.</p>
 </div>
 
 <div class="card">

--- a/public/compare/ai-experience-orchestration.html
+++ b/public/compare/ai-experience-orchestration.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="AI Experience Orchestration vs AI Agent Enforcement">
 <meta property="og:description" content="Broad orchestration platforms route data and decisions. ThumbGate enforces what an AI agent is allowed to execute.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/compare/ai-experience-orchestration">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/compare/ai-experience-orchestration">
+<meta property="og:url" content="https://thumbgate.ai/compare/ai-experience-orchestration">
+<link rel="canonical" href="https://thumbgate.ai/compare/ai-experience-orchestration">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-22",
   "dateModified": "2026-04-22",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/compare/ai-experience-orchestration"
+  "mainEntityOfPage": "https://thumbgate.ai/compare/ai-experience-orchestration"
 }
 </script>
 

--- a/public/compare/heidi.html
+++ b/public/compare/heidi.html
@@ -154,7 +154,7 @@
             <tr>
               <td>Pricing</td>
               <td>Free</td>
-              <td>Free CLI (3 active rules, 10 captures/day) → $19/mo Pro for unlimited</td>
+              <td>Free CLI (3 active rules, 5 captures/day) → $19/mo Pro for unlimited</td>
             </tr>
             <tr>
               <td>Maker</td>

--- a/public/compare/rein.html
+++ b/public/compare/rein.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="ThumbGate vs Rein — Coding-Agent Governance vs Generic Decorator Governance">
 <meta property="og:description" content="Both intercept agent actions before damage. Different layers, different domains, different licenses. Honest side-by-side.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/compare/rein">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/compare/rein">
+<meta property="og:url" content="https://thumbgate.ai/compare/rein">
+<link rel="canonical" href="https://thumbgate.ai/compare/rein">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-05-15",
   "dateModified": "2026-05-15",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/compare/rein"
+  "mainEntityOfPage": "https://thumbgate.ai/compare/rein"
 }
 </script>
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ThumbGate Dashboard — Gate Stats, Agent Inventory, Remediations</title>
 <meta name="description" content="Live ThumbGate dashboard showing gate enforcement stats, agent surface inventory, actionable remediations, prevention impact, and system health for pre-action checks.">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/dashboard">
+<link rel="canonical" href="https://thumbgate.ai/dashboard">
 <link rel="icon" type="image/png" href="/thumbgate-icon.png">
 <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
 <meta name="robots" content="noindex">
@@ -18,7 +18,7 @@
   "name": "ThumbGate Dashboard",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "url": "https://thumbgate-production.up.railway.app/dashboard",
+  "url": "https://thumbgate.ai/dashboard",
   "dateModified": "2026-04-20",
   "creator": {
     "@type": "Person",

--- a/public/guide.html
+++ b/public/guide.html
@@ -11,8 +11,8 @@
 <meta property="og:title" content="How to Stop AI Coding Agents From Repeating Mistakes">
 <meta property="og:description" content="Pre-action checks that physically block AI agents from repeating known mistakes. The complete guide.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/guide">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/guide">
+<meta property="og:url" content="https://thumbgate.ai/guide">
+<link rel="canonical" href="https://thumbgate.ai/guide">
 
 <script type="application/ld+json">
 {
@@ -28,11 +28,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-03-27",
   "dateModified": "2026-04-25",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/guide",
+  "mainEntityOfPage": "https://thumbgate.ai/guide",
   "about": [
     {"@type": "Thing", "name": "AI coding agents"},
     {"@type": "Thing", "name": "Model Context Protocol"},
@@ -379,7 +379,7 @@ npx thumbgate init --agent gemini</code></pre>
 <a rel="nofollow noopener noreferrer" target="_blank" href="https://buy.stripe.com/00w14neyUcXA5pL5e33sI0e" class="cta cta-secondary">Pay $499 diagnostic</a>
 <a rel="nofollow noopener noreferrer" target="_blank" href="https://buy.stripe.com/fZu9AT76saPsg4pbCr3sI0f" class="cta cta-secondary">Pay $1500 sprint</a>
 <a href="https://thumbgate.ai/#workflow-sprint-intake" class="cta cta-secondary">Send workflow first</a>
-<p style="color:var(--muted); font-size:0.85rem;">Free: 10 captures/day, 50 total captures, 3 active prevention rules, hook blocking. Pro: hosted sync, dashboard, recall, lesson search, unlimited captures/rules, DPO export. Team: intake first, then $49/seat/mo with a 3-seat minimum.</p>
+<p style="color:var(--muted); font-size:0.85rem;">Free: 5 captures/day, 25 total captures, 3 active prevention rules, hook blocking. Pro: hosted sync, dashboard, recall, lesson search, unlimited captures/rules, DPO export. Team: intake first, then $49/seat/mo with a 3-seat minimum.</p>
 
 </div>
 </body>

--- a/public/guides/claude-code-prevent-repeated-mistakes.html
+++ b/public/guides/claude-code-prevent-repeated-mistakes.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="Claude Code Feedback Memory That Actually Enforces">
 <meta property="og:description" content="Claude Code can remember more when the memory is structured, but reliability improves when thumbs-up/down feedback also becomes enforceable behavior.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/guides/claude-code-prevent-repeated-mistakes">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/guides/claude-code-prevent-repeated-mistakes">
+<meta property="og:url" content="https://thumbgate.ai/guides/claude-code-prevent-repeated-mistakes">
+<link rel="canonical" href="https://thumbgate.ai/guides/claude-code-prevent-repeated-mistakes">
 <link rel="llm-context" href="/llm-context.md" type="text/markdown">
 
 <script type="application/ld+json">
@@ -28,11 +28,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-09",
   "dateModified": "2026-04-09",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/guides/claude-code-prevent-repeated-mistakes",
+  "mainEntityOfPage": "https://thumbgate.ai/guides/claude-code-prevent-repeated-mistakes",
   "about": [
     {"@type": "Thing", "name": "Claude Code memory"},
     {"@type": "Thing", "name": "feedback enforcement"},

--- a/public/guides/cursor-prevent-repeated-mistakes.html
+++ b/public/guides/cursor-prevent-repeated-mistakes.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="Cursor Guardrails That Block Repeated Mistakes">
 <meta property="og:description" content="Cursor moves fast, which makes repeated mistakes expensive. ThumbGate gives Cursor users a feedback loop that turns thumbs-down corrections into pre-action checks.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/guides/cursor-prevent-repeated-mistakes">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/guides/cursor-prevent-repeated-mistakes">
+<meta property="og:url" content="https://thumbgate.ai/guides/cursor-prevent-repeated-mistakes">
+<link rel="canonical" href="https://thumbgate.ai/guides/cursor-prevent-repeated-mistakes">
 <link rel="llm-context" href="/llm-context.md" type="text/markdown">
 
 <script type="application/ld+json">
@@ -28,11 +28,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-09",
   "dateModified": "2026-04-09",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/guides/cursor-prevent-repeated-mistakes",
+  "mainEntityOfPage": "https://thumbgate.ai/guides/cursor-prevent-repeated-mistakes",
   "about": [
     {"@type": "Thing", "name": "Cursor guardrails"},
     {"@type": "Thing", "name": "AI coding agent safety"},

--- a/public/index.html
+++ b/public/index.html
@@ -17,9 +17,9 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:description" content="Frontier LLMs are expensive, opaque, and unreliable in production. ThumbGate gates risky agent actions before they run: workflow shape, inspection evidence, token budget, and repeated-failure memory in one pre-action check.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="__APP_ORIGIN__/">
-<meta property="og:image" content="https://thumbgate-production.up.railway.app/og.png">
+<meta property="og:image" content="https://thumbgate.ai/og.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://thumbgate-production.up.railway.app/og.png">
+<meta name="twitter:image" content="https://thumbgate.ai/og.png">
 <meta name="thumbgate-version" content="1.23.1">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="canonical" href="__APP_ORIGIN__/">
@@ -45,8 +45,8 @@ __GA_BOOTSTRAP__
   "@type": "Organization",
   "name": "ThumbGate",
   "alternateName": "thumbgate",
-  "url": "https://thumbgate-production.up.railway.app",
-  "logo": "https://thumbgate-production.up.railway.app/assets/brand/thumbgate-logo-1200x360.png",
+  "url": "https://thumbgate.ai",
+  "logo": "https://thumbgate.ai/assets/brand/thumbgate-logo-1200x360.png",
   "description": "ThumbGate ships pre-action gates for AI coding agents. Open-source CLI plus PreToolUse hooks that capture feedback, promote it to memory, generate prevention rules, and block repeated mistakes before the next tool call across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode.",
   "founder": {
     "@type": "Person",
@@ -119,7 +119,7 @@ __GA_BOOTSTRAP__
       "price": "49",
       "priceCurrency": "USD",
       "description": "Intake-led team rollout with a workflow hardening sprint, shared enforcement memory, org dashboard visibility, approval boundaries, release confidence, Docker Sandboxes guidance for risky local autonomy, and pilot support for teams shipping AI-generated changes",
-      "url": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+      "url": "https://thumbgate.ai/#workflow-sprint-intake"
     },
     {
       "@type": "Offer",
@@ -127,7 +127,7 @@ __GA_BOOTSTRAP__
       "price": "19",
       "priceCurrency": "USD",
       "description": "Self-serve side lane for solo operators who want personal enforcement proof, a local dashboard, DPO export, team lesson export/import, and proof-ready exports",
-      "url": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&landing_path=%2F"
+      "url": "https://thumbgate.ai/checkout/pro?plan_id=pro&landing_path=%2F"
     },
     {
       "@type": "Offer",
@@ -135,7 +135,7 @@ __GA_BOOTSTRAP__
       "price": "149",
       "priceCurrency": "USD",
       "description": "Annual Pro for individual operators who want personal enforcement proof, the local dashboard, and proof-ready exports",
-      "url": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&billing_cycle=annual&landing_path=%2F"
+      "url": "https://thumbgate.ai/checkout/pro?plan_id=pro&billing_cycle=annual&landing_path=%2F"
     }
   ],
   "potentialAction": [
@@ -144,7 +144,7 @@ __GA_BOOTSTRAP__
       "name": "Install ThumbGate Free",
       "target": {
         "@type": "EntryPoint",
-        "urlTemplate": "https://thumbgate-production.up.railway.app/guide",
+        "urlTemplate": "https://thumbgate.ai/guide",
         "actionPlatform": [
           "https://schema.org/DesktopWebPlatform"
         ]
@@ -155,7 +155,7 @@ __GA_BOOTSTRAP__
       "name": "Start ThumbGate Pro",
       "target": {
         "@type": "EntryPoint",
-        "urlTemplate": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&landing_path=%2F",
+        "urlTemplate": "https://thumbgate.ai/checkout/pro?plan_id=pro&landing_path=%2F",
         "actionPlatform": [
           "https://schema.org/DesktopWebPlatform"
         ]
@@ -165,7 +165,7 @@ __GA_BOOTSTRAP__
         "name": "Pro Monthly",
         "price": "19",
         "priceCurrency": "USD",
-        "url": "https://thumbgate-production.up.railway.app/checkout/pro?plan_id=pro&landing_path=%2F"
+        "url": "https://thumbgate.ai/checkout/pro?plan_id=pro&landing_path=%2F"
       }
     },
     {
@@ -173,7 +173,7 @@ __GA_BOOTSTRAP__
       "name": "Start Workflow Hardening Sprint intake",
       "target": {
         "@type": "EntryPoint",
-        "urlTemplate": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+        "urlTemplate": "https://thumbgate.ai/#workflow-sprint-intake",
         "actionPlatform": [
           "https://schema.org/DesktopWebPlatform"
         ]
@@ -192,21 +192,21 @@ __GA_BOOTSTRAP__
   "provider": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
-  "url": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+  "url": "https://thumbgate.ai/#workflow-sprint-intake",
   "description": "Founder-led workflow hardening for one AI-agent workflow that needs approval boundaries, rollback safety, and rollout proof before wider team rollout.",
   "offers": {
     "@type": "Offer",
     "name": "Workflow Hardening Sprint intake",
-    "url": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake"
+    "url": "https://thumbgate.ai/#workflow-sprint-intake"
   },
   "potentialAction": {
     "@type": "CommunicateAction",
     "name": "Book a workflow hardening intake",
     "target": {
       "@type": "EntryPoint",
-      "urlTemplate": "https://thumbgate-production.up.railway.app/#workflow-sprint-intake",
+      "urlTemplate": "https://thumbgate.ai/#workflow-sprint-intake",
       "actionPlatform": [
         "https://schema.org/DesktopWebPlatform"
       ]
@@ -1305,9 +1305,9 @@ __GA_BOOTSTRAP__
         <div class="tier" style="color:var(--cyan);">Free</div>
         <div class="price">$0</div>
         <div class="price-sub">Block repeated mistakes daily. Forever free for solo devs.</div>
-        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">10 captures/day, 3 active rules. Enough to see the value — upgrade when you need more.</p>
+        <p style="font-size:13px;color:#aaa;margin-bottom:16px;">5 captures/day, 3 active rules. Enough to see the value — upgrade when you need more.</p>
         <ul>
-          <li><strong>10 feedback captures/day</strong> — 50 total on Free, then Pro for unlimited</li>
+          <li><strong>5 feedback captures/day</strong> — 25 total on Free, then Pro for unlimited</li>
           <li>Up to 3 active auto-promoted prevention rules</li>
           <li>No recall or lesson search</li>
           <li>No exports (DPO, Databricks, HuggingFace)</li>
@@ -1479,7 +1479,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">Do I need a cloud account?</div>
-        <div class="faq-a">No. Free keeps local enforcement on your machine with 10 feedback captures/day, up to 3 active auto-promoted prevention rules, built-in safety checks, and hook blocking. Recall, lesson search, unlimited rules, unlimited captures, and exports open up on Pro. No cloud account is required. The business starts when a team wants shared rules, approval boundaries, hosted review views, org dashboard visibility, and proof that survives handoffs. Pro is the optional solo side lane for a personal dashboard, DPO export, and team lesson export/import — share lessons across projects so one team's mistakes become every team's prevention rules.</div>
+        <div class="faq-a">No. Free keeps local enforcement on your machine with 5 feedback captures/day, up to 3 active auto-promoted prevention rules, built-in safety checks, and hook blocking. Recall, lesson search, unlimited rules, unlimited captures, and exports open up on Pro. No cloud account is required. The business starts when a team wants shared rules, approval boundaries, hosted review views, org dashboard visibility, and proof that survives handoffs. Pro is the optional solo side lane for a personal dashboard, DPO export, and team lesson export/import — share lessons across projects so one team's mistakes become every team's prevention rules.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What if my thumbs-down is vague?</div>

--- a/public/learn.html
+++ b/public/learn.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="Learn — AI Agent Safety Guides by ThumbGate">
 <meta property="og:description" content="Practical guides for stopping AI coding agent mistakes with pre-action checks and feedback-driven enforcement.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn">
+<meta property="og:url" content="https://thumbgate.ai/learn">
+<link rel="canonical" href="https://thumbgate.ai/learn">
 <link rel="icon" type="image/png" href="/thumbgate-icon.png">
 <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
 
@@ -21,7 +21,7 @@
   "@type": "CollectionPage",
   "name": "ThumbGate Learning Hub",
   "description": "Practical guides for AI coding agent safety, pre-action checks, and vibe coding guardrails.",
-  "url": "https://thumbgate-production.up.railway.app/learn",
+  "url": "https://thumbgate.ai/learn",
   "dateModified": "2026-04-20",
   "author": {
     "@type": "Person",
@@ -35,7 +35,7 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "mainEntity": {
     "@type": "ItemList",
@@ -43,25 +43,25 @@
       {
         "@type": "ListItem",
         "position": 1,
-        "url": "https://thumbgate-production.up.railway.app/learn/stop-ai-agent-force-push",
+        "url": "https://thumbgate.ai/learn/stop-ai-agent-force-push",
         "name": "How to Stop AI Agents From Force-Pushing to Main"
       },
       {
         "@type": "ListItem",
         "position": 2,
-        "url": "https://thumbgate-production.up.railway.app/learn/vibe-coding-safety-net",
+        "url": "https://thumbgate.ai/learn/vibe-coding-safety-net",
         "name": "The Vibe Coding Safety Net You Are Missing"
       },
       {
         "@type": "ListItem",
         "position": 3,
-        "url": "https://thumbgate-production.up.railway.app/learn/mcp-pre-action-checks-explained",
+        "url": "https://thumbgate.ai/learn/mcp-pre-action-checks-explained",
         "name": "MCP Pre-Action Checks Explained"
       },
       {
         "@type": "ListItem",
         "position": 4,
-        "url": "https://thumbgate-production.up.railway.app/learn/agent-harness-pattern",
+        "url": "https://thumbgate.ai/learn/agent-harness-pattern",
         "name": "The Agent Harness Pattern: Why Your AI Needs a Seatbelt"
       },
       {
@@ -73,7 +73,7 @@
       {
         "@type": "ListItem",
         "position": 6,
-        "url": "https://thumbgate-production.up.railway.app/learn/ai-agent-persistent-memory",
+        "url": "https://thumbgate.ai/learn/ai-agent-persistent-memory",
         "name": "How to Give Your AI Coding Agent Persistent Memory Across Sessions"
       },
       {

--- a/public/learn/agent-harness-pattern.html
+++ b/public/learn/agent-harness-pattern.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="The Agent Harness Pattern: Why Your AI Needs a Seatbelt">
 <meta property="og:description" content="Academic research meets production code. How the natural-language agent harness pattern maps to real pre-action checks.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/agent-harness-pattern">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/agent-harness-pattern">
+<meta property="og:url" content="https://thumbgate.ai/learn/agent-harness-pattern">
+<link rel="canonical" href="https://thumbgate.ai/learn/agent-harness-pattern">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-02",
   "dateModified": "2026-04-02",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/agent-harness-pattern",
+  "mainEntityOfPage": "https://thumbgate.ai/learn/agent-harness-pattern",
   "about": [
     {"@type": "Thing", "name": "agent harness pattern"},
     {"@type": "Thing", "name": "natural language agent harness"},

--- a/public/learn/agent-swarms-shared-gates.html
+++ b/public/learn/agent-swarms-shared-gates.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="Agent Swarms: One Gate Layer, Every Model">
 <meta property="og:description" content="Why multi-agent swarms need shared gates, not duplicated rules — and how a single MCP layer makes Opus, GPT, and Gemini fail the same way only once.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/agent-swarms-shared-gates">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/agent-swarms-shared-gates">
+<meta property="og:url" content="https://thumbgate.ai/learn/agent-swarms-shared-gates">
+<link rel="canonical" href="https://thumbgate.ai/learn/agent-swarms-shared-gates">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-05-18",
   "dateModified": "2026-05-18",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/agent-swarms-shared-gates",
+  "mainEntityOfPage": "https://thumbgate.ai/learn/agent-swarms-shared-gates",
   "about": [
     {"@type": "Thing", "name": "agent swarm"},
     {"@type": "Thing", "name": "multi-agent system"},

--- a/public/learn/ai-agent-governance.html
+++ b/public/learn/ai-agent-governance.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="AI Agent Governance — The Four Layers Pattern">
 <meta property="og:description" content="Four governance layers exist for AI agents. Each catches a different failure mode. Picking the right one is the whole game.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/ai-agent-governance">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/ai-agent-governance">
+<meta property="og:url" content="https://thumbgate.ai/learn/ai-agent-governance">
+<link rel="canonical" href="https://thumbgate.ai/learn/ai-agent-governance">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-05-15",
   "dateModified": "2026-05-15",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/ai-agent-governance"
+  "mainEntityOfPage": "https://thumbgate.ai/learn/ai-agent-governance"
 }
 </script>
 

--- a/public/learn/ai-agent-persistent-memory.html
+++ b/public/learn/ai-agent-persistent-memory.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="How to Give Your AI Coding Agent Persistent Memory Across Sessions">
 <meta property="og:description" content="Context windows are ephemeral. Real memory persists. Here is how to build durable memory for any MCP-compatible AI coding agent.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/ai-agent-persistent-memory">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/ai-agent-persistent-memory">
+<meta property="og:url" content="https://thumbgate.ai/learn/ai-agent-persistent-memory">
+<link rel="canonical" href="https://thumbgate.ai/learn/ai-agent-persistent-memory">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-02",
   "dateModified": "2026-04-02",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/ai-agent-persistent-memory",
+  "mainEntityOfPage": "https://thumbgate.ai/learn/ai-agent-persistent-memory",
   "about": [
     {"@type": "Thing", "name": "ai agent memory"},
     {"@type": "Thing", "name": "persistent memory"},

--- a/public/learn/claude-code-goal-with-rubrics.html
+++ b/public/learn/claude-code-goal-with-rubrics.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="Claude Code /goal vs Todo: The 4-Field Pattern That Actually Holds">
 <meta property="og:description" content="The /goal command becomes ten times more useful when you treat it as a verifiable contract, not a todo. Here is the 4-field pattern and how to enforce it.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/claude-code-goal-with-rubrics">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/claude-code-goal-with-rubrics">
+<meta property="og:url" content="https://thumbgate.ai/learn/claude-code-goal-with-rubrics">
+<link rel="canonical" href="https://thumbgate.ai/learn/claude-code-goal-with-rubrics">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-05-18",
   "dateModified": "2026-05-18",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/claude-code-goal-with-rubrics",
+  "mainEntityOfPage": "https://thumbgate.ai/learn/claude-code-goal-with-rubrics",
   "about": [
     {"@type": "Thing", "name": "Claude Code /goal command"},
     {"@type": "Thing", "name": "AI agent rubric"},

--- a/public/learn/mcp-pre-action-checks-explained.html
+++ b/public/learn/mcp-pre-action-checks-explained.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="MCP Pre-Action Checks Explained">
 <meta property="og:description" content="Technical deep-dive: how pre-action checks intercept tool calls and enforce safety rules for AI coding agents.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/mcp-pre-action-checks-explained">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/mcp-pre-action-checks-explained">
+<meta property="og:url" content="https://thumbgate.ai/learn/mcp-pre-action-checks-explained">
+<link rel="canonical" href="https://thumbgate.ai/learn/mcp-pre-action-checks-explained">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-01",
   "dateModified": "2026-04-01",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/mcp-pre-action-checks-explained",
+  "mainEntityOfPage": "https://thumbgate.ai/learn/mcp-pre-action-checks-explained",
   "about": [
     {"@type": "Thing", "name": "Model Context Protocol"},
     {"@type": "Thing", "name": "PreToolUse hooks"},

--- a/public/learn/regulated-agent-execution-boundary.html
+++ b/public/learn/regulated-agent-execution-boundary.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="The $1.4M Cost of Building Agent Guardrails — And Why Pre-Action Gates Are the Buy-Side Answer">
 <meta property="og:description" content="Bryan Ross at GitLab argued buy-don't-build for agentic AI platforms in regulated industries. He's right — and there's one layer the article didn't name. Even after you buy the platform, agents still touch prod.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/regulated-agent-execution-boundary">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/regulated-agent-execution-boundary">
+<meta property="og:url" content="https://thumbgate.ai/learn/regulated-agent-execution-boundary">
+<link rel="canonical" href="https://thumbgate.ai/learn/regulated-agent-execution-boundary">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-05-18",
   "dateModified": "2026-05-18",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/regulated-agent-execution-boundary",
+  "mainEntityOfPage": "https://thumbgate.ai/learn/regulated-agent-execution-boundary",
   "citation": {
     "@type": "Article",
     "headline": "The hidden cost of build vs. buy for agentic AI in regulated industries",

--- a/public/learn/spec-driven-development.html
+++ b/public/learn/spec-driven-development.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="Spec-Driven Development for AI Agents — Runtime Enforcement with ThumbGate">
 <meta property="og:description" content="Writing the spec is half the work. The other half is making the agent stay inside it. ThumbGate gates tool calls against your spec so drift is blocked at the hook layer.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/spec-driven-development">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/spec-driven-development">
+<meta property="og:url" content="https://thumbgate.ai/learn/spec-driven-development">
+<link rel="canonical" href="https://thumbgate.ai/learn/spec-driven-development">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-05-14",
   "dateModified": "2026-05-14",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/spec-driven-development"
+  "mainEntityOfPage": "https://thumbgate.ai/learn/spec-driven-development"
 }
 </script>
 

--- a/public/learn/stop-ai-agent-force-push.html
+++ b/public/learn/stop-ai-agent-force-push.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="How to Stop AI Agents From Force-Pushing to Main">
 <meta property="og:description" content="Make force-push to main physically impossible for your AI coding agent with a pre-action check.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/stop-ai-agent-force-push">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/stop-ai-agent-force-push">
+<meta property="og:url" content="https://thumbgate.ai/learn/stop-ai-agent-force-push">
+<link rel="canonical" href="https://thumbgate.ai/learn/stop-ai-agent-force-push">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-01",
   "dateModified": "2026-04-01",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/stop-ai-agent-force-push",
+  "mainEntityOfPage": "https://thumbgate.ai/learn/stop-ai-agent-force-push",
   "about": [
     {"@type": "Thing", "name": "git force push prevention"},
     {"@type": "Thing", "name": "AI coding agent safety"},

--- a/public/learn/vibe-coding-safety-net.html
+++ b/public/learn/vibe-coding-safety-net.html
@@ -10,8 +10,8 @@
 <meta property="og:title" content="The Vibe Coding Safety Net You Are Missing">
 <meta property="og:description" content="Vibe coding is fast until your AI agent breaks something. Add guardrails without slowing down.">
 <meta property="og:type" content="article">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/learn/vibe-coding-safety-net">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/learn/vibe-coding-safety-net">
+<meta property="og:url" content="https://thumbgate.ai/learn/vibe-coding-safety-net">
+<link rel="canonical" href="https://thumbgate.ai/learn/vibe-coding-safety-net">
 
 <script type="application/ld+json">
 {
@@ -27,11 +27,11 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   },
   "datePublished": "2026-04-01",
   "dateModified": "2026-04-01",
-  "mainEntityOfPage": "https://thumbgate-production.up.railway.app/learn/vibe-coding-safety-net"
+  "mainEntityOfPage": "https://thumbgate.ai/learn/vibe-coding-safety-net"
 }
 </script>
 

--- a/public/lessons.html
+++ b/public/lessons.html
@@ -12,7 +12,7 @@
   "@context": "https://schema.org",
   "@type": "WebPage",
   "name": "ThumbGate Lessons Learned",
-  "url": "https://thumbgate-production.up.railway.app/lessons",
+  "url": "https://thumbgate.ai/lessons",
   "dateModified": "2026-04-20",
   "author": {
     "@type": "Person",
@@ -26,7 +26,7 @@
   "publisher": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "https://thumbgate-production.up.railway.app"
+    "url": "https://thumbgate.ai"
   }
 }
 </script>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -127,7 +127,7 @@ This alignment means ThumbGate is not an experimental tool — it implements the
 ## Pricing
 
 - **Free GPT**: Advice, checkpointing, setup help, and typed thumbs-up/down memory capture inside ChatGPT.
-- **Free local CLI**: Local enforcement for individual developers after install. Includes 10 feedback captures/day, 50 total captures, up to 3 active auto-promoted prevention rules, and PreToolUse hook blocking. Recall, lesson search, unlimited captures/rules, and exports are Pro-only.
+- **Free local CLI**: Local enforcement for individual developers after install. Includes 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and PreToolUse hook blocking. Recall, lesson search, unlimited captures/rules, and exports are Pro-only.
 - **Workflow Hardening Sprint / Team**: Team pricing anchors at $49/seat/mo with a 3-seat minimum after qualification. The first paid step is an intake-led sprint around one workflow, one repeated blocker, and one proof review.
 - **Pro**: $19/mo or $149/yr. Adds personal enforcement proof, a local dashboard, DPO export for fine-tuning, a check debugger, and advanced data exports for solo operators who want a self-serve side lane.
 
@@ -165,11 +165,11 @@ npx thumbgate dashboard
 
 ## Additional Resources
 
-- Agent discovery manifest: https://thumbgate-production.up.railway.app/.well-known/mcp.json
-- Progressive MCP tool index: https://thumbgate-production.up.railway.app/.well-known/mcp/tools.json
-- Context footprint report: https://thumbgate-production.up.railway.app/.well-known/mcp/footprint.json
-- ThumbGate skill manifests: https://thumbgate-production.up.railway.app/.well-known/mcp/skills.json
-- ThumbGate MCP applications: https://thumbgate-production.up.railway.app/.well-known/mcp/applications.json
+- Agent discovery manifest: https://thumbgate.ai/.well-known/mcp.json
+- Progressive MCP tool index: https://thumbgate.ai/.well-known/mcp/tools.json
+- Context footprint report: https://thumbgate.ai/.well-known/mcp/footprint.json
+- ThumbGate skill manifests: https://thumbgate.ai/.well-known/mcp/skills.json
+- ThumbGate MCP applications: https://thumbgate.ai/.well-known/mcp/applications.json
 - Marketing site: https://thumbgate.ai
 - Browser automation safety guide: https://thumbgate.ai/guides/browser-automation-safety
 - Native messaging host security guide: https://thumbgate.ai/guides/native-messaging-host-security

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -10,9 +10,9 @@
 <meta property="og:title" content="ThumbGate — The Numbers">
 <meta property="og:description" content="Generated first-party operational snapshot: configured gates, recorded interventions, and explicit zero-evidence caveats.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://thumbgate-production.up.railway.app/numbers">
+<meta property="og:url" content="https://thumbgate.ai/numbers">
 <meta name="twitter:card" content="summary_large_image">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/numbers">
+<link rel="canonical" href="https://thumbgate.ai/numbers">
 <link rel="icon" type="image/png" href="/thumbgate-icon.png">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <script defer data-domain="thumbgate-production.up.railway.app" src="https://plausible.io/js/script.js"></script>
@@ -26,7 +26,7 @@
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
   "softwareVersion": "1.23.1",
-  "url": "https://thumbgate-production.up.railway.app/numbers",
+  "url": "https://thumbgate.ai/numbers",
   "dateModified": "2026-05-07",
   "creator": {
     "@type": "Person",
@@ -46,7 +46,7 @@
   "@type": "Dataset",
   "name": "ThumbGate Operational Snapshot",
   "description": "First-party operational snapshot from the ThumbGate pre-action check runtime: configured checks, recorded block/warn events, estimated token savings from recorded blocks, and Bayes error rate when the sample supports it.",
-  "url": "https://thumbgate-production.up.railway.app/numbers",
+  "url": "https://thumbgate.ai/numbers",
   "license": "https://opensource.org/licenses/MIT",
   "creator": {
     "@type": "Person",

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -50,7 +50,7 @@ __GA_BOOTSTRAP__
   "@context": "https://schema.org",
   "@type": "FAQPage",
   "mainEntity": [
-    { "@type": "Question", "name": "What does Pro add over the free CLI?", "acceptedAnswer": { "@type": "Answer", "text": "Free gives you 10 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for infrastructure we run, not features we hide." } },
+    { "@type": "Question", "name": "What does Pro add over the free CLI?", "acceptedAnswer": { "@type": "Answer", "text": "Free gives you 5 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for infrastructure we run, not features we hide." } },
     { "@type": "Question", "name": "Does ThumbGate send my code to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. The CLI is local-first — no data leaves your machine. Pro and Team add hosted sync for dashboards and shared lessons, but your source code stays local." } },
     { "@type": "Question", "name": "When should I pick Team over Pro?", "acceptedAnswer": { "@type": "Answer", "text": "When one engineer's correction should protect the whole team. Team shares the lesson database across seats so a fix in one repo prevents the same mistake in every repo." } },
     { "@type": "Question", "name": "Can I cancel anytime?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Pro and Team are month-to-month with a 7-day refund window on the first charge. Cancel from the billing portal and your subscription ends at the period close." } }
@@ -238,7 +238,7 @@ __GA_BOOTSTRAP__
       <div class="price">$0</div>
       <div class="price-sub">Block repeated mistakes daily. Forever free for solo devs.</div>
       <ul>
-        <li>10 feedback captures/day (50 total) — enough to see the value</li>
+        <li>5 feedback captures/day (25 total) — enough to see the value</li>
         <li>Up to 3 active prevention rules</li>
         <li>All MCP integrations (Claude Code, Cursor, Codex, Gemini, Amp)</li>
         <li>PreToolUse hook blocking with built-in safety checks</li>
@@ -297,7 +297,7 @@ __GA_BOOTSTRAP__
     <div class="faq-list">
       <div class="faq-item">
         <div class="faq-q">What does Pro add over the free CLI?</div>
-        <div class="faq-a">Free gives you 10 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for infrastructure we run, not features we hide.</div>
+        <div class="faq-a">Free gives you 5 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for infrastructure we run, not features we hide.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q">Does ThumbGate send my code to the cloud?</div>

--- a/public/use-cases/platform-teams.html
+++ b/public/use-cases/platform-teams.html
@@ -9,7 +9,7 @@
 <meta property="og:title" content="ThumbGate for Platform Teams">
 <meta property="og:description" content="Standardize AI agent behavior across repos and workflows with Pre-Action Checks, shared lessons, and proof-backed rollout patterns.">
 <meta property="og:type" content="article">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/use-cases/platform-teams">
+<link rel="canonical" href="https://thumbgate.ai/use-cases/platform-teams">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/public/use-cases/regulated-workflows.html
+++ b/public/use-cases/regulated-workflows.html
@@ -9,7 +9,7 @@
 <meta property="og:title" content="ThumbGate for Regulated AI Workflows">
 <meta property="og:description" content="Keep approval boundaries, evidence, and execution control attached to AI agent actions in finance, healthcare, and other high-trust workflows.">
 <meta property="og:type" content="article">
-<link rel="canonical" href="https://thumbgate-production.up.railway.app/use-cases/regulated-workflows">
+<link rel="canonical" href="https://thumbgate.ai/use-cases/regulated-workflows">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/scripts/ai-search-visibility.js
+++ b/scripts/ai-search-visibility.js
@@ -15,10 +15,22 @@ const PROMPTS = [
   'workflow vs agent reliability for coding agents',
   'how to require environment inspection before AI agent actions',
   'how to block bad tool calls in AI agents',
+  'local pre-action gates for AI agents',
+  'agent governance platform for Claude Code Cursor Codex',
+  'AI agent audit trail and approval gates',
   'alternatives to thumbgate',
   'pre-tool-use hooks for AI agents',
   'AI coding agent memory and learning',
 ];
+
+const DISCOVERY_SURFACES = Object.freeze([
+  { surface: 'canonical_site', url: 'https://thumbgate.ai/', purpose: 'human and crawler canonical landing page' },
+  { surface: 'llms_txt', url: 'https://thumbgate.ai/llms.txt', purpose: 'LLM-readable product map' },
+  { surface: 'well_known_llms_txt', url: 'https://thumbgate.ai/.well-known/llms.txt', purpose: 'well-known LLM discovery path' },
+  { surface: 'llm_context', url: 'https://thumbgate.ai/llm-context.md', purpose: 'long-form answer context for AI search systems' },
+  { surface: 'openapi', url: 'https://thumbgate.ai/openapi.yaml', purpose: 'GPT Actions and tool import schema' },
+  { surface: 'sitemap', url: 'https://thumbgate.ai/sitemap.xml', purpose: 'canonical crawl route inventory' },
+]);
 
 async function queryPerplexity(prompt, apiKey, opts = {}) {
   const client = opts.client || new PerplexityClient({ apiKey });
@@ -79,6 +91,11 @@ function formatReport(results) {
   } else {
     lines.push('', `Manual checklist: ${results.length} prompts to test`);
   }
+  lines.push('', 'Discovery surfaces to verify:');
+  for (const surface of DISCOVERY_SURFACES) {
+    lines.push(`- ${surface.surface}: ${surface.url} — ${surface.purpose}`);
+  }
+  lines.push('', 'Distribution note: crawler files make ThumbGate eligible for discovery; citations still require third-party mentions, backlinks, and prompt-match content.');
   return lines.join('\n');
 }
 
@@ -94,6 +111,7 @@ function saveReport(results, opts = {}) {
   const report = {
     date,
     score: total > 0 ? `${found}/${total}` : 'manual',
+    discoverySurfaces: DISCOVERY_SURFACES,
     results: results.map((r) => ({
       prompt: r.prompt,
       status: r.status,
@@ -105,7 +123,7 @@ function saveReport(results, opts = {}) {
   return filePath;
 }
 
-module.exports = { PROMPTS, queryPerplexity, runVisibilityCheck, formatReport, saveReport };
+module.exports = { PROMPTS, DISCOVERY_SURFACES, queryPerplexity, runVisibilityCheck, formatReport, saveReport };
 
 if (require.main === module) {
   (async () => {

--- a/scripts/check-congruence.js
+++ b/scripts/check-congruence.js
@@ -336,8 +336,8 @@ async function main() {
     'public/index.html must mention the linked feedback session flow'
   );
   check(
-    /10 captures\/day/i.test(landingHtml) && /50 total/i.test(landingHtml),
-    'public/index.html must advertise the truthful free-tier capture limits (10/day, 50 total)'
+    /5 captures\/day/i.test(landingHtml) && /25 total/i.test(landingHtml),
+    'public/index.html must advertise the truthful free-tier capture limits (5/day, 25 total)'
   );
   check(
     /3 (active )?(auto-promoted )?prevention rules/i.test(landingHtml),

--- a/scripts/rate-limiter.js
+++ b/scripts/rate-limiter.js
@@ -17,32 +17,32 @@ const USAGE_FILE = path.join(process.env.HOME || '/tmp', '.thumbgate', 'usage-li
 // hit the wall within the first week, not the first quarter.
 // ──────────────────────────────────────────────────────────
 const FREE_TIER_LIMITS = {
-  capture_feedback:   { daily: 10,       lifetime: 50,       label: 'feedback captures (10/day, 50 total on free)' },
-  prevention_rules:   { daily: 3,        lifetime: 15,       label: 'prevention rules generated (3/day on free)' },
+  capture_feedback:   { daily: 5,        lifetime: 25,       label: 'feedback captures (5/day, 25 total on free)' },
+  prevention_rules:   { daily: 2,        lifetime: 6,        label: 'prevention rules generated (2/day on free)' },
   recall:             { daily: 0,        lifetime: 0,        label: 'recall queries (Pro only)' },
   search_lessons:     { daily: 0,        lifetime: 0,        label: 'lesson searches (Pro only)' },
   search_thumbgate:   { daily: 0,        lifetime: 0,        label: 'ThumbGate searches (Pro only)' },
   commerce_recall:    { daily: 0,        lifetime: 0,        label: 'commerce recalls (Pro only)' },
   export_dpo:         { daily: 0,        lifetime: 0,        label: 'DPO exports (Pro only)' },
   export_databricks:  { daily: 0,        lifetime: 0,        label: 'Databricks exports (Pro only)' },
-  construct_context_pack: { daily: 5,    lifetime: Infinity,  label: 'context packs (5/day on free)' },
+  construct_context_pack: { daily: 3,    lifetime: Infinity,  label: 'context packs (3/day on free)' },
 };
 
 const FREE_TIER_MAX_GATES = 3; // 3 active prevention rules on free; Pro is unlimited
-const FREE_TIER_DAILY_BLOCKS = 5; // 5 gate blocks/day on free; after limit, deny → warn + upgrade CTA
+const FREE_TIER_DAILY_BLOCKS = 3; // 3 gate blocks/day on free; after limit, deny → warn + upgrade CTA
 
 const UPGRADE_MESSAGE = `Pro: ${PRO_PRICE_LABEL} — unlimited rules, recall, lesson search, dashboard, and exports: ${PRO_MONTHLY_PAYMENT_LINK}\n  Team: ${TEAM_PRICE_LABEL} after workflow qualification.`;
 
 const PAYWALL_MESSAGES = {
-  capture_feedback: 'Free tier: 10 captures/day (50 total). Your feedback is stored locally — upgrade to capture unlimited.',
-  prevention_rules: 'Free tier includes 3 active prevention rules. Upgrade to Pro for unlimited rules.',
+  capture_feedback: 'Free tier: 5 captures/day (25 total). Your feedback is stored locally — upgrade to capture unlimited.',
+  prevention_rules: 'Free tier includes 3 active prevention rules and 2 rule generations/day. Upgrade to Pro for unlimited rules.',
   recall: 'Recall is a Pro feature. Your past feedback is stored locally — upgrade to search and reuse it.',
   search_lessons: 'Lesson search is a Pro feature. Upgrade to find patterns in your agent\'s mistakes.',
-  construct_context_pack: 'Free tier: 5 context packs/day. Upgrade to Pro for unlimited.',
+  construct_context_pack: 'Free tier: 3 context packs/day. Upgrade to Pro for unlimited.',
   default: 'This feature requires Pro. Start Pro — card required; billed today.',
 };
 
-const TRIAL_DAYS = 14;
+const TRIAL_DAYS = 7;
 
 function getInstallAgeDays() {
   try {
@@ -93,7 +93,8 @@ function isProTier(authContext) {
     const { isProLicensed } = require('./license');
     if (isProLicensed()) return true;
   } catch (_) {}
-  // 14-day reverse trial: new installs get full Pro access
+  // 7-day reverse trial: new installs get full Pro access, then hit a clear
+  // hosted-sync/unlimited-rules pay moment while the product is still fresh.
   if (isInTrialPeriod()) return true;
   return false;
 }

--- a/scripts/revenue-observability-doctor.js
+++ b/scripts/revenue-observability-doctor.js
@@ -183,6 +183,13 @@ async function buildRevenueObservabilityDoctor({
       envPresence(env, QUERY_ACCESS_KEYS.posthog)
     ),
     buildCheck(
+      'first_party_journey_export',
+      Boolean(hostedApiKey),
+      'high',
+      'Operator-key gated /v1/telemetry/export now returns session-level journeySummary, stage counts, and dropoff buckets from first-party ledgers.',
+      { endpoint: '/v1/telemetry/export', requires: 'THUMBGATE_OPERATOR_KEY or THUMBGATE_API_KEY' }
+    ),
+    buildCheck(
       'public_funnel_health',
       publicFunnel.ok,
       'critical',
@@ -209,7 +216,8 @@ async function buildRevenueObservabilityDoctor({
     canProveRevenue: checks.find((check) => check.id === 'stripe_query_access')?.ok === true,
     canProveVisitorBehavior: (
       checks.find((check) => check.id === 'plausible_query_access')?.ok === true ||
-      checks.find((check) => check.id === 'posthog_query_access')?.ok === true
+      checks.find((check) => check.id === 'posthog_query_access')?.ok === true ||
+      checks.find((check) => check.id === 'first_party_journey_export')?.ok === true
     ),
     checks,
     nextActions: checks

--- a/scripts/visitor-journey.js
+++ b/scripts/visitor-journey.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const STAGE_ORDER = [
+  'landing',
+  'pricing',
+  'checkout_viewed',
+  'email_submitted',
+  'stripe_redirect',
+  'purchase',
+];
+
+function parseTimestamp(row) {
+  const raw = row && (row.timestamp || row.receivedAt || row.ts);
+  const ms = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function pickText(...values) {
+  for (const value of values) {
+    const text = String(value || '').trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+function extractSessionId(row) {
+  return pickText(
+    row.sessionId,
+    row.visitorSessionId,
+    row.visitor_session_id,
+    row.attribution && row.attribution.sessionId,
+    row.metadata && row.metadata.sessionId,
+    row.stripeSessionId,
+    row.traceId,
+    row.acquisitionId,
+  );
+}
+
+function extractVisitorId(row) {
+  return pickText(
+    row.visitorId,
+    row.visitor_id,
+    row.installId,
+    row.attribution && row.attribution.visitorId,
+    row.metadata && row.metadata.visitorId,
+  );
+}
+
+function extractPath(row) {
+  return pickText(
+    row.path,
+    row.page,
+    row.landingPath,
+    row.landing_path,
+    row.attribution && row.attribution.landingPath,
+  );
+}
+
+function classifyStage(row) {
+  const event = String(row.eventType || row.event || '').toLowerCase();
+  const stage = String(row.stage || '').toLowerCase();
+  const path = extractPath(row).toLowerCase();
+  const cta = String(row.ctaId || row.cta_id || '').toLowerCase();
+
+  if (/purchase|paid|checkout\.session\.completed/.test(event) || stage === 'purchase') return 'purchase';
+  if (/stripe_redirect|stripe redirect|redirect started/.test(event) || stage === 'stripe_redirect') return 'stripe_redirect';
+  if (/email_submitted|email submitted|checkout_interstitial_cta_clicked/.test(event)) return 'email_submitted';
+  if (/checkout/.test(path) || /checkout.*view|checkout pro viewed/.test(event)) return 'checkout_viewed';
+  if (/pricing/.test(path) || /pricing/.test(cta) || /pricing_cta/.test(event)) return 'pricing';
+  if (/landing|page_view|landing_page_view|discovery/.test(event) || stage === 'discovery') return 'landing';
+  return null;
+}
+
+function stageRank(stage) {
+  const index = STAGE_ORDER.indexOf(stage);
+  return index === -1 ? -1 : index;
+}
+
+function nextMissingStage(maxStage) {
+  const index = stageRank(maxStage);
+  if (index < 0) return 'unknown';
+  if (maxStage === 'purchase') return 'converted';
+  return STAGE_ORDER[index + 1] || 'unknown';
+}
+
+function buildVisitorJourneySummary({ telemetryRows = [], funnelRows = [], limit = 100 } = {}) {
+  const sessions = new Map();
+  const stageCounts = Object.fromEntries(STAGE_ORDER.map((stage) => [stage, 0]));
+
+  function ingest(row, source) {
+    const ts = parseTimestamp(row);
+    if (ts == null) return;
+    const sessionId = extractSessionId(row) || `anonymous:${extractVisitorId(row) || ts}`;
+    const visitorId = extractVisitorId(row) || null;
+    const stage = classifyStage(row);
+    const path = extractPath(row);
+    const existing = sessions.get(sessionId) || {
+      sessionId,
+      visitorId,
+      firstSeen: new Date(ts).toISOString(),
+      lastSeen: new Date(ts).toISOString(),
+      maxStage: null,
+      dropoffStage: 'unknown',
+      events: [],
+      paths: [],
+      ctas: [],
+      sources: [],
+      visitorType: row.visitorType || null,
+      utm: {},
+      referrerHost: pickText(row.referrerHost, row.referrer_host, row.referrer),
+    };
+
+    existing.visitorId = existing.visitorId || visitorId;
+    existing.firstSeen = new Date(Math.min(Date.parse(existing.firstSeen), ts)).toISOString();
+    existing.lastSeen = new Date(Math.max(Date.parse(existing.lastSeen), ts)).toISOString();
+    existing.sources.push(source);
+    if (stage) {
+      stageCounts[stage] += 1;
+      if (stageRank(stage) > stageRank(existing.maxStage)) existing.maxStage = stage;
+    }
+    if (path && !existing.paths.includes(path)) existing.paths.push(path);
+    const cta = pickText(row.ctaId, row.cta_id);
+    if (cta && !existing.ctas.includes(cta)) existing.ctas.push(cta);
+    for (const key of ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']) {
+      const value = pickText(row[key], row.attribution && row.attribution[key]);
+      if (value && !existing.utm[key]) existing.utm[key] = value;
+    }
+    existing.events.push({
+      timestamp: new Date(ts).toISOString(),
+      source,
+      eventType: pickText(row.eventType, row.event, row.stage, 'unknown'),
+      stage,
+      path: path || null,
+      ctaId: cta || null,
+    });
+    sessions.set(sessionId, existing);
+  }
+
+  for (const row of telemetryRows) ingest(row, 'telemetry');
+  for (const row of funnelRows) ingest(row, 'funnel');
+
+  const journeys = [...sessions.values()].map((session) => {
+    session.sources = [...new Set(session.sources)];
+    session.events.sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+    session.maxStage = session.maxStage || 'unknown';
+    session.dropoffStage = nextMissingStage(session.maxStage);
+    session.eventCount = session.events.length;
+    return session;
+  }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen));
+
+  const dropoffCounts = {};
+  for (const journey of journeys) {
+    dropoffCounts[journey.dropoffStage] = (dropoffCounts[journey.dropoffStage] || 0) + 1;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    sessionCount: journeys.length,
+    stageCounts,
+    dropoffCounts,
+    journeys: journeys.slice(0, Math.max(1, Math.min(Number(limit) || 100, 500))),
+    truncated: journeys.length > Math.max(1, Math.min(Number(limit) || 100, 500)),
+  };
+}
+
+module.exports = {
+  STAGE_ORDER,
+  buildVisitorJourneySummary,
+  classifyStage,
+  extractSessionId,
+  extractVisitorId,
+};

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.IgorGanapolsky/thumbgate",
   "description": "Pre-action gates that block AI agents from repeating known mistakes.",
   "title": "ThumbGate",
-  "websiteUrl": "https://thumbgate-production.up.railway.app",
+  "websiteUrl": "https://thumbgate.ai",
   "repository": {
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5630,6 +5630,7 @@ async function addContext(){
         source,
         telemetry: { rows: [], truncated: false, totalAfterSince: 0 },
         funnel: { rows: [], truncated: false, totalAfterSince: 0 },
+        journeySummary: null,
       };
 
       function readJsonlSince(p) {
@@ -5675,6 +5676,19 @@ async function addContext(){
         result.funnel.totalAfterSince = all.length;
         result.funnel.rows = all.slice(-limit);
         result.funnel.truncated = all.length > limit;
+      }
+
+      try {
+        const { buildVisitorJourneySummary } = require('../../scripts/visitor-journey');
+        result.journeySummary = buildVisitorJourneySummary({
+          telemetryRows: wantTelemetry ? result.telemetry.rows : [],
+          funnelRows: wantFunnel ? result.funnel.rows : [],
+          limit: Math.min(limit, 500),
+        });
+      } catch (err) {
+        result.journeySummary = {
+          error: err && err.message ? err.message : 'journey_summary_unavailable',
+        };
       }
 
       sendJson(res, 200, result);

--- a/tests/adapters.test.js
+++ b/tests/adapters.test.js
@@ -375,7 +375,7 @@ test('cursor marketplace plugin keeps metadata versioned while runtime tracks th
   assert.equal(marketplace.plugins[0].name, pluginManifest.name);
   assert.equal(pluginManifest.version, packageVersion);
   assert.deepEqual(pluginConfig.mcpServers.thumbgate.args, explicitLatestServeArgs);
-  assert.equal(pluginManifest.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(pluginManifest.homepage, 'https://thumbgate.ai');
   assert.equal(pluginManifest.repository, 'https://github.com/IgorGanapolsky/ThumbGate');
 });
 
@@ -398,9 +398,9 @@ test('claude plugin metadata stays aligned with the released package and install
   assert.ok(pluginManifest.keywords.includes('pre-action-checks'));
   assert.ok(pluginManifest.keywords.includes('ai-agent-safety'));
   assert.ok(marketplaceEntry.metadata.keywords.includes('pre-action-checks'));
-  assert.equal(pluginManifest.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(pluginManifest.homepage, 'https://thumbgate.ai');
   assert.equal(pluginManifest.repository, 'https://github.com/IgorGanapolsky/ThumbGate');
-  assert.equal(marketplaceEntry.metadata.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(marketplaceEntry.metadata.homepage, 'https://thumbgate.ai');
   assert.match(readme, /Privacy Policy/i);
   assert.match(readme, /Data Collection/i);
   assert.match(readme, /Support/i);
@@ -448,7 +448,7 @@ test('codex app plugin surface is present and aligned to ThumbGate metadata', ()
   const pluginEntry = marketplace.plugins.find((plugin) => plugin.name === pluginManifest.name);
 
   assert.equal(pluginManifest.version, packageVersion);
-  assert.equal(pluginManifest.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(pluginManifest.homepage, 'https://thumbgate.ai');
   assert.equal(pluginManifest.repository, 'https://github.com/IgorGanapolsky/ThumbGate');
   assert.equal(pluginManifest.interface.displayName, 'ThumbGate for Codex');
   assert.equal(pluginManifest.mcpServers, './.mcp.json');
@@ -463,7 +463,7 @@ test('Claude Codex bridge plugin surface is present and aligned to ThumbGate met
   const readme = fs.readFileSync(path.join(root, 'plugins/claude-codex-bridge/README.md'), 'utf-8');
 
   assert.equal(pluginManifest.version, packageVersion);
-  assert.equal(pluginManifest.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(pluginManifest.homepage, 'https://thumbgate.ai');
   assert.equal(pluginManifest.repository, 'https://github.com/IgorGanapolsky/ThumbGate');
   assert.equal(pluginManifest.name, 'codex-bridge');
   assert.deepEqual(pluginConfig.mcpServers.thumbgate.args, explicitServeArgs);

--- a/tests/ai-search-visibility.test.js
+++ b/tests/ai-search-visibility.test.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 
 const {
   PROMPTS,
+  DISCOVERY_SURFACES,
   runVisibilityCheck,
   formatReport,
   saveReport,
@@ -20,6 +21,15 @@ test('PROMPTS array is non-empty and contains expected entries', () => {
   assert.ok(PROMPTS.some((p) => /parallel AI coding agent safety/i.test(p)));
   assert.ok(PROMPTS.some((p) => /environment inspection/i.test(p)));
   assert.ok(PROMPTS.some((p) => /thumbgate/i.test(p)));
+  assert.ok(PROMPTS.some((p) => /pre-action gates/i.test(p)));
+  assert.ok(PROMPTS.some((p) => /agent governance platform/i.test(p)));
+});
+
+test('DISCOVERY_SURFACES covers canonical AI-search entrypoints', () => {
+  assert.ok(DISCOVERY_SURFACES.some((surface) => surface.url === 'https://thumbgate.ai/llms.txt'));
+  assert.ok(DISCOVERY_SURFACES.some((surface) => surface.url === 'https://thumbgate.ai/.well-known/llms.txt'));
+  assert.ok(DISCOVERY_SURFACES.some((surface) => surface.url === 'https://thumbgate.ai/llm-context.md'));
+  assert.ok(DISCOVERY_SURFACES.some((surface) => surface.url === 'https://thumbgate.ai/openapi.yaml'));
 });
 
 test('runVisibilityCheck with mocked queryFn returns found results', async () => {
@@ -53,6 +63,7 @@ test('formatReport produces correct tags for found results', async () => {
   assert.ok(report.includes('[FOUND]'));
   assert.ok(report.includes('[MISSING]'));
   assert.ok(/Score: \d+\/\d+/.test(report));
+  assert.ok(report.includes('Discovery surfaces to verify'));
 });
 
 test('formatReport manual-only produces manual score line', async () => {
@@ -80,6 +91,7 @@ describe('saveReport', () => {
     assert.ok(fs.existsSync(filePath));
     const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     assert.equal(data.score, '1/2');
+    assert.ok(Array.isArray(data.discoverySurfaces));
     assert.equal(data.results.length, 2);
     assert.equal(data.results[0].status, 'FOUND');
   });

--- a/tests/check-congruence.test.js
+++ b/tests/check-congruence.test.js
@@ -54,8 +54,8 @@ test('README commercial copy stays aligned with current Pro and Team packaging',
   assert.match(readme, /org dashboard/i);
   assert.match(readme, /history-aware/i);
   assert.match(readme, /feedback session|open_feedback_session|append_feedback_context|finalize_feedback_session/i);
-  assert.match(readme, /10 feedback captures\/day/i);
-  assert.match(readme, /50 total captures/i);
+  assert.match(readme, /5 feedback captures\/day/i);
+  assert.match(readme, /25 total captures/i);
   assert.match(readme, /3 active auto-promoted prevention rules/i);
   assert.match(readme, /lesson/i);
   assert.doesNotMatch(readme, /\$12\/seat\/mo/i);

--- a/tests/claude-codex-bridge.test.js
+++ b/tests/claude-codex-bridge.test.js
@@ -24,7 +24,7 @@ test('Claude Codex bridge plugin ships a repo-local Claude Code plugin surface',
 
   assert.equal(plugin.name, 'codex-bridge');
   assert.equal(plugin.version, packageVersion);
-  assert.equal(plugin.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(plugin.homepage, 'https://thumbgate.ai');
   assert.equal(plugin.repository, 'https://github.com/IgorGanapolsky/ThumbGate');
   assert.deepEqual(mcpConfig.mcpServers.thumbgate.args, ['--yes', '--package', `thumbgate@${packageVersion}`, 'thumbgate', 'serve']);
   assert.match(readme, /Codex review/i);

--- a/tests/cli-trial-and-help.test.js
+++ b/tests/cli-trial-and-help.test.js
@@ -86,7 +86,7 @@ test('thumbgate trial: prints status section + upgrade URL', () => {
 test('thumbgate trial: in-trial install reports remaining days + expiry date', () => {
   const home = freshHome();
   try {
-    makeInstallId(home, 4); // ~10 days remaining of a 14-day trial
+    makeInstallId(home, 4); // ~10 days remaining of a 7-day trial
     const result = runCli(['trial'], unlicensedEnv(home));
     assert.equal(result.status, 0, `trial subcommand should exit 0; stderr=${result.stderr}`);
     // Acceptable: either trial active OR (on machines where creator-dev bypass kicks in)

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1072,7 +1072,7 @@ describe('bin/cli.js', () => {
     });
     assert.strictEqual(result.status, 0, `init should succeed: ${result.stderr}`);
     assert.match(result.stdout, /npx thumbgate init --email you@company\.com/);
-    assert.match(result.stdout, /14-day Pro trial active through \d{4}-\d{2}-\d{2}/);
+    assert.match(result.stdout, /7-day Pro trial active through \d{4}-\d{2}-\d{2}/);
     assert.match(result.stdout, /utm_source=cli_init/);
     fs.rmSync(initDir, { recursive: true, force: true });
     fs.rmSync(homeDir, { recursive: true, force: true });

--- a/tests/codex-plugin.test.js
+++ b/tests/codex-plugin.test.js
@@ -55,7 +55,7 @@ test('codex plugin manifest uses ThumbGate branding and local MCP config', () =>
 
   assert.equal(plugin.name, 'codex-profile');
   assert.equal(plugin.interface.displayName, 'ThumbGate for Codex');
-  assert.equal(plugin.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(plugin.homepage, 'https://thumbgate.ai');
   assert.equal(plugin.repository, 'https://github.com/IgorGanapolsky/ThumbGate');
   assert.equal(plugin.mcpServers, './.mcp.json');
   assertCodexLatestShellEntry(mcpConfig.mcpServers.thumbgate);
@@ -75,7 +75,7 @@ test('root README promotes the Codex plugin as a first-class install path', () =
 
   assert.match(readme, /Install Codex Plugin/);
   assert.match(readme, /Open the Codex plugin install page/i);
-  assert.match(readme, /thumbgate-production\.up\.railway\.app\/codex-plugin/i);
+  assert.match(readme, /thumbgate\.ai\/codex-plugin/i);
   assert.match(readme, /plugins\/codex-profile\/INSTALL\.md/);
   assert.match(readme, new RegExp(getCodexPluginLatestDownloadUrl(root).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 });

--- a/tests/docs-claim-hygiene.test.js
+++ b/tests/docs-claim-hygiene.test.js
@@ -67,10 +67,10 @@ test('README keeps buyer CTAs on current first-party ThumbGate surfaces', () => 
   const readme = fs.readFileSync(path.join(projectRoot, 'README.md'), 'utf8');
 
   assert.doesNotMatch(readme, /https:\/\/usethumbgate\.com/i);
-  assert.match(readme, /https:\/\/thumbgate-production\.up\.railway\.app\/\?utm_source=github&utm_medium=readme/);
-  assert.match(readme, /https:\/\/thumbgate-production\.up\.railway\.app\/checkout\/pro\?utm_source=github&utm_medium=readme/);
-  assert.match(readme, /https:\/\/thumbgate-production\.up\.railway\.app\/dashboard\?utm_source=github&utm_medium=readme/);
-  assert.match(readme, /https:\/\/thumbgate-production\.up\.railway\.app\/guides\/codex-cli-guardrails\?utm_source=github&utm_medium=readme/);
+  assert.match(readme, /https:\/\/thumbgate\.ai\/\?utm_source=github&utm_medium=readme/);
+  assert.match(readme, /https:\/\/thumbgate\.ai\/checkout\/pro\?utm_source=github&utm_medium=readme/);
+  assert.match(readme, /https:\/\/thumbgate\.ai\/dashboard\?utm_source=github&utm_medium=readme/);
+  assert.match(readme, /https:\/\/thumbgate\.ai\/guides\/codex-cli-guardrails\?utm_source=github&utm_medium=readme/);
 });
 
 test('active commercial surfaces avoid stale free-tier limit claims', () => {
@@ -89,7 +89,7 @@ test('active commercial surfaces avoid stale free-tier limit claims', () => {
 test('pricing comparison keeps free-tier pro features out of the free column', () => {
   const pricing = fs.readFileSync(path.join(projectRoot, 'docs/marketing/pricing-comparison.md'), 'utf8');
 
-  assert.match(pricing, /\|\s*Feedback capture\s*\|\s*10\/day, 50 total\s*\|\s*Unlimited\s*\|/i);
+  assert.match(pricing, /\|\s*Feedback capture\s*\|\s*5\/day, 25 total\s*\|\s*Unlimited\s*\|/i);
   assert.match(pricing, /\|\s*Prevention rules\s*\|\s*Up to 3 active\s*\|\s*Unlimited\s*\|/i);
   assert.match(pricing, /\|\s*Recall \+ lesson search\s*\|\s*No\s*\|\s*Yes\s*\|/i);
   assert.match(pricing, /\|\s*DPO\/KTO export\s*\|\s*No\s*\|\s*Yes\s*\|/i);

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -53,22 +53,22 @@ describe('Free tier bullets: extraction', () => {
 });
 
 describe('Free tier bullets: code-backed claims', () => {
-  test('"10 feedback captures/day" matches FREE_TIER_LIMITS.capture_feedback', () => {
+  test('"5 feedback captures/day" matches FREE_TIER_LIMITS.capture_feedback', () => {
     const { FREE_TIER_LIMITS } = require(path.join(ROOT, 'scripts', 'rate-limiter.js'));
-    assert.equal(FREE_TIER_LIMITS.capture_feedback.daily, 10,
+    assert.equal(FREE_TIER_LIMITS.capture_feedback.daily, 5,
       'free tier daily captures must match the public pricing page');
-    assert.equal(FREE_TIER_LIMITS.capture_feedback.lifetime, 50,
+    assert.equal(FREE_TIER_LIMITS.capture_feedback.lifetime, 25,
       'free tier lifetime captures must match the public pricing page');
     assert.ok(
-      FREE_BULLETS.some((b) => /10 feedback captures\/day/i.test(b)),
-      'Landing page must claim "10 feedback captures/day"',
+      FREE_BULLETS.some((b) => /5 feedback captures\/day/i.test(b)),
+      'Landing page must claim "5 feedback captures/day"',
     );
   });
 
   test('"3 prevention rules" matches FREE_TIER_MAX_GATES', () => {
     const { FREE_TIER_LIMITS, FREE_TIER_MAX_GATES } = require(path.join(ROOT, 'scripts', 'rate-limiter.js'));
     assert.equal(FREE_TIER_MAX_GATES, 3, 'FREE_TIER_MAX_GATES must be 3 to back "3 active prevention rules" claim');
-    assert.equal(FREE_TIER_LIMITS.prevention_rules.daily, 3, 'prevention_rules.daily must be 3');
+    assert.equal(FREE_TIER_LIMITS.prevention_rules.daily, 2, 'prevention_rules.daily must be 2');
     assert.ok(
       FREE_BULLETS.some((b) => /3 (active )?(auto-promoted )?prevention rules/i.test(b)),
       'Landing page must claim 3 active prevention rules',

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -269,9 +269,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 263 → 264 (2026-05-22) to ship scripts/self-healing-check.js.
   // bin/cli.js runs it before scripts/self-heal.js for `thumbgate self-heal`;
   // without this file, published installs fail with a missing-module error.
+  // Bumped 264 → 265 (2026-05-26) to ship scripts/visitor-journey.js because
+  // src/api/server.js uses it for the operator-gated telemetry journey export.
   assert.ok(
-    manifest.fileCount <= 264,
-    `npm package should stay <= 264 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 265,
+    `npm package should stay <= 265 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -66,7 +66,7 @@ test('README keeps the business sprint-first while preserving the Pro side lane'
   assert.match(readme, /Workflow Hardening Sprint/i);
   assert.match(readme, /Paid path for individual operators/i);
   assert.match(readme, /self-serve side lane/i);
-  assert.match(readme, /https:\/\/thumbgate-production\.up\.railway\.app\/checkout\/pro\?utm_source=github&utm_medium=readme&utm_campaign=pro_page/);
+  assert.match(readme, /https:\/\/thumbgate\.ai\/checkout\/pro\?utm_source=github&utm_medium=readme&utm_campaign=pro_page/);
   assert.doesNotMatch(readme, /https:\/\/usethumbgate\.com/i);
 });
 
@@ -88,7 +88,7 @@ test('README exposes prompt-shaped buyer questions with tracked guide links', ()
   assert.match(readme, /guides\/gemini-cli-feedback-memory\?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions/);
   assert.match(readme, /guides\/gcp-mcp-guardrails\?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions/);
   assert.match(readme, /guides\/roo-code-alternative-cline\?utm_source=github&utm_medium=readme&utm_campaign=buyer_questions/);
-  assert.match(readme, /https:\/\/thumbgate-production\.up\.railway\.app/);
+  assert.match(readme, /https:\/\/thumbgate\.ai/);
   assert.doesNotMatch(readme, /https:\/\/usethumbgate\.com/i);
   assert.match(readme, /\/\?utm_source=github&utm_medium=readme&utm_campaign=top_cta#workflow-sprint-intake/);
   assert.match(readme, /\/\?utm_source=github&utm_medium=readme&utm_campaign=team_rollout#workflow-sprint-intake/);

--- a/tests/postinstall.test.js
+++ b/tests/postinstall.test.js
@@ -42,7 +42,7 @@ describe('postinstall banner', () => {
     assert.equal(exitCode, 0);
     assert.ok(stderr.includes('ThumbGate'), 'should mention ThumbGate');
     assert.ok(stderr.includes('npx thumbgate'), 'should include quick start');
-    assert.match(stderr, /14-day Pro trial/i, 'should mention reverse trial');
+    assert.match(stderr, /7-day Pro trial/i, 'should mention reverse trial');
     assert.match(stderr, /thumbgate\.ai\/dashboard/i, 'should include dashboard URL');
     assert.match(stderr, /unlimited rules/i, 'should list trial features');
     assert.match(stderr, /Lesson search/i, 'should mention lesson search');

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -60,7 +60,9 @@ const path = require('node:path');
 //            only from source checkouts.
 // 263 → 264: scripts/self-healing-check.js added so `thumbgate self-heal`
 //            works from npm installs instead of failing before self-heal.js.
-const BASELINE_FILE_COUNT = 264;
+// 264 → 265: scripts/visitor-journey.js added so hosted telemetry export can
+//            produce session-level path/dropoff summaries in packaged runtime.
+const BASELINE_FILE_COUNT = 265;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -127,8 +127,8 @@ test('public landing page includes pricing section with Free, Pro, and Team tier
   // Free tier is intentionally capped so the npm package proves value without
   // cannibalizing Pro.
   assert.match(landingPage, /Block repeated mistakes daily/);
-  assert.match(landingPage, /10 captures\/day, 3 active rules/i);
-  assert.match(landingPage, /10 feedback captures\/day/i);
+  assert.match(landingPage, /5 captures\/day, 3 active rules/i);
+  assert.match(landingPage, /5 feedback captures\/day/i);
   assert.match(landingPage, /Up to 3 active auto-promoted prevention rules/i);
   assert.doesNotMatch(landingPage, /3 captures.*1 rule.*1 agent/i);
   assert.doesNotMatch(landingPage, /3 captures total/i);

--- a/tests/rate-limiter.test.js
+++ b/tests/rate-limiter.test.js
@@ -51,18 +51,18 @@ describe('rate-limiter', () => {
     if (fs.existsSync(TEMP_USAGE_FILE)) fs.unlinkSync(TEMP_USAGE_FILE);
   });
 
-  it('allows 10 capture_feedback events per day on free tier, then nudges Pro', () => {
-    assert.equal(rateLimiter.FREE_TIER_LIMITS.capture_feedback.daily, 10);
-    assert.equal(rateLimiter.FREE_TIER_LIMITS.capture_feedback.lifetime, 50);
-    for (let i = 0; i < 10; i++) {
+  it('allows 5 capture_feedback events per day on free tier, then nudges Pro', () => {
+    assert.equal(rateLimiter.FREE_TIER_LIMITS.capture_feedback.daily, 5);
+    assert.equal(rateLimiter.FREE_TIER_LIMITS.capture_feedback.lifetime, 25);
+    for (let i = 0; i < 5; i++) {
       const result = rateLimiter.checkLimit('capture_feedback');
       assert.equal(result.allowed, true, `call ${i + 1} should be allowed`);
     }
     const blocked = rateLimiter.checkLimit('capture_feedback');
-    assert.equal(blocked.allowed, false, 'call 11 should be blocked on the free daily limit');
+    assert.equal(blocked.allowed, false, 'call 6 should be blocked on the free daily limit');
     assert.equal(blocked.limitType, 'daily');
     assert.match(blocked.message, /Daily limit reached/i);
-    assert.match(blocked.message, /10 captures\/day \(50 total\)/i);
+    assert.match(blocked.message, /5 captures\/day \(25 total\)/i);
     assert.match(blocked.message, /Upgrade|Pro/i);
   });
 
@@ -81,10 +81,10 @@ describe('rate-limiter', () => {
     }
   });
 
-  it('14-day reverse trial grants pro tier for new installs', () => {
+  it('7-day reverse trial grants pro tier for new installs', () => {
     assert.equal(typeof rateLimiter.isInTrialPeriod, 'function');
     assert.equal(typeof rateLimiter.trialDaysRemaining, 'function');
-    assert.equal(rateLimiter.TRIAL_DAYS, 14);
+    assert.equal(rateLimiter.TRIAL_DAYS, 7);
   });
 
   it('unknown actions have no limit', () => {

--- a/tests/revenue-observability-doctor.test.js
+++ b/tests/revenue-observability-doctor.test.js
@@ -133,4 +133,5 @@ test('doctor is ready when proof access and focused public funnel are present', 
   assert.equal(report.verdict, 'ready');
   assert.equal(report.canProveRevenue, true);
   assert.equal(report.canProveVisitorBehavior, true);
+  assert.ok(report.checks.some((check) => check.id === 'first_party_journey_export' && check.ok));
 });

--- a/tests/telemetry-export.test.js
+++ b/tests/telemetry-export.test.js
@@ -42,8 +42,9 @@ const ONE_DAY = 24 * ONE_HOUR;
 
 const telemetryRows = [
   { eventType: 'page_view', path: '/', timestamp: new Date(NOW_MS - 3 * ONE_DAY).toISOString() }, // outside 24h
-  { eventType: 'cta_clicked', ctaId: 'pricing_pro', path: '/pricing', timestamp: new Date(NOW_MS - 2 * ONE_HOUR).toISOString() }, // inside
-  { eventType: 'cta_clicked', ctaId: 'workflow_sprint_intake', path: '/', timestamp: new Date(NOW_MS - 30 * 60 * 1000).toISOString() }, // inside
+  { eventType: 'cta_clicked', ctaId: 'pricing_pro', path: '/pricing', sessionId: 'sess-checkout-leak', visitorId: 'visitor-a', timestamp: new Date(NOW_MS - 2 * ONE_HOUR).toISOString() }, // inside
+  { eventType: 'checkout_interstitial_cta_clicked', ctaId: 'pro_checkout_confirmed', path: '/checkout/pro', sessionId: 'sess-checkout-leak', visitorId: 'visitor-a', timestamp: new Date(NOW_MS - 90 * 60 * 1000).toISOString() }, // inside
+  { eventType: 'cta_clicked', ctaId: 'workflow_sprint_intake', path: '/', sessionId: 'sess-workflow', visitorId: 'visitor-b', timestamp: new Date(NOW_MS - 30 * 60 * 1000).toISOString() }, // inside
 ];
 fs.writeFileSync(
   path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl'),
@@ -137,9 +138,9 @@ describe('GET /v1/telemetry/export', () => {
     const body = await res.json();
     assert.equal(body.source, 'both');
     assert.equal(body.limit, 1000);
-    // Two telemetry rows are inside the 24h window; the 3-day-old one is out.
-    assert.equal(body.telemetry.rows.length, 2);
-    assert.equal(body.telemetry.totalAfterSince, 2);
+    // Three telemetry rows are inside the 24h window; the 3-day-old one is out.
+    assert.equal(body.telemetry.rows.length, 3);
+    assert.equal(body.telemetry.totalAfterSince, 3);
     assert.equal(body.telemetry.truncated, false);
     // One funnel row inside the window.
     assert.equal(body.funnel.rows.length, 1);
@@ -159,7 +160,7 @@ describe('GET /v1/telemetry/export', () => {
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.source, 'telemetry');
-    assert.equal(body.telemetry.rows.length, 2);
+    assert.equal(body.telemetry.rows.length, 3);
     assert.equal(body.funnel.rows.length, 0);
     assert.equal(body.funnel.totalAfterSince, 0);
   });
@@ -181,7 +182,7 @@ describe('GET /v1/telemetry/export', () => {
     assert.equal(res.status, 200);
     const body = await res.json();
     // Expanding the window to 5 days picks up all 3 telemetry rows and both funnel rows.
-    assert.equal(body.telemetry.rows.length, 3);
+    assert.equal(body.telemetry.rows.length, 4);
     assert.equal(body.funnel.rows.length, 2);
   });
 
@@ -192,7 +193,7 @@ describe('GET /v1/telemetry/export', () => {
     assert.equal(res.status, 200);
     const body = await res.json();
     // Default 24h window, same as the no-param call.
-    assert.equal(body.telemetry.rows.length, 2);
+    assert.equal(body.telemetry.rows.length, 3);
   });
 
   it('truncates to limit and reports truncated=true with totalAfterSince intact', async () => {
@@ -203,7 +204,7 @@ describe('GET /v1/telemetry/export', () => {
     const body = await res.json();
     assert.equal(body.limit, 1);
     assert.equal(body.telemetry.rows.length, 1);
-    assert.equal(body.telemetry.totalAfterSince, 2);
+    assert.equal(body.telemetry.totalAfterSince, 3);
     assert.equal(body.telemetry.truncated, true);
     // Keeps the MOST RECENT row when truncating (slice(-limit)).
     const keptCta = body.telemetry.rows[0].ctaId;
@@ -237,5 +238,22 @@ describe('GET /v1/telemetry/export', () => {
     }
     assert.ok(body.generatedAt);
     assert.ok(body.since);
+  });
+
+  it('returns a visitor journey summary with path and dropoff buckets', async () => {
+    const res = await get('/v1/telemetry/export', { Authorization: `Bearer ${ENV.THUMBGATE_OPERATOR_KEY}` });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.journeySummary, 'journeySummary must be present for dashboard-grade readback');
+    assert.equal(typeof body.journeySummary.sessionCount, 'number');
+    assert.ok(body.journeySummary.sessionCount >= 2);
+    assert.ok(body.journeySummary.stageCounts.pricing >= 1);
+    assert.ok(body.journeySummary.stageCounts.email_submitted >= 1);
+    assert.ok(body.journeySummary.dropoffCounts.stripe_redirect >= 1);
+    const checkoutJourney = body.journeySummary.journeys.find((journey) => journey.sessionId === 'sess-checkout-leak');
+    assert.ok(checkoutJourney, 'checkout journey should be grouped by session id');
+    assert.equal(checkoutJourney.maxStage, 'email_submitted');
+    assert.equal(checkoutJourney.dropoffStage, 'stripe_redirect');
+    assert.deepEqual(checkoutJourney.paths, ['/pricing', '/checkout/pro']);
   });
 });

--- a/tests/thumbgate-scope.test.js
+++ b/tests/thumbgate-scope.test.js
@@ -51,5 +51,5 @@ test('canonical package metadata points only at ThumbGate', () => {
   assert.equal(packageJson.name, 'thumbgate');
   assert.equal(packageJson.repository.url, 'https://github.com/IgorGanapolsky/ThumbGate.git');
   assert.equal(packageJson.bugs.url, 'https://github.com/IgorGanapolsky/ThumbGate/issues');
-  assert.equal(packageJson.homepage, 'https://thumbgate-production.up.railway.app');
+  assert.equal(packageJson.homepage, 'https://thumbgate.ai');
 });

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -23,7 +23,9 @@ const {
 const PROJECT_ROOT = path.join(__dirname, '..');
 const CANONICAL_APP_ORIGIN = 'https://thumbgate.ai';
 const CANONICAL_DEPLOY_ORIGIN = 'https://thumbgate-production.up.railway.app';
-const CANONICAL_PUBLIC_ORIGIN = CANONICAL_APP_ORIGIN;
+// CANONICAL_PUBLIC_ORIGIN was a duplicate alias for CANONICAL_APP_ORIGIN; both
+// resolved to 'https://thumbgate.ai', so the constant has been removed. Restore
+// only if the two ever need to diverge.
 const CURRENT_REPOSITORY_URL = 'https://github.com/IgorGanapolsky/ThumbGate';
 const PRIVATE_CORE_REPOSITORY_URL = 'https://github.com/IgorGanapolsky/ThumbGate-Core';
 
@@ -40,7 +42,10 @@ function escapeRegExp(value) {
 }
 
 function mentionsCanonicalOrigin(artifact) {
-  return [CANONICAL_PUBLIC_ORIGIN, CANONICAL_APP_ORIGIN, CANONICAL_DEPLOY_ORIGIN].some((origin) => {
+  // CANONICAL_PUBLIC_ORIGIN was an alias for CANONICAL_APP_ORIGIN — removed
+  // the duplicate from the list per Gitar review on PR #2337. Add back as a
+  // distinct entry only if the two ever diverge again.
+  return [CANONICAL_APP_ORIGIN, CANONICAL_DEPLOY_ORIGIN].some((origin) => {
     const originPattern = new RegExp(`(^|[^\\w.+-])${escapeRegExp(origin)}(?=$|[/?#"'\\s<>).])`);
     return originPattern.test(artifact);
   });

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -21,8 +21,9 @@ const {
 } = require('../scripts/distribution-surfaces');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
-const CANONICAL_APP_ORIGIN = 'https://thumbgate-production.up.railway.app';
-const CANONICAL_PUBLIC_ORIGIN = 'https://thumbgate.ai';
+const CANONICAL_APP_ORIGIN = 'https://thumbgate.ai';
+const CANONICAL_DEPLOY_ORIGIN = 'https://thumbgate-production.up.railway.app';
+const CANONICAL_PUBLIC_ORIGIN = CANONICAL_APP_ORIGIN;
 const CURRENT_REPOSITORY_URL = 'https://github.com/IgorGanapolsky/ThumbGate';
 const PRIVATE_CORE_REPOSITORY_URL = 'https://github.com/IgorGanapolsky/ThumbGate-Core';
 
@@ -39,7 +40,7 @@ function escapeRegExp(value) {
 }
 
 function mentionsCanonicalOrigin(artifact) {
-  return [CANONICAL_PUBLIC_ORIGIN, CANONICAL_APP_ORIGIN].some((origin) => {
+  return [CANONICAL_PUBLIC_ORIGIN, CANONICAL_APP_ORIGIN, CANONICAL_DEPLOY_ORIGIN].some((origin) => {
     const originPattern = new RegExp(`(^|[^\\w.+-])${escapeRegExp(origin)}(?=$|[/?#"'\\s<>).])`);
     return originPattern.test(artifact);
   });
@@ -87,7 +88,7 @@ test('public docs render the current package version', () => {
   const productHuntKit = readText('docs/marketing/product-hunt-launch.md');
 
   assert.match(readme, /Open ThumbGate GPT/);
-  assert.match(readme, /https:\/\/thumbgate-production\.up\.railway\.app\/go\/gpt\?utm_source=github/);
+  assert.match(readme, /https:\/\/thumbgate\.ai\/go\/gpt\?utm_source=github/);
   assert.match(readme, /ThumbGate GPT: start here/i);
   assert.match(readme, /No, users do not have to keep chatting inside the ThumbGate GPT to use ThumbGate/i);
   assert.match(readme, /hard enforcement layer still runs where the work happens/i);


### PR DESCRIPTION
## Summary
- add session-level journeySummary to the operator-gated telemetry export so visitor paths, checkout stages, and dropoff buckets are visible from first-party ledgers
- tighten the free tier and 7-day reverse trial so the public CLI still proves value but creates a clearer Pro upgrade moment
- align public CTAs and metadata on thumbgate.ai, including README, MCP/plugin metadata, llms context, and AI-search visibility surfaces
- extend revenue observability and AI-search tests for the new proof surfaces

## Evidence
- node --test tests/telemetry-export.test.js tests/revenue-observability-doctor.test.js tests/free-to-paid-conversion-units.test.js tests/rate-limiter.test.js tests/landing-page-claims.test.js tests/public-landing.test.js tests/check-congruence.test.js tests/docs-claim-hygiene.test.js tests/ai-search-visibility.test.js tests/postinstall.test.js tests/cli.test.js tests/package-boundary.test.js tests/public-bundle-ratchet.test.js
- npm run test:sync-version && npm run test:hosted-config && npm run test:public-core-boundary
- npm pack --dry-run --json
- git diff --check
- pre-commit guards passed
- pre-push guards passed