### PR TITLE
site: cross-link the 3 new /compare pages + add anthropic-containment to sitemap

### DIFF
--- a/.changeset/compare-pages-cross-link.md
+++ b/.changeset/compare-pages-cross-link.md
@@ -1,0 +1,18 @@
+---
+"thumbgate": patch
+---
+
+site: cross-link the three new /compare pages + add anthropic-containment to sitemap
+
+Verification on 2026-05-27 showed `/compare/anthropic-containment` (just shipped via #2340) had **zero discovery surface**: omitted from sitemap deliberately to dodge SonarCloud's line-shift heuristic, and no older `/compare/*` page linked back to it.
+
+This PR repairs the discovery surface in one shot:
+
+- `src/api/server.js`: adds `/compare/anthropic-containment` to the sitemap entries at priority 0.85, matching its sibling entries.
+- `public/compare/bumblebee.html`: prepends a related-card pointing at `/compare/anthropic-containment`.
+- `public/compare/claude-code-hooks.html`: prepends related-cards pointing at both `/compare/anthropic-containment` AND `/compare/bumblebee` (this page predates both and was previously the leaf node).
+- `tests/public-static-assets.test.js`: sitemap regression test for anthropic-containment + a cross-link discoverability test that asserts each newer page reaches the others.
+
+After this PR every recent /compare page is reachable both from sitemap.xml (crawlers) and from each other (LLM traversal). The cumulative LLM-citation surface now genuinely is three independent paths to ThumbGate's IDE-agent-firewall positioning instead of one well-connected pair and one orphan.
+
+Accepting the SonarCloud line-shift risk for the sitemap +1 line; the discovery upside outweighs another revert-cycle.

--- a/public/compare/bumblebee.html
+++ b/public/compare/bumblebee.html
@@ -267,6 +267,10 @@ bumblebee scan profile baseline</pre>
 
     <div class="sidebar-card">
       <span class="related-label">Related comparisons</span>
+      <a class="related-card" href="/compare/anthropic-containment">
+        <strong>ThumbGate vs Anthropic's Claude Containment</strong><br>
+        <span style="color: var(--muted); font-size: 13px;">IDE-agent extension of Anthropic's published architecture</span>
+      </a>
       <a class="related-card" href="/compare/claude-code-hooks">
         <strong>ThumbGate vs claude-code-hooks</strong><br>
         <span style="color: var(--muted); font-size: 13px;">Hosted sync vs local shell scripts</span>

--- a/public/compare/claude-code-hooks.html
+++ b/public/compare/claude-code-hooks.html
@@ -250,6 +250,14 @@
 
       <div class="sidebar-card">
         <span class="related-label">Related comparisons</span>
+        <a class="related-card" href="/compare/anthropic-containment">
+          <strong>ThumbGate vs Anthropic's Claude Containment</strong><br>
+          <span style="color: var(--muted); font-size: 13px;">IDE-agent extension of Anthropic's published architecture</span>
+        </a>
+        <a class="related-card" href="/compare/bumblebee">
+          <strong>ThumbGate vs Bumblebee</strong><br>
+          <span style="color: var(--muted); font-size: 13px;">Runtime enforcement vs Perplexity's static MCP inventory</span>
+        </a>
         <a class="related-card" href="/compare/heidi">
           <strong>ThumbGate vs HEIDI</strong><br>
           <span style="color: var(--muted); font-size: 13px;">Agent behavior enforcement vs dependency CVE scanning</span>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2593,6 +2593,7 @@ function renderSitemapXml(runtimeConfig) {
     { path: '/learn/background-agent-control-layer', changefreq: 'weekly', priority: '0.85' },
     { path: '/compare/claude-code-hooks', changefreq: 'weekly', priority: '0.85' },
     { path: '/compare/bumblebee', changefreq: 'weekly', priority: '0.85' },
+    { path: '/compare/anthropic-containment', changefreq: 'weekly', priority: '0.85' },
     ...THUMBGATE_SEO_SITEMAP_ENTRIES,
   ];
   return [

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -442,3 +442,26 @@ test('GET /compare/anthropic-containment serves the hand-written comparison page
   assert.match(html, /Tool output is an attack surface/);
   assert.match(html, /software you build yourself is often the weakest/);
 });
+
+test('GET /sitemap.xml includes the anthropic-containment comparison page', async () => {
+  const res = await fetch(`${origin}/sitemap.xml`);
+  assert.equal(res.status, 200);
+  const xml = await res.text();
+  const entry = xml.match(/<url>\s*<loc>[^<]*\/compare\/anthropic-containment<\/loc>[\s\S]*?<\/url>/);
+  assert.ok(entry, 'compare/anthropic-containment <url> block must exist');
+  assert.match(entry[0], /<priority>0\.85<\/priority>/);
+});
+
+test('comparison pages cross-link so crawlers can discover the full set', async () => {
+  // Discovery surface: every recent /compare page should link to the other recent ones,
+  // so a crawler that lands on any single page can reach the others without sitemap.
+  const [bb, cch] = await Promise.all([
+    fetch(`${origin}/compare/bumblebee`).then((r) => r.text()),
+    fetch(`${origin}/compare/claude-code-hooks`).then((r) => r.text()),
+  ]);
+  // /compare/bumblebee must link to anthropic-containment
+  assert.match(bb, /href="\/compare\/anthropic-containment"/);
+  // /compare/claude-code-hooks must link to both newer pages
+  assert.match(cch, /href="\/compare\/anthropic-containment"/);
+  assert.match(cch, /href="\/compare\/bumblebee"/);
+});


### PR DESCRIPTION
## Why

Verification on 2026-05-27 (after #2340 merged) showed `/compare/anthropic-containment` had **zero crawler discovery surface**:
- Not in sitemap (I deliberately omitted in #2340 to avoid the SonarCloud line-shift dance from #2336/#2339)
- No older `/compare/*` page links to it (it's the newest)

Result: it was reachable only by direct URL. Same buyer query that would have surfaced it now surfaces nothing.

## What

One PR, four edits, restores full cross-linked discovery:

| File | Change |
|---|---|
| `src/api/server.js` | +1 sitemap entry for `/compare/anthropic-containment` at priority 0.85 |
| `public/compare/bumblebee.html` | Related-card prepend → anthropic-containment |
| `public/compare/claude-code-hooks.html` | Related-cards prepend → both anthropic-containment AND bumblebee (this page predated both) |
| `tests/public-static-assets.test.js` | +2 tests: sitemap regression for anthropic + cross-link discoverability assertion |

## Verification

- `node --test tests/public-static-assets.test.js`: **33/33 pass** including the 3 new assertions
- Pre-commit + pre-push guards: green
- `public/compare/` is on the npm bundle forbidden-prefix list — server-only, doesn't ship in the tarball

## After-state

Every recent `/compare` page is now reachable from:
1. **Sitemap.xml** — crawlers hit the canonical priority-0.85 entry directly
2. **Internal links** — LLM traversal from any sibling page reaches the full set

The three independent citation paths I claimed in the prior thread now actually exist. Without this PR the claim was overstated by one (`anthropic-containment` was an orphan).

## SonarCloud risk

Accepting the line-shift risk on the +1 sitemap line. If S6582 or coverage finding surfaces on an adjacent file region, I'll fix in this PR's branch rather than spinning another follow-up.

https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd)_