### PR TITLE
docs(readme): cross-link to mac-yolo-safeguards as OS-layer companion kit

### DIFF
--- a/.changeset/cross-link-mac-yolo-safeguards.md
+++ b/.changeset/cross-link-mac-yolo-safeguards.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+docs(readme): cross-link to mac-yolo-safeguards as the OS-layer companion kit. ThumbGate handles token-layer governance (block repeated mistakes via thumbs-down). mac-yolo-safeguards handles OS-layer blast-radius (prevent Mac freeze when agents spawn runaway processes). Same author, both MIT, both no-telemetry. UTM-tagged to attribute click-through in mac-yolo-safeguards's GitHub traffic.

--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Pro ($19/mo or $149/yr) removes the capture/rule caps and adds history-aware les
 - [SEO Guide: Claude Code Guardrails](docs/learn/claude-code-guardrails.md)
 - [Unsupervised Learning Signals](docs/UL.md) — silent-failure clustering (experimental, behind `THUMBGATE_SILENT_FAILURE_CLUSTERING=1`; only useful on workspaces with ≥ 50 tool calls/day)
 - [ThumbGate-Core](https://github.com/IgorGanapolsky/ThumbGate-Core) — private core for hosted overlays, ranking, policy synthesis, billing intelligence, and org/team workflows
+- [mac-yolo-safeguards](https://github.com/IgorGanapolsky/mac-yolo-safeguards?utm_source=thumbgate&utm_medium=readme&utm_campaign=companion_kit) — OS-level companion kit (macOS). ThumbGate stops the agent from billing you for repeated mistakes (token-layer governance). mac-yolo-safeguards stops the agent from freezing your Mac when it spawns runaway processes (OS-layer blast-radius containment). Same author, MIT, no telemetry.
 
 ---
 


### PR DESCRIPTION
## What

Adds one entry to the Docs list pointing to `mac-yolo-safeguards` ([repo](https://github.com/IgorGanapolsky/mac-yolo-safeguards)).

## Why

Positions ThumbGate + mac-yolo-safeguards as a coherent safety stack with non-overlapping scope:

- **ThumbGate** — token-layer governance. Stops the agent from billing you for the same repeated mistake on every future call.
- **mac-yolo-safeguards** — OS-layer blast-radius containment. Stops the Mac from freezing when the agent spawns runaway processes (most commonly: iOS Simulator auto-restart loops under `agy --dangerously-skip-permissions`, but the pattern hits Claude Code / Cursor / Codex YOLO modes too).

Same author, both MIT, both no-telemetry. Reciprocal of the cross-link [mac-yolo-safeguards@3138e98](https://github.com/IgorGanapolsky/mac-yolo-safeguards/commit/3138e98) just shipped pointing back here.

## Tracking

Link is UTM-tagged (`utm_source=thumbgate&utm_medium=readme&utm_campaign=companion_kit`) so we can attribute mac-yolo-safeguards visits originating from ThumbGate readers via GitHub Insights → Traffic → Referrers.

## Scope

Single-line addition to one list. No code changes, no test changes, no behavior changes.