### PR TITLE
Position ThumbGate for agentic development cycle

### DIFF
--- a/.changeset/agentic-development-cycle-positioning.md
+++ b/.changeset/agentic-development-cycle-positioning.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Position ThumbGate as the pre-action execution gate for the agentic development cycle across the homepage, README, llms.txt, and full LLM context.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -24,6 +24,15 @@
 4. PreToolUse hooks block the pattern before it executes again
 5. Thompson Sampling adapts gate confidence over time
 
+## Agentic development cycle fit
+
+ThumbGate maps to Guide, Generate, Verify, Solve by adding a pre-action execution gate:
+
+- Guide: feedback and policies become concrete rules
+- Generate: agents still produce plans, edits, and tool calls
+- Verify: risky actions require evidence before execution
+- Solve: blocked failures become reusable lessons and prevention gates
+
 ## Who it's for
 
 - Developers using Claude Code, Cursor, Codex, Gemini CLI, or any MCP-compatible agent

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and 
 
 ---
 
+## Agentic development cycle fit
+
+Agentic development is becoming a loop: **Guide → Generate → Verify → Solve**. ThumbGate gives that loop a hard execution boundary.
+
+- **Guide:** standards, prior thumbs-downs, and approval policies become concrete context.
+- **Generate:** Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and MCP agents keep producing plans and tool calls.
+- **Verify:** risky actions need evidence before execution, not just after PR review.
+- **Solve:** blocked failures become reusable lessons, shared prevention rules, DPO exports, and audit events.
+
+In that stack, ThumbGate is the pre-action gate between generated intent and executed action.
+
+---
+
 ## 🎬 90-second demo
 
 Watch the force-push scenario: agent tries to `git push --force`, one thumbs-down, next session it's blocked — zero tokens spent on the repeat.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and 
 
 **Free:** 5 feedback captures/day (25 total captures), 3 active auto-promoted prevention rules, all MCP integrations, local-first.
 **[Pro — $19/mo or $149/yr](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme):** no limits on captures or rules, history-aware lessons, feedback sessions, hosted dashboard, DPO export.
-**Team — $49/seat/mo:** shared lesson DB, org dashboard, approval boundaries.
+**Team — $49/seat/mo:** shared hosted lesson DB, org dashboard, approval boundaries.
 
 [![CI](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/thumbgate)](https://www.npmjs.com/package/thumbgate)

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate.ai/og.png">
 <meta name="thumbgate-version" content="1.23.1">
-<meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
+<meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agentic development cycle, AC/DC framework, Guide Generate Verify Solve, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="canonical" href="__APP_ORIGIN__/">
 <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
@@ -89,6 +89,7 @@ __GA_BOOTSTRAP__
     "ThumbGate GPT for ChatGPT — preflight risky commands, refunds, deploys, and PR actions, capture typed thumbs-up/down lessons, and route users into local enforcement",
     "Workflow Sentinel — score blast radius before PR, merge, release, and publish actions fire",
     "Workflow architecture checks — distinguish predefined workflows, parallel fan-out, and open-ended agents before execution",
+    "Agentic development cycle control — maps Guide, Generate, Verify, and Solve into enforceable pre-action gates before risky tool calls execute",
     "Environment inspection evidence — require read-before-write, screenshots, API response checks, tests, or output validation for open-ended agent loops",
     "Parallel branch budgets — prevent agent desktops and fan-out workflows from silently multiplying token spend",
     "Docker Sandboxes routing — move high-risk local runs into isolated microVM-backed execution",
@@ -319,6 +320,14 @@ __GA_BOOTSTRAP__
       "acceptedAnswer": {
         "@type": "Answer",
         "text": "Prompt rules are suggestions agents can ignore. Pre-Action Checks are enforcement — they block the action before execution via PreToolUse hooks. Checks are auto-generated from feedback and use Thompson Sampling to adapt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does ThumbGate fit the agentic development cycle?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Agentic development is converging around Guide, Generate, Verify, and Solve. ThumbGate adds the execution-control layer between those stages: project guidance and feedback become rules, generated tool calls are checked before execution, verification evidence is required for risky actions, and solved failures become reusable prevention gates."
       }
     },
     {
@@ -808,6 +817,36 @@ __GA_BOOTSTRAP__
         <span data-anchor="team-intake-form">Start Team Pilot Intake id="team-pilot-intake-form" data-team-intake-form name="ctaPlacement" value="team_visible_intake" name="utmMedium" value="visible_team_intake" name="planId" value="team" name="ctaId" value="workflow_sprint_intake" Team checkout happens after scope. team_workflow_sprint_recovery_intake scope_first workflow_sprint_intake_started workflow_sprint_intake_submit_attempted pricing_team_intake team_intake_started</span>
         <span data-anchor="chatgpt-context">No, you do not have to chat inside the GPT forever. ChatGPT is the discovery and memory surface. Do not rely on ChatGPT's native rating buttons for ThumbGate memory. Explore GPTs choose the GPT by Igor Ganapolsky Programming Do I have to chat inside the ThumbGate GPT for enforcement? capture thumbs-up/down lessons Real blocking for coding agents still runs locally adapters/chatgpt/INSTALL.md Native ChatGPT rating buttons are not the ThumbGate capture path. thumbs up: this review named exact files, commands, and tests. thumbs down: the answer ignored my request.</span>
       </div>
+    </div>
+  </div>
+</section>
+
+<section class="compatibility" id="agentic-development-cycle">
+  <div class="container">
+    <div class="section-label">Agentic Development Cycle</div>
+    <h2 class="section-title">Guide, Generate, Verify, Solve still needs an execution gate.</h2>
+    <p style="text-align:center;font-size:16px;color:var(--text-muted);max-width:900px;margin:0 auto 28px;line-height:1.7;">The market is converging on agentic development as a control loop, not a code-generation trick. <a href="https://thenewstack.io/agentic-development-cycle-framework/" target="_blank" rel="noopener" style="color:var(--cyan);text-decoration:underline;">The New Stack's May 2026 AC/DC framing</a> names the core stages: Guide, Generate, Verify, and Solve. ThumbGate gives that loop a hard pre-action boundary so agent work is governed before it touches files, terminals, CI, payments, or production systems.</p>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:14px;max-width:1080px;margin:0 auto;">
+      <div class="compat-card" style="cursor:default;">
+        <h3>Guide</h3>
+        <p>Rules, standards, past thumbs-downs, workflow boundaries, and approval policies are loaded as concrete operating context instead of vague prompt advice.</p>
+      </div>
+      <div class="compat-card" style="cursor:default;">
+        <h3>Generate</h3>
+        <p>Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and MCP-compatible agents keep generating plans, edits, and tool calls.</p>
+      </div>
+      <div class="compat-card" style="cursor:default;">
+        <h3>Verify</h3>
+        <p>Pre-Action Checks require inspection evidence, tests, CI, screenshots, API responses, or human approval before high-risk actions proceed.</p>
+      </div>
+      <div class="compat-card" style="cursor:default;">
+        <h3>Solve</h3>
+        <p>Blocked failures and accepted fixes become lessons, shared rules, DPO exports, and audit events so the same mistake is not paid for again.</p>
+      </div>
+    </div>
+    <div style="max-width:900px;margin:22px auto 0;padding:16px 18px;border:1px solid rgba(74,222,128,0.28);border-radius:8px;background:rgba(74,222,128,0.07);">
+      <strong style="display:block;color:var(--green);margin-bottom:6px;">ThumbGate's role: the pre-action gate between generated intent and executed action.</strong>
+      <p style="margin:0;color:var(--text-muted);font-size:14px;line-height:1.65;">Verification after a pull request is useful, but it is too late for force-pushes, destructive SQL, unsafe deploys, leaked secrets, and costly external API calls. ThumbGate checks the action before it runs, then feeds the result back into the next Guide and Solve cycle.</p>
     </div>
   </div>
 </section>
@@ -1488,6 +1527,10 @@ __GA_BOOTSTRAP__
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How are pre-action checks different from prompt rules?</div>
         <div class="faq-a">Prompt rules are a starting point, not a finish line. Without prompt evaluation you do not know whether they still hold up under real tool use. ThumbGate adds the human-in-the-loop measurement loop and the enforcement layer: proof lanes, ThumbGate Bench, and self-heal checks show whether behavior improved, and Pre-Action Checks block the action before execution when it did not.</div>
+      </div>
+      <div class="faq-item">
+        <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How does ThumbGate fit the agentic development cycle?</div>
+        <div class="faq-a">Agentic development is not just generation. Teams need Guide, Generate, Verify, and Solve working as a repeatable loop. ThumbGate is the pre-action execution gate in that loop: guidance and feedback become rules, generated tool calls are checked before execution, verification evidence is required for risky actions, and solved failures become reusable prevention gates.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What does Pro cost?</div>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -111,6 +111,17 @@ The high-ROI pattern is progressive disclosure:
 
 The CLI command `npx thumbgate harness-audit` scores global docs, progressive MCP discovery, and specialized harness coverage so teams can see whether their agent setup is compounding useful context or compounding instruction bloat.
 
+## Agentic Development Cycle Alignment
+
+The May 2026 agentic development conversation is converging around Guide, Generate, Verify, and Solve. ThumbGate fits this cycle as the pre-action execution gate:
+
+- **Guide**: team standards, approval policies, prior thumbs-downs, and workflow boundaries are loaded as concrete operating context.
+- **Generate**: Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, and MCP-compatible agents keep generating plans and tool calls.
+- **Verify**: ThumbGate requires evidence before high-risk actions execute: tests, CI, read-before-write, screenshots, API responses, or human approval.
+- **Solve**: blocked failures and accepted fixes become lessons, shared rules, DPO exports, and audit events.
+
+The key distinction is timing. Post-generation verification catches some mistakes after work has happened. ThumbGate checks the proposed tool call before it runs, then feeds the result back into the next Guide and Solve cycle.
+
 ## Enterprise Safety Framework Alignment
 
 ThumbGate's architecture maps directly to the enterprise safety framework pattern recommended by Google Cloud for agentic AI workflows (April 2026). Google Cloud's reference architecture routes every agent action through a Safety Framework check before execution, with unsafe actions producing a canned response and safe actions proceeding to the Agentic Workflow, followed by a Quality Framework check on the output.

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -136,6 +136,25 @@ test('LLM context keeps team pricing and CLI-first positioning aligned with comm
   assert.doesNotMatch(context, /\$12\/seat\/mo/i);
 });
 
+test('AI-visible surfaces map ThumbGate to the agentic development cycle', () => {
+  const readme = readText('README.md');
+  const landingPage = readText(path.join('public', 'index.html'));
+  const llms = readText(path.join('.well-known', 'llms.txt'));
+  const context = readText(path.join('public', 'llm-context.md'));
+
+  for (const surface of [readme, landingPage, llms, context]) {
+    assert.match(surface, /Guide/i);
+    assert.match(surface, /Generate/i);
+    assert.match(surface, /Verify/i);
+    assert.match(surface, /Solve/i);
+    assert.match(surface, /pre-action (?:execution )?gate|pre-action boundary/i);
+  }
+
+  assert.match(landingPage, /The New Stack's May 2026 AC\/DC framing/);
+  assert.match(context, /Agentic Development Cycle Alignment/);
+  assert.match(llms, /Agentic development cycle fit/);
+});
+
 test('LLM context maps ThumbGate to LangChain three-layer continual learning framework', () => {
   const context = readText(path.join('public', 'llm-context.md'));
 

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -55,6 +55,16 @@ test('public landing page routes Pro buyers through the hosted checkout surface'
   assert.doesNotMatch(landingPage, /gumroad\.com/);
 });
 
+test('public landing page maps agentic development cycle to pre-action execution gate', () => {
+  const landingPage = readLandingPage();
+
+  assert.match(landingPage, /Agentic Development Cycle/);
+  assert.match(landingPage, /Guide, Generate, Verify, Solve still needs an execution gate/);
+  assert.match(landingPage, /The New Stack's May 2026 AC\/DC framing/);
+  assert.match(landingPage, /ThumbGate's role: the pre-action gate between generated intent and executed action/);
+  assert.match(landingPage, /How does ThumbGate fit the agentic development cycle\?/);
+});
+
 test('public landing page exposes above-fold paid Pro CTA with canonical revenue analytics', () => {
   const landingPage = readLandingPage();
   const heroStart = landingPage.indexOf('<!-- HERO -->');


### PR DESCRIPTION
## Summary
- Adds a homepage Agentic Development Cycle section mapping Guide, Generate, Verify, and Solve to ThumbGate's pre-action gate
- Updates README, llms.txt, and llm-context.md so human and AI-search surfaces carry the same positioning
- Adds regression tests for the homepage and AI-visible positioning contract

## Verification
- node --test tests/public-landing.test.js tests/positioning-contract.test.js tests/landing-page-claims.test.js tests/public-static-assets.test.js
- git diff --check
- git diff | rg -n "sk_live_|whsec_|backup code|Rockland|GGBpd520Q" || true
- local Playwright visual pass at 1440px and 390px for #agentic-development-cycle