### PR TITLE
Add ApplyOps Instagram dispatch

### DIFF
--- a/.changeset/applyops-instagram-dispatch.md
+++ b/.changeset/applyops-instagram-dispatch.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add ApplyOps Instagram dispatch workflow and card publisher for partner-pilot revenue distribution.

--- a/.github/workflows/applyops-instagram-dispatch.yml
+++ b/.github/workflows/applyops-instagram-dispatch.yml
@@ -46,12 +46,15 @@ jobs:
         run: node scripts/social-analytics/generate-applyops-instagram-card.js
 
       - name: Validate or publish ApplyOps Instagram post
+        env:
+          PUBLISH_ENABLED: ${{ github.event.inputs.publish_enabled }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
-          if [ "${{ github.event.inputs.publish_enabled }}" != "true" ]; then
+          if [ "$PUBLISH_ENABLED" != "true" ]; then
             node scripts/social-analytics/publish-applyops-instagram.js --dry-run
             exit 0
           fi
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             node scripts/social-analytics/publish-applyops-instagram.js --dry-run
             exit 0
           fi

--- a/.github/workflows/applyops-instagram-dispatch.yml
+++ b/.github/workflows/applyops-instagram-dispatch.yml
@@ -1,0 +1,66 @@
+name: ApplyOps Instagram Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Generate and validate only; do not publish'
+        required: false
+        type: boolean
+        default: true
+      publish_enabled:
+        description: 'Required to publish through Zernio'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: applyops-instagram-dispatch
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      ZERNIO_API_KEY: ${{ secrets.ZERNIO_API_KEY }}
+      THUMBGATE_ANALYTICS_DB: .thumbgate/marketing-analytics.sqlite
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - run: npm ci --onnxruntime-node-install-cuda=skip
+
+      - run: npm install --no-save sharp
+
+      - name: Generate ApplyOps card
+        run: node scripts/social-analytics/generate-applyops-instagram-card.js
+
+      - name: Validate or publish ApplyOps Instagram post
+        run: |
+          if [ "${{ github.event.inputs.publish_enabled }}" != "true" ]; then
+            node scripts/social-analytics/publish-applyops-instagram.js --dry-run
+            exit 0
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            node scripts/social-analytics/publish-applyops-instagram.js --dry-run
+            exit 0
+          fi
+          node scripts/social-analytics/publish-applyops-instagram.js
+
+      - name: Upload card artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: applyops-instagram-card-${{ github.run_id }}
+          retention-days: 7
+          path: .thumbgate/applyops-instagram-card.png

--- a/scripts/social-analytics/generate-applyops-instagram-card.js
+++ b/scripts/social-analytics/generate-applyops-instagram-card.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+let sharp;
+try { sharp = require('sharp'); } catch { /* optional dependency */ }
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const DEFAULT_OUTPUT = path.join(REPO_ROOT, '.thumbgate', 'applyops-instagram-card.png');
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+async function generateApplyOpsInstagramCard(outputPath = DEFAULT_OUTPUT) {
+  if (!sharp) {
+    throw new Error('sharp is not installed. Run: npm install sharp');
+  }
+
+  const width = 1080;
+  const height = 1080;
+  const lines = [
+    'Resume firms:',
+    'audit technical',
+    'candidate risk',
+    'before rewrite.',
+  ];
+  const bullets = [
+    '10 resume-risk audits',
+    'Anonymized findings memo',
+    '$500 deposit -> $1,500 pilot',
+  ];
+
+  const svg = `
+    <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+      <rect width="1080" height="1080" fill="#111827"/>
+      <rect x="72" y="72" width="936" height="936" rx="36" fill="#f8fafc"/>
+      <text x="112" y="150" font-size="36" font-weight="700" fill="#0f766e" font-family="Arial, sans-serif">ApplyOps Partner Pilot</text>
+      ${lines.map((line, i) => `
+        <text x="112" y="${270 + i * 82}" font-size="70" font-weight="800" fill="#111827" font-family="Arial, sans-serif">${escapeXml(line)}</text>
+      `).join('')}
+      <rect x="112" y="660" width="856" height="2" fill="#d1d5db"/>
+      ${bullets.map((line, i) => `
+        <circle cx="132" cy="${740 + i * 62}" r="8" fill="#0f766e"/>
+        <text x="160" y="${755 + i * 62}" font-size="38" font-weight="600" fill="#1f2937" font-family="Arial, sans-serif">${escapeXml(line)}</text>
+      `).join('')}
+      <text x="112" y="975" font-size="34" font-weight="700" fill="#0f766e" font-family="Arial, sans-serif">igorganapolsky.github.io/applyops/partners.html</text>
+    </svg>
+  `;
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  await sharp(Buffer.from(svg)).png().toFile(outputPath);
+  console.log(`[applyops:instagram] card=${outputPath}`);
+  console.log(`[applyops:instagram] bytes=${fs.statSync(outputPath).size}`);
+  return outputPath;
+}
+
+if (require.main === module) {
+  const outputArg = process.argv.find((arg) => arg.startsWith('--output='));
+  const outputPath = outputArg ? outputArg.slice('--output='.length) : DEFAULT_OUTPUT;
+
+  generateApplyOpsInstagramCard(outputPath).catch((err) => {
+    console.error(`[applyops:instagram] failed: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { generateApplyOpsInstagramCard };

--- a/scripts/social-analytics/generate-applyops-instagram-card.js
+++ b/scripts/social-analytics/generate-applyops-instagram-card.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 let sharp;
 try { sharp = require('sharp'); } catch { /* optional dependency */ }
 
@@ -11,10 +11,10 @@ const DEFAULT_OUTPUT = path.join(REPO_ROOT, '.thumbgate', 'applyops-instagram-ca
 
 function escapeXml(value) {
   return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
 }
 
 async function generateApplyOpsInstagramCard(outputPath = DEFAULT_OUTPUT) {
@@ -60,7 +60,7 @@ async function generateApplyOpsInstagramCard(outputPath = DEFAULT_OUTPUT) {
   return outputPath;
 }
 
-if (require.main === module) {
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
   const outputArg = process.argv.find((arg) => arg.startsWith('--output='));
   const outputPath = outputArg ? outputArg.slice('--output='.length) : DEFAULT_OUTPUT;
 

--- a/scripts/social-analytics/publish-applyops-instagram.js
+++ b/scripts/social-analytics/publish-applyops-instagram.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const {
   getConnectedAccounts,
   publishPost,
@@ -67,7 +67,7 @@ async function main() {
   console.log(`[applyops:instagram] published id=${result.id || result.data?.id || 'unknown'}`);
 }
 
-if (require.main === module) {
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
   main().catch((err) => {
     console.error(`[applyops:instagram] failed: ${err.message}`);
     process.exit(1);

--- a/scripts/social-analytics/publish-applyops-instagram.js
+++ b/scripts/social-analytics/publish-applyops-instagram.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  getConnectedAccounts,
+  publishPost,
+  uploadLocalMedia,
+} = require('./publishers/zernio');
+
+const DEFAULT_IMAGE = path.resolve(__dirname, '../../.thumbgate/applyops-instagram-card.png');
+const DEFAULT_CAPTION = `Resume firms and staffing teams:
+
+I have 2 ApplyOps paid-pilot slots open.
+
+I audit 10 technical-candidate resumes for unsupported claims, ATS/title-fit risk, and writer-throughput blockers, then deliver an anonymized findings memo and 30-minute readout.
+
+$500 deposit credited toward the $1,500 pilot:
+https://igorganapolsky.github.io/applyops/partners.html?utm_source=instagram&utm_medium=social&utm_campaign=applyops_partner_pilot_20260527`;
+
+function getArg(name) {
+  const prefix = `${name}=`;
+  const found = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
+  return found ? found.slice(prefix.length) : '';
+}
+
+async function main() {
+  const imagePath = path.resolve(getArg('--image-path') || DEFAULT_IMAGE);
+  const captionPath = getArg('--caption-file');
+  const dryRun = process.argv.includes('--dry-run');
+  const caption = captionPath
+    ? fs.readFileSync(path.resolve(captionPath), 'utf8').trim()
+    : DEFAULT_CAPTION;
+
+  if (!fs.existsSync(imagePath)) {
+    throw new Error(`image not found: ${imagePath}`);
+  }
+
+  console.log(`[applyops:instagram] caption_chars=${caption.length}`);
+  console.log(`[applyops:instagram] image=${imagePath}`);
+
+  const accounts = await getConnectedAccounts();
+  const instagram = accounts.find((account) => account.platform === 'instagram');
+  if (!instagram) {
+    throw new Error('No Instagram account found in Zernio connected accounts.');
+  }
+  console.log(`[applyops:instagram] instagram_account=${instagram.accountId}`);
+
+  if (dryRun) {
+    console.log('[applyops:instagram] dry-run: publish skipped');
+    return;
+  }
+
+  const mediaItem = await uploadLocalMedia(imagePath);
+  const result = await publishPost(caption, [
+    { platform: 'instagram', accountId: instagram.accountId },
+  ], {
+    mediaItems: [mediaItem],
+    utm: {
+      source: 'instagram',
+      medium: 'social',
+      campaign: 'applyops_partner_pilot_20260527',
+    },
+  });
+
+  console.log(`[applyops:instagram] published id=${result.id || result.data?.id || 'unknown'}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`[applyops:instagram] failed: ${err.message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Adds a scoped ApplyOps Instagram dispatch workflow plus card generator/publisher scripts. This lets the revenue loop publish the ApplyOps partner pilot to Instagram through Zernio after validation.\n\nEvidence before PR:\n- Cherry-picked onto origin/main as a single scoped commit.\n- node --check passed for both new scripts.\n- Card generation was tested in the primary clone where sharp is installed.\n- Main direct push was rejected by branch protection, so this PR is the protected path.