### PR TITLE
site: /ai-malpractice-prevention hero — feedback-loop callout + jump-link to live demos

### DIFF
--- a/.changeset/aimp-jump-link-and-loop-callout.md
+++ b/.changeset/aimp-jump-link-and-loop-callout.md
@@ -1,0 +1,13 @@
+---
+"thumbgate": patch
+---
+
+site: `/ai-malpractice-prevention` hero — feedback-loop callout + jump-link to live demos (last-mile Greenberg Traurig polish)
+
+Two surgical hero-section edits before tomorrow's 2026-05-28 3pm Greenberg Traurig pilot meeting, surfaced by a critical audit just before the demo:
+
+1. **Feedback-loop callout in the hero** — pre-empts misreading ThumbGate as a static rule engine. Cyan-bordered single-paragraph callout under the `lead` paragraph: *"The gate learns from your attorneys. Every 👍/👎 an attorney logs on an AI answer becomes a lesson in your firm's local DB. Recurring patterns promote to deterministic rules. The next time a similar action is proposed, the rule fires before any human is asked to approve."* Links to `/learn/feedback-loop-vs-decision-layer` (shipped earlier tonight) for the full mechanism. Surfaces the CEO's full-loop scope correction directly on the highest-priority demo page where Matt will actually start.
+
+2. **"Try the live gates →" jump-link in the hero CTAs row** — anchored to `#live-gate-demos` (the three interactive UPL / Conflict / Egress gates at the bottom of the 9-section page). Eliminates a 2-3 second mid-demo scroll-fumble: Igor can click straight from the hero to the demos when Matt's attention is freshest, without scrolling through 8 sections of pilot-design narrative.
+
+No new files. No structural changes to the existing hero copy. No h1/og/canonical/schema changes (deliberate — too risky to alter under 14 hours before the meeting). 5 minutes of work, immediate demo-day impact.

--- a/public/ai-malpractice-prevention.html
+++ b/public/ai-malpractice-prevention.html
@@ -305,8 +305,14 @@
       <span class="eyebrow">Pre-read for law-firm AI governance pilots</span>
       <h1>Pre-execution controls for legal AI agents.</h1>
       <p class="lead">Block unauthorized advice, conflict-check failures, privilege leaks, and unapproved model calls before an intake agent replies, fetches records, schedules a meeting, or sends data outside the firm's approved boundary.</p>
+      <p style="color: var(--soft); font-size: 0.95rem; max-width: 760px; margin: 0 0 1rem; padding: 0.55rem 0.85rem; border-left: 3px solid var(--cyan); background: rgba(45, 212, 191, 0.05); border-radius: 0 6px 6px 0;">
+        <strong style="color: var(--cyan)">The gate learns from your attorneys.</strong>
+        Every 👍 / 👎 an attorney logs on an AI answer becomes a lesson in your firm's local DB. Recurring patterns promote to deterministic rules. The next time a similar action is proposed, the rule fires before any human is asked to approve.
+        <a href="/learn/feedback-loop-vs-decision-layer" style="color: var(--cyan); white-space: nowrap;">How the feedback loop works &rarr;</a>
+      </p>
       <div class="hero-actions">
         <a class="cta" href="mailto:iganapolsky@gmail.com?subject=ThumbGate%2025-minute%20legal%20AI%20pilot%20walkthrough&amp;body=Hi%20Igor%2C%0A%0AWe%27d%20like%20to%20review%20the%2025-minute%20ThumbGate%20legal%20AI%20intake%20pilot.%20Please%20send%20the%20meeting%20invite%20and%20demo%20materials.%0A%0ABest%2C">Book a 25-minute pilot walkthrough</a>
+        <a class="ghost" href="#live-gate-demos">Try the live gates &rarr;</a>
         <a class="ghost" href="#demo">View the 25-minute demo plan</a>
       </div>
       <div class="proof-row" aria-label="Key proof points">

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -662,3 +662,14 @@ test('comparison pages link back to anthropic-claude-for-legal for discovery', a
   assert.match(gk, /href="\/compare\/anthropic-claude-for-legal"/);
   assert.match(arc, /href="\/compare\/anthropic-claude-for-legal"/);
 });
+
+test('/ai-malpractice-prevention surfaces feedback-loop framing + jump-link to live demos in the hero', async () => {
+  const res = await fetch(`${origin}/ai-malpractice-prevention`);
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  // The feedback-loop callout (CEO scope correction surfaced in the hero)
+  assert.match(html, /The gate learns from your attorneys/);
+  assert.match(html, /href="\/learn\/feedback-loop-vs-decision-layer"/);
+  // The jump-link to the live gate demos (so Igor doesn't have to scroll through 9 sections mid-demo)
+  assert.match(html, /href="#live-gate-demos"[^>]*>Try the live gates/);
+});


### PR DESCRIPTION
## Why — last-mile demo polish for tomorrow 3pm

Critical audit just before tomorrow's 2026-05-28 3pm Greenberg Traurig pilot surfaced two specific gaps on the demo page:

1. **The page doesn't surface the feedback-loop framing** the CEO corrected me on tonight. Matt reads it as a *static rule engine*, not as *the gate that learns from every attorney's 👍/👎*.
2. **The interactive demos are at the bottom of a 9-section, 3,377-word page.** During the demo Igor screen-shares and scrolls past 8 sections to reach the live gates. A 2-3 second scroll-fumble in the first minute breaks momentum.

## What ships

**1. Feedback-loop callout in the hero** — cyan-bordered single-paragraph callout under the `lead`:
> *"The gate learns from your attorneys. Every 👍/👎 an attorney logs on an AI answer becomes a lesson in your firm's local DB. Recurring patterns promote to deterministic rules. The next time a similar action is proposed, the rule fires before any human is asked to approve."*

With a "How the feedback loop works →" link to `/learn/feedback-loop-vs-decision-layer` (shipped earlier tonight in #2356). Surfaces all four loop stages (capture / memory / rule promotion / enforcement) on the page Matt actually starts on.

**2. "Try the live gates →" jump-link** in the hero CTAs row, anchored to `#live-gate-demos`. Igor can click straight from the hero to the interactive UPL / Conflict / Egress demos when Matt's attention is freshest.

## What I deliberately did NOT change
- The `<h1>` (`"Pre-execution controls for legal AI agents."`) — accurate, SEO-stable, og-stable. Risk-cost of changing it under 14 hours before the meeting outweighs marginal copy improvement.
- The 9-section structure — reads as a pre-read for Matt's *internal* pitch to his Innovation team. That's the right posture for BigLaw innovation buyers who socialize before signing.

## Test plan
- [x] `node --test tests/public-static-assets.test.js` — 47/47 green (1 new test asserts both hero elements)
- [x] Pre-commit + pre-push hooks (parity, version sync, claims, internal-links, npm pack dry-run, regression-guard) — all green
- [ ] CI on push
- [ ] Post-merge: `/ai-malpractice-prevention` returns 200 with feedback-loop callout + jump-link in rendered HTML

## Time-critical

Demo is **<13 hours away**. Ready for review, requesting `/trunk merge` next comment.

https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd)_