### PR TITLE
ops: bin/revenue-truth.sh wrapper — kill the cloud-session 401 report-loop

### DIFF
--- a/.changeset/revenue-truth-wrapper.md
+++ b/.changeset/revenue-truth-wrapper.md
@@ -1,0 +1,23 @@
+---
+"thumbgate": patch
+---
+
+ops: `bin/revenue-truth.sh` wrapper — kill the "401 from cloud session" report-loop
+
+Closes a repeatable-skill gap the CEO called out tonight: cloud Claude Code sessions and the bootstrap probe were repeatedly reporting "hosted billing summary returned 401" as if it were news, because `node scripts/revenue-status.js` run from a container without `THUMBGATE_OPERATOR_KEY` always hits 401 and the agent kept treating that as a blocker instead of the expected posture.
+
+The wrapper handles three branches in one place:
+
+1. **Fresh operator key configured** (env OR `~/.config/thumbgate/operator.json`) → runs the canonical `scripts/revenue-status.js` pipeline, exits with its code.
+2. **Stale operator key** (file exists OR env var set, but the pipeline falls back to `Source: local-fallback` because the key no longer authenticates against Railway after a rotation) → runs the pipeline, then prints a loud `WARNING — configured operator key authenticated against the LOCAL fallback` block with the exact fix (`node bin/cli.js billing:setup` on the CEO's local machine). Detected by grepping the captured pipeline output for `Source: local-fallback` or `Hosted summary working: no`.
+3. **No operator key AND shell looks cloudy** (`$CI`, `$CODESPACES`, `$GITHUB_ACTIONS`, `$CLAUDE_CODE_REMOTE`, or `/home/user/...` on Linux container) → prints a one-paragraph "revenue truth is a local operation by design, run from your own machine, do NOT paste the key here" message and exits **`0`**. Exiting 0 is deliberate: cloud sessions hitting this case is the *expected* posture, not a bug to alarm about.
+
+Refuses to accept the operator key as a CLI argument (exits `64`). Pasting on the command line would leak to shell history; pasting into the Claude transcript would leak to model context. Per CLAUDE.md hard-block rule #2.
+
+Ships with:
+
+- `bin/revenue-truth.sh` (executable, no argv acceptance)
+- `npm run revenue:truth` alias in `package.json`
+- Troubleshooting block appended to `.claude/skills/revenue-truth/SKILL.md` documenting the three branches + the anti-pattern this exists to prevent (an agent reporting 401 as news across multiple turns).
+
+Smoke-tested in this container: stale-key branch fires the WARNING block correctly. Argv-refusal branch exits 64. Operator key in this container is intentionally stale (Railway rotated; container's `operator.json` still has the old value), and the wrapper now surfaces that loudly instead of silently letting another session conclude "we have no traffic."

--- a/.claude/skills/revenue-truth/SKILL.md
+++ b/.claude/skills/revenue-truth/SKILL.md
@@ -105,3 +105,21 @@ curl -fsS \
 ```
 
 This tells you whether traffic came from channels we actually posted to (Bluesky, Threads, Reddit) or from background ai_search / direct. Channel mismatch is usually the real story.
+
+## If you're running from a cloud Claude Code session and seeing 401
+
+Use the wrapper, not the raw script:
+
+```bash
+npm run revenue:truth     # or: bash bin/revenue-truth.sh
+```
+
+The wrapper handles three branches:
+
+1. **Operator key configured AND fresh.** Runs the canonical pipeline. Output starts with `Source: hosted-billing-summary`.
+2. **Operator key configured but STALE** (env var or `~/.config/thumbgate/operator.json` exists but no longer authenticates against Railway after a rotation). Runs the pipeline, then prints a loud `WARNING — configured operator key authenticated against the LOCAL fallback` block with the exact fix command. This is what you want to see when describing the 401 to the CEO instead of guessing.
+3. **No operator key AND shell looks like a cloud session** (`$CI`, `$CODESPACES`, `$GITHUB_ACTIONS`, `$CLAUDE_CODE_REMOTE`, or `/home/user/...` Linux container path). Prints a one-paragraph "revenue truth is local-only by design, run from your laptop, do NOT paste the key here" message and exits `0`. This is the **expected** posture for cloud sessions — not a bug, not a blocker, not something to keep reporting back to the CEO.
+
+The wrapper refuses to accept the operator key as a CLI argument (exits 64). Pasting the key on the command line would leak it to shell history; pasting it into the Claude transcript would leak it to the model context. Per CLAUDE.md hard-block rule #2.
+
+**Anti-pattern this section exists to prevent:** an agent in a cloud session running `node scripts/revenue-status.js` directly, hitting 401, then repeatedly telling the CEO "I can't see hosted revenue" across multiple turns as if it were news. After the first observation, route to `npm run revenue:truth` so the diagnostic message is the response, not a back-and-forth.

--- a/bin/revenue-truth.sh
+++ b/bin/revenue-truth.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# bin/revenue-truth.sh
+#
+# Wrapper around `npm run revenue:status` that NEVER asks for the operator key
+# to be pasted into a chat, a session log, or this script's argv. Designed for
+# the case where a cloud Claude Code session (or any non-CEO-laptop shell)
+# would otherwise repeatedly 401 and the agent would describe the 401 as a
+# blocker forever.
+#
+# Decision tree:
+#   1. Operator key already configured (env OR ~/.config/thumbgate/operator.json)
+#      → run the canonical revenue-status pipeline.
+#   2. Operator key NOT configured but the shell is on a personal machine
+#      (THUMBGATE_LOCAL_OK=1 OR macOS-like markers)
+#      → print the exact `bin/cli.js billing:setup` flow that writes the key
+#        to ~/.config/thumbgate/operator.json from a one-time browser dance.
+#   3. Operator key NOT configured AND the shell looks like a cloud agent
+#      (CI=true, CODESPACES=true, /home/user/ThumbGate path on Linux container)
+#      → print a friendly "this is a local-only operation, here is how to run
+#        it from your own machine" message and exit 0 (do NOT throw).
+#
+# Refuses to accept the operator key as a CLI argument or stdin paste — that
+# would leak it into shell history and the agent transcript.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OPERATOR_FILE="${HOME}/.config/thumbgate/operator.json"
+
+color_warn=$'\033[33m'
+color_ok=$'\033[32m'
+color_dim=$'\033[2m'
+color_reset=$'\033[0m'
+
+if [[ "$#" -gt 0 ]]; then
+  echo "${color_warn}bin/revenue-truth.sh does not accept arguments.${color_reset}" >&2
+  echo "  The operator key MUST come from \$THUMBGATE_OPERATOR_KEY or ${OPERATOR_FILE}." >&2
+  echo "  Pasting the key on the command line would leak it to shell history." >&2
+  exit 64
+fi
+
+have_env_key=0
+have_file_key=0
+if [[ -n "${THUMBGATE_OPERATOR_KEY:-}" ]]; then have_env_key=1; fi
+if [[ -f "$OPERATOR_FILE" ]]; then
+  # crude check — just confirm the file exists and is non-empty; do not read the value
+  if [[ -s "$OPERATOR_FILE" ]]; then have_file_key=1; fi
+fi
+
+if [[ "$have_env_key" -eq 1 || "$have_file_key" -eq 1 ]]; then
+  echo "${color_ok}Operator key detected. Querying live billing summary…${color_reset}"
+  cd "$REPO_ROOT"
+  tmp_out="$(mktemp -t revenue-truth.XXXXXX)"
+  trap 'rm -f "$tmp_out"' EXIT
+  set +e
+  node scripts/revenue-status.js "$@" | tee "$tmp_out"
+  rc=${PIPESTATUS[0]}
+  set -e
+  # Even when the canonical pipeline returns exit 0, it may fall back to local
+  # if the configured operator key is stale (existing file or env var that no
+  # longer authenticates against Railway). Surface that case loudly instead of
+  # silently letting another session conclude "we have no traffic."
+  if grep -qE "Source: local-fallback|Hosted summary working: no" "$tmp_out"; then
+    cat >&2 <<EOF
+
+${color_warn}WARNING — configured operator key authenticated against the LOCAL fallback,${color_reset}
+${color_warn}not the hosted Railway billing summary. The numbers above are the local${color_reset}
+${color_warn}lesson DB, not Stripe-reconciled hosted truth.${color_reset}
+
+Likely causes:
+  - The operator key in $OPERATOR_FILE (or \$THUMBGATE_OPERATOR_KEY) is stale.
+  - Railway rotated THUMBGATE_OPERATOR_KEY and this machine still has the old value.
+
+Fix on the CEO's local machine (do NOT paste the key into any chat session):
+  node bin/cli.js billing:setup   # writes a fresh key to $OPERATOR_FILE
+
+After re-running setup, re-run \`bin/revenue-truth.sh\`. If \`Source:\`
+becomes \`hosted-billing-summary\`, the rotation worked.
+EOF
+  fi
+  exit "$rc"
+fi
+
+# No key. Determine which guidance to print.
+looks_like_cloud_agent=0
+if [[ -n "${CI:-}" || -n "${CODESPACES:-}" || -n "${GITHUB_ACTIONS:-}" || -n "${CLAUDE_CODE_REMOTE:-}" ]]; then
+  looks_like_cloud_agent=1
+fi
+if [[ "$looks_like_cloud_agent" -eq 0 && "$(uname -s 2>/dev/null || echo unknown)" == "Linux" && "${PWD:-}" =~ ^/home/user/ ]]; then
+  # Heuristic: the cloud-execution containers we use are Linux + /home/user/...
+  looks_like_cloud_agent=1
+fi
+
+cat >&2 <<EOF
+${color_warn}No THUMBGATE_OPERATOR_KEY found.${color_reset}
+  - \$THUMBGATE_OPERATOR_KEY:           $( [[ "$have_env_key" -eq 1 ]] && echo set || echo unset )
+  - ${OPERATOR_FILE}: $( [[ "$have_file_key" -eq 1 ]] && echo present || echo missing )
+
+EOF
+
+if [[ "$looks_like_cloud_agent" -eq 1 ]]; then
+  cat >&2 <<EOF
+${color_warn}This shell looks like a cloud / CI session.${color_reset}
+  Revenue truth is a LOCAL operation by design: the operator key lives on
+  the CEO's laptop and on Railway, never in a cloud Claude Code session.
+
+  To unblock: run this same command from your local terminal, where
+  \`~/.config/thumbgate/operator.json\` already exists. Do NOT paste the
+  operator key into this session.
+
+  Exiting 0 — this is the expected posture for cloud sessions, not a bug.
+EOF
+  exit 0
+fi
+
+cat >&2 <<EOF
+${color_warn}One-time local setup (writes the key to a file on your machine, never to chat or git):${color_reset}
+
+    node bin/cli.js billing:setup
+
+  This walks an OAuth-style dance with the hosted Railway deployment and
+  writes the operator key to ${OPERATOR_FILE} with 0600 perms. After it
+  completes, re-run this script.
+
+${color_dim}Alternative (advanced): export THUMBGATE_OPERATOR_KEY=<value> in your
+shell rc file. Do not paste it into chat. Do not commit it.${color_reset}
+EOF
+exit 1

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     "verify:full": "node scripts/verify-run.js full",
     "budget:status": "node scripts/budget-guard.js --status",
     "revenue:status": "node scripts/revenue-status.js",
+    "revenue:truth": "bash bin/revenue-truth.sh",
     "revenue:doctor": "node scripts/revenue-observability-doctor.js",
     "revenue:plan": "node scripts/may-2026-revenue-machine.js",
     "revenue:status:local": "node bin/cli.js cfo",


### PR DESCRIPTION
## Why

CEO called out tonight: cloud Claude Code sessions kept reporting `Hosted billing summary returned 401` as if it were news, because `node scripts/revenue-status.js` from a container without `THUMBGATE_OPERATOR_KEY` always hits 401 and the agent kept treating that as a blocker. **Cloud-session 401 is the expected posture, not a bug.** This PR encodes that into a wrapper so no future session has to re-derive it.

## What ships

**`bin/revenue-truth.sh`** with three branches:

1. **Fresh operator key** → runs canonical `scripts/revenue-status.js`, exits with its code.
2. **Stale operator key** (file or env var exists but pipeline falls back to `Source: local-fallback`) → runs pipeline, then prints a loud `WARNING — configured operator key authenticated against the LOCAL fallback` with the exact fix (`node bin/cli.js billing:setup` on the CEO's local machine).
3. **No key + cloud-session markers** (`$CI`, `$CODESPACES`, `$GITHUB_ACTIONS`, `$CLAUDE_CODE_REMOTE`, or `/home/user/...` Linux container) → prints one-paragraph "local-only by design, do NOT paste the key here" and exits **`0`**.

Plus:
- `npm run revenue:truth` alias in `package.json`
- Troubleshooting block appended to `.claude/skills/revenue-truth/SKILL.md`
- **Refuses argv (exit 64)** — pasting the key on the command line would leak to shell history; pasting into chat would leak to model context. Per CLAUDE.md hard-block rule #2.

## What I deliberately did NOT ship

The earlier proposal to add Pro-tier paywall enforcement to hosted endpoints. Curl probe at 23:09 UTC confirmed all seven hosted endpoints I checked (`/v1/lessons/search`, `/v1/lessons/export`, `/v1/lessons/import`, `/v1/feedback/stats`, `/v1/feedback/summary`, `/v1/dashboard`, `/v1/dpo/export`) already return 401. The real "too-thin paywall" problem is that **the free `npm install thumbgate` gives the full feedback loop locally** (capture → memory → rule promotion → PreToolUse enforcement). Adding more 401s to hosted infra doesn't move that needle. That's a pricing-copy + truly-hosted-only-features problem, not a code patch — and not honest to ship as "I fixed the paywall."

## Test plan

- [x] Smoke test (stale-key branch): WARNING block fires correctly, exits 0
- [x] Smoke test (argv refusal): exits 64 with no key in output
- [x] Pre-commit + pre-push hooks all green
- [ ] CI on push

https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd)_