### PR TITLE
Constrain Zernio dispatch defaults to working platforms

### DIFF
--- a/.github/workflows/zernio-custom-post-dispatch.yml
+++ b/.github/workflows/zernio-custom-post-dispatch.yml
@@ -7,6 +7,11 @@ on:
         description: 'Post body to publish via Zernio'
         required: true
         type: string
+      platforms:
+        description: 'Comma-separated Zernio platforms to publish to. Exclude twitter/youtube until those accounts are fixed.'
+        required: false
+        type: string
+        default: 'reddit,threads,bluesky'
 
 permissions:
   contents: read
@@ -36,6 +41,7 @@ jobs:
       - name: Publish via Zernio
         env:
           POST_TEXT: ${{ github.event.inputs.text }}
+          POST_PLATFORMS: ${{ github.event.inputs.platforms }}
           THUMBGATE_DEDUP_LOG_PATH: ${{ runner.temp }}/zernio-dedup-log.json
         run: |
           if [ -z "${ZERNIO_API_KEY:-}" ]; then
@@ -43,4 +49,6 @@ jobs:
             exit 1
           fi
 
-          node scripts/social-analytics/publishers/zernio.js --text="$POST_TEXT"
+          node scripts/social-analytics/publishers/zernio.js \
+            --text="$POST_TEXT" \
+            --platforms="$POST_PLATFORMS"

--- a/.github/workflows/zernio-offer-dispatch.yml
+++ b/.github/workflows/zernio-offer-dispatch.yml
@@ -11,7 +11,7 @@ on:
         description: 'Comma-separated Zernio platforms to publish to.'
         required: false
         type: string
-        default: 'linkedin,threads,bluesky'
+        default: 'threads,bluesky'
       campaign:
         description: 'UTM campaign slug.'
         required: false

--- a/tests/zernio-integration.test.js
+++ b/tests/zernio-integration.test.js
@@ -434,7 +434,7 @@ describe('zernio publisher', () => {
     assert.match(workflow, /workflow_dispatch:/);
     assert.match(workflow, /ZERNIO_API_KEY: \$\{\{ secrets\.ZERNIO_API_KEY \}\}/);
     assert.match(workflow, /thumbgate\\\.ai\|buy\\\.stripe\\\.com/);
-    assert.match(workflow, /default: 'linkedin,threads,bluesky'/);
+    assert.match(workflow, /default: 'threads,bluesky'/);
     assert.match(workflow, /--platforms="\$OFFER_PLATFORMS"/);
     assert.match(workflow, /--campaign="\$OFFER_CAMPAIGN"/);
     assert.match(workflow, /--medium="\$OFFER_MEDIUM"/);


### PR DESCRIPTION
## Summary
- default Zernio offer dispatch to threads/bluesky instead of including LinkedIn
- add platform selection to custom Zernio dispatch
- default custom dispatch to reddit, threads, and bluesky, excluding known failing twitter/youtube surfaces

## Verification
- ruby YAML parse for both workflow files passed
- ThumbGate pre-commit guards passed
- pre-push npm pack dry-run, public HTML link validation, and regression-guard tests passed

## Revenue context
Recent ApplyOps Zernio pushes partially published but failed overall due Twitter account ownership and YouTube video requirements. This makes future revenue-distribution runs cleaner and easier to verify.