### PR TITLE
ops: SessionStart bootstrap suppresses the 4-line 401 nag in stale-key state

### DIFF
--- a/.changeset/bootstrap-suppress-stale-key.md
+++ b/.changeset/bootstrap-suppress-stale-key.md
@@ -1,0 +1,21 @@
+---
+"thumbgate": patch
+---
+
+ops: SessionStart bootstrap suppresses 4-line 401 nag in stale-key state
+
+The CEO called out tonight that every session resume shows the same multi-line `Hosted billing summary returned 401` / `operator key on this machine does not match` / `local operational billing summary is unavailable` Gaps block, even after I shipped `bin/revenue-truth.sh` (PR #2359) earlier. **PR #2359 shipped the wrapper at the wrong path** — the SessionStart hook calls `.claude/scripts/session-bootstrap/revenue-truth.sh`, not `bin/revenue-truth.sh`. Even if #2359 had merged, the bootstrap would still nag.
+
+This PR fixes the actual file the hook calls. After running the canonical `scripts/revenue-status.js` pipeline, it detects the stale-key case (output contains `Source: local-fallback` or `Hosted summary working: no`) and:
+
+1. Filters out the four noisy `Gaps:` lines that re-derive the 401 every session:
+   - `- spawnSync gh ENOENT` (gh CLI absent — expected in cloud containers)
+   - `- Hosted billing summary today returned 401`
+   - `- Hosted billing summary rejected credentials (HTTP 401) …`
+   - `- local operational billing summary is unavailable`
+
+2. Replaces them with a single short paragraph: *"authenticated against LOCAL fallback (not hosted Railway summary). Numbers above are local lesson DB readings, not Stripe-reconciled hosted revenue. EXPECTED posture for any session that does not hold the rotated Railway operator key — not a blocker."* + the exact local-machine fix command (`node bin/cli.js billing:setup`) + a reminder NOT to paste the key into chat or argv (CLAUDE.md hard-block rule #2).
+
+Happy-path output (key fresh, hosted summary authenticates) is unchanged — same full pipeline output as before.
+
+Smoke test in this container (which is in the stale-key state by design) confirms the 4 noisy lines are gone and the replacement paragraph fires correctly. PR #2359 should be closed as superseded — the wrapper at `bin/revenue-truth.sh` was at the wrong path and the legacy bootstrap is the correct fix surface.

--- a/.claude/scripts/session-bootstrap/revenue-truth.sh
+++ b/.claude/scripts/session-bootstrap/revenue-truth.sh
@@ -53,4 +53,40 @@ EOF
 fi
 
 # Defer to the canonical pipeline so this hook can never drift again.
-( cd "${ROOT}" && node scripts/revenue-status.js 2>&1 ) | sed 's/^/  /'
+# Capture output to detect the stale-key case (key configured but pipeline
+# still falls back to Source: local-fallback because the configured key no
+# longer authenticates against Railway after a rotation). Without this, every
+# cloud session sees a multi-line 401 nag in the SessionStart bootstrap and
+# re-derives "operator key mismatch is a blocker" — it isn't, it's the
+# expected posture for any session that doesn't hold the Railway key.
+RAW="$( cd "${ROOT}" && node scripts/revenue-status.js 2>&1 )"
+RC=$?
+
+if echo "$RAW" | grep -qE "Source: local-fallback|Hosted summary working: no"; then
+  # Stale or insufficient credential. Show the live numbers (still valid
+  # local lesson DB readings, just not Stripe-reconciled) and replace the
+  # 401-shaped Gaps lines with a single one-liner so it stops reading as a
+  # blocker.
+  echo "$RAW" \
+    | grep -vE "^[[:space:]]*- spawnSync gh ENOENT$" \
+    | grep -vE "^[[:space:]]*- Hosted billing summary today returned 401$" \
+    | grep -vE "^[[:space:]]*- Hosted billing summary rejected credentials \(HTTP 401\)" \
+    | grep -vE "^[[:space:]]*- local operational billing summary is unavailable$" \
+    | sed 's/^/  /'
+  cat <<EOF
+
+  ${KEY_SOURCE}: authenticated against LOCAL fallback (not hosted Railway
+  summary). Numbers above are local lesson DB readings, not Stripe-
+  reconciled hosted revenue. EXPECTED posture for any session that does
+  not hold the rotated Railway operator key — not a blocker. To see
+  hosted truth, run \`node bin/cli.js billing:setup\` from a machine
+  that can write to ~/.config/thumbgate/operator.json. Do NOT paste the
+  key into chat or argv (CLAUDE.md hard-block rule #2).
+EOF
+  exit 0
+fi
+
+# Happy path: hosted summary authenticated. Print full pipeline output as
+# the original script did.
+echo "$RAW" | sed 's/^/  /'
+exit $RC


### PR DESCRIPTION
## What's the problem this fixes

CEO called out tonight (and again on session resume): the SessionStart bootstrap keeps re-deriving the same multi-line 401 / operator-key-mismatch block at the start of every session. Root cause was two-fold:

1. **PR #2359 shipped the wrapper at the wrong path** — at `bin/revenue-truth.sh`. The SessionStart hook in `.claude/settings.json` calls `.claude/scripts/session-bootstrap/revenue-truth.sh`, a different file. Even if #2359 merged, the bootstrap would still nag.
2. **The legacy bootstrap had no handling for the stale-key case** — it ran the canonical pipeline and dumped the raw 401 Gaps block into every session resume, where every cloud agent then re-derived "operator key mismatch is a blocker" (it isn't).

## What ships

Patches the file the hook actually calls. After running the canonical `scripts/revenue-status.js` pipeline:

- Detects `Source: local-fallback` or `Hosted summary working: no` in the output → stale-key branch
- Filters the four noisy Gaps lines that fire every cloud session:
  - `- spawnSync gh ENOENT` (gh CLI absent in cloud containers — expected)
  - `- Hosted billing summary today returned 401`
  - `- Hosted billing summary rejected credentials (HTTP 401) …`
  - `- local operational billing summary is unavailable`
- Replaces with one short paragraph documenting **this is the expected posture, not a blocker** + the exact local-machine fix command (`node bin/cli.js billing:setup`) + the reminder NOT to paste the key into chat or argv (CLAUDE.md hard-block rule #2).

Happy-path output (key fresh, hosted summary authenticates) is unchanged — same full pipeline output as before.

## Test plan

- [x] Smoke test in this container (stale-key state by design): four noisy lines gone, replacement paragraph fires correctly. Output verified above commit message.
- [x] Pre-commit + pre-push hooks all green.
- [ ] CI on push.
- [ ] **Next session start should no longer surface the 4-line 401 nag — that's the user-visible test.**

## #2359 disposition

Should be closed as superseded. The `bin/revenue-truth.sh` wrapper in that PR is at the wrong path and would never have been called by the hook. The legacy bootstrap (this PR) is the correct fix surface.

https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd)_