### PR TITLE
site: BigLaw conversion clarity — pilot-scope blocks + compare-page callout

### DIFF
--- a/.changeset/biglaw-pilot-scope-clarity.md
+++ b/.changeset/biglaw-pilot-scope-clarity.md
@@ -1,0 +1,8 @@
+---
+"thumbgate": patch
+---
+
+site: BigLaw conversion clarity — two pages, three new procurement-defensible blocks
+
+- `/ai-malpractice-prevention` recommended-pilot section now includes three color-coded blocks: "What you walk away with" (audit log + RAG of every gated detection), "What we don't claim" (pre-SOC2, no hallucination indemnity, local-first), "What you bring" (one owner, one workflow, your approved disclaimer, read-only conflicts DB access). Pre-empts procurement objections without overpromising.
+- `/compare/anthropic-claude-for-legal` hero now carries the same BigLaw-internal-AI callout the malpractice page added — anyone landing from the Claude-for-Legal comparison sees the no-public-chatbot framing without needing to navigate.

--- a/public/ai-malpractice-prevention.html
+++ b/public/ai-malpractice-prevention.html
@@ -524,6 +524,20 @@
         <p>Start narrow: one intake channel, one practice-area workflow, one adverse-party fixture, one approved-model routing policy, and one audit export format.</p>
         <p>Deliverables: preloaded rule pack, demo agent, screenshot set, 60-second walkthrough clip, security data-flow note, pilot metrics, and a go/no-go rollout recommendation.</p>
         <p style="margin:1.2rem 0 0.6rem;color:var(--amber);font-size:1.1rem;font-weight:700;">Pilot setup fee: $2,500 &ndash; $7,500 flat (scope-dependent). No per-seat or per-query billing during the pilot.</p>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:0.75rem;margin:1.4rem 0 1rem;">
+          <div style="background:rgba(114,227,165,0.06);border-left:3px solid var(--green);padding:0.7rem 0.9rem;border-radius:0 6px 6px 0">
+            <strong style="color:var(--green);font-size:0.78rem;text-transform:uppercase;letter-spacing:0.08em;display:block;margin-bottom:0.3rem">What you walk away with</strong>
+            <span style="font-size:0.9rem;color:var(--soft)">A searchable audit log + RAG of every gated detection over 30 days, broken down by rule, agent, and disposition. Defensible in front of your risk committee.</span>
+          </div>
+          <div style="background:rgba(251,191,36,0.06);border-left:3px solid #fbbf24;padding:0.7rem 0.9rem;border-radius:0 6px 6px 0">
+            <strong style="color:#fbbf24;font-size:0.78rem;text-transform:uppercase;letter-spacing:0.08em;display:block;margin-bottom:0.3rem">What we don't claim</strong>
+            <span style="font-size:0.9rem;color:var(--soft)">Not SOC 2 today. Not BAA-ready as a blanket claim. No hallucination indemnity for third-party model output. Local-first deployment makes the pilot a no-client-data engagement.</span>
+          </div>
+          <div style="background:rgba(45,212,191,0.06);border-left:3px solid var(--cyan);padding:0.7rem 0.9rem;border-radius:0 6px 6px 0">
+            <strong style="color:var(--cyan);font-size:0.78rem;text-transform:uppercase;letter-spacing:0.08em;display:block;margin-bottom:0.3rem">What you bring</strong>
+            <span style="font-size:0.9rem;color:var(--soft)">One named owner, one workflow you're already evaluating AI on, your approved disclaimer language, and read-only access to whichever conflicts DB you already run.</span>
+          </div>
+        </div>
         <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-top:1rem;">
           <a class="cta" href="mailto:iganapolsky@gmail.com?subject=ThumbGate%2025-minute%20legal%20AI%20pilot%20walkthrough&amp;body=Hi%20Igor%2C%0A%0AWe%27d%20like%20to%20review%20the%2025-minute%20ThumbGate%20legal%20AI%20intake%20pilot.%20Please%20send%20the%20meeting%20invite%20and%20demo%20materials.%0A%0ABest%2C">Book a 25-minute pilot walkthrough</a>
           <a class="ghost" href="/dashboard">View the live dashboard demo</a>

--- a/public/compare/anthropic-claude-for-legal.html
+++ b/public/compare/anthropic-claude-for-legal.html
@@ -134,6 +134,10 @@
       <span class="eyebrow">ThumbGate vs Claude for Legal</span>
       <h1>Anthropic generates the legal action. ThumbGate learns from the attorney and gates the legal action.</h1>
       <p><strong>Claude for Legal</strong> (launched 2026-05-12) is a vertical bundle: Claude Opus 4.7 (90.9% on Harvey's BigLaw Bench), 12 practice-area plugins (Commercial, Employment, Privacy, Corporate, AI Governance, and more), and 20+ connectors (DocuSign, Ironclad, iManage, NetDocuments, LexisNexis, Thomson Reuters, Box, Everlaw, LSuite) embedded into Word, Outlook, Claude Cowork, and Claude Projects. <strong>ThumbGate</strong> is the full feedback-to-enforcement loop underneath: every 👍 / 👎 an attorney gives on any AI answer becomes a lesson in a local lesson DB, recurring lessons get promoted to prevention rules, and those rules then fire at the PreToolUse hook before Claude's next proposed tool call executes. Anthropic's safety story is <em>"human in the loop on decision making."</em> Ours is <em>"the attorney's vote becomes the rule, and the rule fires deterministically before the next decision is even shown to a human."</em> Most regulated firms need both.</p>
+      <p style="margin-top:18px; padding:14px 18px; border-left:3px solid #a78bfa; background:rgba(167,139,250,0.08); border-radius:0 6px 6px 0; max-width:760px;">
+        <strong style="color:#a78bfa">No public-facing chatbot? You still have the risk surface.</strong>
+        Most BigLaw firms don't take client intake through a chatbot &mdash; but associates already paste matter context into Claude (including Claude for Legal), Cursor, Codex, and internal LLM gateways every day. The risk isn't a bot giving public advice; it's <em>internal</em> agent use the firm can't see. ThumbGate produces a searchable audit log + RAG of every gated detection &mdash; queryable by ethics, risk, and innovation owners. Your conflicts DB and document systems stay where they are.
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
Three procurement-defensible blocks added to convert today's traffic to pilot conversations. All three changes pre-empt objections heard live on the GT call without overpromising.

## Changes

### 1. `/ai-malpractice-prevention` — pilot scope clarity blocks
Three color-coded blocks added inside the recommended-pilot section:
- **What you walk away with** (green) — searchable audit log + RAG of every gated detection over 30 days. Frames the deliverable in language a risk committee can defend.
- **What we don't claim** (amber) — pre-SOC2 today, no BAA as blanket claim, no hallucination indemnity, local-first by design. Honest posture beats vague enterprise-ese for sophisticated buyers.
- **What you bring** (cyan) — one owner, one workflow, approved disclaimer, read-only access to the firm's existing conflicts DB. Makes the buyer commitment concrete.

### 2. `/compare/anthropic-claude-for-legal` — internal-AI callout
Same purple "no public-facing chatbot, you still have the risk surface" callout the malpractice page got this afternoon. Now anyone landing from the Claude-for-Legal comparison sees the BigLaw framing in the hero without needing to navigate.

## Why this should convert
- BigLaw buyer told us this afternoon that the pilot-deliverable language is what they need for risk-committee defensibility. We now have that language on the public page.
- The "what we don't claim" block reads as honesty to sophisticated procurement teams. Vague "enterprise-grade" copy reads as evasion.
- The compare-page callout extends the new positioning to a second high-priority surface without splitting attention or creating a sibling page.

## Verified before push
- 123 tests pass across `public-static-assets`, `public-landing`, `landing-page-claims`.

## Deploy posture
HTML-only, no version bump. Railway auto-rebuilds on merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFYGvwwHYt8Z9oxLVtg4wd)_