### PR TITLE
feat(connector): publish ThumbGate to the MCP Registry + document the Claude remote connector

### DIFF
--- a/.changeset/claude-connector-publish.md
+++ b/.changeset/claude-connector-publish.md
@@ -1,0 +1,18 @@
+---
+"thumbgate": patch
+---
+
+Make the Claude/MCP connector discoverable: fix the MCP Registry publish + document the remote connector.
+
+ThumbGate already runs as a working remote MCP server (https://thumbgate.ai/mcp),
+but it wasn't listed in the MCP Registry — the publish workflow had been failing.
+
+- `.github/workflows/mcp-registry-publish.yml`: bump `mcp-publisher` v1.5.0 → v1.7.9
+  (v1.5.0 requested the old OIDC audience `mcp-registry`; the registry now requires
+  `https://registry.modelcontextprotocol.io` and 401s the old one). Add a step that
+  waits for the npm package version in `server.json` to be live on npmjs.org before
+  publishing, so a release that bumps the version ahead of npm no longer 404s the
+  registry publish.
+- README: add an "Add ThumbGate to Claude (remote connector)" section pointing at
+  `https://thumbgate.ai/mcp` (Settings → Connectors → Add custom connector) — usable
+  today with no install.

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -16,9 +16,30 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download mcp-publisher
+        # v1.7.9: v1.5.0 requested the old OIDC audience ("mcp-registry"); the
+        # registry now requires "https://registry.modelcontextprotocol.io" and
+        # rejects the old one (401 invalid audience). Newer publisher fixes it.
         run: |
-          curl -sL https://github.com/modelcontextprotocol/registry/releases/download/v1.5.0/mcp-publisher_linux_amd64.tar.gz | tar xz
+          curl -sL https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz | tar xz
           chmod +x mcp-publisher
+          ./mcp-publisher --version || true
+
+      - name: Wait for the npm package version to be live on npm
+        # The registry validates that the npm package+version in server.json
+        # already exists on npmjs.org. On release the npm publish can lag, and a
+        # version bump can land before npm has it — both 404 the registry publish.
+        # Poll until it's available (up to 10 min) so this never races.
+        run: |
+          NAME="$(node -p "require('./server.json').packages[0].identifier")"
+          VER="$(node -p "require('./server.json').packages[0].version")"
+          echo "Waiting for ${NAME}@${VER} on npm (registry validates it exists)..."
+          for i in $(seq 1 30); do
+            if curl -sfo /dev/null "https://registry.npmjs.org/${NAME}/${VER}"; then
+              echo "✓ ${NAME}@${VER} is live on npm"; exit 0
+            fi
+            echo "  not yet (${i}/30); sleeping 20s"; sleep 20
+          done
+          echo "✗ ${NAME}@${VER} never appeared on npm after 10 min — aborting"; exit 1
 
       - name: Validate server.json
         run: ./mcp-publisher validate

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ npx thumbgate init   # auto-detects your agent, wires hooks, 30 seconds
 
 Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and any MCP-compatible agent.
 
+### Add ThumbGate to Claude (remote connector, 30 seconds, no install)
+
+ThumbGate is a hosted remote MCP server. To use it in **Claude.ai / Claude Desktop**:
+**Settings → Connectors → Add custom connector**, then paste:
+
+```
+https://thumbgate.ai/mcp
+```
+
+That's it — Claude can now call ThumbGate's gate-check and feedback tools directly.
+For local/CLI agents (Claude Code, Cursor, Codex, …) use `npx thumbgate init`, which
+auto-wires the hooks. (The same server is published to the [MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.IgorGanapolsky/thumbgate`.)
+
 **Free:** 5 feedback captures/day (25 total captures), 3 active auto-promoted prevention rules, all MCP integrations, local-first.
 **[Pro — $19/mo or $149/yr](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme):** no limits on captures or rules, history-aware lessons, feedback sessions, hosted dashboard, DPO export.
 **Team — $49/seat/mo:** shared hosted lesson DB, org dashboard, approval boundaries.


### PR DESCRIPTION
## Why
You asked: shouldn't we publish a Claude connector? We already **have** a working remote MCP server (`https://thumbgate.ai/mcp` — verified via `initialize` handshake), but it's **not discoverable**: `registry.modelcontextprotocol.io` returns `count:0`, and the auto-publish workflow has been failing.

## Root causes fixed
1. **OIDC audience** — `mcp-publisher v1.5.0` requested audience `mcp-registry`; the registry now requires `https://registry.modelcontextprotocol.io` and 401s the old one (`invalid audience`). Bumped **v1.5.0 → v1.7.9**.
2. **npm race** — the registry validates the npm package+version in `server.json` exists *first*; a release that bumps the version ahead of npm 404s (this is exactly why the 2026-04-18 run failed: `NPM package 'thumbgate' not found`). Added a step that **waits for `thumbgate@<version>` to be live on npm** before publishing.
3. **README** — added "Add ThumbGate to Claude (remote connector)" → `https://thumbgate.ai/mcp` (Settings → Connectors → Add custom connector). Usable today, no install.

## Distribution impact
Once merged (and dispatched), ThumbGate is listed as `io.github.IgorGanapolsky/thumbgate` in the MCP Registry — discoverable by MCP-aware clients — and the README gives Claude users a 30-second add path. The curated Claude "Browse connectors" directory is a separate Anthropic submission (not self-publish); this covers everything that *is* self-serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)