### PR TITLE
chore(readme): accuracy pass — verifiable credibility line + 33→36 checks

### DIFF
--- a/.changeset/readme-about-accuracy.md
+++ b/.changeset/readme-about-accuracy.md
@@ -1,0 +1,11 @@
+---
+"thumbgate": patch
+---
+
+README + npm metadata accuracy pass.
+
+- Replace the third-party named-executive testimonial (an unverifiable implied
+  endorsement) with a verifiable, ownable credibility line: the value prop plus the
+  MCP Registry listing + one-line Claude connector.
+- Fix stale count in the package description: "33 pre-action checks" → "36" (matches
+  config/gates/default.json).

--- a/README.md
+++ b/README.md
@@ -49,11 +49,9 @@ auto-wires the hooks. (The same server is published to the [MCP Registry](https:
 
 ---
 
-> *"A better dashboard doesn't make the agents more reliable. The hard part isn't visibility. It's trust."*
+> **Visibility isn't trust.** A dashboard shows you what an agent did; it doesn't stop the agent from doing it again. ThumbGate is the enforcement layer: PreToolUse gates, thumbs-down → rule, and an audit trail on every interception — so a mistake gets blocked, not just logged.
 >
-> — **Rob May**, CEO & co-founder, Neurometric AI, quoted in [The New Stack](https://thenewstack.io/claude-code-agent-view/) on Anthropic's Claude Code Agent View (May 2026).
->
-> ThumbGate is the open-source layer that makes the trust part real: PreToolUse gates, thumbs-down to rule, audit trail on every interception.
+> Published in the [MCP Registry](https://registry.modelcontextprotocol.io) (`io.github.IgorGanapolsky/thumbgate`) and usable as a one-line Claude connector.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "version": "1.23.2",
-  "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 33 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
+  "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 36 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate.ai",
   "repository": {
     "type": "git",


### PR DESCRIPTION
README + npm metadata accuracy/marketability pass (paired with the GitHub **About** + topics, already applied directly).

## Accuracy fixes
- **Removed the unverifiable testimonial risk.** The "Rob May / Neurometric AI" block reframed a third-party named-executive quote to imply a ThumbGate endorsement he never gave — an accuracy/legal exposure. Replaced with an **ownable, verifiable** credibility line: the value prop (enforcement, not just visibility) + the **MCP Registry listing** + one-line Claude connector. (If the quote is genuinely usable as attributed commentary, you can restore it — but the implied-endorsement framing is gone.)
- **`package.json` description: "33 pre-action checks" → "36"** — matches `config/gates/default.json` (verified 36 gates on main).

## Already applied (no PR, per your go-ahead)
- **About description** fixed (was grammatically "Agent governance *for ThumbGate*"): now "Agent governance: 👍/👎 feedback becomes Pre-Action Checks… MCP connector for Claude, Cursor, Codex."
- **Topics** retuned: +`mcp-registry` +`claude-connector` +`supply-chain-security`, −redundant `thompson-sampling`/`reduce-llm-cost`/`save-llm-tokens`.

## Deliberately NOT included
- The **slopsquat security bullet** — that feature is on PR #2382, **not yet on main**. Marketing it now would be an overclaim. I'll add it the moment #2382 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)