### PR TITLE
test(connector): cover /docs/connectors + /favicon.ico routes (SonarCloud coverage backfill for #2410)

### DIFF
--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -684,3 +684,26 @@ test('/ai-malpractice-prevention surfaces the GT-aligned predictability bridge',
   assert.match(html, /Predictability\. Insights\. Value\./);
   assert.match(html, /agentic-AI deployment.*predictable enough to sell/i);
 });
+
+test('GET /favicon.ico serves the directory-verification favicon without an API key', async () => {
+  const res = await fetch(`${origin}/favicon.ico`);
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') || '', /icon/);
+  assert.ok(Number(res.headers.get('content-length')) > 0, 'favicon must be non-zero');
+});
+
+test('GET /docs/connectors serves the MCP connector documentation (PRM resource_documentation target)', async () => {
+  const res = await fetch(`${origin}/docs/connectors`);
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') || '', /text\/html/);
+  const body = await res.text();
+  assert.match(body, /Remote MCP Connector/, 'must render the connector doc title');
+  assert.match(body, /\/mcp/, 'must show the connect URL');
+  assert.match(body, /reviewer credential/i, 'must document the read-only reviewer credential');
+  assert.match(body, /PKCE/i, 'must describe the OAuth 2.1 PKCE flow');
+});
+
+test('GET /docs/connectors/ (trailing slash) also resolves', async () => {
+  const res = await fetch(`${origin}/docs/connectors/`);
+  assert.equal(res.status, 200);
+});


### PR DESCRIPTION
## What

Adds the 3 route-coverage tests that PR #2410 shipped its `/docs/connectors` + `/favicon.ico` handlers without — leaving SonarCloud new-code coverage red on that change (the new route handler was at 18.8%).

Cherry-picked from the orphaned `fix/connector-directory-404s` branch (original tip `494dd6d8`), rebased onto latest `main`.

## Tests added (`tests/public-static-assets.test.js`)

- `GET /favicon.ico` → 200, `content-type: */icon`, non-zero length (directory-verification favicon, no API key).
- `GET /docs/connectors` → 200 `text/html`, renders connector doc title, `/mcp` connect URL, reviewer-credential note, and PKCE flow description.
- `GET /docs/connectors/` (trailing slash) → 200.

## Verification

- Cherry-pick applied cleanly onto `main`.
- `node --test tests/public-static-assets.test.js` → **54/54 pass** (incl. the 3 new).
- `npm run changeset:check` → "No release-relevant changes detected. Changeset not required." (test-only change; `tests/public-static-assets.test.js` is exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
