### PR TITLE
Add ThumbGate feedback self-test dogfood proof

### DIFF
--- a/.changeset/feedback-self-test-dogfood.md
+++ b/.changeset/feedback-self-test-dogfood.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": minor
+---
+
+Add `thumbgate feedback-self-test` and the `thumbgate dogfood` alias to prove feedback capture is wired before agents claim thumbs signals are being stored.
+
+The command captures a synthetic thumbs signal, verifies both `feedback-log.jsonl` and `memory-log.jsonl`, uses an isolated test store by default, and supports `--persist` when intentionally dogfooding the active project store. The Codex onboarding prompt now points first-time users to this short proof command instead of a long multi-flag capture example.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,6 +29,7 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 const { execSync, execFileSync } = require('child_process');
@@ -845,17 +846,12 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
   // ---------------------------------------------------------------------------
   console.log('');
   console.log('  ╭──────────────────────────────────────────────────────────╮');
-  console.log('  │  NEXT: Create your first prevention rule (30 seconds)   │');
+  console.log('  │  NEXT: Prove feedback capture works                     │');
   console.log('  │                                                         │');
-  console.log('  │  When your AI agent makes a mistake, capture it:        │');
+  console.log('  │  npx thumbgate feedback-self-test                       │');
   console.log('  │                                                         │');
-  console.log('  │  npx thumbgate capture --feedback=down \\               │');
-  console.log('  │    --context="agent deleted prod config" \\              │');
-  console.log('  │    --what-went-wrong="ran rm on .env" \\                 │');
-  console.log('  │    --what-to-change="never delete .env files"           │');
-  console.log('  │                                                         │');
-  console.log('  │  ThumbGate auto-promotes this to a prevention rule      │');
-  console.log('  │  that blocks the mistake from happening again.          │');
+  console.log('  │  Then dogfood it in chat:                               │');
+  console.log('  │  thumbs down: agent skipped verification                │');
   console.log('  ╰──────────────────────────────────────────────────────────╯');
   console.log('');
   printInitConversionPrompt(onboardingEmail);
@@ -986,6 +982,116 @@ function capture() {
     console.log('─'.repeat(50));
     console.log(`  Reason      : ${result.reason}\n`);
     process.exit(2);
+  }
+}
+
+function readJsonlEntries(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch (_) {
+    return [];
+  }
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function feedbackSelfTest() {
+  const args = parseArgs(process.argv.slice(3));
+  const signalArg = String(args.feedback || args.signal || 'down').toLowerCase();
+  const normalized = ['up', 'thumbsup', 'thumbs_up', 'positive'].some((v) => signalArg.includes(v)) ? 'up'
+    : ['down', 'thumbsdown', 'thumbs_down', 'negative'].some((v) => signalArg.includes(v)) ? 'down'
+    : signalArg;
+
+  if (normalized !== 'up' && normalized !== 'down') {
+    console.error('feedback-self-test needs --feedback=up|down when overriding the default.');
+    process.exit(1);
+  }
+
+  const previousFeedbackDir = process.env.THUMBGATE_FEEDBACK_DIR;
+  const previousNoNudge = process.env.THUMBGATE_NO_NUDGE;
+  const feedbackDir = args['feedback-dir']
+    ? path.resolve(CWD, args['feedback-dir'])
+    : args.persist
+      ? null
+      : fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-feedback-self-test-'));
+  const isolated = Boolean(feedbackDir);
+
+  if (feedbackDir) process.env.THUMBGATE_FEEDBACK_DIR = feedbackDir;
+  process.env.THUMBGATE_NO_NUDGE = '1';
+
+  try {
+    const { captureFeedback, getFeedbackPaths } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
+    const context = args.context || `feedback self-test: typed thumbs ${normalized} reaches ThumbGate capture`;
+    const result = captureFeedback({
+      signal: normalized,
+      context,
+      whatWentWrong: normalized === 'down'
+        ? (args['what-went-wrong'] || 'Need proof that feedback capture is wired in this runtime')
+        : undefined,
+      whatToChange: normalized === 'down'
+        ? (args['what-to-change'] || 'Run a one-command self-test before claiming thumbs feedback is captured')
+        : undefined,
+      whatWorked: normalized === 'up'
+        ? (args['what-worked'] || 'Feedback capture persisted and was verified by a self-test')
+        : undefined,
+      tags: args.tags || 'self-test,dogfood,feedback-capture',
+    });
+
+    const paths = getFeedbackPaths();
+    const feedbackRows = readJsonlEntries(paths.FEEDBACK_LOG_PATH);
+    const memoryRows = readJsonlEntries(paths.MEMORY_LOG_PATH);
+    const feedbackId = result.feedbackEvent && result.feedbackEvent.id;
+    const memoryId = result.memoryRecord && result.memoryRecord.id;
+    const feedbackStored = Boolean(feedbackId && feedbackRows.some((row) => row.id === feedbackId));
+    const memoryStored = Boolean(memoryId && memoryRows.some((row) => row.id === memoryId));
+    const ok = Boolean(result.accepted && feedbackStored && memoryStored);
+
+    const payload = {
+      ok,
+      command: 'feedback-self-test',
+      signal: normalized,
+      accepted: Boolean(result.accepted),
+      feedbackId: feedbackId || null,
+      memoryId: memoryId || null,
+      feedbackStored,
+      memoryStored,
+      isolated,
+      feedbackDir: paths.FEEDBACK_DIR,
+      nextDogfoodCommand: `npx thumbgate capture --feedback=${normalized} --context=${shellSingleQuote(context)}`,
+    };
+
+    if (args.json) {
+      console.log(JSON.stringify(payload, null, 2));
+    } else if (ok) {
+      console.log('\nThumbGate feedback self-test: PASS');
+      console.log('─'.repeat(50));
+      console.log(`  Captured     : ${normalized} (${feedbackId})`);
+      console.log(`  Stored lesson: ${memoryId}`);
+      console.log(`  Storage      : ${paths.FEEDBACK_DIR}`);
+      console.log(`  Mode         : ${isolated ? 'isolated test store' : 'active ThumbGate store'}`);
+      console.log('\nDogfood in chat with:');
+      console.log(`  thumbs ${normalized}: ${context}`);
+    } else {
+      console.log('\nThumbGate feedback self-test: FAIL');
+      console.log('─'.repeat(50));
+      console.log(`  Accepted       : ${payload.accepted}`);
+      console.log(`  Feedback stored: ${feedbackStored}`);
+      console.log(`  Memory stored  : ${memoryStored}`);
+      console.log(`  Storage        : ${paths.FEEDBACK_DIR}`);
+    }
+
+    if (!ok) process.exit(2);
+  } finally {
+    if (previousFeedbackDir === undefined) delete process.env.THUMBGATE_FEEDBACK_DIR;
+    else process.env.THUMBGATE_FEEDBACK_DIR = previousFeedbackDir;
+    if (previousNoNudge === undefined) delete process.env.THUMBGATE_NO_NUDGE;
+    else process.env.THUMBGATE_NO_NUDGE = previousNoNudge;
   }
 }
 
@@ -2456,6 +2562,7 @@ function help() {
     console.log('');
     console.log('Common commands:');
     console.log('  init                                              Detect agent and wire ThumbGate hooks');
+    console.log('  feedback-self-test                                Prove thumbs capture works locally');
     console.log('  capture --feedback=up|down --context="<text>"    Capture a thumbs signal as a stored lesson');
     console.log('  stats                                             Approval rate, recent trend, blocked-pattern count');
     console.log('  lessons [query]                                   Search promoted lessons');
@@ -2557,6 +2664,7 @@ function help() {
 
   console.log('Examples:');
   console.log('  npx thumbgate init');
+  console.log('  npx thumbgate feedback-self-test');
   console.log('  npx thumbgate status --json');
   console.log('  npx thumbgate explore lessons --json');
   console.log('  npx thumbgate explore gates --json');
@@ -2598,6 +2706,8 @@ const _wantsHelp = _cliSubArgs.includes('--help') || _cliSubArgs.includes('-h');
 const SUBCOMMAND_HELP = {
   capture:       'Usage: npx thumbgate capture --feedback=up|down --context="..." [--what-worked="..."] [--what-went-wrong="..."] [--what-to-change="..."] [--tags=a,b]',
   feedback:      'Usage: npx thumbgate feedback --feedback=up|down --context="..." [--what-worked="..."] [--what-went-wrong="..."] [--what-to-change="..."] [--tags=a,b]',
+  'feedback-self-test': 'Usage: npx thumbgate feedback-self-test [--json] [--persist] [--feedback=up|down]\n\nCapture a synthetic thumbs signal and verify feedback-log + memory-log writes. Defaults to an isolated test store; use --persist to dogfood the active ThumbGate store.',
+  dogfood:       'Usage: npx thumbgate dogfood [--json] [--persist] [--feedback=up|down]\n\nAlias for feedback-self-test.',
   stats:         'Usage: npx thumbgate stats\n\nShow gate enforcement statistics: blocked/warned counts, active gates, time saved.',
   trial:         'Usage: npx thumbgate trial\n\nShow Pro trial status, remaining days, and upgrade path.',
   pro:           'Usage: npx thumbgate pro [--activate <key>]\n\nLaunch the local Pro dashboard or activate a Pro license key.',
@@ -2665,6 +2775,10 @@ switch (COMMAND) {
   case 'feedback':
     capture();
     upgradeNudge();
+    break;
+  case 'feedback-self-test':
+  case 'dogfood':
+    feedbackSelfTest();
     break;
   case 'stats':
     stats();

--- a/plugins/codex-profile/INSTALL.md
+++ b/plugins/codex-profile/INSTALL.md
@@ -45,6 +45,14 @@ That now installs:
 - the ThumbGate MCP server in `~/.codex/config.toml`
 - Codex hooks plus the ThumbGate status line target in `~/.codex/config.json`
 
+Immediately verify the feedback loop:
+
+```bash
+npx thumbgate feedback-self-test
+```
+
+This is the dogfood check: it captures a synthetic thumbs signal and verifies the local feedback + lesson files. Use `npx thumbgate feedback-self-test --persist` only when you want the self-test stored in the active ThumbGate project memory.
+
 If you only want the MCP server block manually, add it to your Codex config:
 
 ```bash
@@ -93,7 +101,13 @@ The real generated command includes a `mkdir -p ~/.thumbgate/runtime` guard befo
 
 ## Verify
 
-Start the MCP server manually to confirm it runs:
+First prove capture works:
+
+```bash
+npx thumbgate feedback-self-test
+```
+
+Then start the MCP server manually if you are debugging transport:
 
 ```bash
 node adapters/mcp/server-stdio.js

--- a/plugins/codex-profile/README.md
+++ b/plugins/codex-profile/README.md
@@ -49,6 +49,14 @@ npx thumbgate init --agent codex
 
 That writes the MCP server block to `~/.codex/config.toml` and the Codex hook/status-line bundle to `~/.codex/config.json`.
 
+Verify feedback capture with one command:
+
+```bash
+npx thumbgate feedback-self-test
+```
+
+The self-test captures a synthetic thumbs signal, verifies both `feedback-log.jsonl` and `memory-log.jsonl`, and prints the storage path. It uses an isolated test store by default; add `--persist` when you intentionally want to dogfood the active ThumbGate store.
+
 If you only need the MCP server manually, copy the MCP profile from `adapters/codex/config.toml` into `~/.codex/config.toml`.
 
 That profile launches the latest npm release instead of pinning a stale local runtime:

--- a/scripts/cli-schema.js
+++ b/scripts/cli-schema.js
@@ -51,6 +51,20 @@ const CLI_COMMANDS = [
       { name: 'json',            type: 'boolean', description: 'Output as JSON' },
     ],
   },
+  {
+    name: 'feedback-self-test',
+    aliases: ['dogfood'],
+    description: 'Prove thumbs feedback capture works in the current runtime',
+    group: 'capture',
+    mcpTool: 'capture_feedback',
+    flags: [
+      { name: 'feedback',     type: 'string',  description: 'Signal to test: up or down (default down)' },
+      { name: 'context',      type: 'string',  description: 'Context to store in the test capture' },
+      { name: 'persist',      type: 'boolean', description: 'Use the active ThumbGate store instead of an isolated test store' },
+      { name: 'feedback-dir', type: 'string',  description: 'Explicit feedback directory for the self-test' },
+      { name: 'json',         type: 'boolean', description: 'Output as JSON' },
+    ],
+  },
 
   // -------------------------------------------------------------------------
   // Discovery

--- a/tests/cli-agent-experience.test.js
+++ b/tests/cli-agent-experience.test.js
@@ -341,13 +341,14 @@ describe('agent-first CLI experience', () => {
   // help includes new commands
   // -------------------------------------------------------------------------
 
-  test('help all lists status, demo, and explore subcommands', () => {
+  test('help all lists status, demo, feedback self-test, and explore subcommands', () => {
     // These specialist + sub-mode commands live in the full surface now;
     // default `help` is curated to 8 common commands. (Shortened 2026-05-18.)
     const result = runCliSync(['help', 'all'], { cwd: tmpDir });
     assert.equal(result.status, 0);
     assert.match(result.stdout, /status/);
     assert.match(result.stdout, /demo/);
+    assert.match(result.stdout, /feedback-self-test/);
     assert.match(result.stdout, /explore lessons/);
     assert.match(result.stdout, /explore gates/);
     assert.match(result.stdout, /explore rules/);
@@ -357,11 +358,15 @@ describe('agent-first CLI experience', () => {
   // cli-schema includes new commands
   // -------------------------------------------------------------------------
 
-  test('cli-schema includes status and demo commands', () => {
+  test('cli-schema includes status, demo, and feedback self-test commands', () => {
     const { findCommand } = require('../scripts/cli-schema');
     const statusCmd = findCommand('status');
     assert.ok(statusCmd, 'status command not in schema');
     assert.ok(statusCmd.flags.some(f => f.name === 'json'), 'status missing --json flag');
+    const selfTestCmd = findCommand('feedback-self-test');
+    assert.ok(selfTestCmd, 'feedback-self-test command not in schema');
+    assert.ok(selfTestCmd.aliases.includes('dogfood'), 'feedback-self-test missing dogfood alias');
+    assert.ok(selfTestCmd.flags.some(f => f.name === 'persist'), 'feedback-self-test missing --persist flag');
 
     const demoCmd = findCommand('demo');
     assert.ok(demoCmd, 'demo command not in schema');

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -546,7 +546,7 @@ describe('bin/cli.js', () => {
     assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\n${result.stderr}`);
     assert.ok(result.stdout.includes('thumbgate'), 'Help should include CLI name');
     // Core commands a first-time user should see immediately.
-    for (const cmd of ['init', 'capture', 'stats', 'lessons', 'explore', 'dashboard', 'doctor', 'pro']) {
+    for (const cmd of ['init', 'feedback-self-test', 'capture', 'stats', 'lessons', 'explore', 'dashboard', 'doctor', 'pro']) {
       assert.ok(result.stdout.includes(cmd), `Default help should mention ${cmd}`);
     }
     // Hint to discover the rest, instead of dumping ~70 commands.
@@ -574,10 +574,39 @@ describe('bin/cli.js', () => {
       'export-databricks', 'lessons', 'stats', 'north-star', 'eval',
       'rules', 'self-heal', 'prove', 'doctor', 'dispatch',
       'background-governance', 'analytics', 'gate-check', 'statusline-render',
+      'feedback-self-test',
     ];
     for (const cmd of expected) {
       assert.ok(result.stdout.includes(cmd), `\`help all\` should mention ${cmd}`);
     }
+  });
+
+  test('feedback-self-test verifies capture and lesson writes in explicit isolated store', () => {
+    const feedbackDir = makeTmpDir();
+    const result = runCliSync(['feedback-self-test', '--json', `--feedback-dir=${feedbackDir}`], {
+      env: {
+        THUMBGATE_NO_NUDGE: '1',
+      },
+    });
+
+    assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.command, 'feedback-self-test');
+    assert.equal(payload.signal, 'down');
+    assert.equal(payload.feedbackStored, true);
+    assert.equal(payload.memoryStored, true);
+    assert.equal(payload.isolated, true);
+    assert.equal(payload.feedbackDir, feedbackDir);
+    assert.match(payload.feedbackId, /^fb_/);
+    assert.match(payload.memoryId, /^mem_/);
+
+    const feedbackLog = fs.readFileSync(path.join(feedbackDir, 'feedback-log.jsonl'), 'utf8');
+    const memoryLog = fs.readFileSync(path.join(feedbackDir, 'memory-log.jsonl'), 'utf8');
+    assert.match(feedbackLog, new RegExp(payload.feedbackId));
+    assert.match(memoryLog, new RegExp(payload.memoryId));
+
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
   });
 
   test('eval command turns local feedback into reusable proof JSON', () => {
@@ -1071,6 +1100,10 @@ describe('bin/cli.js', () => {
       }),
     });
     assert.strictEqual(result.status, 0, `init should succeed: ${result.stderr}`);
+    assert.match(result.stdout, /npx thumbgate feedback-self-test/);
+    assert.match(result.stdout, /thumbs down: agent skipped verification/);
+    assert.doesNotMatch(result.stdout, /--what-went-wrong/);
+    assert.doesNotMatch(result.stdout, /--what-to-change/);
     assert.match(result.stdout, /npx thumbgate init --email you@company\.com/);
     assert.match(result.stdout, /7-day Pro trial active through \d{4}-\d{2}-\d{2}/);
     assert.match(result.stdout, /utm_source=cli_init/);


### PR DESCRIPTION
## Summary
- add `thumbgate feedback-self-test` plus `thumbgate dogfood` alias to prove feedback capture works in the current runtime
- verify the command writes both `feedback-log.jsonl` and `memory-log.jsonl`, with isolated test storage by default and `--persist` for active dogfooding
- replace the long first-install onboarding capture command with a short self-test prompt and chat-ready thumbs sentence
- document the self-test in the Codex profile install/readme flow

## Evidence
- Captured user thumbs-down feedback before fixing:
  - `fb_1780278070282_adn7z1` / `mem_1780278070290_yb43v0`
  - `fb_1780278134048_mh228w` / `mem_1780278134053_6ge5fj`
- New active dogfood proof:
  - `node bin/cli.js feedback-self-test --json --persist`
  - `feedbackId`: `fb_1780278648993_mjcf9l`
  - `memoryId`: `mem_1780278648996_lvbt5l`
  - `feedbackStored`: `true`
  - `memoryStored`: `true`

## Verification
- `node --check bin/cli.js`
- `node --check scripts/cli-schema.js`
- `git diff --check`
- `node --test tests/cli.test.js tests/cli-agent-experience.test.js tests/cli-schema.test.js tests/adapters.test.js`
  - 158 tests, 158 pass, 0 fail
- pre-commit guards: package parity, version sync, congruence all passed
- pre-push guards: npm pack dry-run, public HTML link validation, regression-guard tests all passed
