### PR TITLE
fix: format revenue pulse traffic channels

### DIFF
--- a/.changeset/revenue-pulse-channel-label.md
+++ b/.changeset/revenue-pulse-channel-label.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Format structured revenue-pulse traffic channel entries as readable labels instead of leaking JavaScript object strings in operator next actions.

--- a/scripts/operator-artifacts.js
+++ b/scripts/operator-artifacts.js
@@ -62,6 +62,19 @@ function formatCurrency(cents) {
   return `$${(safeNumber(cents) / 100).toFixed(2)}`;
 }
 
+function formatCounterEntry(value) {
+  if (!value) return null;
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.filter((part) => part !== undefined && part !== null).join(': ');
+  if (typeof value === 'object') {
+    const key = value.key || value.name || value.channel || value.source || value.label;
+    const count = value.count === undefined || value.count === null ? null : safeNumber(value.count);
+    if (!key) return null;
+    return count === null ? String(key) : `${key} (${count})`;
+  }
+  return String(value);
+}
+
 function compactList(items, limit = 5) {
   return (Array.isArray(items) ? items : []).filter(Boolean).slice(0, limit);
 }
@@ -189,7 +202,8 @@ function buildRevenuePulseArtifact(options = {}) {
   const acquisitionLeads = safeNumber(funnel.acquisitionLeads);
   const paidOrders = safeNumber(revenue.paidOrders, safeNumber(funnel.paidOrders));
   const bookedRevenueCents = safeNumber(revenue.bookedRevenueCents);
-  const topTrafficChannel = funnel.topTrafficChannel || getPath(seo, ['topSurface', 'key'], null);
+  const topTrafficChannel = formatCounterEntry(funnel.topTrafficChannel)
+    || formatCounterEntry(getPath(seo, ['topSurface'], null));
   const topPaidSource = Object.entries(attribution.paidBySource || {})
     .sort((a, b) => safeNumber(b[1]) - safeNumber(a[1]))[0];
 

--- a/tests/operator-artifacts.test.js
+++ b/tests/operator-artifacts.test.js
@@ -73,6 +73,32 @@ test('revenue artifact prioritizes acquisition when the system is at zero dollar
   assert.match(artifact.decision.nextActions.join('\n'), /ThumbGate proof chunk/);
 });
 
+test('revenue artifact formats structured top traffic channel labels', () => {
+  const artifact = buildRevenuePulseArtifact({
+    now: NOW,
+    dashboardData: {
+      analytics: {
+        funnel: {
+          visitors: 5,
+          ctaClicks: 0,
+          checkoutStarts: 0,
+          acquisitionLeads: 1,
+          paidOrders: 0,
+          topTrafficChannel: { key: 'organic', count: 5 },
+        },
+        revenue: {
+          paidOrders: 0,
+          bookedRevenueCents: 0,
+        },
+      },
+    },
+  });
+
+  assert.doesNotMatch(artifact.decision.nextActions.join('\n'), /\[object Object\]/);
+  assert.match(artifact.decision.nextActions.join('\n'), /organic \(5\)/);
+  assert.match(artifact.sections.flatMap((section) => section.bullets).join('\n'), /organic \(5\)/);
+});
+
 test('PR artifact classifies ready, blocked, pending, and draft PRs', async () => {
   const artifact = await buildPrPulseArtifact({
     now: NOW,


### PR DESCRIPTION
## Summary
- format structured revenue-pulse traffic channel entries as readable labels
- add regression coverage against [object Object] operator guidance

## Verification
- node --test tests/operator-artifacts.test.js tests/mcp-server.test.js tests/tool-registry.test.js
- git diff --check
- ThumbGate pre-commit guard passed
- ThumbGate pre-push guard passed