### PR TITLE
fix: ship operational dashboard in npm package

### DIFF
--- a/.changeset/operational-dashboard-package-runtime.md
+++ b/.changeset/operational-dashboard-package-runtime.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+Fix the published `thumbgate dashboard` CLI by shipping its operational dashboard runtime files in the npm package.
+
+The package now includes `scripts/operational-dashboard.js` and `scripts/operational-summary.js`, and the package boundary ratchets were updated with the runtime reason so future releases do not silently omit dashboard dependencies.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.26.0",
+      "version": "1.26.1",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.26.1",
+      "version": "1.26.2",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.26.0"
+    "version": "1.26.1"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.26.1"
+    "version": "1.26.2"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate.ai",
   "transport": "stdio",

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate.ai",
   "transport": "stdio",

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.26.1 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.26.2 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.26.0 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.26.1 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.26.1", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.26.2", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.26.1", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.26.2", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.26.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.26.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.26.0", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.26.1", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -230,7 +230,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.26.0' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.26.1' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -230,7 +230,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.26.1' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.26.2' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.26.1",
+        "thumbgate@1.26.2",
         "thumbgate",
         "serve"
       ],

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.26.0",
+        "thumbgate@1.26.1",
         "thumbgate",
         "serve"
       ],

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.26.0 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.26.1 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.26.0 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.26.1 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -43,7 +43,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 ## Claude (MCP)
 
 - Use: `adapters/claude/.mcp.json`
-- Transport: local stdio MCP server launched via `npx -y thumbgate@1.26.1 serve`
+- Transport: local stdio MCP server launched via `npx -y thumbgate@1.26.2 serve`
 
 ## Claude Desktop Extensions
 
@@ -58,7 +58,7 @@ This avoids platform-specific rewrite cost and keeps the product under a small b
 - Release workflow: `.github/workflows/publish-claude-plugin.yml`
 - Latest direct download: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb`
 - Latest review packet zip: `https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-plugin-review.zip`
-- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.26.1 serve`
+- Local install path: `claude mcp add thumbgate -- npx -y thumbgate@1.26.2 serve`
 - Promotion rule: treat directory inclusion as a discoverability lane, not customer proof
 
 Build the `.mcpb` for Claude Desktop review or direct installation with:

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1562,7 +1562,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.26.0 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.26.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2779,7 +2779,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.26.0 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.26.1 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -1562,7 +1562,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.26.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.26.2 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2779,7 +2779,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.26.1 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.26.2 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.26.0`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.26.1`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.26.1`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.26.2`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.26.1 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.26.2 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.26.1", "serve"],
+      "args": ["-y", "thumbgate@1.26.2", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.26.1", "serve"],
+      "args": ["-y", "thumbgate@1.26.2", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.26.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.26.2 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.26.1
+1.26.2
 
 ---
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.26.0 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.26.1 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.26.0", "serve"],
+      "args": ["-y", "thumbgate@1.26.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.26.0", "serve"],
+      "args": ["-y", "thumbgate@1.26.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.26.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.26.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.26.0
+1.26.1
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.26.0"
+version: "1.26.1"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.26.1"
+version: "1.26.2"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 36 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate.ai",
   "repository": {
@@ -136,6 +136,7 @@
     "scripts/noop-detect.js",
     "scripts/obsidian-export.js",
     "scripts/operational-dashboard.js",
+    "scripts/operational-summary.js",
     "scripts/operational-integrity.js",
     "scripts/oss-pr-opportunity-scout.js",
     "scripts/otel-declarative-config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 36 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate.ai",
   "repository": {
@@ -135,6 +135,7 @@
     "scripts/natural-language-harness.js",
     "scripts/noop-detect.js",
     "scripts/obsidian-export.js",
+    "scripts/operational-dashboard.js",
     "scripts/operational-integrity.js",
     "scripts/oss-pr-opportunity-scout.js",
     "scripts/otel-declarative-config.js",

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.26.0",
+        "thumbgate@1.26.1",
         "thumbgate",
         "serve"
       ]

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.26.1",
+        "thumbgate@1.26.2",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "ThumbGate for Codex: pre-action gates, skill packs, hallucination detection, PII scanning, progressive disclosure (82% token savings), and MCP-backed reliability memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "author": {
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "author": {
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.26.0", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.26.1", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.26.1", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.26.2", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Pre-action checks for AI coding agents in VS Code, Open VSX-compatible IDEs, and Antigravity-style VS Code forks.",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Pre-action checks for AI coding agents in VS Code, Open VSX-compatible IDEs, and Antigravity-style VS Code forks.",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:image" content="https://thumbgate.ai/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate.ai/og.png">
-<meta name="thumbgate-version" content="1.26.1">
+<meta name="thumbgate-version" content="1.26.2">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agentic development cycle, AC/DC framework, Guide Generate Verify Solve, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="canonical" href="__APP_ORIGIN__/">
 <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
@@ -1594,7 +1594,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.26.1</span>
+    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.26.2</span>
   </div>
 </footer>
 

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:image" content="https://thumbgate.ai/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate.ai/og.png">
-<meta name="thumbgate-version" content="1.26.0">
+<meta name="thumbgate-version" content="1.26.1">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agentic development cycle, AC/DC framework, Guide Generate Verify Solve, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="canonical" href="__APP_ORIGIN__/">
 <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
@@ -1594,7 +1594,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.26.0</span>
+    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.26.1</span>
   </div>
 </footer>
 

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.26.1",
+  "softwareVersion": "1.26.2",
   "url": "https://thumbgate.ai/numbers",
   "dateModified": "2026-05-07",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-05-07 · Version 1.26.1</div>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.26.2</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.26.0",
+  "softwareVersion": "1.26.1",
   "url": "https://thumbgate.ai/numbers",
   "dateModified": "2026-05-07",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-05-07 · Version 1.26.0</div>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.26.1</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.26.1",
+  "version": "1.26.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.26.0",
+  "version": "1.26.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -175,7 +175,6 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     'scripts/dispatch-brief.js',
     'scripts/distribution-surfaces.js',
     'scripts/funnel-analytics.js',
-    'scripts/operational-dashboard.js',
     'scripts/operational-summary.js',
     'scripts/optimize-context.js',
     'scripts/pulse.js',
@@ -284,9 +283,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // scripts/noop-detect.js, and scripts/action-receipts.js because
   // adapters/mcp/server-stdio.js and scripts/dashboard.js require them in the
   // packaged runtime (action-loop instrumentation).
+  // Bumped 271 → 272 (2026-06-02) to ship scripts/operational-dashboard.js
+  // because bin/cli.js requires it for the packaged `thumbgate dashboard` CLI.
   assert.ok(
-    manifest.fileCount <= 271,
-    `npm package should stay <= 271 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 272,
+    `npm package should stay <= 272 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing
@@ -391,9 +392,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Observed package after the addition is ~3.937 MB.
   // Bumped 3.95 MB -> 3.97 MB (2026-06-01) for Vertex AI setup CLI, guides,
   // and enterprise cost-containment HTML/script additions.
+  // Bumped 3.97 MB -> 3.98 MB (2026-06-02) to ship
+  // scripts/operational-dashboard.js for the packaged dashboard CLI.
   assert.ok(
-    manifest.unpackedSize <= 3_970_000,
-    `npm package should stay <= 3.97 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 3_980_000,
+    `npm package should stay <= 3.98 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -175,7 +175,6 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     'scripts/dispatch-brief.js',
     'scripts/distribution-surfaces.js',
     'scripts/funnel-analytics.js',
-    'scripts/operational-summary.js',
     'scripts/optimize-context.js',
     'scripts/pulse.js',
     'scripts/session-episode-store.js',
@@ -283,11 +282,12 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // scripts/noop-detect.js, and scripts/action-receipts.js because
   // adapters/mcp/server-stdio.js and scripts/dashboard.js require them in the
   // packaged runtime (action-loop instrumentation).
-  // Bumped 271 → 272 (2026-06-02) to ship scripts/operational-dashboard.js
-  // because bin/cli.js requires it for the packaged `thumbgate dashboard` CLI.
+  // Bumped 271 → 273 (2026-06-02) to ship scripts/operational-dashboard.js
+  // and scripts/operational-summary.js because bin/cli.js requires them for
+  // the packaged `thumbgate dashboard` CLI.
   assert.ok(
-    manifest.fileCount <= 272,
-    `npm package should stay <= 272 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 273,
+    `npm package should stay <= 273 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing


### PR DESCRIPTION
## Summary
- publish ThumbGate 1.26.2 after fixing packaged dashboard runtime dependencies
- include scripts/operational-dashboard.js and scripts/operational-summary.js in npm files
- update package boundary ratchets and synced version metadata

## Verification
- node --test tests/package-boundary.test.js tests/operational-dashboard.test.js tests/public-package-parity.test.js tests/test-suite-parity.test.js tests/sync-version.test.js
- npm pack proof: thumbgate@1.26.2 includes operational-dashboard and operational-summary
- installed tarball smoke: THUMBGATE_METRICS_SOURCE=local thumbgate dashboard --json starts and prints ThumbGate Dashboard
- npm published: thumbgate@1.26.2
- latest smoke: THUMBGATE_METRICS_SOURCE=local npx -y thumbgate@latest dashboard --json prints ThumbGate Dashboard