### PR TITLE
fix(gates): per-repo workflow-sequence dirty tracking (stop cross-repo commit blocking)

### DIFF
--- a/.changeset/per-repo-sequence-guard.md
+++ b/.changeset/per-repo-sequence-guard.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix: workflow-sequence "source edited but not verified" guardrail now tracks the dirty flag per repo instead of via a single global `~/.thumbgate/sequence-state.json`. Previously an edit in any repo hard-denied the next commit/publish in every other repo (cross-repo contamination). The dirty state is keyed by the nearest `.git` root resolved from the action's path / `cd` target / `repoPath`; the guardrail still blocks an unverified commit within the same repo that was edited. Legacy flat-format state is dropped on load (worst case: one extra allowed commit, never a wrong block).

--- a/scripts/sequence-guard.js
+++ b/scripts/sequence-guard.js
@@ -33,17 +33,23 @@ function saveState(state) {
 // Resolve which repo an action belongs to, so "edited but not verified" is tracked
 // per-repo instead of one global flag. Walks up from the action's path to the nearest
 // .git; falls back to the base directory when none is found.
+function expandHome(p) {
+  return String(p || '').replace(/^~(?=\/|$)/, process.env.HOME || '');
+}
+
 function resolveRepoKey(toolName, toolInput = {}) {
   let base = '';
   if (EDIT_LIKE_TOOLS.has(toolName)) {
     const fp = toolInput.file_path || toolInput.path || toolInput.filePath || toolInput.target_path;
-    if (fp) base = path.dirname(path.resolve(String(fp)));
+    if (fp) base = path.dirname(path.resolve(expandHome(String(fp))));
   } else if (toolName === 'Bash') {
     const cmd = String(toolInput.command || '');
-    const m = cmd.match(/\bcd\s+(['"]?)([^&;|'"]+)\1/);
-    if (m) base = path.resolve(m[2].trim());
+    // honor both `cd <path>` and `git -C <path>` — both set the effective repo dir
+    const m = cmd.match(/\bcd\s+(['"]?)([^&;|'"]+)\1/)
+      || cmd.match(/\bgit\b[^&;|]*?\s-C\s+(['"]?)([^&;|'"\s]+)\1/);
+    if (m) base = path.resolve(expandHome(m[2].trim()));
   }
-  if (!base && toolInput.repoPath) base = path.resolve(String(toolInput.repoPath));
+  if (!base && toolInput.repoPath) base = path.resolve(expandHome(String(toolInput.repoPath)));
   if (!base) base = process.cwd();
 
   let dir = base;

--- a/scripts/sequence-guard.js
+++ b/scripts/sequence-guard.js
@@ -11,10 +11,15 @@ const COMPLETION_BASH_PATTERN = /\b(?:git\s+commit|gh\s+pr\s+merge|npm\s+publish
 
 function loadState() {
   try {
-    if (!fs.existsSync(SEQUENCE_STATE_PATH)) return { dirty: false, lastEditAt: 0 };
-    return JSON.parse(fs.readFileSync(SEQUENCE_STATE_PATH, 'utf8'));
+    if (!fs.existsSync(SEQUENCE_STATE_PATH)) return { repos: {} };
+    const raw = JSON.parse(fs.readFileSync(SEQUENCE_STATE_PATH, 'utf8'));
+    if (raw && typeof raw === 'object' && raw.repos && typeof raw.repos === 'object') return raw;
+    // Legacy flat format ({dirty,lastEditAt}) was a single GLOBAL bucket that caused
+    // cross-repo contamination (an edit in repo A blocked commits in repo B). Drop it
+    // and start per-repo; the worst case is one extra commit allowed, never a wrong block.
+    return { repos: {} };
   } catch {
-    return { dirty: false, lastEditAt: 0 };
+    return { repos: {} };
   }
 }
 
@@ -25,13 +30,44 @@ function saveState(state) {
   } catch (e) {}
 }
 
+// Resolve which repo an action belongs to, so "edited but not verified" is tracked
+// per-repo instead of one global flag. Walks up from the action's path to the nearest
+// .git; falls back to the base directory when none is found.
+function resolveRepoKey(toolName, toolInput = {}) {
+  let base = '';
+  if (EDIT_LIKE_TOOLS.has(toolName)) {
+    const fp = toolInput.file_path || toolInput.path || toolInput.filePath || toolInput.target_path;
+    if (fp) base = path.dirname(path.resolve(String(fp)));
+  } else if (toolName === 'Bash') {
+    const cmd = String(toolInput.command || '');
+    const m = cmd.match(/\bcd\s+(['"]?)([^&;|'"]+)\1/);
+    if (m) base = path.resolve(m[2].trim());
+  }
+  if (!base && toolInput.repoPath) base = path.resolve(String(toolInput.repoPath));
+  if (!base) base = process.cwd();
+
+  let dir = base;
+  for (let i = 0; i < 40; i++) {
+    try {
+      if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    } catch { /* ignore */ }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return base;
+}
+
 function evaluateSequenceState(toolName, toolInput) {
   const state = loadState();
   const now = Date.now();
+  const repoKey = resolveRepoKey(toolName, toolInput);
+  const entry = state.repos[repoKey] || { dirty: false, lastEditAt: 0 };
 
   if (EDIT_LIKE_TOOLS.has(toolName)) {
-    state.dirty = true;
-    state.lastEditAt = now;
+    entry.dirty = true;
+    entry.lastEditAt = now;
+    state.repos[repoKey] = entry;
     saveState(state);
   }
 
@@ -43,15 +79,18 @@ function evaluateSequenceState(toolName, toolInput) {
     }
   } catch {}
 
-  if (testsPassedAt > state.lastEditAt) {
-    state.dirty = false;
+  // tests_passed is a global signal (no repo attribution); treat it as clearing the
+  // dirty flag for any repo whose last edit predates the passing test run.
+  if (testsPassedAt > entry.lastEditAt && entry.dirty) {
+    entry.dirty = false;
+    state.repos[repoKey] = entry;
     saveState(state);
   }
 
   const isCompletion = (toolName === 'Bash' && COMPLETION_BASH_PATTERN.test(toolInput.command || '')) ||
                        (toolName === 'complete_handoff');
 
-  if (isCompletion && state.dirty) {
+  if (isCompletion && entry.dirty) {
     return {
       decision: 'deny',
       gate: 'workflow-sequence-violation',
@@ -62,4 +101,4 @@ function evaluateSequenceState(toolName, toolInput) {
   return null;
 }
 
-module.exports = { evaluateSequenceState, loadState, saveState };
+module.exports = { evaluateSequenceState, loadState, saveState, resolveRepoKey };

--- a/tests/sequence-guard.test.js
+++ b/tests/sequence-guard.test.js
@@ -3,38 +3,65 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { evaluateSequenceState, saveState } = require('../scripts/sequence-guard');
+const { evaluateSequenceState } = require('../scripts/sequence-guard');
 
 const SEQUENCE_STATE_PATH = path.join(process.env.HOME || '/tmp', '.thumbgate', 'sequence-state.json');
 const SESSION_ACTIONS_PATH = path.join(process.env.HOME || '/tmp', '.thumbgate', 'session-actions.json');
 
-test('sequence-guard - sets dirty flag on source edit', () => {
-  saveState({ dirty: false, lastEditAt: 0 });
-  const result = evaluateSequenceState('Edit', { filePath: 'src/api/server.js' });
-  assert.equal(result, null);
-  const state = JSON.parse(fs.readFileSync(SEQUENCE_STATE_PATH, 'utf8'));
-  assert.equal(state.dirty, true);
+function resetSequenceState() {
+  try { fs.rmSync(SEQUENCE_STATE_PATH, { force: true }); } catch { /* ignore */ }
+}
+
+function clearTestsPassed() {
+  try {
+    if (fs.existsSync(SESSION_ACTIONS_PATH)) {
+      const actions = JSON.parse(fs.readFileSync(SESSION_ACTIONS_PATH, 'utf8'));
+      delete actions.tests_passed;
+      fs.writeFileSync(SESSION_ACTIONS_PATH, JSON.stringify(actions));
+    }
+  } catch { /* ignore */ }
+}
+
+// process.cwd() during `node --test` is the repo root, which is a real git repo, so
+// edits + commits here resolve to the same repo key.
+const REPO = process.cwd();
+
+test('sequence-guard - edit then unverified commit in the same repo is blocked', () => {
+  resetSequenceState();
+  clearTestsPassed();
+  const edit = evaluateSequenceState('Edit', { file_path: path.join(REPO, 'src/api/server.js') });
+  assert.equal(edit, null);
+  const commit = evaluateSequenceState('Bash', { command: 'git commit -m "fixed"', repoPath: REPO });
+  assert.ok(commit, 'expected a block');
+  assert.equal(commit.decision, 'deny');
+  assert.equal(commit.gate, 'workflow-sequence-violation');
+  resetSequenceState();
 });
 
-test('sequence-guard - blocks commit when dirty', () => {
-  saveState({ dirty: true, lastEditAt: Date.now() });
-  if (fs.existsSync(SESSION_ACTIONS_PATH)) {
-    const actions = JSON.parse(fs.readFileSync(SESSION_ACTIONS_PATH, 'utf8'));
-    delete actions.tests_passed;
-    fs.writeFileSync(SESSION_ACTIONS_PATH, JSON.stringify(actions));
-  }
-  const result = evaluateSequenceState('Bash', { command: 'git commit -m "fixed"' });
-  assert.ok(result);
-  assert.equal(result.decision, 'deny');
-});
-
-test('sequence-guard - allows commit after tests_passed', () => {
-  const editTime = Date.now();
-  saveState({ dirty: true, lastEditAt: editTime });
-  const actions = fs.existsSync(SESSION_ACTIONS_PATH) ? JSON.parse(fs.readFileSync(SESSION_ACTIONS_PATH, 'utf8')) : {};
-  actions.tests_passed = { timestamp: editTime + 1000, metadata: {} };
+test('sequence-guard - allows commit after tests_passed clears the repo', () => {
+  resetSequenceState();
+  evaluateSequenceState('Edit', { file_path: path.join(REPO, 'src/api/server.js') });
+  const actions = fs.existsSync(SESSION_ACTIONS_PATH)
+    ? JSON.parse(fs.readFileSync(SESSION_ACTIONS_PATH, 'utf8'))
+    : {};
+  actions.tests_passed = { timestamp: Date.now() + 1000, metadata: {} };
   fs.writeFileSync(SESSION_ACTIONS_PATH, JSON.stringify(actions));
-  const result = evaluateSequenceState('Bash', { command: 'git commit -m "verified"' });
+  const result = evaluateSequenceState('Bash', { command: 'git commit -m "verified"', repoPath: REPO });
   assert.equal(result, null);
+  resetSequenceState();
+  clearTestsPassed();
+});
+
+test('sequence-guard - edit in one repo does NOT block a commit in another (per-repo isolation)', () => {
+  resetSequenceState();
+  clearTestsPassed();
+  // Edit a file in this repo (marks THIS repo dirty)...
+  evaluateSequenceState('Edit', { file_path: path.join(REPO, 'src/api/server.js') });
+  // ...then commit in an unrelated path. Previously the global dirty flag blocked this.
+  const otherRepo = os.tmpdir();
+  const commit = evaluateSequenceState('Bash', { command: 'git commit -m wip', repoPath: otherRepo });
+  assert.equal(commit, null, 'a commit in an unrelated repo must not be blocked by this repo\'s edits');
+  resetSequenceState();
 });


### PR DESCRIPTION
## Problem
The `workflow-sequence-violation` guardrail ("source edited but not verified") tracked a **single global dirty flag** in `~/.thumbgate/sequence-state.json`. An Edit/Write in **any** repo set it, so the next `git commit`/`publish` in **any other** repo was hard-denied. Editing one project blocked committing in an unrelated workspace — cross-repo blocking that's wrong regardless of the verify-before-commit policy.

## Fix
Dirty state is now keyed **per repo** (resolved by walking up to the nearest `.git` from the action's path / `cd` target / `repoPath`). The guardrail still blocks an unverified commit *within the same repo* that was edited; it no longer blocks commits in unrelated repos. Legacy flat-format state is dropped on load (worst case: one extra allowed commit, never a wrong block).

## Verification
- edit in repo A → commit in repo B: **ALLOW**
- commit in repo A (edited, unverified): **BLOCK** (guardrail preserved)
- Tests updated for per-repo semantics + a cross-repo isolation case. 3/3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)