### PR TITLE
docs(positioning): lead with local-first coding-agent firewall (post-Fiddler)

### DIFF
--- a/.changeset/positioning-coding-agent-firewall.md
+++ b/.changeset/positioning-coding-agent-firewall.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Positioning: sharpen messaging to emphasize ThumbGate as the local-first firewall for AI coding agents, differentiating on deployment model (runs in the PreToolUse hook on the developer's machine) and shipped-today coding-agent coverage rather than enterprise governance. Updates the homepage hero lede, README intro, and adds a pricing FAQ ("Why not just use an enterprise AI control plane?"). Demotes the enterprise/regulated-industry framing to a secondary use case.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   </a>
 </p>
 
-**AI agents repeat mistakes. In regulated industries, one wrong action is a liability event.**
+**AI coding agents repeat mistakes — and one wrong tool call can wipe a directory, leak a key, or push broken code.**
 
-ThumbGate is deterministic pre-action governance for AI agents. From developer workflows to legal intake to financial compliance — one rule blocks unauthorized actions before they execute, across every session, every agent, every model.
+ThumbGate is the local-first firewall for AI coding agents. It runs in the PreToolUse hook on your machine and blocks dangerous tool calls — `rm -rf`, secret exfiltration, off-scope edits, a bad `git push` — before they execute, across Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode. No server, no gateway. (Regulated-industry policy templates — legal intake, financial compliance, healthcare — build on the same engine.)
 
 The product is a self-improving enforcement layer: thumbs-down feedback, prompt evaluation, and proof from prior runs become prevention rules that permanently stop repeated failures before the next tool call.
 

--- a/public/index.html
+++ b/public/index.html
@@ -722,7 +722,7 @@ __GA_BOOTSTRAP__
   <div class="container">
     <div class="hero-badge">👍 👎 The Firewall for AI Agents</div>
     <h1>The Infrastructure Firewall for AI Coding Agents.</h1>
-    <p class="hero-lede">AI will always hallucinate and break things. We don't try to make AI smarter; we make its mistakes harmless. ThumbGate keeps the Senior Architect in control by blocking dangerous tool calls before they hit the disk.</p>
+    <p class="hero-lede">AI agents will always hallucinate and break things — we make their mistakes harmless. ThumbGate runs in the PreToolUse hook on your machine and blocks the dangerous tool call — rm -rf, leaked keys, off-scope edits, a bad git push — before it executes. No server, no gateway, no waiting on an enterprise rollout.</p>
 
     <div class="hero-proof-card" aria-label="ThumbGate blocking example">
       <div class="terminal-row muted">$ agent attempts risky action</div>

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -300,6 +300,10 @@ __GA_BOOTSTRAP__
         <div class="faq-a">Free gives you 5 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for infrastructure we run, not features we hide.</div>
       </div>
       <div class="faq-item">
+        <div class="faq-q">Why not just use an enterprise AI control plane?</div>
+        <div class="faq-a">Enterprise control planes govern agents from a server-side gateway, sold to platform teams on a Fortune-500 timeline. ThumbGate runs local-first, in the PreToolUse hook on your machine, and ships enforcement for the coding agents developers actually use today — Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — with an <code>npm install</code> and minutes to value, not a procurement cycle.</div>
+      </div>
+      <div class="faq-item">
         <div class="faq-q">Does ThumbGate send my code to the cloud?</div>
         <div class="faq-a">No. The CLI is local-first and no source code leaves your machine. Pro and Team add hosted sync for dashboards and shared lessons, but your code stays local.</div>
       </div>


### PR DESCRIPTION
## Why
Fiddler raised $30M for 'the Control Plane for AI Agents' + acquired Lumeus for the code-generation boundary, and explicitly claims IDE/CLI/MCP runtime enforcement. We can't win the enterprise-governance narrative head-on, and 'they only guard outputs' is refutable by their own homepage. So this sharpens positioning around what's **defensible**: local-first deployment (in the `PreToolUse` hook on the dev machine), dev-native npm/MCP distribution, and shipped-today coverage for the coding agents developers actually use.

## Changes (3 surfaces)
- **Homepage hero lede** (`public/index.html`): local-first, 'no server, no gateway, no enterprise rollout' framing.
- **README intro**: lead with the coding-agent firewall; demote the regulated-industry / 'deterministic governance' framing to a secondary use case.
- **Pricing FAQ** (`public/pricing.html`): add 'Why not just use an enterprise AI control plane?' — differentiates on deployment + time-to-value, not a capability claim.

## Notes
- Explicitly avoids claiming Fiddler can't enforce actions (they claim they can).
- Marketing/SEO/landing tests 150/150 green; pre-commit 'landing claims vs code' guard passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)