### PR TITLE
fix(gates): exempt credential-hardening chmod + rebase absolute task-scope globs

### DIFF
--- a/.changeset/gate-unblock-coding-agents.md
+++ b/.changeset/gate-unblock-coding-agents.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+Two pre-action gate fixes that were unblocking legitimate coding-agent work:
+
+1. **memory-high-risk gate exempts credential-hardening chmod** — `chmod 600` on a credential path (e.g. `~/.resume_secrets/key.json`, `~/.ssh/id_*`) is a hardening (safety) action. It was being hard-denied by `memory-high-risk-default-deny` when recurring negative memory matched. The `isSafeLocalCredentialHardeningCommand` exemption (already guarding the permission-change-approval gate) now also guards the memory gate.
+
+2. **task-scope rebases absolute allowedPaths to repo-relative** — affected files are compared repo-relative, so an absolute `allowedPath` silently never matched (no-op scope). `setTaskScope` now rebases absolute globs under `repoPath` to their repo-relative form; the repoPath itself collapses to `**`. Relative globs and globs outside repoPath are unchanged (monotonic — can't regress a working scope).

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -217,6 +217,25 @@ function sanitizeGlobList(globs) {
   return [...new Set(globs.map((glob) => normalizeGlob(glob)).filter(Boolean))];
 }
 
+// Affected files are compared as repo-relative paths (git --name-only output and
+// inline paths are relative to the repo root). A caller who passes an ABSOLUTE
+// allowedPath (e.g. "/Users/me/proj/src/**") therefore declares a glob that can never
+// match — a silent no-op scope. When repoPath is known, rebase absolute globs that
+// live under it to the repo-relative form so the scope actually applies. Globs already
+// relative, or absolute but outside repoPath, are returned unchanged.
+function rebaseGlobsToRepoRoot(globs, repoPath) {
+  const repoRel = normalizePosix(repoPath);
+  if (!repoRel) return globs;
+  return globs.map((glob) => {
+    if (glob === repoRel) return '**';
+    if (glob.startsWith(`${repoRel}/`)) {
+      const rebased = glob.slice(repoRel.length + 1);
+      return rebased || '**';
+    }
+    return glob;
+  });
+}
+
 function globToRegExp(glob) {
   const normalized = normalizeGlob(glob);
   let pattern = '^';
@@ -305,23 +324,24 @@ function setTaskScope(scopeInput = {}) {
     return null;
   }
 
-  const allowedPaths = sanitizeGlobList(scopeInput.allowedPaths);
+  const repoPath = String(scopeInput.repoPath || '').trim() || null;
+  const allowedPaths = rebaseGlobsToRepoRoot(sanitizeGlobList(scopeInput.allowedPaths), repoPath);
   if (allowedPaths.length === 0) {
     throw new Error('allowedPaths must be a non-empty array');
   }
 
-  const protectedPaths = sanitizeGlobList(
+  const protectedPaths = rebaseGlobsToRepoRoot(sanitizeGlobList(
     Array.isArray(scopeInput.protectedPaths) && scopeInput.protectedPaths.length > 0
       ? scopeInput.protectedPaths
       : DEFAULT_PROTECTED_FILE_GLOBS
-  );
+  ), repoPath);
   const taskScope = {
     taskId: String(scopeInput.taskId || '').trim() || null,
     summary: String(scopeInput.summary || '').trim() || null,
     allowedPaths,
     protectedPaths,
     localOnly: scopeInput.localOnly === true,
-    repoPath: String(scopeInput.repoPath || '').trim() || null,
+    repoPath,
     createdAt: new Date().toISOString(),
     timestamp: Date.now(),
   };
@@ -1347,6 +1367,13 @@ function isSafeLocalCredentialHardeningCommand(toolName, toolInput = {}) {
 function evaluateMemoryGuard(toolName, toolInput = {}) {
   const affected = extractAffectedFiles(toolName, toolInput);
   const affectedFiles = affected.files;
+  // Hardening a credential file's permissions (chmod 600 on a key/secret path) is
+  // a safety action, not a risk. The same exemption already guards the
+  // permission-change-approval gate; without it here, `chmod 600 ~/.resume_secrets/key`
+  // gets hard-denied by recurring-negative-memory matching — the opposite of intent.
+  if (isSafeLocalCredentialHardeningCommand(toolName, toolInput)) {
+    return null;
+  }
   if (!isHighRiskAction(toolName, toolInput, affectedFiles)) {
     return null;
   }

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -307,6 +307,29 @@ test('matchesGate handles missing tool_input fields', () => {
 // Block action
 // ---------------------------------------------------------------------------
 
+test('setTaskScope rebases absolute allowedPaths under repoPath to repo-relative', () => {
+  cleanupStateFiles();
+  // Affected files are compared repo-relative, so an absolute allowedPath silently
+  // never matches (no-op scope). With repoPath known, absolute globs under it must be
+  // rebased to repo-relative; the repoPath itself collapses to '**'.
+  const scope = setTaskScope({
+    summary: 'abs path rebasing',
+    repoPath: '/Users/me/workspace/proj',
+    allowedPaths: [
+      '/Users/me/workspace/proj/src/**',   // absolute under repo -> 'src/**'
+      '/Users/me/workspace/proj',           // repo root itself -> '**'
+      'tests/**',                           // already relative -> unchanged
+      '/etc/somewhere/**',                  // absolute OUTSIDE repo -> unchanged
+    ],
+  });
+  assert.ok(scope.allowedPaths.includes('src/**'), `got ${JSON.stringify(scope.allowedPaths)}`);
+  assert.ok(scope.allowedPaths.includes('**'));
+  assert.ok(scope.allowedPaths.includes('tests/**'));
+  assert.ok(scope.allowedPaths.includes('etc/somewhere/**'));
+  setTaskScope({ clear: true });
+  cleanupStateFiles();
+});
+
 test('evaluateGates returns deny for git push', () => {
   cleanupStateFiles();
   const repoPath = createPushTestRepo();
@@ -772,6 +795,26 @@ test('permission-change approval still catches unsafe chmod commands', () => {
   const result = evaluateGates('Bash', { command: 'chmod 777 ~/.config/gemini/key.json' });
   assert.equal(result.decision, 'approve');
   assert.equal(result.gate, 'permission-change-approval');
+  cleanupStateFiles();
+});
+
+test('memory-high-risk gate exempts safe credential-hardening chmod (vault key)', () => {
+  cleanupStateFiles();
+  // chmod 600 on a credential path is a hardening (safety) action; it must never be
+  // hard-denied (decision:'deny') by memory-high-risk-default-deny. Advisory warns are
+  // fine — the action proceeds. Regression guard for the evaluateMemoryGuard exemption.
+  for (const cmd of [
+    'chmod 600 ~/.resume_secrets/stripe.json',
+    'chmod 600 /Users/igorganapolsky/.resume_secrets/stripe.json',
+    'chmod 600 ~/.ssh/id_ed25519',
+  ]) {
+    const result = evaluateGates('Bash', { command: cmd });
+    const denied = result && result.decision === 'deny';
+    assert.ok(!denied, `expected not-denied for: ${cmd} (got ${result && result.gate})`);
+    if (result) {
+      assert.notEqual(result.gate, 'memory-high-risk-default-deny', `must not be memory-denied: ${cmd}`);
+    }
+  }
   cleanupStateFiles();
 });
 


### PR DESCRIPTION
Re-homes two verified fixes from the unmergeable `fix/reliability-rollout` branch onto a clean `main` base (re-applied fresh — no dependency on branch-only commits).

1. **memory-high-risk gate exempts credential-hardening chmod** — `chmod 600` on a credential path (`~/.resume_secrets/key.json`, `~/.ssh/id_*`) is a hardening/safety action but was hard-denied by `memory-high-risk-default-deny` on recurring-memory match. The `isSafeLocalCredentialHardeningCommand` exemption (already on the permission-change gate) now also guards the memory gate. `chmod -R 777 /` and non-credential chmods stay blocked.

2. **task-scope rebases absolute allowedPaths to repo-relative** — affected files are compared repo-relative, so an absolute `allowedPath` silently never matched (no-op scope; cost real debugging time). `setTaskScope` now rebases absolute globs under `repoPath`; the repoPath itself collapses to `**`. Monotonic — relative globs and out-of-repo globs unchanged, can't regress a working scope.

gates-engine **153/153** green (2 new regression tests). Verified on main's code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)