### PR TITLE
docs(strategy): retire Team tier — pricing is Free / Pro / Enterprise

### DIFF
--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -1,7 +1,7 @@
 # Commercial Truth
 
 Status: current
-Updated: April 10, 2026
+Updated: June 3, 2026
 
 This document is the source of truth for product, pricing, traction, and proof claims in this repository.
 
@@ -9,10 +9,10 @@ This document is the source of truth for product, pricing, traction, and proof c
 
 - The open-source `thumbgate` package is free and MIT licensed.
 - The local CLI is the adoption wedge; it is not the primary monetization story.
-- The primary commercial motion is the **Workflow Hardening Sprint** for one workflow, followed by Team expansion when shared enforcement, approval boundaries, and auditability matter across operators.
+- The customer-facing tiers are **Free / Pro / Enterprise**. The self-serve commercial offer is **Pro ($19/mo or $149/yr)**; **Enterprise** is a contact-sales motion for regulated teams (Vertex AI / VPC gating, regulatory templates, SLA). **"Team" was retired as a tier and sales motion on 2026-06-03** — it had 0 customers and $0 revenue, and its intake-led consulting motion mismatched a local-first, self-serve dev tool.
 - The current public self-serve commercial offer is **Pro at $19/mo or $149/yr** via Stripe checkout.
 - Legacy one-time Stripe links are retained only for past buyers and are not a current public offer.
-- The current Team pricing anchor is **$49/seat/mo with a 3-seat minimum**, and the public Team path remains an **intake-led pilot for the first workflow** until hosted rollout scope is qualified.
+- Shared-team enforcement (one operator's thumbs-down protecting every teammate via a shared lesson database) is retained as a **deferred Pro per-seat capability and an Enterprise feature**, not a standalone tier — surfaced only when a paying customer requests multi-seat. The underlying billing code stays intact but dormant.
 - The open-source runtime now supports history-aware lesson distillation from up to 8 prior recorded entries in the current Claude auto-capture path, linked 60-second feedback sessions, and reflector rule proposals across CLI, hosted API, Cursor, and Claude Desktop surfaces.
 - The runtime now supports Workflow Sentinel blast-radius scoring plus Docker Sandboxes routing guidance for high-risk local actions, and the hosted path supports signed sandbox dispatch for isolated team automations.
 - Package publishing is governed by Changesets, SemVer, version-sync checks, and verification evidence; release claims should stay inspectable instead of being inferred from a diff.
@@ -37,18 +37,17 @@ This document is the source of truth for product, pricing, traction, and proof c
 - DPO export and advanced data exports
 - Review-ready workflow support for the first risky flow
 - Unlimited captures and custom checks with auto-promotion into prevention rules
-- Secondary self-serve lane for solo operators, not the default enterprise pitch
+- The primary self-serve paid tier for individual developers; seat-scalable for small teams when a paying customer requests it
 
-### Team ($49/seat/mo, min 3, hosted rollout intake-first)
+### Enterprise (contact sales)
 
-- Workflow hardening sprint as the first paid step
-- Shared hosted lesson database
-- Generated hosted review views for team, incident, and rollout operations
-- Org dashboard with active agents, check hit rates, and risk agents
-- Curated check template library
-- Isolated execution guidance for risky local autonomy and signed hosted sandbox dispatch for team workflows
-- Workflow hardening sprint intake and rollout support
-- Team-wide sharing of prevention rules and proof artifacts
+- Vertex AI / VPC gating — route agent checks through Gemini models in the customer's own Google Cloud project (`npx thumbgate setup-vertex`)
+- Regulatory gate templates — legal intake, financial compliance, healthcare
+- Custom policy layers scoped to firm / practice area
+- Compliance audit export, dedicated onboarding, and SLA
+- Org dashboard plus shared/team enforcement (shared hosted lesson database, prevention-rule and proof-artifact sharing)
+
+> The former standalone **Team** tier ($49/seat, 3-seat minimum, intake-led Workflow Hardening Sprint) was retired 2026-06-03. Its shared-enforcement features fold into Enterprise and a future Pro per-seat option; the underlying billing/code remains but is not sold as a separate tier.
 
 ## Data Processing & Telemetry Boundaries
 

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -434,7 +434,7 @@ test('commercial truth sources stay aligned across public and historical docs', 
   const directoryGuide = readText('docs/marketing/mcp-directories.md');
 
   assert.match(commercialTruth, /Pro at \$19\/mo or \$149\/yr/);
-  assert.match(commercialTruth, /Team pricing anchor is \*\*\$49\/seat\/mo/i);
+  assert.match(commercialTruth, /customer-facing tiers are \*\*Free \/ Pro \/ Enterprise/i);
   assert.match(commercialTruth, /auto-promotion into prevention rules/);
   assert.match(commercialTruth, /Do not treat GitHub stars, watchers, dependents, or npm download counts as customer or revenue proof/);
 


### PR DESCRIPTION
CEO decision (2026-06-03): drop Team as a customer-facing tier. It had **0 customers / $0 revenue**, and its intake-led consulting motion ("send your workflow first", 3-seat min) mismatched a local-first self-serve dev tool — plus the Pro-vs-Team split was a source of the pricing incoherence.

Updates the source-of-truth doc to **Free / Pro / Enterprise**. Shared-team enforcement is preserved as a **deferred Pro-per-seat capability + Enterprise feature** (billing code stays, not sold as a tier) — it's the strongest wedge vs free DIY Claude Code hooks, so kept not deleted.

Relevant tests 204/204. **Doc-only** — surface follow-ups (README pricing table, pricing.html Team card, sprint pages) still reference Team and need a separate pass to be fully coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)