### PR TITLE
fix(test): pricing FAQ count 5->6 — unbreak main E2E

### DIFF
--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -89,7 +89,7 @@ test.describe('/pricing clickability — full CTA coverage', () => {
     await expect(link).toHaveAttribute('href', /#workflow-sprint-intake$/);
   });
 
-  // --- FAQ accordion (5 items, vanilla addEventListener — no IIFE issue) ---
+  // --- FAQ accordion (6 items, vanilla addEventListener — no IIFE issue) ---
 
   test('FAQ has 6 items, all closed on initial load', async ({ page }) => {
     await page.goto('/pricing');

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -91,11 +91,11 @@ test.describe('/pricing clickability — full CTA coverage', () => {
 
   // --- FAQ accordion (5 items, vanilla addEventListener — no IIFE issue) ---
 
-  test('FAQ has 5 items, all closed on initial load', async ({ page }) => {
+  test('FAQ has 6 items, all closed on initial load', async ({ page }) => {
     await page.goto('/pricing');
     const items = page.locator('.faq-item');
-    await expect(items).toHaveCount(5);
-    for (let i = 0; i < 5; i++) {
+    await expect(items).toHaveCount(6);
+    for (let i = 0; i < 6; i++) {
       await expect(items.nth(i)).not.toHaveClass(/(^|\s)open(\s|$)/);
     }
   });


### PR DESCRIPTION
**Main is red.** PR #2453 added a 6th FAQ item to pricing.html (the 'Why not an enterprise control plane?' entry — intentional) but left `tests/e2e/pricing-page-clickability.spec.js` pinned to `toHaveCount(5)`. The E2E workflow on main (commit a1332836) is failing as a result.

This updates the assertion + loop to **6** to match the live page. The FAQ addition stays; only the stale count is corrected. Also unblocks #2455 and #2458 (both inherit the 6-FAQ pricing page from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)