### PR TITLE
fix(gates): rebaseGlobsToRepoRoot handles trailing-slash repoPath

### DIFF
--- a/.changeset/rebase-trailing-slash-fix.md
+++ b/.changeset/rebase-trailing-slash-fix.md
@@ -1,0 +1,11 @@
+---
+"thumbgate": patch
+---
+
+fix(gates): rebaseGlobsToRepoRoot handles repoPath with a trailing slash
+
+`rebaseGlobsToRepoRoot` used `normalizePosix(repoPath)`, which preserved a
+trailing slash and produced malformed rebased globs (e.g. `repo//**`) when a
+task scope was set with a `repoPath` ending in `/`. Switched to
+`normalizeGlob(repoPath)` so task-scope edit-boundary globs resolve correctly
+regardless of trailing slash. (Addresses the edge case flagged on #2454.)

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -224,7 +224,9 @@ function sanitizeGlobList(globs) {
 // live under it to the repo-relative form so the scope actually applies. Globs already
 // relative, or absolute but outside repoPath, are returned unchanged.
 function rebaseGlobsToRepoRoot(globs, repoPath) {
-  const repoRel = normalizePosix(repoPath);
+  // normalizeGlob strips both leading AND trailing slashes, so a repoPath with a
+  // trailing slash ("/Users/me/proj/") still matches the repo-relative globs.
+  const repoRel = normalizeGlob(repoPath);
   if (!repoRel) return globs;
   return globs.map((glob) => {
     if (glob === repoRel) return '**';


### PR DESCRIPTION
Follow-up to #2454 (which merged before this one-line fix landed). `normalizePosix` strips only leading slashes, so `repoPath` with a trailing slash (`/Users/me/proj/`) left `repoRel` with a trailing slash and the prefix match failed → the scope silently didn't rebase. Use `normalizeGlob` (strips both). Caught by gitar-bot on #2454. gates-engine 153/153 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)