### PR TITLE
skill: thumbgate-brand-voice authoring skill (on-brand copy, no more generic SaaS voice)

### DIFF
--- a/.changeset/thumbgate-brand-voice-skill.md
+++ b/.changeset/thumbgate-brand-voice-skill.md
@@ -1,0 +1,12 @@
+---
+"thumbgate": patch
+---
+
+skill: add thumbgate-brand-voice authoring skill
+
+Repo-internal skill (not bundled to npm) that makes ThumbGate-facing copy
+on-brand: direct, technical, honest, anti-hype. Adapts the contrast-based
+"Claude brand skill" method (good / too-far / too-flat rewrites) into
+brand-foundation, voice-and-tone, content-formats, and a SKILL.md orchestrator.
+Codifies the no-overclaim rule and the "mistakes not malice" reframe so social,
+landing, README, and outreach copy stop sounding generic.

--- a/skills/thumbgate-brand-voice/SKILL.md
+++ b/skills/thumbgate-brand-voice/SKILL.md
@@ -34,4 +34,4 @@ messages, or internal notes.
 **Never overclaim.** ThumbGate is pre-revenue and honesty is the brand. No
 fabricated traction ("trusted by N teams"), no benchmark claims without a cited
 source, no "live" integration we don't ship. Honest-and-specific beats
-impressive-and-vague every time. See [[feedback_no_overclaiming]].
+impressive-and-vague every time.

--- a/skills/thumbgate-brand-voice/SKILL.md
+++ b/skills/thumbgate-brand-voice/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: ThumbGate Brand Voice
+description: Make any ThumbGate-facing copy (landing pages, README, Reddit/LinkedIn/Bluesky posts, comparison pages, docs, outreach drafts) sound like ThumbGate — direct, technical, honest, anti-hype. Use BEFORE writing or editing any customer-facing or marketing text for ThumbGate.
+---
+
+# ThumbGate Brand Voice
+
+Orchestrator skill for producing on-brand ThumbGate copy. Method adapted from
+the "Claude brand skill" approach (contrast-based learning: show the model a
+good line, a line that goes too far, and a line that dies of beige).
+
+## When to use
+
+Use this whenever you are about to write or edit copy a human will read as
+ThumbGate: landing/pricing/compare/guide pages, README, postinstall banners,
+CLI receipts, social posts (Reddit, LinkedIn, Bluesky, Threads), outreach
+drafts, or blog/launch content. Do **not** use it for code comments, commit
+messages, or internal notes.
+
+## How to use (in order)
+
+1. Read [`brand-foundation.md`](./brand-foundation.md) — who ThumbGate is, the
+   5 personality traits, and the explicit "what we aren't" list.
+2. Read [`voice-and-tone.md`](./voice-and-tone.md) — per-trait good / too-far /
+   too-flat rewrites. Match the "good" column; never the other two.
+3. Read [`content-formats.md`](./content-formats.md) — which traits amplify or
+   recede per channel, with on/off-brand examples per channel.
+4. Draft. Then **stress-test**: reread your draft against the "what we aren't"
+   list and the channel rules. If a sentence could appear verbatim on a generic
+   "AI governance platform" site, rewrite it until it could only be ThumbGate.
+
+## The one rule that overrides everything
+
+**Never overclaim.** ThumbGate is pre-revenue and honesty is the brand. No
+fabricated traction ("trusted by N teams"), no benchmark claims without a cited
+source, no "live" integration we don't ship. Honest-and-specific beats
+impressive-and-vague every time. See [[feedback_no_overclaiming]].

--- a/skills/thumbgate-brand-voice/brand-foundation.md
+++ b/skills/thumbgate-brand-voice/brand-foundation.md
@@ -1,0 +1,37 @@
+# ThumbGate — Brand Foundation
+
+**Summary (one paragraph).** ThumbGate is a local-first firewall for AI coding
+agents. It runs in the PreToolUse hook on the developer's machine and blocks
+dangerous tool calls — `rm -rf`, leaked secrets, off-scope edits, a bad
+`git push` — *before* they execute, then turns a 👎 thumbs-down into a
+prevention rule so the same mistake never repeats. It is enforcement at the
+tool-call boundary, not a dashboard you read after the damage.
+
+**Mission (one sentence).** Make AI coding agents' inevitable mistakes harmless.
+
+**Audience emotional context.** A developer or eng lead who has already watched
+an agent do something dumb (or fears the next one) and is tired of re-explaining
+the same correction. They want control without a procurement cycle. They are
+skeptical of hype and allergic to enterprise buzzwords. They respect tools that
+respect their time and their intelligence.
+
+**Positioning.** The control layer for what an agent is *allowed to execute* —
+local-first, dev-native, install in minutes. Not a server-side gateway, not a
+prompt wrapper, not a chatbot. Complements orchestration/agent tools; it decides
+what runs, not what to do.
+
+## Personality traits (with contrast)
+
+1. **Direct** — lead with the concrete action and the outcome. *Good:* "Blocks `rm -rf` before it runs." *Too far:* "OBLITERATES catastrophic agent failures." *Too flat:* "Helps manage agent operations."
+2. **Technically precise** — name the real mechanism. *Good:* "Runs in the PreToolUse hook." *Too far:* "Leverages a proprietary AI-native security mesh." *Too flat:* "Adds a layer of protection."
+3. **Honest / anti-hype** — claim only what's true and shippable. *Good:* "Pre-revenue; here's exactly what it does." *Too far:* "Trusted by thousands of teams." *Too flat:* "A solution for modern teams."
+4. **Pragmatic** — recommend the free/native option when it fits. *Good:* "Native Claude Code hooks cover most cases — start there." *Too far:* "You'd be reckless not to buy this." *Too flat:* "There are various options available."
+5. **Quietly confident** — let the mechanism do the bragging. *Good:* "Same block, every session, no config." *Too far:* "The only tool that truly understands agent risk." *Too flat:* "We think you'll find it useful."
+
+## What we aren't
+
+- **Fear-mongering about "rogue / lying AI."** Our risk story is *mistakes and blast radius*, not malice. Intent-agnostic enforcement: malice, prompt-injection, or honest error — same block.
+- **Enterprise-buzzword salad.** No "control plane for the agentic enterprise," "AI-native security fabric," "holistic governance posture."
+- **A chatbot / assistant.** ThumbGate doesn't chat; it gates actions.
+- **Vague or aspirational.** No "seamless," "robust," "next-generation," "revolutionary."
+- **Overclaiming.** No invented traction, benchmarks, certifications (SOC 2), or "live" integrations we don't ship.

--- a/skills/thumbgate-brand-voice/content-formats.md
+++ b/skills/thumbgate-brand-voice/content-formats.md
@@ -12,7 +12,7 @@ YouTube. X is retired.
 
 ## LinkedIn
 - Amplify: quietly confident, technically precise. Recede: jargon, hustle-bro energy.
-- One insight, one mechanism, no hash16-hashtag wall. Engineer-credible, not thought-leader-y.
+- One insight, one mechanism, no hashtag wall. Engineer-credible, not thought-leader-y.
 - ✅ "Zero-trust for agents has to be enforced at the tool call, not the prompt. Here's the boundary where it actually happens."
 - 🚫 "🚀 Excited to share how AI is REVOLUTIONIZING developer security! #AI #ML #Security #Innovation"
 

--- a/skills/thumbgate-brand-voice/content-formats.md
+++ b/skills/thumbgate-brand-voice/content-formats.md
@@ -1,0 +1,43 @@
+# ThumbGate — Format-Specific Rules
+
+Which traits **amplify** vs **recede** per channel, with on/off-brand examples.
+Active channels (per CLAUDE.md): Reddit, LinkedIn, Bluesky, Threads, Instagram,
+YouTube. X is retired.
+
+## Reddit (r/ClaudeAI, r/cursor, r/opensourceeai)
+- Amplify: pragmatic, honest. Recede: any promotion.
+- **Always disclose authorship** ("disclosure: I built this"). Value first; recommend the free/native option honestly; ThumbGate is one option, not "the answer."
+- ✅ "The built-in fix is Claude Code's PreToolUse hooks — start there. The gap is they don't learn; I built ThumbGate (disclosure: mine) to add that. Free/local."
+- 🚫 "ThumbGate is the best way to secure your AI agents! Check it out 👉"
+
+## LinkedIn
+- Amplify: quietly confident, technically precise. Recede: jargon, hustle-bro energy.
+- One insight, one mechanism, no hash16-hashtag wall. Engineer-credible, not thought-leader-y.
+- ✅ "Zero-trust for agents has to be enforced at the tool call, not the prompt. Here's the boundary where it actually happens."
+- 🚫 "🚀 Excited to share how AI is REVOLUTIONIZING developer security! #AI #ML #Security #Innovation"
+
+## Bluesky / Threads
+- Amplify: direct, dry. Recede: length. Punchy, one concrete idea, no thread-bait.
+- ✅ "Your coding agent doesn't need to be evil to drop a prod table. Just confused. Gate the action, not the intent."
+
+## Landing / pricing / compare pages
+- Amplify: all five traits. Recede: nothing — this is the flagship voice.
+- Lead with the concrete failure → the block → the learning loop. Name real tiers and real limits. Fair comparison sections ("choose the free option when…").
+
+## README / docs
+- Amplify: technically precise, honest. Recede: marketing tone.
+- Copy-pasteable commands, accurate limits, the honest disclaimer ("does not update model weights"). No aspirational features.
+
+## CLI receipts / postinstall
+- Amplify: direct, quietly confident. Recede: everything else — terminal space is scarce.
+- One line of value, one next command. Never a paragraph of pitch.
+
+## YouTube (comments / shorts)
+- Amplify: pragmatic, dry. Recede: promotion.
+- Value-first reframe, not a link drop. Use clips as a foil for the honest thesis (mistakes > malice).
+
+## Universal stress test (run before publishing)
+1. Could this sentence appear verbatim on a generic "AI governance platform"? → rewrite until it could only be ThumbGate.
+2. Does any claim need a source or assert traction we don't have? → cut or cite.
+3. Is there a banned word or an exclamation mark? → fix.
+4. Did I recommend the honest free/native option where it genuinely fits? → if not, add it.

--- a/skills/thumbgate-brand-voice/voice-and-tone.md
+++ b/skills/thumbgate-brand-voice/voice-and-tone.md
@@ -1,0 +1,42 @@
+# ThumbGate — Voice & Tone (contrast pairs)
+
+For each trait: **On-brand** (write like this) · **Too far** (hype/cringe) ·
+**Too flat** (generic, could be any SaaS). The model learns the edges by seeing
+all three.
+
+## Direct
+- ✅ "An agent ran `rm -rf` on the wrong directory. ThumbGate blocks that before it executes."
+- 🚫 Too far: "Stop catastrophic AI meltdowns from nuking your entire codebase forever."
+- 💤 Too flat: "ThumbGate helps you reduce risk in your AI workflows."
+
+## Technically precise
+- ✅ "Installs as a PreToolUse hook (`npx thumbgate init`). Checks each risky tool call against your prevention rules before it runs."
+- 🚫 Too far: "Our patented neural firewall intercepts threats at machine speed."
+- 💤 Too flat: "It integrates with your tools to provide protection."
+
+## Honest / anti-hype
+- ✅ "Free tier: 5 captures/day, 25 total, 3 active rules. Pro removes the caps. That's the actual difference."
+- 🚫 Too far: "Unlimited everything, trusted by the world's best engineering teams."
+- 💤 Too flat: "Flexible plans to fit teams of every size."
+
+## Pragmatic (recommend the honest alternative)
+- ✅ "If a short, static blocklist covers you, native hooks are enough — use them. ThumbGate earns its place when the same mistake keeps coming back."
+- 🚫 Too far: "Native hooks are a toy. Real teams need ThumbGate."
+- 💤 Too flat: "ThumbGate is one of many tools you might consider."
+
+## Quietly confident
+- ✅ "A thumbs-down becomes a prevention rule. The repeat is blocked next time — every session, every agent, no config edit."
+- 🚫 Too far: "The only AI safety tool that actually works. Period."
+- 💤 Too flat: "Our learning system continuously improves over time."
+
+## The "rogue AI" trap (recurring temptation — always reframe)
+- ✅ "Even if AI never 'lies,' a confused agent still pushes to `main`. ThumbGate doesn't argue about intent — it checks the action."
+- 🚫 Too far: "AI is lying to you and plotting against your codebase."
+- 💤 Too flat: "AI safety is important for modern teams."
+
+## Mechanics
+- Prefer concrete verbs (blocks, runs, checks, captures, gates) over abstract ones (enables, empowers, leverages, facilitates).
+- Use the real command/flag/file when relevant (`rm -rf`, `git push`, PreToolUse, `npx thumbgate`).
+- One claim per sentence; cite a source for any number that isn't a product limit.
+- Em dashes for asides are fine. Avoid exclamation marks (max one per page, and usually zero).
+- Banned words: seamless, robust, holistic, next-generation, revolutionary, game-changing, cutting-edge, synergy, posture (as a noun).


### PR DESCRIPTION
## Why
Stolen from ["How to train Claude to sound like your brand"](https://searchengineland.com/train-claude-sound-like-your-brand-479023): a contrast-based brand skill teaches voice by showing good / too-far / too-flat rewrites, not abstract adjectives. ThumbGate's autonomous social + marketing copy keeps drifting generic; this fixes the source.

## What
New repo-internal skill `skills/thumbgate-brand-voice/`:
- `brand-foundation.md` — who ThumbGate is, 5 traits with contrast, explicit "what we aren't" (no rogue-AI fear-mongering, no enterprise-buzzword salad, no overclaiming).
- `voice-and-tone.md` — per-trait on-brand / too-far / too-flat pairs + banned words.
- `content-formats.md` — per-channel rules (Reddit discloses authorship, LinkedIn no hashtag wall, CLI receipts one line, etc.) + a pre-publish stress test.
- `SKILL.md` — orchestrator; the overriding rule is **never overclaim** (pre-revenue honesty is the brand).

## Scope / risk
- **Repo-internal, not shipped to npm** (not in package.json `files[]`) → no bundle-ratchet impact (ratchet 2/0).
- Skill-validation tests green: claude-skill 5/0, skill-generator 26/0, skill-exporter 15/0, progressive 18/0, thumbgate-skill 9/0, evoskill 7/0.
- Additive off current `main` — no conflict with the in-flight pricing work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)