### PR TITLE
content(seo): /guides/govern-claude-for-legal-agents — ride the 90-agent launch

### DIFF
--- a/.changeset/govern-claude-for-legal-guide.md
+++ b/.changeset/govern-claude-for-legal-guide.md
@@ -1,0 +1,12 @@
+---
+"thumbgate": patch
+---
+
+content(seo): add /guides/govern-claude-for-legal-agents
+
+Buyer-intent guide riding Anthropic's "Claude for Legal has 90+ agents" launch.
+Positions ThumbGate as the governance layer that gates those agents' side effects
+(send/file/write) at the tool-call boundary, in the firm's own tenant, with a
+SIEM-exportable audit trail. Complementary framing (governs, does not replace);
+no overclaim (design-partner pilot, not turnkey). Server-rendered via seo-gsd
+spec; linked from the landing compare-guides section.

--- a/public/index.html
+++ b/public/index.html
@@ -1129,6 +1129,7 @@ __GA_BOOTSTRAP__
       <div style="color:var(--cyan);font-weight:700;">Compare ThumbGate with other agent-safety approaches</div>
       <div style="display:flex;flex-wrap:wrap;gap:10px;margin-top:14px;font-size:13px;line-height:1.4;">
         <a href="/learn">Browse the guide library</a>
+        <a href="/guides/govern-claude-for-legal-agents" title="Govern Claude for Legal's 90+ agents — a gate before they act">Govern Claude for Legal agents</a>
         <a href="/compare/speclock">SpecLock</a>
         <a href="/compare/mem0">Mem0</a>
         <a href="/compare/fallow">Fallow</a>

--- a/public/index.html
+++ b/public/index.html
@@ -1129,7 +1129,6 @@ __GA_BOOTSTRAP__
       <div style="color:var(--cyan);font-weight:700;">Compare ThumbGate with other agent-safety approaches</div>
       <div style="display:flex;flex-wrap:wrap;gap:10px;margin-top:14px;font-size:13px;line-height:1.4;">
         <a href="/learn">Browse the guide library</a>
-        <a href="/guides/govern-claude-for-legal-agents" title="Govern Claude for Legal's 90+ agents — a gate before they act">Govern Claude for Legal agents</a>
         <a href="/compare/speclock">SpecLock</a>
         <a href="/compare/mem0">Mem0</a>
         <a href="/compare/fallow">Fallow</a>

--- a/scripts/prove-seo-gsd.js
+++ b/scripts/prove-seo-gsd.js
@@ -143,6 +143,7 @@ async function run() {
           '/guides/relational-knowledge-ai-recommendations',
           '/guides/claude-code-feedback',
           '/guides/autoresearch-agent-safety',
+          '/guides/govern-claude-for-legal-agents',
         ]) {
           const loc = pathname === '/'
             ? '<loc>https://app.example.com/</loc>'

--- a/scripts/seo-gsd.js
+++ b/scripts/seo-gsd.js
@@ -446,6 +446,65 @@ function buildZeroTrustGuide() {
   });
 }
 
+const GOVERN_CLAUDE_FOR_LEGAL_GUIDE_SPEC = Object.freeze({
+  slug: 'govern-claude-for-legal-agents',
+  meta: {
+    query: 'govern claude for legal agents',
+    title: 'Govern Claude for Legal Agents | A Gate Before They Act',
+    heroTitle: 'Govern Claude for Legal’s 90+ Agents at the Tool Call',
+    heroSummary: 'Claude for Legal ships 90+ named agents that review contracts, answer DSARs, and run continuously on document and email streams. Anthropic’s own guidance is that there must be a gate before anything is filed, sent, or relied on. ThumbGate is that gate — it checks each agent action at the tool-call boundary, in your tenant, and logs every decision for the record.',
+  },
+  takeaways: [
+    'Claude for Legal’s agents take real side effects — sending a DSAR response, filing a document, writing to a system of record. ThumbGate gates the action before the side effect runs, not after, on a dashboard.',
+    'Intent-agnostic: whether an agent is wrong, prompt-injected, or off-playbook, ThumbGate blocks the same way and records the rule that fired. The risk is not a “rogue” agent — it is an ordinary one acting at volume.',
+    'Every gated decision is logged with its source rule — a SIEM-exportable audit trail your ethics, risk, and conflicts owners can query.',
+  ],
+  sections: [
+    ['paragraphs', 'Why 90+ legal agents need a gate before the side effect', [
+      'A firm running Claude for Legal now has dozens of agents acting on ongoing document and email streams — vendor-agreement review, termination review, DSAR responses, claim charts. No one can review every action by hand. The risk is not malice; it is an ordinary agent that sends the wrong response, files against the wrong playbook, or surfaces a privileged document.',
+      'Anthropic’s own framing names the control: an explicit gate before anything is filed, sent, or relied on. ThumbGate implements that gate at the tool-call boundary — the moment before the action executes — instead of trusting the agent’s stated intent.',
+    ]],
+    ['bullets', 'What ThumbGate gates for legal agents', [
+      'The send/file/write action itself — e.g. a DSAR or client response before it leaves, a filing before it goes out, a write to a conflicted matter — held or blocked at the boundary.',
+      'Playbook deviations — an action that departs from the firm’s approved workflow is stopped for review rather than executed.',
+      'Privileged-document exposure — flagged before an agent surfaces or forwards it.',
+      'Continuous runs — one rule set covers every agent and every scheduled run, so coverage scales with agent count, not headcount.',
+    ]],
+    ['paragraphs', 'Enforcement in your tenant, with an audit trail', [
+      'ThumbGate runs as a pre-action gate in front of agent fulfillment, including a Dialogflow CX webhook gate deployed in your own GCP tenant, so matter content does not leave your boundary. Risk and planning scoring can run on Gemini via Vertex, in-tenant. This is a white-glove design-partner pilot, not a turnkey product purchase.',
+      'Every gated detection is logged with the rule that fired and the feedback event that generated it. That decision trail is the evidence a firm needs for malpractice defense and bar-compliance review — queryable, exportable, and tied to a named owner.',
+    ]],
+    ['paragraphs', 'ThumbGate complements Claude for Legal — it does not replace it', [
+      'Claude for Legal decides what the work is. ThumbGate decides what is allowed to execute. Use both: keep the 90+ agents doing the legal work, and put a gate between each agent and its next side effect. A thumbs-down on a bad action becomes a prevention rule, so the same mistake is blocked across every agent and matter next time.',
+    ]],
+  ],
+  faq: [
+    [
+      'Does ThumbGate replace Claude for Legal?',
+      'No. Claude for Legal’s agents do the legal work; ThumbGate governs what they are allowed to execute — a gate before anything is filed, sent, or relied on. You run both.',
+    ],
+    [
+      'Where does the gate run?',
+      'In your tenant. ThumbGate gates agent fulfillment locally or via a Dialogflow CX webhook gate in your own GCP project; matter content does not leave your boundary, and Vertex/Gemini scoring runs in-tenant. It is a white-glove design-partner pilot, not a turnkey purchase.',
+    ],
+    [
+      'What proof does a firm get?',
+      'Every gated decision is logged with the rule that fired and the feedback that generated it — a SIEM-exportable audit trail for ethics, risk, and conflicts owners.',
+    ],
+  ],
+  relatedPaths: ['/guides/ai-coding-agent-zero-trust', '/guides/pre-action-checks'],
+});
+
+function buildGovernClaudeForLegalGuide() {
+  return preActionGuide(GOVERN_CLAUDE_FOR_LEGAL_GUIDE_SPEC.slug, {
+    ...GOVERN_CLAUDE_FOR_LEGAL_GUIDE_SPEC.meta,
+    takeaways: GOVERN_CLAUDE_FOR_LEGAL_GUIDE_SPEC.takeaways,
+    sections: GOVERN_CLAUDE_FOR_LEGAL_GUIDE_SPEC.sections.map(([kind, heading, entries]) => buildSectionFromSpec(kind, heading, entries)),
+    faq: GOVERN_CLAUDE_FOR_LEGAL_GUIDE_SPEC.faq.map(([question, text]) => answer(question, text)),
+    relatedPaths: GOVERN_CLAUDE_FOR_LEGAL_GUIDE_SPEC.relatedPaths,
+  });
+}
+
 const PROXY_POINTER_RAG_GUARDRAILS_SPEC = Object.freeze({
   slug: 'proxy-pointer-rag-guardrails',
   meta: {
@@ -1589,6 +1648,7 @@ const PAGE_BLUEPRINTS = [
   },
   buildSemanticPseoGuide(),
   buildZeroTrustGuide(),
+  buildGovernClaudeForLegalGuide(),
   buildProxyPointerRagGuide(),
   buildRagPrecisionTuningGuide(),
   buildAiEngineeringStackGuide(),


### PR DESCRIPTION
## Why
Stolen from [artificiallawyer: "Claude for Legal has over 90 AI agents"](https://www.artificiallawyer.com/2026/06/01/claude-for-legal-has-over-90-ai-agents/): Anthropic just put 90+ named legal agents into firms, and their own guidance requires **"a gate before anything is filed, sent, or relied on."** That is exactly ThumbGate. We're invisible for that legal buyer-intent query; this page claims it.

## What
New server-rendered guide `/guides/govern-claude-for-legal-agents` (same seo-gsd spec mechanism as the merged Zero-Trust guide #2458 and /compare/claude-code-hooks #2461):
- Positions ThumbGate as the **governance layer** that gates legal agents' side effects (send/file/write) at the tool-call boundary, **in the firm's own tenant**, with a SIEM-exportable audit trail.
- **Complementary framing** — "governs, does not replace" Claude for Legal. Honest: "design-partner pilot, not a turnkey purchase" (matches docs/enterprise/gcp-dfcx-pilot.md). No overclaim, no rogue-AI fear-mongering ("the risk is not malice — it's an ordinary agent at volume").
- Dogfoods the new brand-voice skill (#2467).
- Linked from the landing compare-guides section for internal-link equity.

## Scope / risk
- **Sidesteps the pricing-model conflict** entirely: the guide inherits main's existing pricing footer (server-rendered, shared) — touches no tier copy, so it's independent of the Team-vs-Enterprise decision.
- Additive off current `main`. Verified: prove-seo-gsd 6/6, seo-guides 0 fail, public-landing 0 fail, check-congruence pass. Renders valid TechArticle + FAQPage JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)