### PR TITLE
fix(e2e): dashboard-page-clickability — match new Perplexity-hybrid banner

### DIFF
--- a/.changeset/e2e-dashboard-gemini-hint-fix.md
+++ b/.changeset/e2e-dashboard-gemini-hint-fix.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix Playwright E2E: `dashboard-page-clickability` expected `'Gemini API key configured'` but the Perplexity-hybrid dashboard reworded the success banner to `'✓ Key validated. Hybrid (Perplexity/Gemini) supported for chat with your data.'` Test now matches the stable `'Key validated'` substring (with fallback to the old copy) so future banner tweaks don't break it. Unblocks PR #2463 + #2464 from the pre-existing E2E failure on main.

--- a/tests/e2e/dashboard-page-clickability.spec.js
+++ b/tests/e2e/dashboard-page-clickability.spec.js
@@ -204,8 +204,12 @@ test.describe('/dashboard clickability — non-stat-card surfaces', () => {
     await input.fill('test-key');
     await btn.click();
 
-    // Check success state
+    // Check success state. The chatHint banner was reworded in the
+    // Perplexity-hybrid dashboard update — the validated-key success now
+    // reads "✓ Key validated. Hybrid (Perplexity/Gemini) supported for chat
+    // with your data." Match the stable substring "Key validated" so future
+    // copy tweaks within that banner don't re-break the test.
     await expect(input).toHaveAttribute('placeholder', '✓ Key saved to .env', { timeout: 3000 });
-    await expect(page.locator('#chatHint')).toContainText('Gemini API key configured');
+    await expect(page.locator('#chatHint')).toContainText(/Key validated|Gemini API key configured/);
   });
 });


### PR DESCRIPTION
## Why

E2E test `dashboard-page-clickability.spec.js:209` has been failing on main since the dashboard `#chatHint` copy was reworded for Perplexity hybrid support.

**Expected**: `"Gemini API key configured"`
**Actual** (current dashboard, [public/dashboard.html:834](https://github.com/IgorGanapolsky/ThumbGate/blob/main/public/dashboard.html#L834)): `"✓ Key validated. Hybrid (Perplexity/Gemini) supported for chat with your data."`

This blocks every PR currently rebased on main, including #2463 (perplexity-tailwind landing) and #2464 (critic-rubric posttool).

## Fix

Use a regex that matches either the new wording or the old one — forward/backward compatible. Captures the stable token `Key validated` so future banner copy tweaks won't re-break.

```diff
-await expect(page.locator('#chatHint')).toContainText('Gemini API key configured');
+await expect(page.locator('#chatHint')).toContainText(/Key validated|Gemini API key configured/);
```

## Test plan

- [x] Patch reviewed against current dashboard.html success branch (line 834)
- [ ] Playwright shard 1 on this PR
- [ ] Re-rebase #2463 + #2464 onto main after merge to inherit the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)