### PR TITLE
fix(ci): bound mainline sonar refresh

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -269,6 +269,12 @@ jobs:
 
       - name: Run SonarCloud scan (default branch refresh)
         if: steps.sonar-scope.outputs.scan == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        # PR and merge-queue scans are the blocking quality gate. The mainline
+        # refresh only updates SonarCloud's default-branch baseline, so external
+        # scanner download stalls or SonarCloud service hiccups should not leave
+        # an already-verified merge red on main.
+        timeout-minutes: 8
+        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/tests/sonarcloud-workflow.test.js
+++ b/tests/sonarcloud-workflow.test.js
@@ -52,6 +52,8 @@ test('SonarCloud workflow polls quality gates only for PR and merge-queue scans'
     /if:\s*steps\.sonar-scope\.outputs\.scan == 'true' && !\(github\.event_name == 'pull_request' && github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'\) && \(github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch'\)/,
   );
   assert.match(refreshSection, /-Dsonar\.projectVersion=\$\{\{\s*steps\.sonar-mainline-version\.outputs\.value\s*\}\}/);
+  assert.match(refreshSection, /timeout-minutes:\s*8/);
+  assert.match(refreshSection, /continue-on-error:\s*true/);
   assert.doesNotMatch(refreshSection, /-Dsonar\.qualitygate\.wait=true/);
   assert.doesNotMatch(refreshSection, /-Dsonar\.qualitygate\.timeout=600/);
 });


### PR DESCRIPTION
## Summary

Post-merge main SonarCloud refresh for #2470 passed the quality gate API but the GitHub workflow failed/hung on external scanner infrastructure:

- first main run failed downloading the scanner with HTTP 403
- rerun reached the scanner but hung in the default-branch refresh step
- PR/merge-queue Sonar had already passed and remains blocking

This PR keeps PR and merge-queue Sonar quality gates blocking, but makes only the default-branch baseline refresh timeout-bounded and non-blocking.

## Evidence

- Main quality gate API after #2470: `status: OK`
- Branch PR #2470 Sonar: success, 0 new issues, 95.4% new-code coverage
- `node --test tests/sonarcloud-workflow.test.js tests/deployment.test.js`: 57/0
- `npm run test:ci-cd-hygiene-audit`: 11/0
- `node --test tests/changeset-check.test.js`: 15/0
- `actionlint .github/workflows/sonarcloud.yml`: pass
- `git diff --check`: pass
- Pre-commit: pass
- Pre-push: npm pack dry-run, public HTML links, regression guards pass
