### PR TITLE
fix(ci): prevent false deploy and sonar mainline stalls

### DIFF
--- a/.changeset/deploy-scope-verifier.md
+++ b/.changeset/deploy-scope-verifier.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Share deploy-scope evidence between the Railway deploy workflow and the post-merge verifier so non-runtime skips cannot mask a deploy that actually ran.

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -55,38 +55,17 @@ jobs:
       - name: Detect deployable changes
         id: deploy-scope
         run: |
-          BEFORE_SHA='${{ github.event.before }}'
-          CHANGED_FILES=''
-          SHOULD_DEPLOY=true
-          DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
-
-          # workflow_dispatch always deploys — no scope filter
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "workflow_dispatch: deploying unconditionally"
-            SHOULD_DEPLOY=true
-          elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            # Verify BEFORE_SHA exists in the shallow clone; if not, deploy unconditionally
-            # (this prevents the false-positive "skip" when the SHA is unreachable)
-            if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
-              CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" | sed '/^$/d')"
-              if [ -n "$CHANGED_FILES" ] && ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
-                SHOULD_DEPLOY=false
-              fi
-            else
-              echo "::warning::BEFORE_SHA ($BEFORE_SHA) not reachable in shallow clone — deploying unconditionally"
-            fi
-          fi
-
-          echo "before_sha=${BEFORE_SHA:-<none>}"
-          echo 'changed_files:'
-          printf '%s\n' "${CHANGED_FILES:-<none>}"
-          echo "deployable_pattern=$DEPLOYABLE_PATTERN"
-          echo "should_deploy=$SHOULD_DEPLOY"
-
-          echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
-          printf '%s\n' "$CHANGED_FILES" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "should_deploy=$SHOULD_DEPLOY" >> "$GITHUB_OUTPUT"
+          BEFORE_SHA='${{ github.event.before }}' \
+          HEAD_SHA="$GITHUB_SHA" \
+          EVENT_NAME="$GITHUB_EVENT_NAME" \
+          DEPLOY_SCOPE_OUTPUT_JSON='deploy-scope.json' \
+          bash scripts/deploy-scope.sh
+      - name: Upload deploy scope evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: deploy-scope
+          path: deploy-scope.json
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -95,7 +74,7 @@ jobs:
         run: |
           if [ "${{ steps.deploy-scope.outputs.should_deploy }}" != "true" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "Railway deploy skipped: no runtime-serving files changed on this commit."
+            echo "Railway deploy skipped: no runtime-serving files changed in this push range."
             exit 0
           fi
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -270,14 +270,10 @@ jobs:
       - name: Run SonarCloud scan (default branch refresh)
         if: steps.sonar-scope.outputs.scan == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         # PR and merge-queue scans are the blocking quality gate. The mainline
-        # refresh only updates SonarCloud's default-branch baseline, so external
-        # scanner download stalls or SonarCloud service hiccups should not leave
-        # an already-verified merge red on main.
-        timeout-minutes: 8
-        continue-on-error: true
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.projectVersion=${{ steps.sonar-mainline-version.outputs.value }}
+        # refresh used to call the external scanner again on main, but that made
+        # already-verified merges depend on scanner downloads/service health a
+        # second time. Keep the main workflow green and rely on the required
+        # PR/merge-queue scan above for enforcement.
+        run: |
+          echo "::notice::Skipping default-branch Sonar scanner refresh; PR and merge-queue scans are the blocking quality gate."
+          echo "mainline_version=${{ steps.sonar-mainline-version.outputs.value }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -273,7 +273,10 @@ jobs:
         # refresh used to call the external scanner again on main, but that made
         # already-verified merges depend on scanner downloads/service health a
         # second time. Keep the main workflow green and rely on the required
-        # PR/merge-queue scan above for enforcement.
+        # PR/merge-queue scan above for enforcement. This is an explicit
+        # tradeoff: SonarCloud default-branch baselines can lag until the next
+        # full scanner run, so this step is intentionally informational instead
+        # of a quality gate.
         run: |
-          echo "::notice::Skipping default-branch Sonar scanner refresh; PR and merge-queue scans are the blocking quality gate."
+          echo "::notice::Skipping default-branch Sonar scanner refresh; PR and merge-queue scans are the blocking quality gate. Default-branch baseline may lag until a full scanner run."
           echo "mainline_version=${{ steps.sonar-mainline-version.outputs.value }}"

--- a/.github/workflows/verify-deploy-comment.yml
+++ b/.github/workflows/verify-deploy-comment.yml
@@ -49,8 +49,40 @@ jobs:
             echo "pr=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Wait for Railway to settle the new build
+      - name: Detect whether Railway deploy was required
+        id: deploy-scope
         if: steps.find-pr.outputs.pr != ''
+        run: |
+          set -eu
+          DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
+          CHANGED_FILES="$(git diff --name-only "${MERGE_SHA}~1" "${MERGE_SHA}" | sed '/^$/d')"
+          {
+            echo "changed_files<<EOF"
+            printf '%s\n' "$CHANGED_FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "deploy_required=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
+            echo "deploy_required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy_required=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Capture current production health for skipped deploys
+        if: steps.find-pr.outputs.pr != '' && steps.deploy-scope.outputs.deploy_required == 'false'
+        run: |
+          HEALTH_JSON="$(curl -sS --max-time 10 "${PROD_URL}/health" || echo '{}')"
+          ACTUAL_SHA="$(printf '%s' "$HEALTH_JSON" | sed -n 's/.*"buildSha":"\([^"]*\)".*/\1/p')"
+          {
+            echo "actual_sha=${ACTUAL_SHA:-unknown}"
+            echo "build_match=not_required"
+            echo "health_json=${HEALTH_JSON:-{}}"
+          } >> "$GITHUB_ENV"
+
+      - name: Wait for Railway to settle the new build
+        if: steps.find-pr.outputs.pr != '' && steps.deploy-scope.outputs.deploy_required == 'true'
         run: |
           # Railway typically settles within 2-5 minutes of deploy-railway
           # finishing. Poll /health for up to 8 minutes for the buildSha to
@@ -63,9 +95,11 @@ jobs:
             HEALTH_JSON="$(curl -sS --max-time 10 "${PROD_URL}/health" || echo '{}')"
             ACTUAL_SHA="$(printf '%s' "$HEALTH_JSON" | sed -n 's/.*"buildSha":"\([a-f0-9]*\)".*/\1/p')"
             if [ -n "$ACTUAL_SHA" ] && [ "${ACTUAL_SHA}" = "${MERGE_SHA}" ]; then
-              echo "actual_sha=${ACTUAL_SHA}" >> "$GITHUB_ENV"
-              echo "build_match=true" >> "$GITHUB_ENV"
-              echo "health_json=${HEALTH_JSON}" >> "$GITHUB_ENV"
+              {
+                echo "actual_sha=${ACTUAL_SHA}"
+                echo "build_match=true"
+                echo "health_json=${HEALTH_JSON}"
+              } >> "$GITHUB_ENV"
               MATCH=1
               break
             fi
@@ -73,9 +107,11 @@ jobs:
             sleep 10
           done
           if [ "$MATCH" -ne 1 ]; then
-            echo "actual_sha=${ACTUAL_SHA:-unknown}" >> "$GITHUB_ENV"
-            echo "build_match=false" >> "$GITHUB_ENV"
-            echo "health_json=${HEALTH_JSON:-{}}" >> "$GITHUB_ENV"
+            {
+              echo "actual_sha=${ACTUAL_SHA:-unknown}"
+              echo "build_match=false"
+              echo "health_json=${HEALTH_JSON:-{}}"
+            } >> "$GITHUB_ENV"
           fi
 
       - name: Probe required public routes
@@ -122,7 +158,12 @@ jobs:
         run: |
           BUILD_OK="${build_match:-false}"
           ROUTES_OK="${routes_clean:-false}"
-          if [ "$BUILD_OK" = "true" ] && [ "$ROUTES_OK" = "true" ]; then
+          DEPLOY_REQUIRED="${{ steps.deploy-scope.outputs.deploy_required }}"
+          if [ "$DEPLOY_REQUIRED" = "false" ] && [ "$ROUTES_OK" = "true" ]; then
+            STATUS="ℹ️ Deploy not required for non-runtime merge"
+          elif [ "$DEPLOY_REQUIRED" = "false" ] && [ "$ROUTES_OK" = "false" ]; then
+            STATUS="⚠️ Deploy not required, but route probe found failures"
+          elif [ "$BUILD_OK" = "true" ] && [ "$ROUTES_OK" = "true" ]; then
             STATUS="✅ Deploy verified"
           elif [ "$BUILD_OK" = "true" ] && [ "$ROUTES_OK" = "false" ]; then
             STATUS="⚠️ Deployed but route probe found failures"
@@ -138,6 +179,7 @@ jobs:
           **Merge commit:** \`${MERGE_SHA}\`
           **Production buildSha:** \`${actual_sha:-unknown}\`
           **buildSha match:** ${BUILD_OK}
+          **Railway deploy required:** ${DEPLOY_REQUIRED}
 
           **/health snapshot:**
           \`\`\`json

--- a/.github/workflows/verify-deploy-comment.yml
+++ b/.github/workflows/verify-deploy-comment.yml
@@ -13,6 +13,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 
@@ -52,29 +53,44 @@ jobs:
       - name: Detect whether Railway deploy was required
         id: deploy-scope
         if: steps.find-pr.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: |
           set -eu
-          DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
-          CHANGED_FILES="$(git diff --name-only "${MERGE_SHA}~1" "${MERGE_SHA}" | sed '/^$/d')"
-          {
-            echo "changed_files<<EOF"
-            printf '%s\n' "$CHANGED_FILES"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "deploy_required=true" >> "$GITHUB_OUTPUT"
-          elif printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
-            echo "deploy_required=true" >> "$GITHUB_OUTPUT"
+          mkdir -p deploy-scope
+          if gh run download "${{ github.event.workflow_run.id }}" --name deploy-scope --dir deploy-scope; then
+            echo "Loaded deploy-scope artifact from Deploy to Railway run ${{ github.event.workflow_run.id }}."
           else
-            echo "deploy_required=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Deploy scope artifact missing; conservatively requiring buildSha verification."
           fi
+
+          node - <<'NODE' >> "$GITHUB_OUTPUT"
+const fs = require('fs');
+const artifactPath = 'deploy-scope/deploy-scope.json';
+let scope = null;
+try {
+  scope = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+} catch {
+  scope = {
+    shouldDeploy: true,
+    scopeReason: 'artifact_missing_conservative_verify',
+    changedFiles: [],
+  };
+}
+
+const changedFiles = Array.isArray(scope.changedFiles) ? scope.changedFiles : [];
+console.log('changed_files<<EOF');
+console.log(changedFiles.join('\n'));
+console.log('EOF');
+console.log(`deploy_required=${scope.shouldDeploy === false ? 'false' : 'true'}`);
+console.log(`scope_reason=${scope.scopeReason || 'unknown'}`);
+NODE
 
       - name: Capture current production health for skipped deploys
         if: steps.find-pr.outputs.pr != '' && steps.deploy-scope.outputs.deploy_required == 'false'
         run: |
           HEALTH_JSON="$(curl -sS --max-time 10 "${PROD_URL}/health" || echo '{}')"
-          ACTUAL_SHA="$(printf '%s' "$HEALTH_JSON" | sed -n 's/.*"buildSha":"\([^"]*\)".*/\1/p')"
+          ACTUAL_SHA="$(node -e "try { const data = JSON.parse(process.argv[1]); process.stdout.write(String(data.buildSha || '')); } catch {}" "$HEALTH_JSON")"
           {
             echo "actual_sha=${ACTUAL_SHA:-unknown}"
             echo "build_match=not_required"
@@ -93,7 +109,7 @@ jobs:
           MATCH=0
           while [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; do
             HEALTH_JSON="$(curl -sS --max-time 10 "${PROD_URL}/health" || echo '{}')"
-            ACTUAL_SHA="$(printf '%s' "$HEALTH_JSON" | sed -n 's/.*"buildSha":"\([a-f0-9]*\)".*/\1/p')"
+            ACTUAL_SHA="$(node -e "try { const data = JSON.parse(process.argv[1]); process.stdout.write(String(data.buildSha || '')); } catch {}" "$HEALTH_JSON")"
             if [ -n "$ACTUAL_SHA" ] && [ "${ACTUAL_SHA}" = "${MERGE_SHA}" ]; then
               {
                 echo "actual_sha=${ACTUAL_SHA}"

--- a/scripts/deploy-scope.sh
+++ b/scripts/deploy-scope.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -eu
+
+DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
+
+BEFORE_SHA="${BEFORE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-${GITHUB_SHA:-}}"
+EVENT_NAME="${EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
+CHANGED_FILES=''
+SHOULD_DEPLOY=true
+SCOPE_REASON='default_deploy'
+
+if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+  SHOULD_DEPLOY=true
+  SCOPE_REASON='workflow_dispatch'
+elif [ "$EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+  if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+    CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$HEAD_SHA" | sed '/^$/d')"
+    if [ -n "$CHANGED_FILES" ] && ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
+      SHOULD_DEPLOY=false
+      SCOPE_REASON='non_runtime_changes'
+    elif [ -n "$CHANGED_FILES" ]; then
+      SHOULD_DEPLOY=true
+      SCOPE_REASON='deployable_changes'
+    else
+      SHOULD_DEPLOY=true
+      SCOPE_REASON='empty_push_range'
+    fi
+  else
+    SHOULD_DEPLOY=true
+    SCOPE_REASON='before_sha_unreachable'
+    echo "::warning::BEFORE_SHA ($BEFORE_SHA) not reachable in shallow clone - deploying unconditionally"
+  fi
+fi
+
+echo "before_sha=${BEFORE_SHA:-<none>}"
+echo "head_sha=${HEAD_SHA:-<none>}"
+echo "event_name=${EVENT_NAME:-<none>}"
+echo 'changed_files:'
+printf '%s\n' "${CHANGED_FILES:-<none>}"
+echo "deployable_pattern=$DEPLOYABLE_PATTERN"
+echo "should_deploy=$SHOULD_DEPLOY"
+echo "scope_reason=$SCOPE_REASON"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "changed_files<<EOF"
+    printf '%s\n' "$CHANGED_FILES"
+    echo "EOF"
+    echo "should_deploy=$SHOULD_DEPLOY"
+    echo "scope_reason=$SCOPE_REASON"
+    echo "deployable_pattern=$DEPLOYABLE_PATTERN"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [ -n "${DEPLOY_SCOPE_OUTPUT_JSON:-}" ]; then
+  node - "$DEPLOY_SCOPE_OUTPUT_JSON" "$BEFORE_SHA" "$HEAD_SHA" "$EVENT_NAME" "$SHOULD_DEPLOY" "$SCOPE_REASON" "$DEPLOYABLE_PATTERN" "$CHANGED_FILES" <<'NODE'
+const fs = require('fs');
+const [
+  outputPath,
+  beforeSha,
+  headSha,
+  eventName,
+  shouldDeploy,
+  scopeReason,
+  deployablePattern,
+  changedFilesRaw,
+] = process.argv.slice(2);
+
+const changedFiles = String(changedFilesRaw || '')
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+fs.writeFileSync(outputPath, JSON.stringify({
+  beforeSha: beforeSha || null,
+  headSha: headSha || null,
+  eventName: eventName || null,
+  shouldDeploy: shouldDeploy === 'true',
+  scopeReason,
+  deployablePattern,
+  changedFiles,
+}, null, 2) + '\n');
+NODE
+fi

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -7,6 +7,7 @@ const assert = require('node:assert/strict');
 const os = require('node:os');
 const path = require('node:path');
 const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
 
 const tmpFeedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-deploy-test-'));
 process.env.THUMBGATE_FEEDBACK_DIR = tmpFeedbackDir;
@@ -23,12 +24,54 @@ process.env.THUMBGATE_ALLOW_INSECURE = 'true';
 const { createApiServer, startServer } = require('../src/api/server');
 const pkg = require('../package.json');
 const PROJECT_ROOT = path.join(__dirname, '..');
+const DEPLOY_SCOPE_SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'deploy-scope.sh');
 
 let handle;
 let deployOrigin = '';
 
 function deployUrl(pathname = '/') {
   return new URL(pathname, deployOrigin).toString();
+}
+
+function runDeployScopeFixture(changePath, eventName = 'push', beforeShaOverride = null) {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-deploy-scope-'));
+  const githubOutput = path.join(repoDir, 'github-output.txt');
+  const jsonOutput = path.join(repoDir, 'deploy-scope.json');
+
+  try {
+    execFileSync('git', ['init'], { cwd: repoDir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'deploy-scope@example.test'], { cwd: repoDir });
+    execFileSync('git', ['config', 'user.name', 'Deploy Scope Test'], { cwd: repoDir });
+
+    fs.writeFileSync(path.join(repoDir, 'README.md'), 'initial\n');
+    execFileSync('git', ['add', '.'], { cwd: repoDir });
+    execFileSync('git', ['commit', '-m', 'initial'], { cwd: repoDir, stdio: 'ignore' });
+    const beforeSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf8' }).trim();
+
+    const fullChangePath = path.join(repoDir, changePath);
+    fs.mkdirSync(path.dirname(fullChangePath), { recursive: true });
+    fs.writeFileSync(fullChangePath, 'changed\n');
+    execFileSync('git', ['add', '.'], { cwd: repoDir });
+    execFileSync('git', ['commit', '-m', `change ${changePath}`], { cwd: repoDir, stdio: 'ignore' });
+    const headSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf8' }).trim();
+
+    execFileSync('bash', [DEPLOY_SCOPE_SCRIPT], {
+      cwd: repoDir,
+      env: {
+        ...process.env,
+        BEFORE_SHA: beforeShaOverride || beforeSha,
+        HEAD_SHA: headSha,
+        EVENT_NAME: eventName,
+        GITHUB_OUTPUT: githubOutput,
+        DEPLOY_SCOPE_OUTPUT_JSON: jsonOutput,
+      },
+      stdio: 'pipe',
+    });
+
+    return JSON.parse(fs.readFileSync(jsonOutput, 'utf8'));
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
 }
 
 test.before(async () => {
@@ -251,7 +294,8 @@ test('Deploy to Railway workflow is the single authoritative Railway deploy lane
   assert.match(workflow, /RAILWAY_VARIABLE_SYNC_REQUIRED/);
   assert.match(workflow, /RAILWAY_VARIABLE_COMMAND_TIMEOUT_SECONDS/);
   assert.match(workflow, /RAILWAY_DEPLOY_COMMAND_TIMEOUT_SECONDS/);
-  assert.match(workflow, /DEPLOYABLE_PATTERN=.*\\\.github\/workflows\/deploy-railway\\\.yml/);
+  assert.match(workflow, /bash scripts\/deploy-scope\.sh/);
+  assert.match(workflow, /Upload deploy scope evidence/);
   assert.match(workflow, /secrets\.THUMBGATE_API_KEY/);
   assert.match(workflow, /RESEND_API_KEY:\s*\$\{\{\s*secrets\.RESEND_API_KEY\s*\}\}/);
   assert.match(workflow, /THUMBGATE_TRIAL_EMAIL_FROM:\s*\$\{\{\s*secrets\.THUMBGATE_TRIAL_EMAIL_FROM\s*\|\|\s*vars\.THUMBGATE_TRIAL_EMAIL_FROM\s*\}\}/);
@@ -380,34 +424,61 @@ test('Deploy to Railway workflow retries transient Railway CLI failures before f
 
 test('Deploy to Railway workflow skips non-runtime pushes and only deploys when runtime-serving files changed', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'deploy-railway.yml'), 'utf8');
+  const scopeScript = fs.readFileSync(path.join(PROJECT_ROOT, 'scripts', 'deploy-scope.sh'), 'utf8');
 
   assert.match(workflow, /fetch-depth:\s*2/);
   assert.match(workflow, /name: Detect deployable changes/);
   assert.match(workflow, /BEFORE_SHA='\$\{\{\s*github\.event\.before\s*\}\}'/);
-  assert.match(workflow, /git diff --name-only "\$BEFORE_SHA" "\$GITHUB_SHA"/);
-  assert.match(workflow, /DEPLOYABLE_PATTERN='.*src\/.*public\/.*Dockerfile\$/);
+  assert.match(workflow, /HEAD_SHA="\$GITHUB_SHA"/);
+  assert.match(workflow, /DEPLOY_SCOPE_OUTPUT_JSON='deploy-scope\.json'/);
+  assert.match(scopeScript, /git diff --name-only "\$BEFORE_SHA" "\$HEAD_SHA"/);
+  assert.match(scopeScript, /DEPLOYABLE_PATTERN='.*src\/.*public\/.*Dockerfile\$/);
   assert.ok(
-    workflow.includes('scripts/.*\\.(js|mjs|cjs)$'),
-    'workflow should only treat runtime JS script modules as deployable',
+    scopeScript.includes('scripts/.*\\.(js|mjs|cjs)$'),
+    'scope script should only treat runtime JS script modules as deployable',
   );
   assert.ok(
-    workflow.includes('adapters/.*\\.(js|mjs|cjs|json|ya?ml|toml)$'),
-    'workflow should only treat runtime adapter files as deployable',
+    scopeScript.includes('adapters/.*\\.(js|mjs|cjs|json|ya?ml|toml)$'),
+    'scope script should only treat runtime adapter files as deployable',
   );
   assert.ok(
-    !workflow.includes("DEPLOYABLE_PATTERN='^(src/|scripts/|"),
-    'workflow should not treat every scripts/ path as deployable',
+    !scopeScript.includes("DEPLOYABLE_PATTERN='^(src/|scripts/|"),
+    'scope script should not treat every scripts/ path as deployable',
   );
   assert.ok(
-    !workflow.includes('|adapters/|'),
-    'workflow should not treat adapter Markdown docs as deployable',
+    !scopeScript.includes('|adapters/|'),
+    'scope script should not treat adapter Markdown docs as deployable',
   );
-  assert.match(workflow, /! printf '%s\\n' "\$CHANGED_FILES" \| grep -Eq "\$DEPLOYABLE_PATTERN"/);
-  assert.match(workflow, /should_deploy=\$SHOULD_DEPLOY/);
-  assert.match(workflow, /SHOULD_DEPLOY=true/);
-  assert.match(workflow, /SHOULD_DEPLOY=false/);
-  assert.match(workflow, /Railway deploy skipped: no runtime-serving files changed on this commit\./);
+  assert.match(scopeScript, /! printf '%s\\n' "\$CHANGED_FILES" \| grep -Eq "\$DEPLOYABLE_PATTERN"/);
+  assert.match(scopeScript, /should_deploy=\$SHOULD_DEPLOY/);
+  assert.match(scopeScript, /SHOULD_DEPLOY=true/);
+  assert.match(scopeScript, /SHOULD_DEPLOY=false/);
+  assert.match(workflow, /Railway deploy skipped: no runtime-serving files changed in this push range\./);
   assert.doesNotMatch(workflow, /Railway deploy skipped: deploy-scope disabled this run\./);
+});
+
+test('deploy-scope script decides from the actual push range and writes reusable evidence', () => {
+  const docsOnly = runDeployScopeFixture('docs/release-note.md');
+  assert.equal(docsOnly.shouldDeploy, false);
+  assert.equal(docsOnly.scopeReason, 'non_runtime_changes');
+  assert.deepEqual(docsOnly.changedFiles, ['docs/release-note.md']);
+
+  const runtimeChange = runDeployScopeFixture('src/runtime-change.js');
+  assert.equal(runtimeChange.shouldDeploy, true);
+  assert.equal(runtimeChange.scopeReason, 'deployable_changes');
+  assert.deepEqual(runtimeChange.changedFiles, ['src/runtime-change.js']);
+
+  const manualDeploy = runDeployScopeFixture('docs/manual-note.md', 'workflow_dispatch');
+  assert.equal(manualDeploy.shouldDeploy, true);
+  assert.equal(manualDeploy.scopeReason, 'workflow_dispatch');
+
+  const unreachableBefore = runDeployScopeFixture(
+    'docs/unreachable-note.md',
+    'push',
+    '0000000000000000000000000000000000000001'
+  );
+  assert.equal(unreachableBefore.shouldDeploy, true);
+  assert.equal(unreachableBefore.scopeReason, 'before_sha_unreachable');
 });
 
 test('Deploy verification comment does not require a build SHA change for non-runtime merges', () => {
@@ -415,9 +486,10 @@ test('Deploy verification comment does not require a build SHA change for non-ru
 
   assert.match(workflow, /name: Detect whether Railway deploy was required/);
   assert.match(workflow, /id: deploy-scope/);
-  assert.match(workflow, /DEPLOYABLE_PATTERN='.*src\/.*public\/.*Dockerfile\$/);
-  assert.match(workflow, /git diff --name-only "\$\{MERGE_SHA\}~1" "\$\{MERGE_SHA\}"/);
-  assert.match(workflow, /deploy_required=false/);
+  assert.match(workflow, /gh run download "\$\{\{\s*github\.event\.workflow_run\.id\s*\}\}" --name deploy-scope --dir deploy-scope/);
+  assert.match(workflow, /artifact_missing_conservative_verify/);
+  assert.match(workflow, /scope\.shouldDeploy === false/);
+  assert.match(workflow, /deploy_required=\$\{scope\.shouldDeploy === false \? 'false' : 'true'\}/);
   assert.match(workflow, /name: Capture current production health for skipped deploys/);
   assert.match(workflow, /build_match=not_required/);
   assert.match(
@@ -427,6 +499,8 @@ test('Deploy verification comment does not require a build SHA change for non-ru
   assert.match(workflow, /Deploy not required for non-runtime merge/);
   assert.match(workflow, /Railway deploy required:/);
   assert.match(workflow, /Public-route probes/);
+  assert.doesNotMatch(workflow, /DEPLOYABLE_PATTERN='/);
+  assert.doesNotMatch(workflow, /git diff --name-only "\$\{MERGE_SHA\}~1" "\$\{MERGE_SHA\}"/);
 });
 
 test('Deploy to Railway workflow stamps runtime deployment env metadata before health verification', () => {

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -410,6 +410,25 @@ test('Deploy to Railway workflow skips non-runtime pushes and only deploys when 
   assert.doesNotMatch(workflow, /Railway deploy skipped: deploy-scope disabled this run\./);
 });
 
+test('Deploy verification comment does not require a build SHA change for non-runtime merges', () => {
+  const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'verify-deploy-comment.yml'), 'utf8');
+
+  assert.match(workflow, /name: Detect whether Railway deploy was required/);
+  assert.match(workflow, /id: deploy-scope/);
+  assert.match(workflow, /DEPLOYABLE_PATTERN='.*src\/.*public\/.*Dockerfile\$/);
+  assert.match(workflow, /git diff --name-only "\$\{MERGE_SHA\}~1" "\$\{MERGE_SHA\}"/);
+  assert.match(workflow, /deploy_required=false/);
+  assert.match(workflow, /name: Capture current production health for skipped deploys/);
+  assert.match(workflow, /build_match=not_required/);
+  assert.match(
+    workflow,
+    /name: Wait for Railway to settle the new build\n\s+if: steps\.find-pr\.outputs\.pr != '' && steps\.deploy-scope\.outputs\.deploy_required == 'true'/,
+  );
+  assert.match(workflow, /Deploy not required for non-runtime merge/);
+  assert.match(workflow, /Railway deploy required:/);
+  assert.match(workflow, /Public-route probes/);
+});
+
 test('Deploy to Railway workflow stamps runtime deployment env metadata before health verification', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'deploy-railway.yml'), 'utf8');
 
@@ -553,7 +572,7 @@ test('CodeQL workflow supports merge queue and cancels stale non-main runs', () 
   assert.match(workflow, /cancel-in-progress:\s*\$\{\{\s*github\.ref != 'refs\/heads\/main'\s*\}\}/);
 });
 
-test('SonarCloud workflow refreshes main and stamps scans with the package version', () => {
+test('SonarCloud workflow gates PRs and keeps main refresh non-blocking', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'sonarcloud.yml'), 'utf8');
 
   assert.match(workflow, /^name:\s*SonarCloud/m);
@@ -574,7 +593,8 @@ test('SonarCloud workflow refreshes main and stamps scans with the package versi
   assert.match(workflow, /Read package version[\s\S]*?require\("\.\/package\.json"\)\.version/);
   assert.match(workflow, /Build Sonar mainline analysis version[\s\S]*?sha\.\$SHORT_SHA/);
   assert.match(workflow, /Run SonarCloud scan \(default branch refresh\)[\s\S]*?github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch'/);
-  assert.match(workflow, /-Dsonar\.projectVersion=\$\{\{\s*steps\.sonar-mainline-version\.outputs\.value\s*\}\}/);
+  assert.match(workflow, /Skipping default-branch Sonar scanner refresh/);
+  assert.match(workflow, /mainline_version=\$\{\{\s*steps\.sonar-mainline-version\.outputs\.value\s*\}\}/);
 });
 
 test('SonarCloud workflow polls quality gates only for PR and merge-queue scans', () => {

--- a/tests/sonarcloud-workflow.test.js
+++ b/tests/sonarcloud-workflow.test.js
@@ -51,9 +51,11 @@ test('SonarCloud workflow polls quality gates only for PR and merge-queue scans'
     refreshSection,
     /if:\s*steps\.sonar-scope\.outputs\.scan == 'true' && !\(github\.event_name == 'pull_request' && github\.event\.pull_request\.user\.login == 'dependabot\[bot\]'\) && \(github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch'\)/,
   );
-  assert.match(refreshSection, /-Dsonar\.projectVersion=\$\{\{\s*steps\.sonar-mainline-version\.outputs\.value\s*\}\}/);
-  assert.match(refreshSection, /timeout-minutes:\s*8/);
-  assert.match(refreshSection, /continue-on-error:\s*true/);
+  assert.match(refreshSection, /Skipping default-branch Sonar scanner refresh/);
+  assert.match(refreshSection, /mainline_version=\$\{\{\s*steps\.sonar-mainline-version\.outputs\.value\s*\}\}/);
+  assert.doesNotMatch(refreshSection, /uses:\s*SonarSource\/sonarqube-scan-action@v8\.0\.0/);
+  assert.doesNotMatch(refreshSection, /timeout-minutes:\s*8/);
+  assert.doesNotMatch(refreshSection, /continue-on-error:\s*true/);
   assert.doesNotMatch(refreshSection, /-Dsonar\.qualitygate\.wait=true/);
   assert.doesNotMatch(refreshSection, /-Dsonar\.qualitygate\.timeout=600/);
 });


### PR DESCRIPTION
## Summary
- make the deploy verification comment reuse the deployable-file contract so non-runtime merges report deploy-not-required instead of false buildSha failures
- keep default-branch Sonar from starting a second scanner after PR/merge-queue quality gates already passed
- add workflow contract tests for both regressions

## Evidence
- Main #2473 deploy verification comment reported a false failure: routes 200, deploy skipped correctly, but buildSha did not match because no Railway deploy was required
- Main Sonar default-branch refresh still consumed the full 8-minute timeout window after merge queue had already scanned the merged tree

## Local verification
- node --test tests/deployment.test.js tests/sonarcloud-workflow.test.js -> 58/0
- npm run test:ci-cd-hygiene-audit -> 11/0
- npm run test:operational-integrity -> 44/0
- node --test tests/changeset-check.test.js -> 15/0
- npm run test:congruence -> pass
- actionlint .github/workflows/verify-deploy-comment.yml .github/workflows/sonarcloud.yml -> pass
- git diff --check -> pass