### PR TITLE
fix(enforcement): warn+audit by default, strict opt-in (drop leaky regex floor from #2477)

### DIFF
--- a/.changeset/restore-enforcement-warn-default.md
+++ b/.changeset/restore-enforcement-warn-default.md
@@ -2,24 +2,26 @@
 "thumbgate": patch
 ---
 
-fix(enforcement): restore the firewall — warn-by-default, hard-block only catastrophic
+fix(enforcement): restore the firewall — warn+audit by default, strict opt-in for hard-block
 
-The 2026-06-03 hotfix made `gate-check` bypass ALL enforcement by default (it
-approved every action, and shipped that way to npm), so ThumbGate's firewall did
-not actually fire. Restored enforcement with a safe posture (CEO decision
-2026-06-04):
+The 2026-06-03 hotfix bypassed ALL enforcement by default (gate-check approved every
+action, shipped to npm), so the firewall never fired. Restored with an honest posture
+(CEO decision 2026-06-04):
 
-- `bin/cli.js`: the blanket bypass is now an explicit opt-in escape hatch only
+- `bin/cli.js`: the blanket bypass is now an explicit escape hatch only
   (`THUMBGATE_HOTFIX_BYPASS=1`); enforcement runs by default.
-- `gates-engine.js` `applyEnforcementPosture`: warn-by-default — gates still fire
-  and log every decision, but downgrade deny/approve → warn so legitimate work is
-  never hard-blocked. A tight catastrophic FLOOR keeps hard `deny` for
-  irreversibly destructive **commands** (rm -rf / mkfs / dd-to-disk / fork bomb /
-  terraform destroy) and secret exfiltration. Only the executed command
-  (Bash command/cmd/script) is inspected — writing/editing a file that merely
-  *mentions* `rm -rf` is NOT blocked.
-- Full hard enforcement is available via `THUMBGATE_STRICT_ENFORCEMENT=1`.
+- `gates-engine.js` `applyEnforcementPosture`: WARN + AUDIT by default — every gate still
+  fires and is logged, but deny/approve downgrade to `warn` so legitimate work is never
+  hard-blocked. We deliberately do NOT use a regex "catastrophic floor" to hard-block
+  destructive commands: it is unwinnable (sudo / bash -c / find -exec / eval / base64|sh
+  all evade it) and gives false confidence.
+- HARD enforcement is the explicit opt-in `THUMBGATE_STRICT_ENFORCEMENT=1`, which keeps the
+  engine's FULL gate set — its high-risk-command gates catch prefixed/obfuscated forms
+  (e.g. `sudo rm -rf /`) far better than any single regex.
+- Secret exfiltration and the security-vulnerability scan hard-deny on their own paths
+  before this runs, so irreversible data-leak / supply-chain risks stay blocked regardless.
 
-Verified by real gate-check scenarios (rm -rf → deny; git push → warn; Write/Edit
-mentioning rm -rf → warn; bypass → approve; strict → deny) and the gate test
-suites (gates-engine 167/0, cli 93/0, enforcement-teeth 38/0).
+Verified by real gate-check: default → `rm -rf /`, `sudo rm -rf /`, git-commit-mentioning-
+rm-rf all WARN (none hard-blocked); `THUMBGATE_STRICT_ENFORCEMENT=1` → `rm -rf /` AND
+`sudo rm -rf /` DENY; `THUMBGATE_HOTFIX_BYPASS=1` → approve. Suites: gates-engine 168/0,
+cli 93/0, enforcement-teeth 38/0.

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -133,44 +133,20 @@ const KNOWLEDGE_CONFLICT_STRICT_BASH_PATTERN = /\b(?:git\s+push\b|gh\s+pr\s+merg
 // Everything else (memory-high-risk, workflow-sequence, off-scope, git push, deploy,
 // approval gates) downgrades deny/approve -> warn so legitimate work is never blocked.
 // Opt back into full hard enforcement with THUMBGATE_STRICT_ENFORCEMENT=1.
-// Catastrophic floor: `rm -rf` targeting / ~ or $HOME ALWAYS hard-blocks, even in
-// warn-by-default mode and regardless of gate-evaluation order (a non-catastrophic gate
-// can match first and would otherwise shadow + downgrade the rm-rf gate). This mirrors the
-// SMART matcher of config/gates/default.json's `rm-rf-home-or-root`: it requires rm -rf at
-// command start or after a shell separator AND a root/home target, so it does NOT match
-// benign mentions (echo / grep / git commit -m "...rm -rf...") or rm -rf of build dirs.
-const CATASTROPHIC_RM_PATTERN = /(?:^|[;&|]\s*)rm\s+-(?=[^\s]*r)(?=[^\s]*f)[^\s]+\s+(?:\/|\/\*|~(?:\/[^\s]*)?|\$HOME(?:\/[^\s]*)?)(?:\s|$)/;
-// Gates that stay hard-deny even in warn-by-default mode. (secret-exfiltration and the
-// security-vulnerability scan also hard-deny on their own paths before this runs.)
-const CATASTROPHIC_GATE_IDS = new Set(['rm-rf-home-or-root', 'secret-exfiltration']);
-
-// Only inspect the EXECUTED command (Bash command/cmd/script) — never file-write payloads
-// (content/new_string), so writing/editing a file that mentions rm -rf is not blocked.
-function enforcementCommandText(toolInput) {
-  if (!toolInput || typeof toolInput !== 'object') return '';
-  return [toolInput.command, toolInput.cmd, toolInput.script]
-    .filter((v) => typeof v === 'string')
-    .join(' ')
-    .slice(0, MAX_COMMAND_SCAN_CHARS);
-}
-
-function applyEnforcementPosture(result, toolInput) {
-  // Catastrophic floor first — guarantees rm -rf /,~,$HOME hard-blocks regardless of mode
-  // or which gate matched first.
-  if (CATASTROPHIC_RM_PATTERN.test(enforcementCommandText(toolInput))) {
-    if (result && result.decision === 'deny') return result;
-    return {
-      decision: 'deny',
-      gate: 'rm-rf-home-or-root',
-      message: 'Broad rm -rf against root or home is blocked. Use a narrow, reviewed path and explicit approval for destructive deletes.',
-      severity: 'critical',
-    };
-  }
+// Enforcement posture (CEO decision 2026-06-04): WARN + AUDIT by default.
+// The firewall fires and LOGS every decision, but downgrades deny/approve -> warn so
+// legitimate work is never hard-blocked. We deliberately do NOT try to hard-block
+// arbitrary destructive commands here: a regex "catastrophic floor" is unwinnable
+// (sudo / bash -c / find -exec / eval / base64|sh all evade it) and gives false confidence.
+// HARD enforcement is an explicit opt-in via THUMBGATE_STRICT_ENFORCEMENT=1, which keeps
+// the engine's FULL gate set (its high-risk-command gates catch prefixed/obfuscated forms
+// far better than any single regex). Secret exfiltration and the security-vulnerability
+// scan hard-deny on their OWN paths before this runs, so irreversible data-leak / supply
+// chain risks stay blocked regardless of posture.
+function applyEnforcementPosture(result) {
   if (!result || (result.decision !== 'deny' && result.decision !== 'approve')) return result;
   // Full hard enforcement opt-in: keep every deny.
   if (process.env.THUMBGATE_STRICT_ENFORCEMENT === '1') return result;
-  // Keep deny only for inherently-catastrophic gates.
-  if (CATASTROPHIC_GATE_IDS.has(result.gate)) return result;
   // Honor the explicit strict-knowledge-conflict opt-in for that gate.
   if (process.env.THUMBGATE_STRICT_KNOWLEDGE_CONFLICT === '1' && result.gate === 'knowledge-conflict-gate') return result;
   // Warn-by-default: the gate still fired and is recorded; the action is allowed through
@@ -2732,7 +2708,7 @@ async function runAsync(input) {
 
   const sequenceGuard = evaluateSequenceState(toolName, toolInput);
   if (sequenceGuard && sequenceGuard.decision === 'deny') {
-    return formatOutput(applyEnforcementPosture(sequenceGuard, toolInput));
+    return formatOutput(applyEnforcementPosture(sequenceGuard));
   }
 
   const result = await evaluateGatesAsync(toolName, toolInput);
@@ -2752,12 +2728,12 @@ async function runAsync(input) {
   const lessonContext = safeSecretStorageWrite ? null : await buildRelevantLessonContextAsync(toolName, toolInput);
   
   if (lessonContext && lessonContext.decision === "deny") {
-    return formatOutput(applyEnforcementPosture(lessonContext, toolInput));
+    return formatOutput(applyEnforcementPosture(lessonContext));
   }
   
   const recentContext = buildRecentCorrectiveActionsContext();
   const combinedContext = mergeContextStrings(lessonContext, recentContext, behavioralContext);
-  return formatOutput(applyEnforcementPosture(result, toolInput), combinedContext);
+  return formatOutput(applyEnforcementPosture(result), combinedContext);
 
 }
 
@@ -2779,7 +2755,7 @@ function run(input) {
 
   const sequenceGuard = evaluateSequenceState(toolName, toolInput);
   if (sequenceGuard && sequenceGuard.decision === 'deny') {
-    return formatOutput(applyEnforcementPosture(sequenceGuard, toolInput));
+    return formatOutput(applyEnforcementPosture(sequenceGuard));
   }
 
   const result = evaluateGates(toolName, toolInput);
@@ -2799,12 +2775,12 @@ function run(input) {
   const lessonContext = safeSecretStorageWrite ? null : buildRelevantLessonContext(toolName, toolInput);
   
   if (lessonContext && lessonContext.decision === "deny") {
-    return formatOutput(applyEnforcementPosture(lessonContext, toolInput));
+    return formatOutput(applyEnforcementPosture(lessonContext));
   }
   
   const recentContext = buildRecentCorrectiveActionsContext();
   const combinedContext = mergeContextStrings(lessonContext, recentContext, behavioralContext);
-  return formatOutput(applyEnforcementPosture(result, toolInput), combinedContext);
+  return formatOutput(applyEnforcementPosture(result), combinedContext);
 
 }
 

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -1125,29 +1125,28 @@ test('run warns on destructive local git cleanup by default, denies under strict
   cleanupStateFiles();
 });
 
-test('run blocks broad rm -rf against root or home by default', () => {
+test('run warns on broad rm -rf by default, denies under strict enforcement', () => {
   cleanupStateFiles();
-  const rootOutput = JSON.parse(run({
-    tool_name: 'Bash',
-    tool_input: { command: 'rm -rf /' },
-  }));
-  assert.equal(rootOutput.hookSpecificOutput.permissionDecision, 'deny');
-  assert.match(rootOutput.hookSpecificOutput.permissionDecisionReason, /rm-rf-home-or-root/);
-
-  const homeOutput = JSON.parse(run({
-    tool_name: 'Bash',
-    tool_input: { command: 'rm -rf $HOME/tmp' },
-  }));
-  assert.equal(homeOutput.hookSpecificOutput.permissionDecision, 'deny');
-  assert.match(homeOutput.hookSpecificOutput.permissionDecisionReason, /rm-rf-home-or-root/);
+  // Warn+audit posture (CEO decision 2026-06-04): even rm -rf / is flagged + logged, NOT
+  // hard-blocked, by default — we do not pretend a regex can reliably catch destructive
+  // commands (sudo/bash -c/find -exec all evade it). Hard enforcement is the strict opt-in.
+  const warnOut = JSON.parse(run({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } }));
+  assert.notEqual(warnOut.hookSpecificOutput.permissionDecision, 'deny');
+  process.env.THUMBGATE_STRICT_ENFORCEMENT = '1';
+  try {
+    const denyOut = JSON.parse(run({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } }));
+    assert.equal(denyOut.hookSpecificOutput.permissionDecision, 'deny');
+  } finally {
+    delete process.env.THUMBGATE_STRICT_ENFORCEMENT;
+  }
   cleanupStateFiles();
 });
 
-test('warn-by-default never hard-blocks benign commands that merely mention rm -rf', () => {
+test('warn+audit default never hard-blocks benign commands that merely mention rm -rf', () => {
   cleanupStateFiles();
-  // Regression: a crude command regex once hard-denied any command containing the
-  // substring "rm -rf" — echo, grep, even git commit messages, and routine
-  // `rm -rf node_modules`. None of these must be a hard deny.
+  // Regression: a crude command regex once hard-denied any command containing the substring
+  // "rm -rf" — echo, grep, git commit messages, and routine `rm -rf node_modules`. None of
+  // these is a destructive root/home delete, so none must be hard-blocked in default posture.
   const benign = [
     'echo "do not run rm -rf /"',
     'grep -r "rm -rf" scripts/',
@@ -1160,16 +1159,7 @@ test('warn-by-default never hard-blocks benign commands that merely mention rm -
     assert.notEqual(
       out.hookSpecificOutput.permissionDecision,
       'deny',
-      `benign command must not be hard-blocked: ${command}`,
-    );
-  }
-  // But the genuinely catastrophic targets still hard-deny, regardless of gate order.
-  for (const command of ['rm -rf /', 'rm -rf $HOME/work', 'deploy && rm -rf ~']) {
-    const out = JSON.parse(run({ tool_name: 'Bash', tool_input: { command } }));
-    assert.equal(
-      out.hookSpecificOutput.permissionDecision,
-      'deny',
-      `catastrophic rm -rf must hard-block: ${command}`,
+      `benign command must not be hard-blocked by default: ${command}`,
     );
   }
   cleanupStateFiles();


### PR DESCRIPTION
## Why
#2477 restored the firewall but used a regex "catastrophic floor" to hard-block `rm -rf`. That floor is **leaky and gives false confidence** — verified it misses `sudo rm -rf /`, `bash -c "rm -rf /"`, `find -exec rm -rf`, env-prefixed, and `rm -rf /etc`. You can't reliably hard-block destructive commands with a regex (infinite evasions), and the gate that *would* catch them (`task-scope-required`) is the same one that blocked the Resume work — so hard-blocking and not-re-blocking-work conflict.

## Decision (CEO 2026-06-04): warn+audit by default, strict opt-in
- **Drop the regex floor entirely.** Default = the firewall fires, WARNS, and LOGS every decision (the real value: the audit/replay trail). Never hard-blocks arbitrary commands → never re-blocks legitimate work.
- **`THUMBGATE_STRICT_ENFORCEMENT=1`** = real hard enforcement via the engine's FULL gate set, which catches prefixed/obfuscated forms (incl. `sudo rm -rf /`) far better than any regex.
- **Secret exfiltration + security-vulnerability scan** still hard-deny on their own paths regardless of posture (irreversible data-leak / supply-chain).

## Verified (real gate-check)
| | default | STRICT=1 |
|---|---|---|
| `rm -rf /` | warn | **deny** |
| `sudo rm -rf /` | warn | **deny** (regex missed this) |
| git commit mentioning rm -rf | warn (not blocked) | — |
| `THUMBGATE_HOTFIX_BYPASS=1` | approve (escape) | approve |

Suites: gates-engine 168/0, cli 93/0, enforcement-teeth 38/0. Tests updated to the warn-by-default/strict-deny posture; regression test pins that benign rm-rf mentions are never hard-blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)