### PR TITLE
fix(ci): restore deploy verification workflow yaml

### DIFF
--- a/.github/workflows/verify-deploy-comment.yml
+++ b/.github/workflows/verify-deploy-comment.yml
@@ -65,26 +65,26 @@ jobs:
           fi
 
           node - <<'NODE' >> "$GITHUB_OUTPUT"
-const fs = require('fs');
-const artifactPath = 'deploy-scope/deploy-scope.json';
-let scope = null;
-try {
-  scope = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
-} catch {
-  scope = {
-    shouldDeploy: true,
-    scopeReason: 'artifact_missing_conservative_verify',
-    changedFiles: [],
-  };
-}
+          const fs = require('fs');
+          const artifactPath = 'deploy-scope/deploy-scope.json';
+          let scope = null;
+          try {
+            scope = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+          } catch {
+            scope = {
+              shouldDeploy: true,
+              scopeReason: 'artifact_missing_conservative_verify',
+              changedFiles: [],
+            };
+          }
 
-const changedFiles = Array.isArray(scope.changedFiles) ? scope.changedFiles : [];
-console.log('changed_files<<EOF');
-console.log(changedFiles.join('\n'));
-console.log('EOF');
-console.log(`deploy_required=${scope.shouldDeploy === false ? 'false' : 'true'}`);
-console.log(`scope_reason=${scope.scopeReason || 'unknown'}`);
-NODE
+          const changedFiles = Array.isArray(scope.changedFiles) ? scope.changedFiles : [];
+          console.log('changed_files<<EOF');
+          console.log(changedFiles.join('\n'));
+          console.log('EOF');
+          console.log(`deploy_required=${scope.shouldDeploy === false ? 'false' : 'true'}`);
+          console.log(`scope_reason=${scope.scopeReason || 'unknown'}`);
+          NODE
 
       - name: Capture current production health for skipped deploys
         if: steps.find-pr.outputs.pr != '' && steps.deploy-scope.outputs.deploy_required == 'false'

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -503,6 +503,26 @@ test('Deploy verification comment does not require a build SHA change for non-ru
   assert.doesNotMatch(workflow, /git diff --name-only "\$\{MERGE_SHA\}~1" "\$\{MERGE_SHA\}"/);
 });
 
+test('Deploy verification workflow keeps embedded heredoc scripts valid YAML', () => {
+  const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'verify-deploy-comment.yml'), 'utf8');
+  const lines = workflow.split('\n');
+  const startIndex = lines.findIndex((line) => line.includes("node - <<'NODE' >> \"$GITHUB_OUTPUT\""));
+  const endIndex = lines.findIndex((line, index) => index > startIndex && line.trim() === 'NODE');
+
+  assert.notEqual(startIndex, -1, 'expected deploy-scope heredoc start');
+  assert.notEqual(endIndex, -1, 'expected deploy-scope heredoc terminator');
+
+  for (const [offset, line] of lines.slice(startIndex + 1, endIndex + 1).entries()) {
+    if (!line.trim()) continue;
+    assert.match(
+      line,
+      /^\s{10,}\S/,
+      `heredoc line ${startIndex + offset + 2} must stay indented inside the YAML block`
+    );
+  }
+  assert.doesNotMatch(workflow, /^const fs = require\('fs'\);$/m);
+});
+
 test('Deploy to Railway workflow stamps runtime deployment env metadata before health verification', () => {
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'deploy-railway.yml'), 'utf8');
 


### PR DESCRIPTION
## Summary
- Fix the verify-deploy-comment workflow YAML broken by an unindented heredoc body.
- Add a regression test that keeps embedded heredoc scripts indented inside the YAML run block.

## Verification
- actionlint .github/workflows/verify-deploy-comment.yml
- ruby YAML.load_file(.github/workflows/verify-deploy-comment.yml)
- node --test tests/deployment.test.js (55/0)
- npm run test:deployment (114/0)
- CHANGESET_BASE_REF=origin/main npm run changeset:check (changeset not required)
- npm run ops:integrity:ci

## Context
Post-merge main run 26966987748 failed with zero jobs because GitHub could not parse .github/workflows/verify-deploy-comment.yml after #2475. This PR restores the workflow and adds a guard for the exact heredoc indentation regression.