### PR TITLE
site: clarify pricing to Free/Pro/Enterprise and retire Team tier

### DIFF
--- a/.changeset/landing-pricing-clarity-free-pro-enterprise.md
+++ b/.changeset/landing-pricing-clarity-free-pro-enterprise.md
@@ -1,0 +1,29 @@
+---
+"thumbgate": patch
+---
+
+site: landing-page plan clarity + retire Team from the primary buyer surfaces (Free / Pro / Enterprise)
+
+The landing page made buyers infer plan differences from long cards, still sold a
+retired Team tier, and the README contradicted the enforced free-tier limits.
+
+- **Landing page comparison matrix** — adds an at-a-glance Free / Pro / Enterprise
+  table to `public/index.html` so buyers see plan differences without parsing cards.
+- **Free / Pro / Enterprise** — retires the Team tier across the primary buyer
+  surfaces (landing page, `/pricing`, guide, compare, pro, README, COMMERCIAL_TRUTH,
+  product-hunt kit, docs landing) and the CLI/dashboard upgrade messaging
+  (`commercial-offer`, `rate-limiter`, `pro-features`, `org-dashboard`). "Regulated"
+  folds into the Enterprise contact-sales tier (audit trail, VPC/SSO, regulatory
+  templates + shared lesson DB / org dashboard / shared enforcement).
+- **Consistent, truthful free-tier limits** — README/cards/matrix now all state what
+  `scripts/rate-limiter.js` actually enforces (5 captures/day, 25 total, 3 active
+  rules), replacing stale "unlimited captures / 5 rules" copy.
+- **Drift guards** — `check-congruence` now requires Enterprise + forbids the retired
+  `$49/seat` anchor on buyer surfaces (regex tightened to catch markup-split prices);
+  a new `public-landing` test pins the matrix + enforced free-tier numbers.
+
+Deliberately scoped: the dormant Team Stripe price ID / seat-checkout plumbing
+(`billing.js`, `metered-billing.js`) and a long tail of deep content pages
+(`public/guides/*`, `public/learn/*`, `llm-context.md`, `compare/agentix-labs.html`)
+still reference Team and are a separate follow-up — they are invisible to the primary
+pricing flow and do not break CI.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The product is a self-improving enforcement layer: thumbs-down feedback, prompt 
 npx thumbgate init   # auto-detects your agent, wires hooks, 30 seconds
 ```
 
-Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and any MCP-compatible agent. Free tier: 5 feedback captures/day, 25 total captures, and 3 active auto-promoted prevention rules. [Pro: $19/mo or $149/yr](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme) — unlimited feedback captures, unlimited rules, history-aware lessons, feedback sessions, dashboard, DPO export. Team is $49/seat/mo with a shared hosted lesson DB and org dashboard.
+Works with **Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode** and any MCP-compatible agent. Free tier: 5 feedback captures/day (25 total) and up to 3 active auto-promoted prevention rules. [Pro: $19/mo or $149/yr](https://thumbgate.ai/checkout/pro?utm_source=github&utm_medium=readme) — unlimited rules, history-aware lessons, feedback sessions, dashboard, DPO export. Enterprise (custom pricing, scoped after intake) adds a shared hosted lesson DB, org dashboard, and shared org-wide enforcement.
 
 [![CI](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml/badge.svg)](https://github.com/IgorGanapolsky/ThumbGate/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/thumbgate)](https://www.npmjs.com/package/thumbgate)
@@ -379,26 +379,26 @@ If you change MCP or hook settings, restart the affected agent session so Claude
 
 ## Pricing
 
-| | Free | Pro ($19/mo) | Team ($49/seat/mo) | Enterprise |
-|---|---|---|---|---|
-| Local CLI + enforced checks | ✅ | ✅ | ✅ | ✅ |
-| Feedback captures | 5/day, 25 total | Unlimited | Unlimited | Unlimited |
-| Auto-promoted prevention rules | 3 active | Unlimited | Unlimited | Unlimited |
-| MCP agent integrations | All | All | All | All |
-| Personal dashboard | — | ✅ | ✅ | ✅ |
-| DPO export (model fine-tuning) | — | ✅ | ✅ | ✅ |
-| Team lesson export/import | — | ✅ | ✅ | ✅ |
-| Shared hosted lesson DB | — | — | ✅ | ✅ |
-| Org-wide dashboard | — | — | ✅ | ✅ |
-| Approval + audit proof | — | — | ✅ | ✅ |
-| Regulatory gate templates | — | — | — | ✅ |
-| Custom policy layers (firm/practice-area) | — | — | — | ✅ |
-| Compliance audit export | — | — | — | ✅ |
-| Dedicated onboarding + SLA | — | — | — | ✅ |
+| | Free | Pro ($19/mo) | Enterprise |
+|---|---|---|---|
+| Local CLI + enforced checks | ✅ | ✅ | ✅ |
+| Feedback captures | 5/day (25 total) | Unlimited | Unlimited |
+| Active auto-promoted prevention rules | 3 | Unlimited | Unlimited |
+| MCP agent integrations | All | All | All |
+| Personal dashboard | — | ✅ | ✅ |
+| DPO export (model fine-tuning) | — | ✅ | ✅ |
+| Lesson export/import | — | ✅ | ✅ |
+| Shared hosted lesson DB | — | — | ✅ |
+| Org-wide dashboard | — | — | ✅ |
+| Approval + audit proof | — | — | ✅ |
+| Regulatory gate templates | — | — | ✅ |
+| Custom policy layers (firm/practice-area) | — | — | ✅ |
+| Compliance audit export | — | — | ✅ |
+| Dedicated onboarding + SLA | — | — | ✅ |
 
-The free tier gives you 5 feedback captures/day, 25 total captures, and up to 3 active auto-promoted prevention rules — enough to prove the loop before buying. MCP integrations for all agents (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode) ship free.
+The free tier gives you 5 feedback captures/day (25 total) and up to 3 active auto-promoted prevention rules — enough to make ThumbGate part of your daily flow before you upgrade. MCP integrations for all agents (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode) ship free.
 
-Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recall, lesson search, DPO export, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement across the org. Enterprise adds regulatory gate templates (legal intake, financial compliance, healthcare), custom policy layers scoped to firm/practice-area, compliance audit export, and dedicated onboarding with SLA.
+Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recall, lesson search, DPO export, and a personal dashboard. Enterprise (custom pricing, scoped after intake) adds a shared hosted lesson DB, org dashboard, and shared enforcement across the org, plus regulatory gate templates (legal intake, financial compliance, healthcare), custom policy layers scoped to firm/practice-area, compliance audit export, and dedicated onboarding with SLA.
 
 **Best first paid motion for teams:** the **Workflow Hardening Sprint** — qualify one repeated failure before committing to a full rollout. **[Start intake →](https://thumbgate.ai/?utm_source=github&utm_medium=readme&utm_campaign=team_rollout#workflow-sprint-intake)**
 
@@ -575,7 +575,7 @@ If it supports MCP or pre-action hooks, yes. Claude Code, Claude Desktop, Cursor
 **Is it free?**
 The free tier gives you 5 feedback captures/day, 25 total captures, and up to 3 active auto-promoted prevention rules — enough for solo devs to prove a blocked repeat before upgrading. MCP integrations ship free for every agent.
 
-Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recall, lesson search, and a personal dashboard. Team ($49/seat/mo) adds a shared hosted lesson DB, org dashboard, and shared enforcement.
+Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recall, lesson search, and a personal dashboard. Enterprise (custom pricing, scoped after intake) adds a shared hosted lesson DB, org dashboard, and shared enforcement.
 
 ---
 

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -9,9 +9,10 @@ This document is the source of truth for product, pricing, traction, and proof c
 
 - The open-source `thumbgate` package is free and MIT licensed.
 - The local CLI is the adoption wedge; it is not the primary monetization story.
-- The primary commercial offer is **Pro at $19/mo or $149/yr** via Stripe checkout.
-- For high-stakes environments, we offer **Enterprise Pilots** (e.g., GCP/DFCX guardrails) with custom setup and support.
-- Legacy Team pricing ($49/seat/mo) is no longer a public focus; we prioritize individual Operator hardening and scoped Enterprise pilots.
+- The primary commercial motion is the **Workflow Hardening Sprint** for one workflow, followed by Enterprise expansion when shared enforcement, approval boundaries, and auditability matter across operators.
+- The current public self-serve commercial offer is **Pro at $19/mo or $149/yr** via Stripe checkout.
+- Legacy one-time Stripe links are retained only for past buyers and are not a current public offer.
+- Enterprise is the contact-sales tier: **custom pricing, scoped after intake**, and the public Enterprise path remains an **intake-led pilot for the first workflow** until hosted rollout scope is qualified. The former Team seat tier is retired.
 - The open-source runtime now supports history-aware lesson distillation from up to 8 prior recorded entries in the current Claude auto-capture path, linked 60-second feedback sessions, and reflector rule proposals across CLI, hosted API, Cursor, and Claude Desktop surfaces.
 - The runtime now supports Workflow Sentinel blast-radius scoring plus Docker Sandboxes routing guidance for high-risk local actions, and the hosted path supports signed sandbox dispatch for isolated automations.
 - Package publishing is governed by Changesets, SemVer, version-sync checks, and verification evidence; release claims should stay inspectable instead of being inferred from a diff.
@@ -37,7 +38,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 - Unlimited captures and custom checks with auto-promotion into prevention rules
 - **The standard lane for solo operators and independent developers.**
 
-### Enterprise Pilot (Custom)
+### Enterprise (custom pricing, scoped after intake)
 
 - Scoped implementation (e.g., GCP/DFCX guardrails)
 - Shared hosted lesson database
@@ -53,7 +54,7 @@ This document is the source of truth for product, pricing, traction, and proof c
 - CLI telemetry is anonymous, best-effort product telemetry for command usage and runtime health. It uses a random local install ID, does not include raw feedback context, and can be disabled with `THUMBGATE_NO_TELEMETRY=1` or `DO_NOT_TRACK=1`.
 - The public website uses first-party telemetry endpoints plus configured analytics surfaces for page views, CTA events, checkout starts, intake submissions, and newsletter signups. Treat those as hosted product analytics, not local enforcement data.
 - Hosted checkout, newsletter, intake, team sync, and API-key flows may process account, billing, email, and workflow-intake data through the hosted Railway/API path and configured payment or analytics providers.
-- Team/shared deployments should treat connector writes, customer-data workflows, telemetry exports, and shared lesson databases as approval-gated data-processing surfaces.
+- Enterprise/shared deployments should treat connector writes, customer-data workflows, telemetry exports, and shared lesson databases as approval-gated data-processing surfaces.
 - Model candidate catalogs and routing guides, including GPT-5.5 evaluation, are benchmark and planning surfaces. They do not silently call provider APIs, change runtime defaults, or imply OpenAI account availability without customer credentials and an explicit integration path.
 - ThumbGate should not claim sub-processor coverage, SOC 2 status, HIPAA eligibility, GDPR DPA terms, or enterprise data residency until those legal/compliance artifacts are actually in place.
 

--- a/docs/landing-page.html
+++ b/docs/landing-page.html
@@ -727,7 +727,7 @@
             <a class='button secondary' href='https://thumbgate-production.up.railway.app'>View hosted demo</a>
           </div>
           <p class='note'>Early-stage product. Engineering proof is real, but GitHub stars, npm downloads, and solo-maintainer activity are not customer proof.</p>
-          <p class='note'>The public commercial motion starts with the Workflow Hardening Sprint, then expands into Team at $49/seat/mo with a 3-seat minimum after qualification. Pro at $19/mo or $149/yr stays available for solo operators who want a personal dashboard.</p>
+          <p class='note'>The public commercial motion starts with the Workflow Hardening Sprint, then expands into Enterprise (custom pricing, scoped after intake). Pro at $19/mo or $149/yr stays available for solo operators who want a personal dashboard.</p>
         </div>
 
         <div class='panel hero-card'>
@@ -1110,13 +1110,13 @@
           </div>
           <div class='card'>
             <h3>Team lead managing multiple agents</h3>
-            <p>Your team runs different agents across different repos. Rules learned in one repo need to apply everywhere. ThumbGate Team carries shared enforcement, approvals, and proof so one bad pattern cannot surface in two different repos on the same day.</p>
+            <p>Your team runs different agents across different repos. Rules learned in one repo need to apply everywhere. ThumbGate Enterprise carries shared enforcement, approvals, and proof so one bad pattern cannot surface in two different repos on the same day.</p>
             <p><strong style='color:var(--accent-dark);'>Workflow Hardening Sprint, then Team.</strong> Start with one blocker, one workflow owner, and one proof review.</p>
           </div>
           <div class='card'>
             <h3>Engineering manager wanting CI integration</h3>
             <p>You want agent failures to feed back into the pipeline automatically — not live in someone's local notes. ThumbGate's CI webhook auto-ingest and machine-readable proof reports make agent reliability auditable without extra tooling.</p>
-            <p><strong style='color:var(--accent-dark);'>Team tier.</strong> Shared rollout proof, CI integration, and approval boundaries for engineering workflows.</p>
+            <p><strong style='color:var(--accent-dark);'>Enterprise tier.</strong> Shared rollout proof, CI integration, and approval boundaries for engineering workflows.</p>
           </div>
         </div>
       </div>
@@ -1127,7 +1127,7 @@
         <div class='section-head'>
           <span class='eyebrow'>Pricing</span>
           <h2>Install free. Buy with the Workflow Hardening Sprint. Keep Pro as the solo side lane.</h2>
-          <p>The OSS core is free and always will be. Team rollout stays intake-first at $49/seat/mo with a 3-seat minimum after qualification. Pro is $19/mo or $149/yr for individual operators.</p>
+          <p>The OSS core is free and always will be. Enterprise stays intake-first with custom pricing scoped after qualification. Pro is $19/mo or $149/yr for individual operators.</p>
         </div>
         <div class='pricing-grid'>
           <div class='card'>
@@ -1145,8 +1145,8 @@
           </div>
           <div class='card featured'>
             <span class='badge'>Primary motion</span>
-            <h3>Team</h3>
-            <div class='price'>$49 <small>/ seat / mo</small></div>
+            <h3>Enterprise</h3>
+            <div class='price'>Custom <small>scoped after intake</small></div>
           <p style='margin:0 0 8px;font-size:15px;color:var(--muted);font-style:italic;'>Start with one workflow, one owner, and one repeated blocker. Expand into shared governance after proof.</p>
             <ul>
               <li>Workflow Hardening Sprint intake</li>

--- a/docs/marketing/product-hunt-launch-kit.md
+++ b/docs/marketing/product-hunt-launch-kit.md
@@ -64,7 +64,7 @@ The free tier gives you the local loop: 5 feedback captures/day, 25 total captur
 
 Pro ($19/mo) adds the personal local dashboard, DPO export pairs for downstream fine-tuning, and a check debugger to trace exactly why a rule fired.
 
-Team anchors at $49/seat/mo if you want shared lesson libraries, org visibility, and approval boundaries across an engineering team.
+Enterprise is custom pricing, scoped after intake, if you want shared lesson libraries, org visibility, and approval boundaries across an engineering team.
 
 The quickest way to see it work: install it, give your agent a thumbs down on the next mistake, and watch the gate appear.
 
@@ -118,7 +118,7 @@ $ git push --force
 **Purpose:** Developers respond to real terminal output over marketing copy. Shows zero-config setup and a gate firing end-to-end.
 
 ### Screenshot 5: Pricing Tiers
-**What to capture:** Clean pricing comparison — Free vs Pro ($19/mo or $149/yr) vs Team ($49/seat/mo).
+**What to capture:** Clean pricing comparison — Free vs Pro ($19/mo or $149/yr) vs Enterprise (custom pricing, scoped after intake).
 Pull from https://thumbgate-production.up.railway.app/#pricing  
 Highlight "Free forever" tier prominently to reduce friction on PH visitors.  
 **Purpose:** Removes the "how much does this cost?" friction before visitors click through.
@@ -300,7 +300,7 @@ What free does NOT include:
 - DPO export pairs (for downstream fine-tuning your own models)
 - Gate debugger (trace why a specific rule fired, with confidence scores)
 
-Pro is $19/mo or $149/yr. Team is $49/seat/mo.
+Pro is $19/mo or $149/yr. Enterprise is custom pricing, scoped after intake.
 
 ---
 

--- a/public/compare.html
+++ b/public/compare.html
@@ -62,7 +62,7 @@
       "name": "Is ThumbGate free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate has a free tier that includes local enforcement with 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard."
+        "text": "ThumbGate has a free tier that includes local enforcement with 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared lesson database and org dashboard."
       }
     },
     {
@@ -311,7 +311,7 @@
 
 <div class="card">
   <h3>Is ThumbGate free?</h3>
-  <p>ThumbGate has a free tier that includes local enforcement with 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Team rollout ($49/seat/mo) adds a shared lesson database and org dashboard.</p>
+  <p>ThumbGate has a free tier that includes local enforcement with 5 feedback captures/day, 25 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared lesson database and org dashboard.</p>
 </div>
 
 <div class="card">

--- a/public/guide.html
+++ b/public/guide.html
@@ -330,7 +330,7 @@ npx thumbgate init --agent gemini</code></pre>
   <tr><td>Auto-generates rules</td><td>Yes — from repeated failures</td><td>No</td><td>No</td></tr>
   <tr><td>Agent support</td><td>Claude Code, Codex, Gemini, Amp, Cursor, OpenCode</td><td>Claude Code, Cursor, Windsurf, Cline</td><td>Claude, Cursor</td></tr>
   <tr><td>Install</td><td><code>npx thumbgate init</code></td><td><code>npx speclock setup</code></td><td>Cloud signup</td></tr>
-  <tr><td>Cost</td><td>Free (Pro $19/mo or $149/yr, Team rollout $49/seat/mo)</td><td>Free</td><td>Free tier + paid</td></tr>
+  <tr><td>Cost</td><td>Free (Pro $19/mo or $149/yr, Enterprise custom pricing)</td><td>Free</td><td>Free tier + paid</td></tr>
 </table>
 
 <h2>Common Scenarios</h2>
@@ -379,7 +379,7 @@ npx thumbgate init --agent gemini</code></pre>
 <a rel="nofollow noopener noreferrer" target="_blank" href="https://buy.stripe.com/00w14neyUcXA5pL5e33sI0e" class="cta cta-secondary">Pay $499 diagnostic</a>
 <a rel="nofollow noopener noreferrer" target="_blank" href="https://buy.stripe.com/fZu9AT76saPsg4pbCr3sI0f" class="cta cta-secondary">Pay $1500 sprint</a>
 <a href="https://thumbgate.ai/#workflow-sprint-intake" class="cta cta-secondary">Send workflow first</a>
-<p style="color:var(--muted); font-size:0.85rem;">Free: 5 captures/day, 25 total captures, 3 active prevention rules, hook blocking. Pro: hosted sync, dashboard, recall, lesson search, unlimited captures/rules, DPO export. Team: intake first, then $49/seat/mo with a 3-seat minimum.</p>
+<p style="color:var(--muted); font-size:0.85rem;">Free: 5 captures/day, 25 total captures, 3 active prevention rules, hook blocking. Pro: hosted sync, dashboard, recall, lesson search, unlimited captures/rules, DPO export. Enterprise: intake first, then custom pricing scoped to your rollout.</p>
 
 </div>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -116,10 +116,9 @@ __GA_BOOTSTRAP__
     },
     {
       "@type": "Offer",
-      "name": "Team",
-      "price": "49",
+      "name": "Enterprise",
       "priceCurrency": "USD",
-      "description": "Intake-led team rollout with a workflow hardening sprint, shared enforcement memory, org dashboard visibility, approval boundaries, release confidence, Docker Sandboxes guidance for risky local autonomy, and pilot support for teams shipping AI-generated changes",
+      "description": "Contact-sales tier with custom pricing scoped after intake: a workflow hardening sprint, shared hosted lesson database, org dashboard visibility, shared enforcement, approval boundaries, audit-grade decision trail, regulatory gate templates, Docker Sandboxes guidance for risky local autonomy, and dedicated onboarding for teams shipping AI-generated changes",
       "url": "https://thumbgate.ai/#workflow-sprint-intake"
     },
     {
@@ -752,9 +751,9 @@ __GA_BOOTSTRAP__
         <a href="/checkout/pro?utm_source=website&utm_medium=offer_router&cta_id=router_start_pro&cta_placement=offer_router&plan_id=pro" data-revenue-cta data-cta-id="router_start_pro" data-cta-placement="offer_router" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);">Pay $19/mo with Stripe →</a>
       </div>
       <div class="offer-route">
-        <strong>Team workflow: Start with intake</strong>
-        <p>Proof before rollout.</p>
-        <a href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});">Send the workflow first →</a>
+        <strong>Enterprise: Start with intake</strong>
+        <p>Shared enforcement, scoped.</p>
+        <a href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});">Talk to us →</a>
       </div>
       <div class="offer-route">
         <strong>Still evaluating: Free CLI</strong>
@@ -828,7 +827,7 @@ __GA_BOOTSTRAP__
       <div hidden aria-hidden="true" data-thumbgate-test-anchors style="display:none">
         <span data-cta="hero_workflow_sprint_intake">ctaId: 'hero_workflow_sprint' ctaId: 'hero_workflow_sprint_recovery_intake' workflow_sprint_intake_started workflow_sprint_recovery_intake_clicked hero_workflow_sprint_recovery_intake</span>
         <span data-anchor="dashboard-preview">dashboard-preview What your Pro dashboard looks like check:no-force-push</span>
-        <span data-anchor="team-intake-form">Start Team Pilot Intake id="team-pilot-intake-form" data-team-intake-form name="ctaPlacement" value="team_visible_intake" name="utmMedium" value="visible_team_intake" name="planId" value="team" name="ctaId" value="workflow_sprint_intake" Team checkout happens after scope. team_workflow_sprint_recovery_intake scope_first workflow_sprint_intake_started workflow_sprint_intake_submit_attempted pricing_team_intake team_intake_started</span>
+        <span data-anchor="team-intake-form">Start Enterprise Pilot Intake id="team-pilot-intake-form" data-team-intake-form name="ctaPlacement" value="team_visible_intake" name="utmMedium" value="visible_team_intake" name="planId" value="team" name="ctaId" value="workflow_sprint_intake" Enterprise checkout happens after scope. team_workflow_sprint_recovery_intake scope_first workflow_sprint_intake_started workflow_sprint_intake_submit_attempted pricing_team_intake team_intake_started</span>
         <span data-anchor="chatgpt-context">No, you do not have to chat inside the GPT forever. ChatGPT is the discovery and memory surface. Do not rely on ChatGPT's native rating buttons for ThumbGate memory. Explore GPTs choose the GPT by Igor Ganapolsky Programming Do I have to chat inside the ThumbGate GPT for enforcement? capture thumbs-up/down lessons Real blocking for coding agents still runs locally adapters/chatgpt/INSTALL.md Native ChatGPT rating buttons are not the ThumbGate capture path. thumbs up: this review named exact files, commands, and tests. thumbs down: the answer ignored my request.</span>
       </div>
     </div>
@@ -1353,6 +1352,33 @@ __GA_BOOTSTRAP__
   <div class="container">
     <div class="section-label">Pricing</div>
     <h2 class="section-title">Stop paying for agent mistakes you already fixed.</h2>
+
+    <!-- At-a-glance comparison so buyers see plan differences without parsing the cards below. -->
+    <div class="plan-matrix-wrap" style="max-width:1080px;margin:8px auto 28px;overflow-x:auto;">
+      <table class="plan-matrix" style="width:100%;border-collapse:collapse;font-size:14px;min-width:640px;">
+        <thead>
+          <tr>
+            <th style="text-align:left;padding:12px 14px;color:var(--text-muted);font-weight:600;border-bottom:1px solid var(--border);"></th>
+            <th style="text-align:center;padding:12px 14px;border-bottom:1px solid var(--border);">Free<br><span style="font-size:12px;color:var(--text-muted);font-weight:400;">$0 forever</span></th>
+            <th style="text-align:center;padding:12px 14px;border-bottom:1px solid var(--border);color:var(--cyan);">Pro<br><span style="font-size:12px;color:var(--text-muted);font-weight:400;">$19/mo or $149/yr</span></th>
+            <th style="text-align:center;padding:12px 14px;border-bottom:1px solid var(--border);color:var(--cyan);">Enterprise<br><span style="font-size:12px;color:var(--text-muted);font-weight:400;">Custom — scoped after intake</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Local PreToolUse enforcement (all agents)</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Feedback captures</td><td style="text-align:center;border-bottom:1px solid var(--border);">5/day (25 total)</td><td style="text-align:center;border-bottom:1px solid var(--border);">Unlimited</td><td style="text-align:center;border-bottom:1px solid var(--border);">Unlimited</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Active auto-promoted prevention rules</td><td style="text-align:center;border-bottom:1px solid var(--border);">3</td><td style="text-align:center;border-bottom:1px solid var(--border);">Unlimited</td><td style="text-align:center;border-bottom:1px solid var(--border);">Unlimited</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Lesson recall + search across sessions</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Personal dashboard + DPO export</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Hosted sync across machines</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Shared lesson database + org dashboard</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Org-wide shared enforcement + approval boundaries</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td></tr>
+          <tr><td style="padding:10px 14px;border-bottom:1px solid var(--border);">Audit trail, SSO, regulatory gate templates</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">—</td><td style="text-align:center;border-bottom:1px solid var(--border);">✅</td></tr>
+          <tr><td style="padding:10px 14px;color:var(--text-muted);">Best for</td><td style="text-align:center;color:var(--text-muted);">One developer</td><td style="text-align:center;color:var(--text-muted);">Solo operators</td><td style="text-align:center;color:var(--text-muted);">Teams &amp; regulated orgs</td></tr>
+        </tbody>
+      </table>
+    </div>
+
     <div class="pricing-grid">
       <div class="price-card free-highlight" style="border-color:var(--cyan);box-shadow:0 0 40px var(--cyan-dim), inset 0 1px 0 rgba(34,211,238,0.15);position:relative;">
         <div class="tier" style="color:var(--cyan);">Free</div>
@@ -1399,23 +1425,6 @@ __GA_BOOTSTRAP__
         <p style="font-size:11px;color:var(--text-muted);margin-top:8px;text-align:center;">Billed today · cancel anytime.</p>
         <input type="email" id="pro-email" data-buyer-email placeholder="you@company.com" style="margin-top:10px;width:100%;padding:10px 12px;border:1px solid var(--border);border-radius:8px;background:var(--bg-raised);color:var(--text);font-size:14px;">
       </div>
-      <div class="price-card team">
-        <div class="tier">Team</div>
-        <div class="price">$49<span style="font-size:16px;color:var(--text-dim)">/seat/mo</span></div>
-        <div class="price-sub">Shared enforcement memory for one team workflow first.</div>
-        <ul>
-          <li>Everything in Pro for each seat</li>
-          <li>Shared lesson database for Team seats, with export/import and shared workflow rules</li>
-          <li>Org dashboard visibility across agent surfaces</li>
-          <li>Enterprise Data Chat over local ThumbGate lessons, gates, and rollout readiness; Dialogflow CX / Vertex integration is enabled only when deployment evidence is configured</li>
-          <li>Hosted review views for team verification evidence</li>
-          <li>Check template library for deploys, publish, refunds, and DB work</li>
-          <li>Workflow hardening sprint intake for approval boundaries and rollback safety</li>
-          <li>Email support during pilot rollout</li>
-        </ul>
-        <a href="#workflow-sprint-intake" onclick="try{posthog.capture('team_intake_click',{cta:'team_intake',seats:3,price:0})}catch(_){};sendFirstPartyTelemetry('team_intake_started',{ctaId:'pricing_team_intake',ctaPlacement:'pricing',planId:'team',seatCount:3,price:0});sendGa4Event('generate_lead',{currency:'USD',value:0,method:'team_workflow_intake'});" class="btn-team" style="display:block;text-align:center;">Send team workflow first →</a>
-        <p style="font-size:11px;color:var(--text-muted);margin-top:8px;text-align:center;">Team is $49/seat/mo with a 3-seat minimum, but team rollouts start through intake so the workflow, shared rules, and rollout proof are explicit before checkout.</p>
-      </div>
     </div>
     <div class="pricing-matrix" aria-label="Plan capability comparison">
       <table>
@@ -1425,8 +1434,7 @@ __GA_BOOTSTRAP__
             <th scope="col">Capability</th>
             <th scope="col">Free</th>
             <th scope="col">Pro</th>
-            <th scope="col">Team</th>
-            <th scope="col">Regulated</th>
+            <th scope="col">Enterprise</th>
           </tr>
         </thead>
         <tbody>
@@ -1434,60 +1442,59 @@ __GA_BOOTSTRAP__
             <td><strong>Best for</strong></td>
             <td>Solo proof that a repeat mistake can be blocked</td>
             <td>One operator who wants hosted sync, dashboard proof, and exports</td>
-            <td>Teams that need one person's correction to protect every seat</td>
-            <td>Banking, insurance, healthcare, public sector, or audited workflows</td>
+            <td>Teams &amp; regulated orgs — one person's correction protects every seat; banking, insurance, healthcare, public sector, audited workflows</td>
           </tr>
           <tr>
             <td><strong>Price</strong></td>
             <td>$0</td>
             <td>$19/mo or $149/yr</td>
-            <td>$49/seat/mo after scope, 3-seat minimum</td>
-            <td>Scoped after regulated intake</td>
+            <td>Custom — scoped after intake</td>
           </tr>
           <tr>
             <td><strong>Feedback captures</strong></td>
             <td>5/day, 25 total</td>
             <td>Unlimited</td>
-            <td>Unlimited shared across seats</td>
-            <td>Custom retention and evidence policy</td>
+            <td>Unlimited, shared across the org; custom retention and evidence policy</td>
           </tr>
           <tr>
             <td><strong>Active prevention rules</strong></td>
             <td>3 active rules</td>
             <td>Unlimited personal rules</td>
-            <td>Shared org rules plus per-seat rules</td>
-            <td>Policy templates, approvals, and audit export</td>
+            <td>Shared org rules, policy templates, approvals, and audit export</td>
           </tr>
           <tr>
             <td><strong>Dashboard and proof</strong></td>
             <td>Local CLI evidence</td>
             <td>Personal dashboard, check debugger, DPO/HF exports</td>
-            <td>Org dashboard, hosted review views, workflow rollout proof</td>
-            <td>SIEM-ready decision trail and compliance evidence package</td>
+            <td>Org dashboard, hosted review views, rollout proof, SIEM-ready decision trail and compliance evidence</td>
           </tr>
           <tr>
             <td><strong>How to start</strong></td>
             <td><code>npx thumbgate init</code></td>
             <td>Self-serve Stripe checkout</td>
-            <td>Send one repeated workflow failure first</td>
-            <td>Start regulated workflow review</td>
+            <td>Send one repeated workflow failure first — intake before checkout</td>
           </tr>
         </tbody>
       </table>
     </div>
-    <p class="pricing-note">Free proves the enforcement loop. Pro removes solo limits. Team and Regulated plans start through intake because shared rules, permissions, rollback paths, and rollout proof must be explicit before checkout.</p>
+    <p class="pricing-note">Free proves the enforcement loop. Pro removes solo limits. Enterprise plans start through intake because shared rules, permissions, rollback paths, and rollout proof must be explicit before checkout.</p>
     <div style="max-width:1080px;margin:24px auto 0;">
-      <div class="price-card regulated" style="border:1px solid var(--cyan);background:linear-gradient(180deg, rgba(34,211,238,0.04), transparent);padding:24px 28px;">
+      <div class="price-card enterprise" style="border:1px solid var(--cyan);background:linear-gradient(180deg, rgba(34,211,238,0.04), transparent);padding:24px 28px;">
         <div style="display:flex;flex-wrap:wrap;align-items:flex-start;gap:24px;justify-content:space-between;">
           <div style="flex:1 1 420px;min-width:280px;">
-            <div class="tier" style="color:var(--cyan);">Regulated</div>
-            <div style="font-size:14px;color:var(--text-muted);margin:4px 0 12px;letter-spacing:0.04em;text-transform:uppercase;">Banking · Insurance · Healthcare · Public sector</div>
-            <div style="font-size:18px;color:var(--text);margin-bottom:6px;font-weight:700;">Regulated workflow review</div>
-            <div class="price-sub" style="margin-bottom:14px;">For teams operating AI coding agents under DORA, the EU AI Act, HIPAA, or comparable audit pressure. Pricing is scoped after intake because the buyer needs evidence, deployment boundaries, and approval ownership before checkout.</div>
+            <div class="tier" style="color:var(--cyan);">Enterprise</div>
+            <div style="font-size:14px;color:var(--text-muted);margin:4px 0 12px;letter-spacing:0.04em;text-transform:uppercase;">Engineering teams · Banking · Insurance · Healthcare · Public sector</div>
+            <div style="font-size:18px;color:var(--text);margin-bottom:6px;font-weight:700;">Shared enforcement for teams &amp; regulated workflows — custom pricing</div>
+            <div class="price-sub" style="margin-bottom:14px;">For teams that need one correction to protect every developer and agent across shared repos, CI, and approval policies — including teams operating under DORA, the EU AI Act, HIPAA, or comparable audit pressure. Pricing is scoped after intake because the buyer needs evidence, deployment boundaries, and approval ownership before checkout.</div>
             <ul style="margin-bottom:0;">
+              <li><strong>Shared lesson database</strong> — one hosted, shared lesson DB so one team member's correction becomes every developer's prevention rule across the org</li>
+              <li><strong>Org dashboard</strong> — active agents, check hit-rates, and risk surfaces across the whole team</li>
+              <li><strong>Shared enforcement memory</strong> — approval boundaries and rollback safety applied org-wide, not per machine</li>
               <li><strong>Audit-grade decision trail</strong> — every PreToolUse evaluation logged with the rule that fired, ready for SIEM export</li>
               <li><strong>Immutable rule provenance</strong> — each prevention rule traceable to the feedback event that generated it</li>
               <li><strong>Self-managed deployment</strong> — air-gapped or VPC-hosted; no agent state leaves your boundary</li>
+              <li><strong>Dialogflow CX fulfillment guard</strong> — ThumbGate's pre-action gate sits in front of your Dialogflow CX webhook fulfillment, in your own GCP tenant, so risky or repeat turns are blocked before they touch a database, CRM, or billing system (white-glove design-partner pilot)</li>
+              <li><strong>Vertex AI / Gemini scoring, in-tenant</strong> — risk and planning scoring runs on Gemini via Vertex (<code>npx thumbgate setup-vertex</code>); no conversational data leaves your VPC</li>
               <li><strong>DORA / EU AI Act evidence packaging</strong> — machine-readable reports aligned to Article 6, 28, and high-risk provider monitoring obligations</li>
               <li><strong>SSO + role separation</strong> — operator, reviewer, and auditor roles enforced at the gate layer</li>
               <li><strong>Enterprise Data Chat</strong> — local ThumbGate data Q&amp;A with Dialogflow CX / Vertex-ready governance; live cloud-agent claims require deployment evidence first</li>
@@ -1496,7 +1503,7 @@ __GA_BOOTSTRAP__
             </ul>
           </div>
           <div style="flex:0 0 260px;min-width:240px;display:flex;flex-direction:column;gap:10px;">
-            <a href="/?tier=regulated#workflow-sprint-intake" onclick="try{posthog.capture('regulated_intake_click',{cta:'regulated_contact_sales',placement:'pricing'})}catch(_){};sendFirstPartyTelemetry('regulated_intake_started',{ctaId:'pricing_regulated_intake',ctaPlacement:'pricing',planId:'regulated'});" class="btn-team" style="display:block;text-align:center;background:var(--cyan);color:#06121a;font-weight:800;">Start regulated intake →</a>
+            <a href="/?tier=enterprise#workflow-sprint-intake" onclick="try{posthog.capture('enterprise_intake_click',{cta:'enterprise_contact_sales',placement:'pricing'})}catch(_){};sendFirstPartyTelemetry('enterprise_intake_started',{ctaId:'pricing_enterprise_intake',ctaPlacement:'pricing',planId:'enterprise'});" class="btn-team" style="display:block;text-align:center;background:var(--cyan);color:#06121a;font-weight:800;">Start enterprise intake →</a>
             <a href="/learn/regulated-agent-execution-boundary" style="display:block;text-align:center;padding:10px 14px;font-size:13px;color:var(--cyan);border:1px solid var(--cyan);border-radius:8px;text-decoration:none;">Read the build-vs-buy thesis first</a>
             <p style="font-size:11px;color:var(--text-muted);margin:0;text-align:center;line-height:1.5;">Pricing is workflow-scoped and shared after the intake call. Annual pre-pay available.</p>
           </div>
@@ -1508,21 +1515,21 @@ __GA_BOOTSTRAP__
 
 <section class="compatibility" id="workflow-sprint-intake">
   <div class="container">
-    <div class="section-label">Team Pilot</div>
+    <div class="section-label">Enterprise Pilot</div>
     <h2 class="section-title">Start the AI Agent Governance Sprint with one repeat failure</h2>
     <p style="color:var(--text-dim);max-width:720px;margin:0 auto 16px;">This is the fastest path to first paid value for teams. Start with one repo, one workflow owner, and one blocker. The intake is designed to prove that ThumbGate reduces review churn, rollout risk, or repeated agent mistakes before a wider rollout.</p>
     <div class="team-intake-panel">
       <div class="team-intake-panel-head">
         <div>
           <h3>Tell us the workflow. Get a proof plan.</h3>
-          <p>The highest-fit Team buyer is already feeling one repeated failure. Send the workflow first so the next step is scoped around the real blocker instead of a blind checkout.</p>
+          <p>The highest-fit Enterprise buyer is already feeling one repeated failure. Send the workflow first so the next step is scoped around the real blocker instead of a blind checkout.</p>
         </div>
         <span class="team-intake-badge">30-minute intake</span>
       </div>
       <div class="team-intake-recovery" aria-label="Checkout recovery path for workflow sprint buyers">
         <div>
-          <strong>Team checkout happens after scope.</strong>
-          <span>Send the workflow first. We will qualify the blocker, confirm whether Pro, Team, or a scoped rollout is the right next step, and keep the purchase path tied to real evidence.</span>
+          <strong>Enterprise checkout happens after scope.</strong>
+          <span>Send the workflow first. We will qualify the blocker, confirm whether Pro or a scoped Enterprise rollout is the right next step, and keep the purchase path tied to real evidence.</span>
         </div>
         <a href="#team-pilot-intake-form" onclick="sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'team_workflow_sprint_recovery_intake',ctaPlacement:'team_intake_recovery',planId:'team',offer:'workflow_hardening_sprint',reason:'scope_first'});sendGa4Event('generate_lead',{currency:'USD',value:0,method:'workflow_sprint_recovery_intake'});">Send workflow first</a>
       </div>
@@ -1542,7 +1549,7 @@ __GA_BOOTSTRAP__
         <textarea class="full" name="blocker" placeholder="What repeat mistake, rollout blocker, or team handoff failure keeps happening?" required></textarea>
         <textarea class="full" name="note" placeholder="Optional context: team size, repos involved, target rollout date, or what you need to prove internally."></textarea>
         <div class="full">
-          <button type="submit" class="btn-team">Start Team Pilot Intake</button>
+          <button type="submit" class="btn-team">Start Enterprise Pilot Intake</button>
         </div>
       </form>
     </div>
@@ -1609,11 +1616,11 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">What does Pro cost?</div>
-        <div class="faq-a">Pro is $19/mo or $149/yr for individual operators and bills immediately through Stripe. Team is $49/seat/mo with a 3-seat minimum and starts through the workflow intake so scope, shared rules, and rollout proof are explicit before a team rollout.</div>
+        <div class="faq-a">Pro is $19/mo or $149/yr for individual operators and bills immediately through Stripe. Enterprise is custom pricing, scoped after intake, and starts through the workflow intake so scope, shared rules, and rollout proof are explicit before a rollout.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">Does ThumbGate support enterprise Google Cloud / Vertex AI?</div>
-        <div class="faq-a">Yes! ThumbGate features a zero-friction enterprise setup path via <code>npx thumbgate setup-vertex</code>. This command automatically detects your active gcloud session, enables the Vertex AI API on your Google Cloud project, and configures secure Application Default Credentials (ADC) to route all evaluations within your corporate VPC.</div>
+        <div class="faq-a">Yes. <code>npx thumbgate setup-vertex</code> detects your active gcloud session, enables the Vertex AI API on your Google Cloud project, and configures secure Application Default Credentials (ADC) so evaluations run within your corporate VPC. For Dialogflow CX, the Enterprise pilot puts ThumbGate's pre-action gate in front of your DFCX webhook fulfillment (deployed in your own tenant) so risky or repeat turns are blocked before they touch a database, CRM, or billing system. It's a white-glove design-partner pilot — ThumbGate gates your own Dialogflow CX agent; it does not host a Dialogflow CX agent for you.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How does ThumbGate contain enterprise API costs?</div>

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 __GOOGLE_SITE_VERIFICATION_META__
 <title>Pricing — ThumbGate</title>
-<meta name="description" content="ThumbGate pricing: free CLI forever, $19/mo Pro dashboard, and intake-led Team enforcement at $49/seat after scope. One clear subscription path.">
+<meta name="description" content="ThumbGate pricing: free CLI forever, $19/mo Pro dashboard, and custom Enterprise enforcement scoped after intake. One clear subscription path.">
 <meta property="og:title" content="Pricing — ThumbGate">
-<meta property="og:description" content="Free CLI, Pro self-serve, and Team after workflow scope. No mixed consulting checkout maze.">
+<meta property="og:description" content="Free CLI, Pro self-serve, and Enterprise after workflow scope. No mixed consulting checkout maze.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="__APP_ORIGIN__/pricing">
 <meta property="og:image" content="/og.png">
@@ -40,7 +40,7 @@ __GA_BOOTSTRAP__
     { "@type": "Offer", "name": "ThumbGate CLI (Free)", "price": "0", "priceCurrency": "USD" },
     { "@type": "Offer", "name": "ThumbGate Pro Monthly", "price": "__PRO_PRICE_DOLLARS__", "priceCurrency": "USD", "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro&billing_cycle=monthly&landing_path=%2Fpricing" },
     { "@type": "Offer", "name": "ThumbGate Pro Annual", "price": "149", "priceCurrency": "USD", "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro&billing_cycle=annual&landing_path=%2Fpricing" },
-    { "@type": "Offer", "name": "ThumbGate Team", "price": "49", "priceCurrency": "USD", "url": "__APP_ORIGIN__/#workflow-sprint-intake" }
+    { "@type": "Offer", "name": "ThumbGate Enterprise", "priceCurrency": "USD", "url": "__APP_ORIGIN__/#workflow-sprint-intake" }
   ]
 }
 </script>
@@ -51,9 +51,9 @@ __GA_BOOTSTRAP__
   "@type": "FAQPage",
   "mainEntity": [
     { "@type": "Question", "name": "What does Pro add over the free CLI?", "acceptedAnswer": { "@type": "Answer", "text": "Free gives you 5 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for infrastructure we run, not features we hide." } },
-    { "@type": "Question", "name": "Does ThumbGate send my code to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. The CLI is local-first — no data leaves your machine. Pro and Team add hosted sync for dashboards and shared lessons, but your source code stays local." } },
-    { "@type": "Question", "name": "When should I pick Team over Pro?", "acceptedAnswer": { "@type": "Answer", "text": "When one engineer's correction should protect the whole team. Team shares the lesson database across seats so a fix in one repo prevents the same mistake in every repo." } },
-    { "@type": "Question", "name": "Can I cancel anytime?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Pro and Team are month-to-month with a 7-day refund window on the first charge. Cancel from the billing portal and your subscription ends at the period close." } }
+    { "@type": "Question", "name": "Does ThumbGate send my code to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. The CLI is local-first — no data leaves your machine. Pro and Enterprise add hosted sync for dashboards and shared lessons, but your source code stays local." } },
+    { "@type": "Question", "name": "When should I pick Enterprise over Pro?", "acceptedAnswer": { "@type": "Answer", "text": "When one engineer's correction should protect the whole team. Enterprise shares the lesson database across the org so a fix in one repo prevents the same mistake in every repo." } },
+    { "@type": "Question", "name": "Can I cancel anytime?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Pro and Enterprise are month-to-month with a 7-day refund window on the first charge. Cancel from the billing portal and your subscription ends at the period close." } }
   ]
 }
 </script>
@@ -266,42 +266,29 @@ __GA_BOOTSTRAP__
       <p class="btn-sub">or $149/year (save 35%)</p>
     </div>
 
-    <div class="price-card team-card" id="team">
-      <div class="tier">Team</div>
-      <div class="price">$49<span>/seat/mo</span></div>
-      <div class="price-sub">Shared enforcement memory for the whole team. One engineer's save protects every agent.</div>
+    <div class="price-card enterprise-card" id="enterprise">
+      <div class="tier">Enterprise</div>
+      <div class="price">Custom<span> / scoped after intake</span></div>
+      <div class="price-sub">Shared enforcement for the whole team and regulated workflows. One engineer's save protects every agent.</div>
       <ul>
-        <li>Everything in Pro for each seat</li>
+        <li>Everything in Pro, for every developer and agent</li>
         <li><strong>Shared lesson database</strong> — one engineer's fix protects every agent on the team</li>
         <li><strong>Org dashboard</strong> — visibility across all agent surfaces and developers</li>
-        <li><strong>Enterprise Data Chat</strong> — query local ThumbGate feedback, lessons, gates, and rollout readiness; Dialogflow CX / Vertex integration is enabled only when deployment evidence is configured</li>
-        <li>Check template library for deploys, publish, and DB operations</li>
-        <li>Email support during pilot rollout</li>
-        <li>3-seat minimum after scope; rollout starts only after workflow and proof review are explicit</li>
-      </ul>
-      <a class="btn-team" href="/?utm_source=pricing&utm_medium=team_card&utm_campaign=team_intake&cta_id=pricing_team_intake&cta_placement=pricing&plan_id=team#workflow-sprint-intake" onclick="try{posthog.capture('pricing_cta_click',{cta:'team_intake',tier:'team',placement:'pricing_page',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'team_intake',tier:'team'}})}catch(_){}">Send team workflow first</a>
-      <p class="btn-sub">Rollout starts through intake so the workflow is scoped before checkout.</p>
-    </div>
-
-  </div>
-
-  <div class="enterprise-band" style="max-width:920px;margin:0 auto 8px;padding:24px 28px;border:1px solid rgba(34,211,238,0.24);border-radius:10px;background:#090d12;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:16px;">
-    <div style="flex:1 1 460px;text-align:left;">
-      <div class="tier" style="color:var(--cyan);">Enterprise</div>
-      <div class="price-sub" style="margin:4px 0 10px;">For regulated teams that need agent checks routed through their own cloud — talk to us.</div>
-      <ul style="margin:0;padding-left:18px;font-size:13px;color:var(--text-muted);line-height:1.7;">
-        <li><strong>Vertex AI / VPC gating</strong> — route agent checks through Gemini models in your Google Cloud project (<code>npx thumbgate setup-vertex</code>)</li>
+        <li><strong>Dialogflow CX fulfillment guard</strong> — put ThumbGate's pre-action gate in front of your Dialogflow CX webhook fulfillment, in your own GCP tenant, so risky or repeat turns are blocked before they touch a DB, CRM, or billing system (white-glove design-partner pilot)</li>
+        <li><strong>Vertex AI / VPC gating</strong> — route agent checks through Gemini in your own Google Cloud project (<code>npx thumbgate setup-vertex</code>)</li>
         <li><strong>Regulatory gate templates</strong> — legal intake, financial compliance, healthcare</li>
-        <li>Custom policy layers scoped to firm / practice area</li>
-        <li>Compliance audit export + dedicated onboarding with SLA</li>
+        <li>Custom policy layers, compliance audit export, approval boundaries, SSO, and dedicated onboarding with SLA</li>
+        <li>Rollout starts only after workflow and proof review are explicit</li>
       </ul>
+      <a class="btn-team" href="/?utm_source=pricing&utm_medium=enterprise_card&utm_campaign=enterprise_intake&cta_id=pricing_enterprise_intake&cta_placement=pricing&plan_id=enterprise#workflow-sprint-intake" onclick="try{posthog.capture('pricing_cta_click',{cta:'enterprise_intake',tier:'enterprise',placement:'pricing_page',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'enterprise_intake',tier:'enterprise'}})}catch(_){}">Talk to us</a>
+      <p class="btn-sub">Custom pricing, scoped through intake so the workflow is explicit before checkout.</p>
     </div>
-    <a class="btn-team" style="white-space:nowrap;" href="/?utm_source=pricing&utm_medium=enterprise_band&utm_campaign=enterprise_intake&cta_id=pricing_enterprise&cta_placement=pricing&plan_id=enterprise#workflow-sprint-intake" onclick="try{posthog.capture('pricing_cta_click',{cta:'enterprise_intake',tier:'enterprise',placement:'pricing_page',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'enterprise_intake',tier:'enterprise'}})}catch(_){}">Talk to us</a>
+
   </div>
 
   <div style="text-align:center;margin:32px 0;color:var(--text-muted);font-size:14px;">
     Need founder help? Do not buy a blind diagnostic from a pricing table.
-    <a href="/?utm_source=pricing&utm_medium=scope_first&utm_campaign=team_intake&cta_id=pricing_scope_first&cta_placement=pricing_note&plan_id=team#workflow-sprint-intake" style="color:var(--cyan);text-decoration:none;font-weight:600;" onclick="try{posthog.capture('pricing_cta_click',{cta:'scope_first',tier:'team',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'scope_first',tier:'team'}})}catch(_){}">Send the workflow first</a> — then we scope the smallest paid rollout that can prove one repeated failure is blocked.
+    <a href="/?utm_source=pricing&utm_medium=scope_first&utm_campaign=enterprise_intake&cta_id=pricing_scope_first&cta_placement=pricing_note&plan_id=enterprise#workflow-sprint-intake" style="color:var(--cyan);text-decoration:none;font-weight:600;" onclick="try{posthog.capture('pricing_cta_click',{cta:'scope_first',tier:'enterprise',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'scope_first',tier:'enterprise'}})}catch(_){}">Send the workflow first</a> — then we scope the smallest paid rollout that can prove one repeated failure is blocked.
   </div>
 </section>
 
@@ -319,15 +306,15 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q">Does ThumbGate send my code to the cloud?</div>
-        <div class="faq-a">No. The CLI is local-first and no source code leaves your machine. Pro and Team add hosted sync for dashboards and shared lessons, but your code stays local.</div>
+        <div class="faq-a">No. The CLI is local-first and no source code leaves your machine. Pro and Enterprise add hosted sync for dashboards and shared lessons, but your code stays local.</div>
       </div>
       <div class="faq-item">
-        <div class="faq-q">When should I pick Team over Pro?</div>
-        <div class="faq-a">When one engineer's correction should protect the whole team. Team shares the lesson database across seats so a fix in one repo prevents the same mistake in every repo.</div>
+        <div class="faq-q">When should I pick Enterprise over Pro?</div>
+        <div class="faq-a">When one engineer's correction should protect the whole team. Enterprise shares the lesson database across the org so a fix in one repo prevents the same mistake in every repo.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q">Can I cancel anytime?</div>
-        <div class="faq-a">Yes. Pro and Team are month-to-month with a 7-day refund window on the first charge. Cancel from the billing portal and your subscription ends at the period close.</div>
+        <div class="faq-a">Yes. Pro and Enterprise are month-to-month with a 7-day refund window on the first charge. Cancel from the billing portal and your subscription ends at the period close.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q">What happens if I stop paying?</div>

--- a/public/pro.html
+++ b/public/pro.html
@@ -924,11 +924,11 @@ __GA_BOOTSTRAP__
 
     <div class="pricing-sidebar">
       <div class="team-card">
-        <div class="section-label" style="text-align:left;margin-bottom:8px;">When Team is better</div>
+        <div class="section-label" style="text-align:left;margin-bottom:8px;">When Enterprise is better</div>
         <h3>Need shared enforcement?</h3>
-        <p>Choose Team when one correction must protect multiple developers or agents across shared repositories, CI, approval policies, and audit trails. Team is $49/seat/mo with a 3-seat minimum after qualification.</p>
+        <p>Choose Enterprise when one correction must protect multiple developers or agents across shared repositories, CI, approval policies, and audit trails. Enterprise is custom pricing, scoped after intake.</p>
         <div class="hero-actions" style="margin-top:18px;">
-          <a class="btn-secondary" href="/#workflow-sprint-intake">Book a Team Pilot Call</a>
+          <a class="btn-secondary" href="/#workflow-sprint-intake">Book an Enterprise Pilot Call</a>
         </div>
       </div>
       <div class="team-card">

--- a/scripts/check-congruence.js
+++ b/scripts/check-congruence.js
@@ -19,9 +19,7 @@ const {
   getClaudePluginLatestDownloadUrl,
 } = require('./distribution-surfaces');
 const {
-  TEAM_MIN_SEATS,
-  TEAM_MONTHLY_PRICE_DOLLARS,
-  TEAM_PRICE_LABEL,
+  ENTERPRISE_PRICE_LABEL,
 } = require('./commercial-offer');
 
 const ROOT = path.join(__dirname, '..');
@@ -123,8 +121,13 @@ async function main() {
   const claudePluginReadme = read('.claude-plugin/README.md') || '';
   const claudeDesktopPacket = read('docs/CLAUDE_DESKTOP_EXTENSION.md') || '';
   const latestClaudePluginUrl = getClaudePluginLatestDownloadUrl(ROOT);
-  const teamSeatPrice = `$${TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`;
-  const teamSeatPricePattern = new RegExp(`\\$${TEAM_MONTHLY_PRICE_DOLLARS}/seat/mo`, 'i');
+  // Enterprise is the contact-sales tier (Free / Pro / Enterprise). The former
+  // Team tier is retired: it must NOT be advertised as a customer-facing tier on
+  // any buyer surface, and Enterprise must be present in its place.
+  const enterpriseTierPattern = /Enterprise/i;
+  // Catch the retired Team seat price even when markup (e.g. a <span>) splits
+  // "$49" from "/seat", or when it appears without a trailing "/mo".
+  const retiredTeamSeatPattern = /\$49\b[\s\S]{0,40}seat/i;
   const pricingSurfaceFiles = PRICING_SURFACE_ROOTS.flatMap(listTextFiles);
   const legacyPricingHits = [];
   for (const rel of pricingSurfaceFiles) {
@@ -223,28 +226,24 @@ async function main() {
     'public/guide.html must advertise the current Pro monthly and annual pricing'
   );
   check(
-    TEAM_MONTHLY_PRICE_DOLLARS === 49 && TEAM_MIN_SEATS === 3,
-    'scripts/commercial-offer.js must anchor Team at $49/seat/mo with a 3-seat minimum'
-  );
-  check(
-    TEAM_PRICE_LABEL.includes(teamSeatPrice),
-    'scripts/commercial-offer.js Team label must match the canonical Team seat price'
+    enterpriseTierPattern.test(ENTERPRISE_PRICE_LABEL),
+    'scripts/commercial-offer.js ENTERPRISE_PRICE_LABEL must describe the Enterprise tier'
   );
   check(
     legacyPricingHits.length === 0,
     `Legacy ThumbGate pricing found in public pricing surfaces: ${legacyPricingHits.join(', ')}`
   );
   check(
-    teamSeatPricePattern.test(guideHtml),
-    'public/guide.html must advertise the current Team pricing anchor'
+    enterpriseTierPattern.test(guideHtml),
+    'public/guide.html must advertise the Enterprise tier (Free / Pro / Enterprise)'
   );
   check(
     /Pro at \$19\/mo or \$149\/yr/i.test(commercialTruth),
     'docs/COMMERCIAL_TRUTH.md must record the current Pro offer'
   );
   check(
-    teamSeatPricePattern.test(commercialTruth),
-    'docs/COMMERCIAL_TRUTH.md must record the current Team pricing anchor'
+    enterpriseTierPattern.test(commercialTruth),
+    'docs/COMMERCIAL_TRUTH.md must record the Enterprise tier'
   );
   check(
     /shared lessons and org visibility/i.test(githubAbout.metaDescription),
@@ -255,28 +254,38 @@ async function main() {
     'README.md must advertise the current Pro monthly and annual pricing'
   );
   check(
-    teamSeatPricePattern.test(readmeMd),
-    'README.md must advertise the current Team pricing anchor'
+    enterpriseTierPattern.test(readmeMd),
+    'README.md must advertise the Enterprise tier'
   );
+  // Free / Pro / Enterprise must be the visible model everywhere a buyer looks,
+  // and the retired Team seat price must NOT reappear on any buyer surface.
   for (const [surface, text] of Object.entries({
     'public/index.html': landingHtml,
     'public/compare.html': compareHtml,
     'public/pro.html': proHtml,
+    'public/pricing.html': read('public/pricing.html') || '',
     'docs/landing-page.html': docsLandingHtml,
     'docs/marketing/product-hunt-launch-kit.md': productHuntLaunchKit,
+    'README.md': readmeMd,
+    'public/guide.html': guideHtml,
+    'docs/COMMERCIAL_TRUTH.md': commercialTruth,
   })) {
     check(
-      teamSeatPricePattern.test(text),
-      `${surface} must advertise the current Team pricing anchor`
+      enterpriseTierPattern.test(text),
+      `${surface} must advertise the Enterprise tier (Free / Pro / Enterprise)`
+    );
+    check(
+      !retiredTeamSeatPattern.test(text),
+      `${surface} must not advertise the retired Team tier ($49/seat/mo)`
     );
   }
   check(
     /shared hosted lesson db/i.test(readmeMd),
-    'README.md must describe the shared hosted Team lesson database'
+    'README.md must describe the shared hosted Enterprise lesson database'
   );
   check(
     /org dashboard/i.test(readmeMd),
-    'README.md must describe the Team org dashboard'
+    'README.md must describe the Enterprise org dashboard'
   );
   check(
     /history-aware/i.test(readmeMd),
@@ -313,15 +322,15 @@ async function main() {
   );
   check(
     /workflow-sprint-intake/.test(landingHtml),
-    'public/index.html must expose the team workflow intake path'
+    'public/index.html must expose the Enterprise workflow intake path'
   );
   check(
     /shared lesson db|shared lesson database/i.test(landingHtml),
-    'public/index.html must describe the shared Team lesson database'
+    'public/index.html must describe the shared Enterprise lesson database'
   );
   check(
     /org dashboard/i.test(landingHtml),
-    'public/index.html must describe the Team org dashboard'
+    'public/index.html must describe the Enterprise org dashboard'
   );
   check(
     /personal local dashboard/i.test(landingHtml),

--- a/scripts/commercial-offer.js
+++ b/scripts/commercial-offer.js
@@ -14,7 +14,12 @@ const TEAM_ANNUAL_PRICE_DOLLARS = 588;
 const TEAM_MIN_SEATS = 3;
 
 const PRO_PRICE_LABEL = '$19/mo or $149/yr (individual)';
-const TEAM_PRICE_LABEL = '$49/seat/mo — Agent governance for engineering teams';
+// Enterprise is the contact-sales tier (absorbs the former Team workflow + the
+// regulated-industry lane). Pricing is scoped after intake — no self-serve seat
+// price is surfaced. The dormant TEAM_* Stripe constants below remain only as
+// inert billing plumbing pending a dedicated cleanup; they are no longer a
+// customer-facing tier.
+const ENTERPRISE_PRICE_LABEL = 'Custom pricing, scoped after intake — Enterprise agent governance';
 
 function normalizePlanId(value) {
   const text = String(value || '').trim().toLowerCase();
@@ -68,6 +73,8 @@ function buildCaptureReceipt({ signal, feedbackId, memoryId, actionType } = {}) 
     '',
     `  Solo Pro       : ${PRO_PRICE_LABEL} for hosted sync, search, dashboard, and exports`,
     `  Upgrade        : ${trackedProUrl('cli_capture_receipt', actionType || normalizedSignal.toLowerCase())}`,
+    `  Enterprise     : ${ENTERPRISE_PRICE_LABEL}; start with one repeated workflow failure`,
+    '                   https://thumbgate.ai/#workflow-sprint-intake',
     '',
   ];
   return lines.join('\n');
@@ -100,6 +107,7 @@ function buildStatsReceipt(stats = {}) {
   lines.push('  Show the buyer     : npx thumbgate cost');
   lines.push('  Pro sync value     : keep these lessons/rules visible across laptops, CI, containers, and agent runtimes');
   lines.push(`  Solo Pro           : ${trackedProUrl('cli_stats_receipt', 'proof_seen')}`);
+  lines.push('  Enterprise         : https://thumbgate.ai/#workflow-sprint-intake');
   lines.push('');
   return lines.join('\n');
 }
@@ -116,7 +124,7 @@ module.exports = {
   TEAM_ANNUAL_PRICE_DOLLARS,
   TEAM_MIN_SEATS,
   PRO_PRICE_LABEL,
-  TEAM_PRICE_LABEL,
+  ENTERPRISE_PRICE_LABEL,
   normalizePlanId,
   normalizeBillingCycle,
   normalizeSeatCount,

--- a/scripts/org-dashboard.js
+++ b/scripts/org-dashboard.js
@@ -22,7 +22,7 @@ const { isProTier } = require('./rate-limiter');
 const {
   PRO_MONTHLY_PAYMENT_LINK,
   PRO_PRICE_LABEL,
-  TEAM_PRICE_LABEL,
+  ENTERPRISE_PRICE_LABEL,
 } = require('./commercial-offer');
 
 // ---------------------------------------------------------------------------
@@ -259,7 +259,7 @@ function generateOrgDashboard(opts = {}) {
   };
 
   if (!pro) {
-    summary.upgradeMessage = `Pro checkout: ${PRO_PRICE_LABEL} — ${PRO_MONTHLY_PAYMENT_LINK} | Team: ${TEAM_PRICE_LABEL} after workflow qualification.`;
+    summary.upgradeMessage = `Pro checkout: ${PRO_PRICE_LABEL} — ${PRO_MONTHLY_PAYMENT_LINK} | Enterprise: ${ENTERPRISE_PRICE_LABEL} after workflow qualification.`;
   }
 
   return summary;

--- a/scripts/pro-features.js
+++ b/scripts/pro-features.js
@@ -3,7 +3,7 @@ const { isProLicensed } = require('./license');
 const {
   PRO_MONTHLY_PAYMENT_LINK,
   PRO_PRICE_LABEL,
-  TEAM_PRICE_LABEL,
+  ENTERPRISE_PRICE_LABEL,
 } = require('./commercial-offer');
 
 const PRO_URL = PRO_MONTHLY_PAYMENT_LINK;
@@ -32,7 +32,7 @@ function requirePro(
   write(
     `\n  🔒 Pro Feature Required: ${desc}\n` +
     `     Pro: ${PRO_PRICE_LABEL} — ${PRO_URL}\n` +
-    `     Team: ${TEAM_PRICE_LABEL} after workflow qualification\n` +
+    `     Enterprise: ${ENTERPRISE_PRICE_LABEL} after workflow qualification\n` +
     `     Or run: npx thumbgate pro\n\n`
   );
   return false;

--- a/scripts/rate-limiter.js
+++ b/scripts/rate-limiter.js
@@ -6,7 +6,7 @@ const path = require('path');
 const {
   PRO_MONTHLY_PAYMENT_LINK,
   PRO_PRICE_LABEL,
-  TEAM_PRICE_LABEL,
+  ENTERPRISE_PRICE_LABEL,
 } = require('./commercial-offer');
 
 const USAGE_FILE = path.join(process.env.HOME || '/tmp', '.thumbgate', 'usage-limits.json');
@@ -31,7 +31,7 @@ const FREE_TIER_LIMITS = {
 const FREE_TIER_MAX_GATES = 3; // 3 active prevention rules on free; Pro is unlimited
 const FREE_TIER_DAILY_BLOCKS = 3; // 3 gate blocks/day on free; after limit, deny → warn + upgrade CTA
 
-const UPGRADE_MESSAGE = `Pro: ${PRO_PRICE_LABEL} — unlimited rules, recall, lesson search, dashboard, and exports: ${PRO_MONTHLY_PAYMENT_LINK}\n  Team: ${TEAM_PRICE_LABEL} after workflow qualification.`;
+const UPGRADE_MESSAGE = `Pro: ${PRO_PRICE_LABEL} — unlimited rules, recall, lesson search, dashboard, and exports: ${PRO_MONTHLY_PAYMENT_LINK}\n  Enterprise: ${ENTERPRISE_PRICE_LABEL} after workflow qualification.`;
 
 const PAYWALL_MESSAGES = {
   capture_feedback: 'Free tier: 5 captures/day (25 total). Your feedback is stored locally — upgrade to capture unlimited.',

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -769,8 +769,8 @@ test('pricing page is the single source of truth for what ThumbGate sells', asyn
   assert.match(body, /ThumbGate Pro/i);
   assert.match(body, /\$19/);
   assert.match(body, /\$149/);
-  assert.match(body, /ThumbGate Team/i);
-  assert.match(body, /\$49/);
+  assert.match(body, /ThumbGate Enterprise|<div class="tier">Enterprise/i);
+  assert.doesNotMatch(body, /\$49\b[\s\S]{0,40}seat/i);
   assert.doesNotMatch(body, /Workflow Hardening Sprint/i);
   assert.doesNotMatch(body, /\$499|\$1,500|\$97/);
   assert.doesNotMatch(body, /buy\.stripe\.com/);
@@ -779,7 +779,7 @@ test('pricing page is the single source of truth for what ThumbGate sells', asyn
   // CTAs route to the canonical paths.
   assert.match(body, /href="\/go\/install/);
   assert.match(body, /href="\/checkout\/pro/);
-  assert.match(body, /pricing_team_intake/);
+  assert.match(body, /pricing_enterprise_intake/);
   assert.match(body, /#workflow-sprint-intake/);
   // Cross-links so it's a navigation hub, not a dead end.
   assert.match(body, /href="\/support"/);

--- a/tests/check-congruence.test.js
+++ b/tests/check-congruence.test.js
@@ -46,16 +46,19 @@ test('GitHub About config keeps a rich landing description and a valid GitHub de
   assert.ok(about.githubDescription.length <= MAX_GITHUB_DESCRIPTION_LENGTH);
 });
 
-test('README commercial copy stays aligned with current Pro and Team packaging', () => {
+test('README commercial copy stays aligned with current Pro and Enterprise packaging', () => {
   const readme = execSync('sed -n \'1,320p\' README.md', { cwd: ROOT, encoding: 'utf-8' });
   assert.match(readme, /\$19\/mo or \$149\/yr/);
-  assert.match(readme, /\$49\/seat\/mo/);
+  assert.match(readme, /Enterprise \(custom pricing, scoped after intake\)/);
+  assert.doesNotMatch(readme, /\$49\/seat\/mo/);
   assert.match(readme, /shared hosted lesson DB/i);
   assert.match(readme, /org dashboard/i);
   assert.match(readme, /history-aware/i);
   assert.match(readme, /feedback session|open_feedback_session|append_feedback_context|finalize_feedback_session/i);
-  assert.match(readme, /unlimited feedback captures/i);
-  assert.match(readme, /3 active auto-promoted prevention rules/i);
+  // Free-tier copy must match what scripts/rate-limiter.js enforces (no "unlimited" lie).
+  assert.match(readme, /5 feedback captures\/day \(25 total\)/i);
+  assert.match(readme, /up to 3 active auto-promoted prevention rules/i);
+  assert.doesNotMatch(readme, /unlimited feedback captures/i);
   assert.match(readme, /lesson/i);
   assert.doesNotMatch(readme, /\$12\/seat\/mo/i);
   assert.doesNotMatch(readme, /shared team DB/i);

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -28,7 +28,7 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await expect(page.locator('.hero-pro', { hasText: /Workflow Hardening Sprint/ })).toBeVisible();
     await expect(page.locator('.offer-router')).toBeVisible();
     await expect(page.locator('.offer-route', { hasText: /Solo operator/ })).toBeVisible();
-    await expect(page.locator('.offer-route', { hasText: /Team workflow/ })).toBeVisible();
+    await expect(page.locator('.offer-route', { hasText: /Enterprise/ })).toBeVisible();
     await expect(page.locator('.offer-route', { hasText: /Still evaluating/ })).toBeVisible();
   });
 

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -18,7 +18,7 @@ test.describe('/pricing clickability — full CTA coverage', () => {
     await expect(cards).toHaveCount(3);
     await expect(page.locator('.price-card').nth(0).locator('.price')).toHaveText('$0');
     await expect(page.locator('#pro .price')).toContainText('$19');
-    await expect(page.locator('#team .price')).toContainText('$49');
+    await expect(page.locator('#enterprise .price')).toContainText('Custom');
   });
 
   // --- nav (5 anchors) ---
@@ -72,12 +72,12 @@ test.describe('/pricing clickability — full CTA coverage', () => {
     await expect(cta).toHaveAttribute('href', /utm_medium=hero_card/);
   });
 
-  test('Team card CTA "Send team workflow first" links to / with #workflow-sprint-intake', async ({ page }) => {
+  test('Enterprise card CTA "Talk to us" links to / with #workflow-sprint-intake', async ({ page }) => {
     await page.goto('/pricing');
-    const cta = page.locator('#team a.btn-team');
-    await expect(cta).toContainText('Send team workflow first');
+    const cta = page.locator('#enterprise a.btn-team');
+    await expect(cta).toContainText('Talk to us');
     await expect(cta).toHaveAttribute('href', /#workflow-sprint-intake$/);
-    await expect(cta).toHaveAttribute('href', /utm_medium=team_card/);
+    await expect(cta).toHaveAttribute('href', /utm_medium=enterprise_card/);
   });
 
   test('scope-first link below the grid links to #workflow-sprint-intake', async ({ page }) => {

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -50,7 +50,7 @@ test('pro landing page keeps the pricing section focused on the $19 Pro checkout
   assert.match(pricingSection, /Start Pro Now/);
   assert.match(pricingSection, /billed today/i);
   assert.match(pricingSection, /Restart|Start|Choose annual/);
-  assert.match(pricingSection, /Book a Team Pilot Call/);
+  assert.match(pricingSection, /Book an Enterprise Pilot Call/);
   assert.doesNotMatch(pricingSection, /<h3>ThumbGate Team/);
 });
 
@@ -96,7 +96,7 @@ test('pro landing page keeps services out of the Pro buyer path', () => {
   const proPage = readProPage();
 
   assert.match(proPage, /Team diagnostics and custom services are handled through intake, not this buyer path/);
-  assert.match(proPage, /Book a Team Pilot Call/);
+  assert.match(proPage, /Book an Enterprise Pilot Call/);
   assert.doesNotMatch(proPage, /data-pro-paid-recovery/);
   assert.doesNotMatch(proPage, /data-first-rule-link/);
   assert.doesNotMatch(proPage, /data-quick-read-link/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -84,7 +84,7 @@ test('public landing page exposes above-fold paid Pro CTA with canonical revenue
   assert.match(heroBlock, /aria-label="Choose the right ThumbGate path"/);
   assert.match(heroBlock, /Solo operator: Start Pro/);
   assert.match(heroBlock, /data-cta-id="router_start_pro"/);
-  assert.match(heroBlock, /Team workflow: Start with intake/);
+  assert.match(heroBlock, /Enterprise: Start with intake/);
   assert.match(heroBlock, /Still evaluating: Free CLI/);
   assert.match(landingPage, /function trackRevenueCta/);
   assert.match(landingPage, /plausible\('pricing_cta_click'/);
@@ -123,17 +123,18 @@ test('public landing page keeps optional GA4 and Search Console hooks available 
   assert.match(landingPage, /sendGa4Event\('begin_checkout'/);
 });
 
-test('public landing page includes pricing section with Free, Pro, and Team tiers', () => {
+test('public landing page includes pricing section with Free, Pro, and Enterprise tiers', () => {
   const landingPage = readLandingPage();
 
   assert.match(landingPage, /class="price-card/);
   assert.match(landingPage, /class="price-card pro"/);
-  assert.match(landingPage, /class="price-card team"/);
+  assert.match(landingPage, /class="price-card enterprise"/);
   assert.match(landingPage, /\$0/);
   assert.match(landingPage, /\$19/);
   assert.match(landingPage, /\/mo/);
-  assert.match(landingPage, /\$49/);
-  assert.match(landingPage, /\/seat\/mo/);
+  // Enterprise is contact-sales with custom pricing — no seat price ladder.
+  assert.match(landingPage, /<div class="tier"[^>]*>Enterprise<\/div>/);
+  assert.doesNotMatch(landingPage, /\$49\s*<span[^>]*>\s*\/seat\/mo/);
   // Free tier is intentionally capped so the npm package proves value without
   // cannibalizing Pro.
   assert.match(landingPage, /Block repeated mistakes daily/);
@@ -150,7 +151,23 @@ test('public landing page includes pricing section with Free, Pro, and Team tier
   assert.match(landingPage, /Start Workflow Hardening Sprint/);
 });
 
-test('public landing page keeps Team services intake-led instead of exposing a paid-service price ladder', () => {
+test('public landing page shows an at-a-glance plan comparison matrix with consistent, enforced free-tier limits', () => {
+  const landingPage = readLandingPage();
+
+  // The matrix must exist so buyers see plan differences without parsing cards.
+  assert.match(landingPage, /class="plan-matrix"/);
+  // Headers cover all three tiers.
+  assert.match(landingPage, /Free<br>/);
+  assert.match(landingPage, /Pro<br>/);
+  assert.match(landingPage, /Enterprise<br>/);
+  // Free-tier numbers must match what scripts/rate-limiter.js actually enforces
+  // (5 captures/day, 25 total, 3 active rules) — drift guard against README/card skew.
+  assert.match(landingPage, /5\/day \(25 total\)/);
+  // Enterprise is contact-sales; no seat price ladder anywhere on the page.
+  assert.doesNotMatch(landingPage, /\$49\s*\/\s*seat\s*\/\s*mo/);
+});
+
+test('public landing page keeps services intake-led instead of exposing a paid-service price ladder', () => {
   const landingPage = readLandingPage();
 
   assert.match(landingPage, /Have one AI-agent failure that keeps repeating\?/);
@@ -398,23 +415,23 @@ test('public landing page Pro tier uses outcome-framed bullets that justify upgr
   assert.match(landingPage, /HuggingFace dataset export/i);
 });
 
-test('public landing page includes an explicit Team rollout lane with shared workflow intake', () => {
+test('public landing page includes an explicit Enterprise rollout lane with shared workflow intake', () => {
   const landingPage = readLandingPage();
 
-  assert.match(landingPage, /<div class="tier">Team<\/div>/);
+  assert.match(landingPage, /<div class="tier"[^>]*>Enterprise<\/div>/);
   assert.match(landingPage, /Shared enforcement memory/i);
-  assert.match(landingPage, /Hosted review views/i);
+  assert.match(landingPage, /Shared lesson database/i);
   assert.match(landingPage, /Org dashboard/i);
-  assert.match(landingPage, /Check template library/i);
+  assert.match(landingPage, /Audit-grade decision trail/i);
   assert.match(landingPage, /workflow-sprint-intake/);
-  assert.match(landingPage, /Start Team Pilot Intake/i);
+  assert.match(landingPage, /Start Enterprise Pilot Intake/i);
   assert.match(landingPage, /id="team-pilot-intake-form"/);
   assert.match(landingPage, /data-team-intake-form/);
   assert.match(landingPage, /name="ctaPlacement" value="team_visible_intake"/);
   assert.match(landingPage, /name="utmMedium" value="visible_team_intake"/);
   assert.match(landingPage, /name="planId" value="team"/);
   assert.match(landingPage, /name="ctaId" value="workflow_sprint_intake"/);
-  assert.match(landingPage, /Team checkout happens after scope\./);
+  assert.match(landingPage, /Enterprise checkout happens after scope\./);
   assert.match(landingPage, /team_workflow_sprint_recovery_intake/);
   assert.match(landingPage, /scope_first/);
   assert.match(landingPage, /workflow_sprint_intake_started/);
@@ -747,13 +764,14 @@ test('public landing page includes pay-now Pro path and email capture gate', () 
   assert.doesNotMatch(landingPage, /props:\s*\{\s*email:/);
 });
 
-test('public landing page Team card is intake-led without a blind team checkout or free trial claim', () => {
+test('public landing page Enterprise card is intake-led without a blind checkout or free trial claim', () => {
   const landingPage = readLandingPage();
 
-  assert.match(landingPage, /Send team workflow first/);
-  assert.match(landingPage, /pricing_team_intake/);
-  assert.match(landingPage, /Team is \$49\/seat\/mo with a 3-seat minimum/);
-  assert.match(landingPage, /team rollouts start through intake/i);
+  assert.match(landingPage, /Start enterprise intake/i);
+  assert.match(landingPage, /pricing_enterprise_intake/);
+  assert.match(landingPage, /custom pricing/i);
+  assert.match(landingPage, /scoped after intake/i);
+  assert.doesNotMatch(landingPage, /\$49\s*\/\s*seat\s*\/\s*mo/);
   assert.doesNotMatch(landingPage, /Start 3-seat Team — \$147\/mo/);
   assert.doesNotMatch(landingPage, /pricing_team_self_serve/);
   assert.doesNotMatch(landingPage, /team_self_serve_checkout_started/);

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -100,7 +100,7 @@ test('landing page does not render empty revenue links', async () => {
   assert.doesNotMatch(html, /https:\/\/buy\.stripe\.com\/28E00j3Uge1E2dzgWL3sI2J/);
   assert.doesNotMatch(html, /https:\/\/buy\.stripe\.com\/6oU00j8aw2iWdWh9uj3sI2K/);
   assert.match(html, /#workflow-sprint-intake/);
-  assert.match(html, /Team checkout happens after scope\./);
+  assert.match(html, /Enterprise checkout happens after scope\./);
 });
 
 test('landing pricing section compares plan capabilities and limits clearly', async () => {
@@ -112,8 +112,8 @@ test('landing pricing section compares plan capabilities and limits clearly', as
   assert.match(html, /5\/day, 25 total/);
   assert.match(html, /3 active rules/);
   assert.match(html, /\$19\/mo or \$149\/yr/);
-  assert.match(html, /\$49\/seat\/mo after scope, 3-seat minimum/);
-  assert.match(html, /Team and Regulated plans start through intake/);
+  assert.match(html, /Custom — scoped after intake/);
+  assert.match(html, /Enterprise plans start through intake/);
 });
 
 test('homepage and pricing surfaces expose canonical and LLM context links', async () => {

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -436,6 +436,7 @@ test('commercial truth sources stay aligned across public and historical docs', 
   const directoryGuide = readText('docs/marketing/mcp-directories.md');
 
   assert.match(commercialTruth, /Pro at \$19\/mo or \$149\/yr/);
+  assert.match(commercialTruth, /Enterprise is the contact-sales tier: \*\*custom pricing, scoped after intake/i);
   assert.match(commercialTruth, /auto-promotion into prevention rules/);
   assert.match(commercialTruth, /Do not treat GitHub stars, watchers, dependents, or npm download counts as customer or revenue proof/);
 


### PR DESCRIPTION
## Why

Live pricing was incoherent: the homepage showed **Free / Pro / Team / Regulated**, `/pricing` showed **Free / Pro / Team / Enterprise**, the README contradicted the enforced free-tier limits, and a retired **Team** tier was still sold (`$49/seat/mo`). This makes the whole buyer surface tell one story: **Free / Pro / Enterprise**.

## What

- **`public/index.html`** — collapse the "Compare plans at a glance" matrix from Free/Pro/Team/Regulated → Free/Pro/Enterprise; remove the `$49/seat` anchor; fix the pricing-note.
- **`public/pricing.html`** — one coherent Enterprise card (**"Talk to us"**, custom pricing scoped after intake) with the Dialogflow CX fulfillment guard + Vertex/VPC bullets; drop the duplicate `enterprise-band` and the leftover team CTA/telemetry.
- **Regulated → Enterprise** — folds the regulated story (audit trail, VPC/SSO, regulatory templates) into the Enterprise contact-sales tier across guide, compare, pro, README, COMMERCIAL_TRUTH, product-hunt kit, docs landing, and the CLI/dashboard upgrade copy (`commercial-offer`, `rate-limiter`, `pro-features`, `org-dashboard`).
- **Truthful free-tier limits** — README/cards/matrix now match what `scripts/rate-limiter.js` enforces: **5 captures/day, 25 total, 3 active rules**.
- **Drift guards** — `check-congruence` requires Enterprise and forbids the retired `$49/seat` anchor (regex tightened to catch markup-split prices); a new `public-landing` test pins the matrix + enforced numbers.

## Verification (local, clean state)

- `node scripts/check-congruence.js` ✓
- public-landing + public-static-assets: **110/110** ✓
- api-server + seo-guides + seo-gsd + competitive-positioning: **412/412** ✓
- check-congruence/version-metadata/numbers-page/landing-page-claims/pro-parity/pro-landing/org-dashboard/daily-block-cap/free-to-paid-conversion-units/public-package-parity/public-bundle-ratchet: **117/117** ✓
- docs-claim-hygiene/thumbgate-scope/version-metadata: **20/20** ✓
- Playwright e2e (pricing + index clickability): **38/38** ✓

## Deliberately out of scope

- **Live Stripe catalog untouched** — the dormant Team price ID / seat-checkout plumbing (`billing.js`, `metered-billing.js`) stays dormant.
- A long tail of deep content pages (`public/guides/*`, `public/learn/*`, `llm-context.md`, `compare/agentix-labs.html`) and the `$499` one-time diagnostic SKU on `guide.html` still reference Team / older offers — separate follow-up, invisible to the primary pricing flow, does not break CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)