### PR TITLE
feat(dashboard): use local enterprise data chat

### DIFF
--- a/.changeset/open-enterprise-data-chat.md
+++ b/.changeset/open-enterprise-data-chat.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Move the Enterprise dashboard chatbot away from Dialogflow-first framing to a local/open-source Governed Data Chat path. `/v1/chat` now accepts `THUMBGATE_LOCAL_LLM_ENDPOINT` / `THUMBGATE_LOCAL_LLM_MODEL` for OpenAI-compatible local models, augments lesson retrieval with optional LanceDB vector matches, and exposes `/v1/enterprise/data-chat/*` as the primary enterprise status/chat API while retaining legacy `/dialogflow/*` aliases.

--- a/README.md
+++ b/README.md
@@ -539,11 +539,13 @@ Free and self-hosted users can invoke `search_lessons` directly through MCP, and
 
 ---
 
-## Enterprise Gating (Vertex AI & Google Cloud)
+## Enterprise Data Chat and Optional Google Adapters
 
-For enterprise subscriptions, ThumbGate natively integrates with Google Cloud Platform and **Vertex AI** to route all agent checks through compliant Gemini models inside your corporate VPC.
+The Enterprise dashboard chat is local/open-source first: it answers over local ThumbGate data using lesson retrieval, LanceDB-backed vectors, and your configured LLM. Set `THUMBGATE_LOCAL_LLM_ENDPOINT` to an OpenAI-compatible local endpoint (Ollama, llama.cpp, vLLM, LM Studio, etc.) when you want generated answers without sending dashboard data to Google.
 
-### Zero-Friction Setup
+Google Cloud is an optional regulated-enterprise adapter, not a dashboard chatbot requirement. If a buyer already standardizes on Vertex AI or Dialogflow CX, ThumbGate can verify that posture and deploy guard adapters in their tenancy.
+
+### Optional Vertex Setup
 To wire local ThumbGate scoring to Vertex AI, run:
 ```bash
 npx thumbgate setup-vertex
@@ -552,7 +554,7 @@ npx thumbgate setup-vertex
 * **Auto-Enablement:** Programmatically enables the Vertex AI API in your project.
 * **Auto-Configuration:** Writes local Vertex routing settings to your `.env` file.
 
-This command does **not** create or verify a live Dialogflow CX agent. On current Google Cloud CLI installs, the old alpha gcloud CX command group is not available; verify Conversational Agents / Dialogflow CX with the Google Cloud console or the official Dialogflow CX REST API (`projects.locations.agents`) before claiming a live DFCX deployment.
+This command does **not** create or verify a live Dialogflow CX agent. Dialogflow is only relevant when a customer wants ThumbGate guard adapters in front of their own production DFCX agents. On current Google Cloud CLI installs, the old alpha gcloud CX command group is not available; verify Conversational Agents / Dialogflow CX with the Google Cloud console or the official Dialogflow CX REST API (`projects.locations.agents`) before claiming a live DFCX deployment.
 
 ### Zero-Friction Cost Containment ($10/mo Hard Cap)
 Google Cloud budget alerts are "alert-only" and do not stop API traffic, risking unexpected bill shock. ThumbGate completely resolves this on the client side:

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -308,7 +308,7 @@
     <div class="tab active" onclick="switchTab('search')">🔍 Search Memories</div>
     <div class="tab" onclick="switchTab('gates')">🛡️ Active Gates</div>
     <div class="tab" onclick="switchTab('team')">👥 Team</div>
-    <div class="tab" onclick="switchTab('enterprise')">🏢 Enterprise Data Chat</div>
+    <div class="tab" onclick="switchTab('enterprise')">🏢 Governed Data Chat</div>
     <div class="tab" onclick="switchTab('ai-inventory')">🧬 AI Inventory</div>
     <div class="tab" onclick="switchTab('generated')">🧩 Generated Views</div>
     <div class="tab" onclick="switchTab('settings')">⚙️ Policy Origins</div>
@@ -416,25 +416,25 @@
   <!-- ENTERPRISE CHAT TAB -->
   <div class="tab-content" id="tab-enterprise">
     <div class="templates-section">
-      <h2>Enterprise Data Chat</h2>
-      <p class="template-summary">Ask questions over local ThumbGate feedback, lessons, gates, team posture, and Vertex/DFCX readiness. This is a governed local data-query panel with a DFCX-compatible guard before data access; it does not claim a live Google Dialogflow CX agent unless deployment evidence is configured.</p>
+      <h2>Governed Data Chat</h2>
+      <p class="template-summary">Ask questions over your local ThumbGate data (lessons, raw feedback via LanceDB vectors, gate stats, receipts). Uses local retrieval plus your configured LLM, including open-source/local endpoints through <code>THUMBGATE_LOCAL_LLM_ENDPOINT</code>. Dialogflow is not the chatbot layer; DFCX/Vertex cards are optional deployment-readiness checks for buyers who run their own Google agent stack.</p>
       <div class="enterprise-chat-layout">
         <div class="panel">
           <h3>Chat With Local ThumbGate Data</h3>
-          <textarea class="enterprise-chat-box" id="enterpriseChatPrompt" placeholder="Ask: What mistakes are recurring? Which gates blocked the most? Is Vertex configured? What is our DFCX readiness?"></textarea>
+          <textarea class="enterprise-chat-box" id="enterpriseChatPrompt" placeholder="Ask: What mistakes are recurring? Which gates blocked the most? Are we running local-only or cloud-integrated?"></textarea>
           <div style="display:flex;gap:10px;align-items:center;margin-top:12px;flex-wrap:wrap;">
             <button class="btn" id="enterpriseChatBtn" onclick="sendEnterpriseChat()">Ask ThumbGate</button>
             <button class="btn-outline" onclick="setEnterprisePrompt('Which gates are blocking risky actions?')">Gates</button>
             <button class="btn-outline" onclick="setEnterprisePrompt('What feedback mistakes keep repeating?')">Feedback</button>
-            <button class="btn-outline" onclick="setEnterprisePrompt('Is Vertex and DFCX configured?')">Cloud</button>
+            <button class="btn-outline" onclick="setEnterprisePrompt('Are we running local-only or cloud-integrated?')">Runtime</button>
           </div>
           <div class="enterprise-answer" id="enterpriseChatAnswer">Connect your dashboard, then ask about local ThumbGate data.</div>
           <div class="enterprise-source-list" id="enterpriseChatSources"></div>
         </div>
         <div class="panel">
-          <h3>Enterprise Readiness</h3>
+          <h3>Runtime Readiness</h3>
           <div class="inventory-tools" id="enterpriseStatusCards"><div class="loading">Loading enterprise status...</div></div>
-          <div class="template-summary" style="margin-top:14px;margin-bottom:0;">Live DFCX proof must come from the Conversational Agents console, deployed webhook URL, Cloud Run logs, or the Dialogflow CX REST API <code style="font-family:var(--mono);font-size:12px;">projects.locations.agents</code>. Without that proof, the panel stays local-only.</div>
+          <div class="template-summary" style="margin-top:14px;margin-bottom:0;">The chat itself is local RAG plus your LLM. Open-source/local models are the default enterprise path; DFCX/Vertex readiness is optional evidence for teams that already operate Google agents in their own tenancy.</div>
         </div>
       </div>
     </div>
@@ -1308,7 +1308,7 @@ function renderDashboardData(data) {
   renderTemplates(data.templateLibrary || {});
   renderInsights(data);
   loadAiInventory();
-  loadEnterpriseDialogflowStatus();
+  loadEnterpriseDataChatStatus();
 }
 
 async function loadAiInventory() {
@@ -1813,28 +1813,29 @@ function renderEnterpriseStatus(status) {
   if (!target) return;
   var vertex = status && status.vertex ? status.vertex : {};
   var dfcx = status && status.dfcx ? status.dfcx : {};
-  var connectionMode = dfcx.liveAgentConfigured
-    ? 'Dialogflow CX configured'
-    : (vertex.configured ? 'Vertex configured' : 'Local-only');
+  var localLlm = status && status.chat ? status.chat.localLlmEndpointConfigured : false;
+  var connectionMode = localLlm
+    ? 'Local/open-source LLM configured'
+    : (dfcx.liveAgentConfigured ? 'Google agent guard configured' : (vertex.configured ? 'Vertex routing configured' : 'Local deterministic fallback'));
   var rows = [
-    { name: 'Connection mode', value: connectionMode, note: dfcx.liveAgentConfigured ? 'Live DFCX evidence is present in env.' : (vertex.configured ? 'Vertex routing is configured; DFCX still needs live-agent proof.' : 'Local data Q&A only; no cloud agent claim.') },
-    { name: 'Vertex routing', value: vertex.configured ? 'Configured' : 'Not configured', note: vertex.projectId ? ('Project: ' + vertex.projectId + ' · ' + (vertex.location || '')) : 'Run setup-vertex or set GOOGLE_VERTEX_PROJECT.' },
-    { name: 'DFCX live agent', value: dfcx.liveAgentConfigured ? 'Env present' : 'Not proven', note: dfcx.verification || 'Verify with REST/console evidence.' },
-    { name: 'Fulfillment proxy', value: dfcx.fulfillmentProxyConfigured ? 'Configured' : 'Not configured', note: 'Set THUMBGATE_DFCX_FULFILLMENT_URL for a deployed proxy.' },
-    { name: 'gcloud CX command', value: 'Unsupported', note: 'Do not use the old alpha gcloud CX command group; use REST API or console.' }
+    { name: 'Chat runtime', value: connectionMode, note: localLlm ? 'Using THUMBGATE_LOCAL_LLM_ENDPOINT for local/open-source inference.' : 'Local deterministic summaries work without cloud credentials; configure a local LLM for generated answers.' },
+    { name: 'Data boundary', value: 'Local by default', note: 'Dashboard answers are grounded in local ThumbGate data and do not require Google Cloud.' },
+    { name: 'Vertex adapter', value: vertex.configured ? 'Configured' : 'Optional', note: vertex.projectId ? ('Project: ' + vertex.projectId + ' · ' + (vertex.location || '')) : 'Only needed when the buyer chooses Google-hosted routing.' },
+    { name: 'Dialogflow guard adapter', value: dfcx.liveAgentConfigured ? 'Configured' : 'Optional', note: dfcx.verification || 'Only needed for customer-owned Dialogflow CX agent deployments.' },
+    { name: 'Legacy gcloud CX command', value: 'Unsupported', note: 'Do not use the old alpha gcloud CX command group; use REST API or console for DFCX proof.' }
   ];
   target.innerHTML = rows.map(function(row) {
     return '<div class="inventory-row"><div><div class="inventory-name">' + escHtml(row.name) + '</div><div class="inventory-subtitle">' + escHtml(row.note) + '</div></div><span class="remediation-action">' + escHtml(row.value) + '</span></div>';
   }).join('');
 }
 
-async function loadEnterpriseDialogflowStatus() {
+async function loadEnterpriseDataChatStatus() {
   if (!API_KEY || isDemo) {
     renderEnterpriseStatus({ vertex: {}, dfcx: { verification: 'Connect to load local status.' } });
     return;
   }
   try {
-    var res = await fetch('/v1/enterprise/dialogflow/status', { headers: getHeaders() });
+    var res = await fetch('/v1/enterprise/data-chat/status', { headers: getHeaders() });
     if (!res.ok) throw new Error('status unavailable');
     renderEnterpriseStatus(await res.json());
   } catch (err) {
@@ -1864,26 +1865,27 @@ async function sendEnterpriseChat() {
   }
   button.disabled = true;
   answer.className = 'enterprise-answer';
-    answer.textContent = 'Running the data-access guard and reading local dashboard data...';
+  answer.textContent = 'Local RAG (LanceDB + lessons) plus your LLM...';
   sources.innerHTML = '';
   try {
-    var res = await fetch('/v1/enterprise/dialogflow/chat', {
+    var res = await fetch('/v1/chat', {
       method: 'POST',
       headers: getHeaders(),
-      body: JSON.stringify({ prompt: prompt })
+      body: JSON.stringify({ question: prompt })
     });
     var data = await res.json();
-    if (!res.ok) throw new Error(data.detail || data.error || 'chat failed');
-    answer.className = 'enterprise-answer' + (data.blocked ? ' blocked' : '');
-    answer.textContent = data.answer || 'No answer returned.';
+    if (!res.ok) throw new Error(data.detail || data.error || data.message || 'chat failed');
+    answer.className = 'enterprise-answer';
+    answer.textContent = data.answer || data.message || 'No answer returned.';
     var list = Array.isArray(data.sources) ? data.sources : [];
     sources.innerHTML = list.map(function(source) {
-      return '<span class="enterprise-source">' + escHtml(source) + '</span>';
+      var label = typeof source === 'string' ? source : (source && (source.title || source.id || ''));
+      return '<span class="enterprise-source">' + escHtml(label) + '</span>';
     }).join('');
-    renderEnterpriseStatus(data.status || {});
+    loadEnterpriseDataChatStatus();
   } catch (err) {
     answer.className = 'enterprise-answer blocked';
-    answer.textContent = err.message || 'Enterprise chat failed.';
+    answer.textContent = err.message || 'Chat failed. Configure a local LLM endpoint or API key for RAG.';
   } finally {
     button.disabled = false;
   }

--- a/scripts/dashboard-chat.js
+++ b/scripts/dashboard-chat.js
@@ -2,15 +2,15 @@
 
 // scripts/dashboard-chat.js
 // -----------------------------------------------------------------------------
-// "Chat with your data" — the dashboard chat backend. Answers a natural-language
-// question about THIS install's ThumbGate data (captured lessons + prevention
-// rules) by retrieving the most relevant lessons and asking Gemini to answer
-// grounded ONLY in that retrieved context (RAG). No data leaves the box except
-// the retrieved snippets + the question, sent to the configured Gemini endpoint.
+// "Chat with your data" — the dashboard chat backend. Local-first RAG over
+// this install's ThumbGate data (lessons, raw feedback memories via LanceDB
+// vectors, receipts, gate stats). Retrieval is local (lesson search + optional
+// vector-store.searchSimilar). Generation uses your configured LLM: a local
+// OpenAI-compatible endpoint first, then Gemini or Perplexity when explicitly
+// configured.
 //
-// Enterprise framing: this is the in-product "chat with your governed data"
-// experience. (The Dialogflow CX messenger widget is the separate path where a
-// customer connects their own DFCX agent + the ThumbGate webhook gate.)
+// Dialogflow/Google is not the dashboard chatbot brain. It remains an optional
+// guard-adapter path for buyers who already run their own Google agent tenancy.
 // -----------------------------------------------------------------------------
 
 const path = require('path');
@@ -40,7 +40,7 @@ function resolveModel(requested) {
 
 function resolveApiKey(opts = {}) {
   let key = '';
-  if (Object.prototype.hasOwnProperty.call(opts, 'apiKey')) {
+  if (Object.hasOwn(opts, 'apiKey')) {
     key = opts.apiKey || '';
   } else {
     key = opts.apiKey || process.env.GEMINI_API_KEY || process.env.THUMBGATE_GEMINI_API_KEY || process.env.GOOGLE_API_KEY || process.env.PERPLEXITY_API_KEY || process.env.THUMBGATE_PERPLEXITY_API_KEY || '';
@@ -49,31 +49,91 @@ function resolveApiKey(opts = {}) {
   return key.trim().replace(/^["']|["']$/g, '');
 }
 
-// Retrieve the most relevant stored lessons for the question.
-function retrieveContext(question, opts = {}) {
-  let searchLessons;
+function debugChatFallback(label, err) {
+  if (process.env.THUMBGATE_DEBUG_CHAT !== '1') return;
+  const detail = err?.message ? err.message : String(err);
+  console.warn(`[dashboard-chat] ${label}: ${detail}`);
+}
+
+function loadLessonSearcher() {
   try {
-    ({ searchLessons } = require(path.join(__dirname, 'lesson-search')));
-  } catch (_) {
-    return [];
+    return require(path.join(__dirname, 'lesson-search')).searchLessons;
+  } catch (err) {
+    debugChatFallback('lesson search unavailable', err);
+    return null;
   }
-  let res;
+}
+
+function lessonToContextItem(lesson) {
+  return {
+    id: lesson.id,
+    signal: lesson.signal || lesson.feedback || '',
+    title: (lesson.title || '').replace(/^(?:MISTAKE|SUCCESS):\s*/i, '').slice(0, 160),
+    content: String(lesson.content || lesson.context || '').replace(/\s+/g, ' ').trim().slice(0, 600),
+    tags: lesson.tags || [],
+    source: 'lessons',
+  };
+}
+
+function vectorMatchToContextItem(match, index) {
+  return {
+    id: match.id || `vec-${index}`,
+    signal: match.signal || '',
+    title: String(match.context || match.text || '').slice(0, 100),
+    content: match.text || match.context || '',
+    tags: match.tags ? String(match.tags).split(',').filter(Boolean) : [],
+    source: 'lancedb-vector',
+  };
+}
+
+function dedupeContextItems(items, limit = MAX_CONTEXT_LESSONS + 3) {
+  const seen = new Set();
+  return items.filter((item) => {
+    if (!(item.content || item.title)) return false;
+    const key = item.id || item.content.slice(0, 80);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).slice(0, limit);
+}
+
+function retrieveLessonContext(question, opts = {}) {
+  const searchLessons = loadLessonSearcher();
+  if (!searchLessons) return [];
   try {
-    res = searchLessons(String(question || ''), {
+    const res = searchLessons(String(question || ''), {
       limit: MAX_CONTEXT_LESSONS,
       feedbackDir: opts.feedbackDir,
     });
-  } catch (_) {
+    const rows = res?.results || res?.lessons || [];
+    return rows.slice(0, MAX_CONTEXT_LESSONS).map(lessonToContextItem);
+  } catch (err) {
+    debugChatFallback('lesson retrieval failed', err);
     return [];
   }
-  const rows = (res && (res.results || res.lessons)) || [];
-  return rows.slice(0, MAX_CONTEXT_LESSONS).map((l) => ({
-    id: l.id,
-    signal: l.signal || l.feedback || '',
-    title: (l.title || '').replace(/^(?:MISTAKE|SUCCESS):\s*/i, '').slice(0, 160),
-    content: String(l.content || l.context || '').replace(/\s+/g, ' ').trim().slice(0, 600),
-    tags: l.tags || [],
-  })).filter((l) => l.content || l.title);
+}
+
+async function retrieveVectorContext(question, opts = {}) {
+  if (opts.useVectorSearch === false) return [];
+  try {
+    const vectorStore = require(path.join(__dirname, 'vector-store'));
+    const vecResults = vectorStore.searchSimilar
+      ? await vectorStore.searchSimilar(String(question || ''), opts.vectorLimit || 4)
+      : [];
+    return vecResults
+      .filter((match) => match?.text)
+      .map(vectorMatchToContextItem);
+  } catch (err) {
+    debugChatFallback('vector retrieval failed', err);
+    return [];
+  }
+}
+
+// Retrieve relevant stored lessons and optional raw feedback vector matches.
+async function retrieveContext(question, opts = {}) {
+  const lessons = retrieveLessonContext(question, opts);
+  const vectors = await retrieveVectorContext(question, opts);
+  return dedupeContextItems([...lessons, ...vectors]);
 }
 
 // Build a grounded RAG prompt. Pure function (testable).
@@ -97,13 +157,77 @@ function buildChatPrompt(question, lessons) {
 
 // Parse the Gemini generateContent response into plain text. Pure (testable).
 function parseGeminiAnswer(body) {
-  const parts = body
-    && body.candidates
-    && body.candidates[0]
-    && body.candidates[0].content
-    && body.candidates[0].content.parts;
+  const parts = body?.candidates?.[0]?.content?.parts;
   if (!Array.isArray(parts)) return '';
   return parts.map((p) => (p && typeof p.text === 'string' ? p.text : '')).join('').trim();
+}
+
+function buildOpenAiChatPayload(prompt, model) {
+  return JSON.stringify({
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0.2,
+    max_tokens: 1024,
+  });
+}
+
+function parseOpenAiChatAnswer(json) {
+  return json?.choices?.[0]?.message?.content || '';
+}
+
+function parseModelError(json, status) {
+  return json?.error?.message ? String(json.error.message).split('\n')[0] : `HTTP ${status}`;
+}
+
+async function callLocalOpenAiEndpoint({ endpoint, apiKey, model, prompt, fetchImpl, sources }) {
+  const url = endpoint.includes('/chat/completions')
+    ? endpoint
+    : endpoint.replace(/\/+$/, '') + '/chat/completions';
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'Authorization': `Bearer ${apiKey || 'local'}`
+    },
+    body: buildOpenAiChatPayload(prompt, model),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: 'local_llm_error', status: res.status, message: parseModelError(json, res.status), sources };
+  }
+  const answer = parseOpenAiChatAnswer(json);
+  return { ok: true, answer: answer.trim() || '(no answer returned)', sources, model: json.model || model };
+}
+
+async function callPerplexityEndpoint({ apiKey, prompt, fetchImpl, sources }) {
+  const res = await fetchImpl(PERPLEXITY_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+    body: buildOpenAiChatPayload(prompt, 'sonar'),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: 'perplexity_error', status: res.status, message: parseModelError(json, res.status), sources };
+  }
+  const answer = parseOpenAiChatAnswer(json);
+  return { ok: true, answer: answer.trim() || '(no answer returned)', sources, model: json.model || 'perplexity-hybrid' };
+}
+
+async function callGeminiEndpoint({ apiKey, model, prompt, fetchImpl, sources }) {
+  const res = await fetchImpl(`${GEMINI_ENDPOINT}/${encodeURIComponent(model)}:generateContent`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-goog-api-key': apiKey },
+    body: JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.2, maxOutputTokens: 1024 },
+    }),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    return { ok: false, error: 'gemini_error', status: res.status, message: parseModelError(json, res.status), sources };
+  }
+  const answer = parseGeminiAnswer(json);
+  return { ok: true, answer: answer || '(no answer returned)', sources, model: json.modelVersion || model };
 }
 
 // Answer a question grounded in this install's lessons. Returns
@@ -115,15 +239,17 @@ async function answerDataQuestion(question, opts = {}) {
     return { ok: false, error: 'question_too_long', message: `Question exceeds ${MAX_QUESTION_CHARS} characters.` };
   }
 
+  const localEndpoint = opts.localEndpoint || process.env.THUMBGATE_LOCAL_LLM_ENDPOINT || '';
+  const localModel = opts.localModel || process.env.THUMBGATE_LOCAL_LLM_MODEL || 'llama3';
   const apiKey = resolveApiKey(opts);
-  const lessons = retrieveContext(q, opts);
+  const lessons = await retrieveContext(q, opts);
   const sources = lessons.map((l) => ({ id: l.id, title: l.title, signal: l.signal }));
 
-  if (!apiKey) {
+  if (!apiKey && !localEndpoint) {
     return {
       ok: false,
       error: 'no_api_key',
-      message: 'Chat is not configured. Set a valid GEMINI_API_KEY or PERPLEXITY_API_KEY (for hybrid local-cloud) in the project .env or via dashboard Save. See adapters/perplexity/HYBRID.md.',
+      message: 'Chat is not configured. Set a valid GEMINI_API_KEY, PERPLEXITY_API_KEY, or THUMBGATE_LOCAL_LLM_ENDPOINT in the project .env.',
       sources,
     };
   }
@@ -131,47 +257,14 @@ async function answerDataQuestion(question, opts = {}) {
   const model = resolveModel(opts.model);
   const prompt = buildChatPrompt(q, lessons);
   const fetchImpl = opts.fetch || globalThis.fetch;
-  const isPerplexity = apiKey.startsWith('pplx-') || apiKey.includes('perplexity');
+  const isPerplexity = apiKey && (apiKey.startsWith('pplx-') || apiKey.includes('perplexity'));
 
   try {
-    if (isPerplexity) {
-      // Use Perplexity hybrid-capable API (OpenAI compatible) for RAG chat with your data
-      const res = await fetchImpl(PERPLEXITY_ENDPOINT, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
-        body: JSON.stringify({
-          model: 'sonar', // or llama-3.1 etc for hybrid
-          messages: [{ role: 'user', content: prompt }],
-          temperature: 0.2,
-          max_tokens: 1024,
-        }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        const msg = (json && json.error && json.error.message) ? String(json.error.message).split('\n')[0] : `HTTP ${res.status}`;
-        return { ok: false, error: 'perplexity_error', status: res.status, message: msg, sources };
-      }
-      const answer = (json.choices && json.choices[0] && json.choices[0].message && json.choices[0].message.content) || '';
-      return { ok: true, answer: answer.trim() || '(no answer returned)', sources, model: json.model || 'perplexity-hybrid' };
-    } else {
-      const res = await fetchImpl(`${GEMINI_ENDPOINT}/${encodeURIComponent(model)}:generateContent`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', 'x-goog-api-key': apiKey },
-        body: JSON.stringify({
-          contents: [{ role: 'user', parts: [{ text: prompt }] }],
-          generationConfig: { temperature: 0.2, maxOutputTokens: 1024 },
-        }),
-      });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        const msg = (json && json.error && json.error.message) ? String(json.error.message).split('\n')[0] : `HTTP ${res.status}`;
-        return { ok: false, error: 'gemini_error', status: res.status, message: msg, sources };
-      }
-      const answer = parseGeminiAnswer(json);
-      return { ok: true, answer: answer || '(no answer returned)', sources, model: json.modelVersion || model };
-    }
+    if (localEndpoint) return await callLocalOpenAiEndpoint({ endpoint: localEndpoint, apiKey, model: localModel, prompt, fetchImpl, sources });
+    if (isPerplexity) return await callPerplexityEndpoint({ apiKey, prompt, fetchImpl, sources });
+    return await callGeminiEndpoint({ apiKey, model, prompt, fetchImpl, sources });
   } catch (err) {
-    return { ok: false, error: 'network', message: err && err.message ? err.message : String(err), sources };
+    return { ok: false, error: 'network', message: err?.message || String(err), sources };
   }
 }
 

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -678,6 +678,51 @@ function resolveRequestProjectDir(req, parsed) {
   });
 }
 
+function debugApiFallback(label, error) {
+  if (process.env.THUMBGATE_DEBUG_API !== '1') return;
+  console.warn(`[api] ${label}: ${error?.message || String(error)}`);
+}
+
+function stripEnvQuotes(value) {
+  return String(value || '').trim().replace(/^["']|["']$/g, '');
+}
+
+function extractEnvValue(content, names) {
+  const pattern = new RegExp(`^(?:${names.join('|')})=(.*)$`, 'm');
+  const match = pattern.exec(content);
+  return match ? stripEnvQuotes(match[1]) : '';
+}
+
+function readProjectChatSettings(req, parsed) {
+  const settings = {
+    geminiKey: '',
+    perplexityKey: '',
+    localEndpoint: '',
+    localModel: '',
+    geminiValidatedAt: null,
+  };
+  try {
+    const projectDir = resolveRequestProjectDir(req, parsed);
+    const envPath = path.join(projectDir, '.env');
+    if (fs.existsSync(envPath)) {
+      const content = fs.readFileSync(envPath, 'utf8');
+      settings.geminiKey = extractEnvValue(content, ['GEMINI_API_KEY', 'GOOGLE_API_KEY', 'THUMBGATE_GEMINI_API_KEY']);
+      settings.perplexityKey = extractEnvValue(content, ['PERPLEXITY_API_KEY', 'THUMBGATE_PERPLEXITY_API_KEY']);
+      settings.localEndpoint = extractEnvValue(content, ['THUMBGATE_LOCAL_LLM_ENDPOINT']);
+      settings.localModel = extractEnvValue(content, ['THUMBGATE_LOCAL_LLM_MODEL']);
+    }
+
+    const statusPath = path.join(projectDir, '.gemini-validated.json');
+    if (fs.existsSync(statusPath)) {
+      const status = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
+      settings.geminiValidatedAt = status.validatedAt || null;
+    }
+  } catch (error) {
+    debugApiFallback('project chat settings unavailable', error);
+  }
+  return settings;
+}
+
 function shouldPreferProjectScopedFeedback(req, parsed) {
   const explicitProject = getEffectiveRequestedProjectSelection(req, parsed);
   if (explicitProject) return true;
@@ -1455,7 +1500,7 @@ async function loadLiveDashboardDataOrRespondProblem(res, parsed, feedbackDir, i
   }
 }
 
-function buildEnterpriseDialogflowStatus(env = process.env) {
+function buildEnterpriseDataChatStatus(env = process.env) {
   const vertexProject = normalizeNullableText(env.VERTEX_PROJECT_ID)
     || normalizeNullableText(env.GOOGLE_VERTEX_PROJECT);
   const vertexLocation = normalizeNullableText(env.GOOGLE_VERTEX_LOCATION)
@@ -1487,11 +1532,15 @@ function buildEnterpriseDialogflowStatus(env = process.env) {
     },
     chat: {
       available: true,
-      source: 'local ThumbGate dashboard data',
-      guard: 'DFCX-compatible pre-action gate adapter',
+      source: 'local ThumbGate dashboard data with LanceDB-backed retrieval',
+      guard: 'local data-access guard; DFCX adapter optional for customer Dialogflow deployments',
+      providerRequired: false,
+      localLlmEndpointConfigured: Boolean(normalizeNullableText(env.THUMBGATE_LOCAL_LLM_ENDPOINT)),
     },
   };
 }
+
+const buildEnterpriseDialogflowStatus = buildEnterpriseDataChatStatus;
 
 function normalizeEnterpriseChatPrompt(value) {
   const text = normalizeNullableText(value);
@@ -1518,60 +1567,89 @@ function compactNumber(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
-function buildEnterpriseChatAnswer(prompt, dashboardData, status) {
-  const topic = classifyEnterpriseChatTopic(prompt);
+function buildEnterpriseChatSection(topic, dashboardData, status) {
   const approval = dashboardData.approval || {};
   const gates = Array.isArray(dashboardData.gates) ? dashboardData.gates : [];
   const gateStats = dashboardData.gateStats || {};
   const team = dashboardData.team || {};
   const tokenSavings = dashboardData.tokenSavings || {};
   const lessonPipeline = dashboardData.lessonPipeline || {};
-  const lines = [];
-  const sources = ['local dashboard data'];
 
   if (topic === 'feedback') {
-    lines.push(`Feedback total: ${compactNumber(approval.total)} (${compactNumber(approval.positive)} positive, ${compactNumber(approval.negative)} negative).`);
-    lines.push(`Lesson pipeline: ${compactNumber(lessonPipeline.lessons || lessonPipeline.generated || 0)} lessons visible in the current dashboard snapshot.`);
-    sources.push('feedback log', 'lesson pipeline');
-  } else if (topic === 'gates') {
-    lines.push(`Active gates: ${gates.length || compactNumber(gateStats.totalGates)}.`);
-    lines.push(`Blocked actions recorded: ${compactNumber(gateStats.blocked || gateStats.denied || gateStats.totalBlocked)}.`);
-    if (gates[0]) lines.push(`Example gate: ${gates[0].name || gates[0].id || 'unnamed gate'}.`);
-    sources.push('gate stats');
-  } else if (topic === 'team') {
-    lines.push(`Team dashboard is available in this local Enterprise view.`);
-    lines.push(`Tracked agents: ${compactNumber(team.totalAgents || team.agentCount || 0)}; risky agents: ${compactNumber(team.riskyAgents || team.highRiskAgents || 0)}.`);
-    sources.push('team dashboard');
-  } else if (topic === 'cost') {
-    lines.push(`Estimated token savings: ${tokenSavings.dollarsSavedDisplay || '$0.00'} from ${compactNumber(tokenSavings.blockedCalls)} blocked calls.`);
-    lines.push('Google Cloud budget alerts are evidence for spend visibility; ThumbGate-side stop conditions must be verified separately before calling them a hard cap.');
-    sources.push('token savings', 'budget posture');
-  } else if (topic === 'cloud') {
-    lines.push(status.vertex.configured
-      ? `Vertex routing config is present for project ${status.vertex.projectId} (${status.vertex.location}).`
-      : 'Vertex routing config is not present in this server environment.');
-    lines.push(status.dfcx.liveAgentConfigured
-      ? `DFCX env has agent ${status.dfcx.agentId} in ${status.dfcx.location}; verify it with REST/console before production claims.`
-      : 'No live DFCX agent is configured in env. Do not use the old alpha gcloud CX command group; verify agents with the Dialogflow CX REST API or console.');
-    sources.push('enterprise cloud status');
-  } else {
-    lines.push('Ask about feedback, lessons, active gates, team rollout, token savings, or Vertex/DFCX readiness.');
-    lines.push(`Current local snapshot: ${compactNumber(approval.total)} feedback events and ${gates.length || compactNumber(gateStats.totalGates)} active gates.`);
+    return {
+      lines: [
+        `Feedback total: ${compactNumber(approval.total)} (${compactNumber(approval.positive)} positive, ${compactNumber(approval.negative)} negative).`,
+        `Lesson pipeline: ${compactNumber(lessonPipeline.lessons || lessonPipeline.generated || 0)} lessons visible in the current dashboard snapshot.`,
+      ],
+      sources: ['feedback log', 'lesson pipeline'],
+    };
   }
-
+  if (topic === 'gates') {
+    return {
+      lines: [
+        `Active gates: ${gates.length || compactNumber(gateStats.totalGates)}.`,
+        `Blocked actions recorded: ${compactNumber(gateStats.blocked || gateStats.denied || gateStats.totalBlocked)}.`,
+        gates[0] ? `Example gate: ${gates[0].name || gates[0].id || 'unnamed gate'}.` : '',
+      ].filter(Boolean),
+      sources: ['gate stats'],
+    };
+  }
+  if (topic === 'team') {
+    return {
+      lines: [
+        'Team dashboard is available in this local Enterprise view.',
+        `Tracked agents: ${compactNumber(team.totalAgents || team.agentCount || 0)}; risky agents: ${compactNumber(team.riskyAgents || team.highRiskAgents || 0)}.`,
+      ],
+      sources: ['team dashboard'],
+    };
+  }
+  if (topic === 'cost') {
+    return {
+      lines: [
+        `Estimated token savings: ${tokenSavings.dollarsSavedDisplay || '$0.00'} from ${compactNumber(tokenSavings.blockedCalls)} blocked calls.`,
+        'Google Cloud budget alerts are evidence for spend visibility; ThumbGate-side stop conditions must be verified separately before calling them a hard cap.',
+      ],
+      sources: ['token savings', 'budget posture'],
+    };
+  }
+  if (topic === 'cloud') {
+    const vertexLine = status.vertex.configured
+      ? `Vertex routing config is present for project ${status.vertex.projectId} (${status.vertex.location}).`
+      : 'Vertex routing config is not present in this server environment.';
+    const dfcxLine = status.dfcx.liveAgentConfigured
+      ? `DFCX env has agent ${status.dfcx.agentId} in ${status.dfcx.location}; verify it with REST/console before production claims.`
+      : 'No live DFCX agent is configured in env. Do not use the old alpha gcloud CX command group; verify agents with the Dialogflow CX REST API or console.';
+    return {
+      lines: [vertexLine, dfcxLine],
+      sources: ['enterprise cloud status'],
+    };
+  }
   return {
-    topic,
-    answer: lines.join(' '),
-    sources,
+    lines: [
+      'Ask about feedback, lessons, active gates, team rollout, token savings, or Vertex/DFCX readiness.',
+      `Current local snapshot: ${compactNumber(approval.total)} feedback events and ${gates.length || compactNumber(gateStats.totalGates)} active gates.`,
+    ],
+    sources: [],
   };
 }
 
-async function answerEnterpriseDialogflowChat({ prompt, feedbackDir, parsed }) {
+function buildEnterpriseChatAnswer(prompt, dashboardData, status) {
+  const topic = classifyEnterpriseChatTopic(prompt);
+  const section = buildEnterpriseChatSection(topic, dashboardData, status);
+
+  return {
+    topic,
+    answer: section.lines.join(' '),
+    sources: ['local dashboard data', ...section.sources],
+  };
+}
+
+async function answerEnterpriseDataChat({ prompt, feedbackDir, parsed }) {
   const normalizedPrompt = normalizeEnterpriseChatPrompt(prompt);
   if (!normalizedPrompt) {
     throw createHttpError(400, 'prompt is required');
   }
-  const status = buildEnterpriseDialogflowStatus();
+  const status = buildEnterpriseDataChatStatus();
   if (containsUnsafeEnterpriseChatInput(normalizedPrompt)) {
     return {
       ok: false,
@@ -1592,6 +1670,11 @@ async function answerEnterpriseDialogflowChat({ prompt, feedbackDir, parsed }) {
 
   const dashboardResult = await buildLiveDashboardData(parsed, feedbackDir);
   const dashboardData = dashboardResult.data;
+
+  // This guarded stats endpoint stays deterministic for API compatibility.
+  // The dashboard's real local/open-source chatbot turn goes through /v1/chat,
+  // which uses lesson retrieval + optional LanceDB vector search + the user's
+  // configured local or BYO model.
   const chat = buildEnterpriseChatAnswer(normalizedPrompt, dashboardData, status);
   const dfcxRequest = {
     fulfillmentInfo: { tag: 'chat-with-data' },
@@ -1626,6 +1709,8 @@ async function answerEnterpriseDialogflowChat({ prompt, feedbackDir, parsed }) {
     sources: chat.sources,
   };
 }
+
+const answerEnterpriseDialogflowChat = answerEnterpriseDataChat;
 
 function buildLossAnalyticsResponse(data, summaryOptions) {
   return {
@@ -2200,6 +2285,10 @@ function readOptionalPublicTemplate(filePath) {
   }
 }
 
+function escapeJsonForInlineScript(value) {
+  return JSON.stringify(value).replaceAll('<', String.raw`\u003c`);
+}
+
 function resolveLocalPageBootstrap(req, expectedApiKey) {
   const forwardedHost = req.headers['x-forwarded-host'];
   const hostHeader = Array.isArray(forwardedHost)
@@ -2208,7 +2297,13 @@ function resolveLocalPageBootstrap(req, expectedApiKey) {
   const localProBootstrap = process.env.THUMBGATE_PRO_MODE === '1' && Boolean(expectedApiKey) && isLoopbackHost(hostHeader);
   const devOverride = expectedApiKey === null && isLoopbackHost(hostHeader);
   const bootstrapActive = localProBootstrap || devOverride;
-  const serializedBootstrapKey = JSON.stringify(localProBootstrap ? expectedApiKey : devOverride ? (process.env.THUMBGATE_API_KEY || 'dev-override') : '').replace(/</g, '\\u003c');
+  let bootstrapKey = '';
+  if (localProBootstrap) {
+    bootstrapKey = expectedApiKey;
+  } else if (devOverride) {
+    bootstrapKey = process.env.THUMBGATE_API_KEY || 'dev-override';
+  }
+  const serializedBootstrapKey = escapeJsonForInlineScript(bootstrapKey);
 
   return {
     bootstrapActive,
@@ -2249,7 +2344,7 @@ window.THUMBGATE_DASHBOARD_BOOTSTRAP = { enabled: ${bootstrapActive ? 'true' : '
 <p>This lightweight npm dashboard is bundled without marketing assets, so installs stay small while core feedback, lessons, and API routes remain available.</p>
 <div class="grid">
 <a class="card" href="/v1/dashboard"><strong>Dashboard JSON</strong><span>Inspect feedback totals, lesson counts, and Reliability Gateway health.</span></a>
-<a class="card" href="/v1/enterprise/dialogflow/status"><strong>Enterprise Data Chat</strong><span>Check Vertex/DFCX readiness and use /v1/enterprise/dialogflow/chat to query local ThumbGate data through the data-access guard. This does not claim a live Dialogflow CX agent unless deployment evidence is configured.</span></a>
+<a class="card" href="/v1/enterprise/data-chat/status"><strong>Governed Data Chat</strong><span>Local RAG (LanceDB vectors + lessons) over your data plus your LLM. Guard simulation is available; Dialogflow/Vertex are optional adapters for customer-owned agent deployments.</span></a>
 <a class="card" href="/lessons"><strong>Lessons</strong><span>Review remembered thumbs-up/down lessons and enforcement context.</span></a>
 <a class="card" href="/health"><strong>Health</strong><span>Verify the installed package version and runtime status.</span></a>
 </div>
@@ -2329,6 +2424,53 @@ function normalizeLessonSignal(signal) {
   return 'down';
 }
 
+function splitLessonTitlePrefix(titleText) {
+  const prefixMatch = /^(MISTAKE|SUCCESS|LEARNING|PREFERENCE):\s*(.*)/i.exec(titleText);
+  if (!prefixMatch) return { prefix: '', rest: titleText };
+  return {
+    prefix: `${prefixMatch[1].toUpperCase()}: `,
+    rest: prefixMatch[2],
+  };
+}
+
+function maybeParseJsonObject(value) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    debugApiFallback('lesson JSON parse skipped', error);
+    return null;
+  }
+}
+
+function formatLessonJsonTitle(prefix, parsed) {
+  const dirName = parsed.cwd ? parsed.cwd.split('/').pop() : '';
+  const suffix = dirName ? ` inside ${dirName}` : '';
+  if (parsed.prompt) return `${prefix}Prompt "${parsed.prompt}"${suffix}`;
+  const hookVal = parsed.hook_event_name || parsed.hookEventName;
+  if (hookVal) return `${prefix}Hook event ${hookVal}${suffix}`;
+  if (parsed.signal) return `${prefix}${parsed.signal === 'up' ? 'Thumbs Up' : 'Thumbs Down'}${suffix}`;
+  return '';
+}
+
+function cleanLessonTitle(titleText) {
+  if (!titleText) return 'Untitled Lesson';
+  const { prefix, rest } = splitLessonTitlePrefix(titleText);
+  const parsed = maybeParseJsonObject(rest);
+  if (parsed) {
+    const jsonTitle = formatLessonJsonTitle(prefix, parsed);
+    if (jsonTitle) return jsonTitle;
+  }
+  return titleText;
+}
+
+function formatLessonTextValue(value) {
+  if (!value) return '';
+  const parsed = maybeParseJsonObject(value);
+  return parsed ? JSON.stringify(parsed, null, 2) : value;
+}
+
 function renderLessonDetailHtml(record, lessonId) {
   if (!record) {
     return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Lesson Not Found</title>
@@ -2352,58 +2494,10 @@ a{color:#22d3ee;text-decoration:none}</style></head><body>
   const rawWhatWentWrong = merged.whatWentWrong || '';
   const rawWhatWorked = merged.whatWorked || '';
 
-  function cleanTitle(titleText) {
-    if (!titleText) return 'Untitled Lesson';
-    let prefix = '';
-    let rest = titleText;
-    const match = titleText.match(/^(MISTAKE|SUCCESS|LEARNING|PREFERENCE):\s*(.*)/i);
-    if (match) {
-      prefix = match[1].toUpperCase() + ': ';
-      rest = match[2];
-    }
-    
-    const trimmed = rest.trim();
-    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-      try {
-        const parsed = JSON.parse(trimmed);
-        const promptVal = parsed.prompt;
-        const hookVal = parsed.hook_event_name || parsed.hookEventName;
-        if (promptVal) {
-          const dirName = parsed.cwd ? parsed.cwd.split('/').pop() : '';
-          return prefix + `Prompt "${promptVal}"` + (dirName ? ` inside ${dirName}` : '');
-        }
-        if (hookVal) {
-          const dirName = parsed.cwd ? parsed.cwd.split('/').pop() : '';
-          return prefix + `Hook event ${hookVal}` + (dirName ? ` inside ${dirName}` : '');
-        }
-        if (parsed.signal) {
-          const dirName = parsed.cwd ? parsed.cwd.split('/').pop() : '';
-          return prefix + (parsed.signal === 'up' ? 'Thumbs Up' : 'Thumbs Down') + (dirName ? ` inside ${dirName}` : '');
-        }
-      } catch (e) {
-        // ignore
-      }
-    }
-    return titleText;
-  }
-
-  function formatTextValue(value) {
-    if (!value) return '';
-    const trimmed = String(value).trim();
-    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-      try {
-        return JSON.stringify(JSON.parse(trimmed), null, 2);
-      } catch (e) {
-        // ignore
-      }
-    }
-    return value;
-  }
-
-  const title = cleanTitle(rawTitle);
-  const context = formatTextValue(rawContext);
-  const whatWentWrong = formatTextValue(rawWhatWentWrong);
-  const whatWorked = formatTextValue(rawWhatWorked);
+  const title = cleanLessonTitle(rawTitle);
+  const context = formatLessonTextValue(rawContext);
+  const whatWentWrong = formatLessonTextValue(rawWhatWentWrong);
+  const whatWorked = formatLessonTextValue(rawWhatWorked);
   const whatToChange = merged.whatToChange || '';
   const tags = Array.isArray(merged.tags) ? merged.tags.join(', ') : (merged.tags || '');
   const timestamp = merged.timestamp ? new Date(merged.timestamp).toLocaleString() : '';
@@ -4295,7 +4389,10 @@ function createApiServer() {
           });
           sendJson(res, 200, result);
         } catch (e) {
-          sendJson(res, 500, { error: 'feedback submission failed' });
+          sendJson(res, 500, {
+            error: 'feedback submission failed',
+            message: e?.message || 'Unable to submit dashboard feedback.',
+          });
         }
       });
       return;
@@ -7028,47 +7125,32 @@ ${hidden}
           const { getStatuslineMeta } = require('../../scripts/statusline-meta');
           const meta = getStatuslineMeta({ env: process.env });
           stats.tier = meta.tier;
-        } catch (_) {
+        } catch (error) {
+          debugApiFallback('statusline meta unavailable', error);
           stats.tier = 'Pro';
         }
 
-        let projectGeminiKey = '';
-        let projectPerplexityKey = '';
-        let geminiValidatedAt = null;
-        try {
-          const projectDir = resolveRequestProjectDir(req, parsed);
-          const envPath = path.join(projectDir, '.env');
-          if (fs.existsSync(envPath)) {
-            const content = fs.readFileSync(envPath, 'utf8');
-            const geminiMatch = content.match(/^(?:GEMINI_API_KEY|GOOGLE_API_KEY|THUMBGATE_GEMINI_API_KEY)=(.*)$/m);
-            if (geminiMatch) {
-              projectGeminiKey = geminiMatch[1].trim().replace(/^["']|["']$/g, '');
-            }
-            const perplexityMatch = content.match(/^(?:PERPLEXITY_API_KEY|THUMBGATE_PERPLEXITY_API_KEY)=(.*)$/m);
-            if (perplexityMatch) {
-              projectPerplexityKey = perplexityMatch[1].trim().replace(/^["']|["']$/g, '');
-            }
-          }
-          const statusPath = path.join(projectDir, '.gemini-validated.json');
-          if (fs.existsSync(statusPath)) {
-            const st = JSON.parse(fs.readFileSync(statusPath, 'utf8'));
-            geminiValidatedAt = st.validatedAt || null;
-          }
-        } catch (_) {}
+        const projectChatSettings = readProjectChatSettings(req, parsed);
 
         stats.geminiConfigured = Boolean(
-          projectGeminiKey ||
+          projectChatSettings.geminiKey ||
           process.env.GEMINI_API_KEY ||
           process.env.THUMBGATE_GEMINI_API_KEY ||
           process.env.GOOGLE_API_KEY
         );
         stats.perplexityConfigured = Boolean(
-          projectPerplexityKey ||
+          projectChatSettings.perplexityKey ||
           process.env.PERPLEXITY_API_KEY ||
           process.env.THUMBGATE_PERPLEXITY_API_KEY
         );
-        stats.geminiValidatedAt = geminiValidatedAt;
-        stats.geminiKeyStatus = geminiValidatedAt ? 'validated' : (projectGeminiKey ? 'present' : 'none');
+        stats.geminiValidatedAt = projectChatSettings.geminiValidatedAt;
+        stats.geminiKeyStatus = 'none';
+        if (projectChatSettings.geminiKey) {
+          stats.geminiKeyStatus = 'present';
+        }
+        if (projectChatSettings.geminiValidatedAt) {
+          stats.geminiKeyStatus = 'validated';
+        }
         stats.hybridInferenceAvailable = !!(stats.geminiConfigured || stats.perplexityConfigured);
         sendJson(res, 200, stats);
         return;
@@ -7081,28 +7163,14 @@ ${hidden}
         const body = await parseJsonBody(req);
         const { answerDataQuestion } = require('../../scripts/dashboard-chat');
 
-        let projectGeminiKey = '';
-        let projectPerplexityKey = '';
-        try {
-          const projectDir = resolveRequestProjectDir(req, parsed);
-          const envPath = path.join(projectDir, '.env');
-          if (fs.existsSync(envPath)) {
-            const content = fs.readFileSync(envPath, 'utf8');
-            const geminiMatch = content.match(/^(?:GEMINI_API_KEY|GOOGLE_API_KEY|THUMBGATE_GEMINI_API_KEY)=(.*)$/m);
-            if (geminiMatch) {
-              projectGeminiKey = geminiMatch[1].trim().replace(/^["']|["']$/g, '');
-            }
-            const perplexityMatch = content.match(/^(?:PERPLEXITY_API_KEY|THUMBGATE_PERPLEXITY_API_KEY)=(.*)$/m);
-            if (perplexityMatch) {
-              projectPerplexityKey = perplexityMatch[1].trim().replace(/^["']|["']$/g, '');
-            }
-          }
-        } catch (_) {}
+        const projectChatSettings = readProjectChatSettings(req, parsed);
 
         const result = await answerDataQuestion(body.question || body.q || body.message, {
           feedbackDir: requestFeedbackPaths.FEEDBACK_DIR,
           model: typeof body.model === 'string' ? body.model : undefined,
-          apiKey: projectPerplexityKey || projectGeminiKey || process.env.PERPLEXITY_API_KEY || process.env.THUMBGATE_PERPLEXITY_API_KEY || process.env.GEMINI_API_KEY || process.env.THUMBGATE_GEMINI_API_KEY || process.env.GOOGLE_API_KEY || '',
+          apiKey: projectChatSettings.perplexityKey || projectChatSettings.geminiKey || process.env.PERPLEXITY_API_KEY || process.env.THUMBGATE_PERPLEXITY_API_KEY || process.env.GEMINI_API_KEY || process.env.THUMBGATE_GEMINI_API_KEY || process.env.GOOGLE_API_KEY || '',
+          localEndpoint: projectChatSettings.localEndpoint || process.env.THUMBGATE_LOCAL_LLM_ENDPOINT || '',
+          localModel: projectChatSettings.localModel || process.env.THUMBGATE_LOCAL_LLM_MODEL || '',
         });
         sendJson(res, result.ok ? 200 : (result.error === 'no_api_key' ? 503 : 400), result);
         return;
@@ -7128,7 +7196,7 @@ ${hidden}
             apiKey: key,
           });
         } catch (e) {
-          validation = { ok: false, error: 'validation_exception', message: String(e && e.message || e) };
+          validation = { ok: false, error: 'validation_exception', message: String(e?.message || e) };
         }
 
         if (!validation.ok) {
@@ -7166,7 +7234,9 @@ ${hidden}
               validatedAt: new Date().toISOString(),
               validatedBy: 'dashboard-save'
             }, null, 2));
-          } catch (_) { /* non-fatal */ }
+          } catch (error) {
+            debugApiFallback('Gemini validation marker unavailable', error);
+          }
           sendJson(res, 200, { ok: true, message: 'Key saved and validated.' });
         } catch (e) {
           sendJson(res, 500, { ok: false, error: 'fs_error', message: 'Failed to write to .env file: ' + e.message });
@@ -7229,14 +7299,20 @@ ${hidden}
         return;
       }
 
-      if (req.method === 'GET' && pathname === '/v1/enterprise/dialogflow/status') {
-        sendJson(res, 200, buildEnterpriseDialogflowStatus());
+      if (req.method === 'GET' && (
+        pathname === '/v1/enterprise/data-chat/status'
+        || pathname === '/v1/enterprise/dialogflow/status'
+      )) {
+        sendJson(res, 200, buildEnterpriseDataChatStatus());
         return;
       }
 
-      if (req.method === 'POST' && pathname === '/v1/enterprise/dialogflow/chat') {
+      if (req.method === 'POST' && (
+        pathname === '/v1/enterprise/data-chat/chat'
+        || pathname === '/v1/enterprise/dialogflow/chat'
+      )) {
         const body = await parseJsonBody(req, 16 * 1024);
-        const result = await answerEnterpriseDialogflowChat({
+        const result = await answerEnterpriseDataChat({
           prompt: body.prompt || body.message || body.query,
           feedbackDir: requestFeedbackDir,
           parsed,
@@ -8446,7 +8522,7 @@ ${hidden}
         } catch (err) {
           sendJson(res, 500, {
             error: 'ai_inventory_failed',
-            message: err && err.message ? err.message : 'Unable to scan AI component inventory.',
+            message: err?.message || 'Unable to scan AI component inventory.',
           });
         }
         return;
@@ -8471,7 +8547,7 @@ ${hidden}
         const body = await parseJsonBody(req);
         const snapshot = buildReviewSnapshot(requestFeedbackDir);
         // Override snapshot timestamp with client-provided one if available
-        if (body && body.reviewedAt) {
+        if (body?.reviewedAt) {
           snapshot.reviewedAt = body.reviewedAt;
         }
         writeDashboardReviewState(requestFeedbackDir, snapshot);
@@ -8789,8 +8865,10 @@ module.exports = {
     resolveLocalPageBootstrap,
     getPublicMcpTools,
     getServerCardTools,
+    buildEnterpriseDataChatStatus,
     buildEnterpriseDialogflowStatus,
     buildEnterpriseChatAnswer,
+    answerEnterpriseDataChat,
     answerEnterpriseDialogflowChat,
   },
 };

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -3846,8 +3846,8 @@ test('renderPackagedDashboardHtml returns html with bootstrap disabled by defaul
   assert.ok(html.includes('ThumbGate Dashboard'));
   assert.ok(html.includes('enabled: false'));
   assert.ok(html.includes('/v1/dashboard'));
-  assert.ok(html.includes('Enterprise Data Chat'));
-  assert.ok(html.includes('/v1/enterprise/dialogflow/chat'));
+  assert.ok(html.includes('Governed Data Chat'));
+  assert.ok(html.includes('/v1/enterprise/data-chat/status'));
   assert.ok(!html.includes('ENTERPRISE_AGENT_ID'));
   assert.ok(!html.includes('gstatic.com/dialogflow-console'));
   assert.ok(html.includes('/lessons'));
@@ -3861,14 +3861,15 @@ test('renderPackagedDashboardHtml reflects bootstrap enabled state', () => {
   assert.ok(html.includes('"test-key"'));
 });
 
-test('enterprise Dialogflow status reports REST-first verification posture', () => {
-  const { buildEnterpriseDialogflowStatus } = __test__;
-  const status = buildEnterpriseDialogflowStatus({
+test('enterprise data chat status reports local-first chat and optional Google adapters', () => {
+  const { buildEnterpriseDataChatStatus } = __test__;
+  const status = buildEnterpriseDataChatStatus({
     THUMBGATE_PROVIDER_MODE: 'vertex',
     VERTEX_PROJECT_ID: 'project-alpha',
     THUMBGATE_DFCX_AGENT_ID: 'agent-1',
     THUMBGATE_DFCX_LOCATION: 'us-central1',
     THUMBGATE_DFCX_FULFILLMENT_URL: 'https://fulfillment.example.com',
+    THUMBGATE_LOCAL_LLM_ENDPOINT: 'http://localhost:11434/v1/chat/completions',
   });
   assert.equal(status.vertex.configured, true);
   assert.equal(status.vertex.projectId, 'project-alpha');
@@ -3876,15 +3877,18 @@ test('enterprise Dialogflow status reports REST-first verification posture', () 
   assert.equal(status.dfcx.fulfillmentProxyConfigured, true);
   assert.equal(status.dfcx.gcloudCxCommandSupported, false);
   assert.match(status.dfcx.apiSurface, /projects\.locations\.agents/);
+  assert.equal(status.chat.providerRequired, false);
+  assert.equal(status.chat.localLlmEndpointConfigured, true);
+  assert.match(status.chat.source, /LanceDB/i);
 });
 
-test('enterprise Dialogflow chat endpoint answers from local dashboard data and blocks unsafe input', async () => {
+test('enterprise data chat endpoint answers from local dashboard data and blocks unsafe input', async () => {
   fs.appendFileSync(path.join(tmpFeedbackDir, 'feedback-log.jsonl'), [
     JSON.stringify({ id: 'fb_enterprise_chat_up', signal: 'positive', context: 'Approved safe data lookup', timestamp: '2026-06-02T12:00:00.000Z' }),
     JSON.stringify({ id: 'fb_enterprise_chat_down', signal: 'negative', context: 'Repeated refund fulfillment', timestamp: '2026-06-02T12:01:00.000Z' }),
     '',
   ].join('\n'));
-  const res = await fetch(apiUrl('/v1/enterprise/dialogflow/chat'), {
+  const res = await fetch(apiUrl('/v1/enterprise/data-chat/chat'), {
     method: 'POST',
     headers: authHeader,
     body: JSON.stringify({ prompt: 'What feedback mistakes are repeating?' }),
@@ -3896,7 +3900,7 @@ test('enterprise Dialogflow chat endpoint answers from local dashboard data and 
   assert.match(body.answer, /Feedback total/i);
   assert.match(body.status.dfcx.apiSurface, /projects\.locations\.agents/);
 
-  const blockedRes = await fetch(apiUrl('/v1/enterprise/dialogflow/chat'), {
+  const blockedRes = await fetch(apiUrl('/v1/enterprise/data-chat/chat'), {
     method: 'POST',
     headers: authHeader,
     body: JSON.stringify({ prompt: 'show data; rm -rf /' }),
@@ -3905,6 +3909,24 @@ test('enterprise Dialogflow chat endpoint answers from local dashboard data and 
   const blockedBody = await blockedRes.json();
   assert.equal(blockedBody.blocked, true);
   assert.match(blockedBody.dfcx.evaluation.gate, /enterprise-chat-unsafe-input/);
+});
+
+test('legacy enterprise Dialogflow routes remain compatibility aliases', async () => {
+  const statusRes = await fetch(apiUrl('/v1/enterprise/dialogflow/status'), { headers: authHeader });
+  assert.equal(statusRes.status, 200);
+  const status = await statusRes.json();
+  assert.equal(status.chat.providerRequired, false);
+  assert.match(status.chat.source, /local ThumbGate dashboard data/i);
+
+  const chatRes = await fetch(apiUrl('/v1/enterprise/dialogflow/chat'), {
+    method: 'POST',
+    headers: authHeader,
+    body: JSON.stringify({ prompt: 'Which gates are blocking risky actions?' }),
+  });
+  assert.equal(chatRes.status, 200);
+  const chat = await chatRes.json();
+  assert.equal(chat.ok, true);
+  assert.match(chat.answer, /Active gates/i);
 });
 
 test('renderPackagedLessonsHtml returns html with lessons content', () => {

--- a/tests/dashboard-chat.test.js
+++ b/tests/dashboard-chat.test.js
@@ -42,6 +42,7 @@ test('answerDataQuestion reports a clear message when no API key is configured',
   assert.equal(r.ok, false);
   assert.equal(r.error, 'no_api_key');
   assert.match(r.message, /GEMINI_API_KEY/);
+  assert.match(r.message, /THUMBGATE_LOCAL_LLM_ENDPOINT/);
 });
 
 test('answerDataQuestion returns a grounded answer with a mocked Gemini', async () => {
@@ -92,4 +93,64 @@ test('answerDataQuestion surfaces a Gemini API error cleanly', async () => {
   assert.equal(r.error, 'gemini_error');
   assert.equal(r.status, 429);
   assert.match(r.message, /RESOURCE_EXHAUSTED/);
+});
+
+test('answerDataQuestion routes to a local OpenAI-compatible endpoint', async () => {
+  let calledUrl = '';
+  let calledHeaders = {};
+  let calledBody = null;
+  const fakeFetch = async (url, init) => {
+    calledUrl = url;
+    calledHeaders = init.headers;
+    calledBody = JSON.parse(init.body);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: { content: 'local LLM grounded response' } }],
+        model: 'local-model-id',
+      }),
+    };
+  };
+
+  const r = await answerDataQuestion('how to configure gates?', {
+    apiKey: 'dummy-local-key',
+    localEndpoint: 'http://localhost:11434/v1/chat/completions',
+    localModel: 'llama-local',
+    feedbackDir: '/tmp/does-not-exist-xyz',
+    fetch: fakeFetch,
+  });
+
+  assert.equal(r.ok, true);
+  assert.equal(r.answer, 'local LLM grounded response');
+  assert.equal(r.model, 'local-model-id');
+  assert.equal(calledUrl, 'http://localhost:11434/v1/chat/completions');
+  assert.equal(calledHeaders.Authorization, 'Bearer dummy-local-key');
+  assert.equal(calledBody.model, 'llama-local');
+  assert.match(calledBody.messages[0].content, /how to configure gates\?/);
+});
+
+test('answerDataQuestion can use a local endpoint without an API key', async () => {
+  let calledHeaders = {};
+  const fakeFetch = async (url, init) => {
+    calledHeaders = init.headers;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: { content: 'response without apiKey' } }],
+      }),
+    };
+  };
+
+  const r = await answerDataQuestion('how to configure gates?', {
+    apiKey: '',
+    localEndpoint: 'http://localhost:11434/v1',
+    feedbackDir: '/tmp/does-not-exist-xyz',
+    fetch: fakeFetch,
+  });
+
+  assert.equal(r.ok, true);
+  assert.equal(r.answer, 'response without apiKey');
+  assert.equal(calledHeaders.Authorization, 'Bearer local');
 });


### PR DESCRIPTION
## Summary

Moves the Enterprise dashboard chatbot away from Dialogflow-first framing and makes local/open-source Governed Data Chat the primary path.

- Renames the dashboard tab/copy to Governed Data Chat and explains the local-first data boundary.
- Routes the enterprise dashboard chat turn through `/v1/chat` instead of `/v1/enterprise/dialogflow/chat`.
- Adds `THUMBGATE_LOCAL_LLM_ENDPOINT` and `THUMBGATE_LOCAL_LLM_MODEL` support for OpenAI-compatible local endpoints such as Ollama, llama.cpp, vLLM, and LM Studio.
- Augments chat context retrieval with optional LanceDB vector matches while preserving lesson-search fallback.
- Adds `/v1/enterprise/data-chat/status` and `/v1/enterprise/data-chat/chat` as primary enterprise API routes while keeping `/dialogflow/*` as compatibility aliases.
- Updates README and packaged-dashboard copy so Google/Vertex/Dialogflow are optional regulated-enterprise adapters, not chatbot requirements.

## Verification

- `node --check src/api/server.js && node --check scripts/dashboard-chat.js && node --check tests/api-server.test.js && node --check tests/dashboard-chat.test.js && git diff --check`
- `node --test tests/dashboard-chat.test.js` → 9 pass / 0 fail
- `node --test tests/api-server.test.js` → 135 pass / 0 fail
- `npm run ops:integrity:ci` → Operational integrity: ok
- `npm run changeset:check` → no base ref outside PR context; changeset added
- pre-commit guards passed: package parity, version sync, congruence, landing-page claims
- pre-push guards passed: npm pack dry-run, public HTML internal links, regression guards

## Compatibility

Legacy `/v1/enterprise/dialogflow/status` and `/v1/enterprise/dialogflow/chat` routes remain tested aliases so existing installs do not break.
