### PR TITLE
fix(dashboard): remove data chat regex hotspot

### DIFF
--- a/.changeset/data-chat-hotspot-fix.md
+++ b/.changeset/data-chat-hotspot-fix.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Remove a regex hotspot from local Governed Data Chat endpoint normalization.

--- a/scripts/dashboard-chat.js
+++ b/scripts/dashboard-chat.js
@@ -179,10 +179,18 @@ function parseModelError(json, status) {
   return json?.error?.message ? String(json.error.message).split('\n')[0] : `HTTP ${status}`;
 }
 
+function trimTrailingSlashes(value) {
+  let text = String(value || '');
+  while (text.endsWith('/')) {
+    text = text.slice(0, -1);
+  }
+  return text;
+}
+
 async function callLocalOpenAiEndpoint({ endpoint, apiKey, model, prompt, fetchImpl, sources }) {
   const url = endpoint.includes('/chat/completions')
     ? endpoint
-    : endpoint.replace(/\/+$/, '') + '/chat/completions';
+    : `${trimTrailingSlashes(endpoint)}/chat/completions`;
   const res = await fetchImpl(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary\n- Replace the local LLM endpoint trailing-slash regex with a tiny loop helper\n- Removes the Sonar S5852 security hotspot from the Governed Data Chat follow-up\n\n## Verification\n- node --check scripts/dashboard-chat.js\n- git diff --check\n- node --test tests/dashboard-chat.test.js\n- pre-commit guard passed\n- pre-push guard passed