### PR TITLE
ci: cap Actions artifact retention at 7 days (was 90d default)

### DIFF
--- a/.changeset/ci-artifact-retention.md
+++ b/.changeset/ci-artifact-retention.md
@@ -1,0 +1,12 @@
+---
+"thumbgate": patch
+---
+
+ci: cap Actions artifact retention at 7 days
+
+14 workflows uploaded CI artifacts (proof reports, coverage, bundles, deploy
+logs, release notes) with no `retention-days`, so they kept GitHub's 90-day
+default. Combined with high push/PR/merge-queue velocity, that filled the
+account's 0.5 GB Actions storage. Set `retention-days: 7` on every artifact
+upload so storage no longer accumulates. CI/PR debugging keeps a week of
+artifacts; nothing else changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: proof-artifacts
           path: |
             proof/compatibility/report.json

--- a/.github/workflows/daily-revenue-loop.yml
+++ b/.github/workflows/daily-revenue-loop.yml
@@ -273,5 +273,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: revenue-observability-${{ github.run_id }}
           path: reports/revenue/

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -64,6 +64,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: deploy-scope
           path: deploy-scope.json
       - uses: actions/setup-node@v6
@@ -305,6 +306,7 @@ jobs:
         if: always() && steps.railway-config.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: railway-diagnostics-${{ github.run_id }}
           path: railway-diagnostics/
           if-no-files-found: warn

--- a/.github/workflows/gtm-autonomous-loop.yml
+++ b/.github/workflows/gtm-autonomous-loop.yml
@@ -34,5 +34,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: gtm-revenue-loop
           path: .artifacts/gtm/

--- a/.github/workflows/medium-weekly-visibility.yml
+++ b/.github/workflows/medium-weekly-visibility.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Upload Medium visibility kit
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: medium-weekly-visibility-kit
           path: docs/marketing/medium/
           if-no-files-found: error

--- a/.github/workflows/publish-claude-plugin.yml
+++ b/.github/workflows/publish-claude-plugin.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Upload Claude plugin artifact
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: claude-plugin-assets
           path: |
             .artifacts/claude-desktop/${{ steps.assets.outputs.versioned_bundle }}

--- a/.github/workflows/publish-codex-plugin.yml
+++ b/.github/workflows/publish-codex-plugin.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Upload Codex plugin artifact
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: codex-plugin-zip
           path: |
             .artifacts/codex-plugin/${{ steps.assets.outputs.versioned_asset }}

--- a/.github/workflows/publish-ide-marketplace.yml
+++ b/.github/workflows/publish-ide-marketplace.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: thumbgate-vscode-open-vsx-vsix
           path: ${{ steps.vsix.outputs.path }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -195,6 +195,7 @@ jobs:
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.ensure_release == 'true'
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: thumbgate-${{ steps.package.outputs.version }}-release-notes
           path: thumbgate-${{ steps.package.outputs.version }}-release-notes.md
           if-no-files-found: error

--- a/.github/workflows/publish-tessl.yml
+++ b/.github/workflows/publish-tessl.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Upload Tessl artifacts
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: tessl-tiles
           path: |
             .artifacts/tessl/

--- a/.github/workflows/railway-diagnostics.yml
+++ b/.github/workflows/railway-diagnostics.yml
@@ -96,6 +96,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: railway-diagnostics-${{ github.run_id }}
           path: |
             railway-diagnostics/

--- a/.github/workflows/revenue-truth-audit.yml
+++ b/.github/workflows/revenue-truth-audit.yml
@@ -97,5 +97,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: revenue-truth-audit-${{ github.run_id }}
           path: reports/revenue/

--- a/.github/workflows/social-dedupe-cleanup.yml
+++ b/.github/workflows/social-dedupe-cleanup.yml
@@ -75,5 +75,6 @@ jobs:
       - name: Upload cleanup evidence
         uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: social-dedupe-cleanup-result
           path: social-dedupe-cleanup-result.json

--- a/.github/workflows/upstream-contribution-discovery.yml
+++ b/.github/workflows/upstream-contribution-discovery.yml
@@ -46,6 +46,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
+          retention-days: 7
           name: upstream-contribution-engine
           path: |
             upstream-contribution-engine.json


### PR DESCRIPTION
## Why
GitHub emailed that the account hit **100% of its 0.5 GB Actions storage**. Root cause (verified): **14 workflows uploaded CI artifacts with no \`retention-days\`**, so they kept GitHub's **90-day default**. Under this repo's high push/PR/merge-queue velocity, those artifacts (proof reports, coverage, bundles, deploy logs, release notes) accumulated to the cap.

This is **not** the API rate limit (a separate 5,000/hr quota) and **not** scheduled-workflow churn (only 1 workflow — codeql, weekly — is scheduled).

## What
Set \`retention-days: 7\` on **every** artifact upload across these 14 workflows: ci, e2e (already had it), deploy-railway, publish-{npm,claude-plugin,codex-plugin,ide-marketplace,tessl}, railway-diagnostics, revenue-truth-audit, gtm-autonomous-loop, daily-revenue-loop, medium-weekly-visibility, social-dedupe-cleanup, upstream-contribution-discovery.

A week is plenty to debug a recent CI/PR failure; storage no longer grows unbounded.

## Verification
- All 14 changed workflows parse as valid YAML (pyyaml, 14/14).
- Coverage check: 0 \`upload-artifact\` steps remain without \`retention-days\`.
- Pre-commit guards passed.

## Follow-up (not in this PR)
- Existing artifacts keep their original 90-day clock; I can prune old ones to free the current 0.5 GB once you ok it (they're disposable CI outputs).
- Optional one-shot: lower the repo-wide *Artifact and log retention* setting (Settings → Actions) — that's a settings change, your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)