### PR TITLE
dashboard: make 'Chat with your data' local-first (off Gemini)

### DIFF
--- a/.changeset/dashboard-chat-local-first.md
+++ b/.changeset/dashboard-chat-local-first.md
@@ -1,0 +1,17 @@
+---
+"thumbgate": patch
+---
+
+dashboard: "Chat with your data" is local-first, not Gemini
+
+The dashboard chat panel routed every question through Gemini RAG over lessons
+only — so it depended on the cloud (contradicting ThumbGate's local-first thesis)
+and couldn't answer factual questions like "how many mistakes were blocked
+today?" (block counts live in gate/feedback telemetry, not lessons).
+
+`/v1/chat` now answers data/metric questions (gates, blocks, feedback, token
+savings, team) DETERMINISTICALLY from this install's own dashboard data — no
+cloud, no LLM, no API key. Only open-ended questions fall through to lesson
+retrieval + the user's configured LOCAL model; a BYO cloud key is optional. When
+no model is configured, open-ended questions still get a local answer instead of
+a hard "no_api_key" failure. Dashboard subtitle updated to say answers are local.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -263,7 +263,7 @@
   <div class="panel" id="chatPanel" style="margin-bottom:20px;">
     <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;margin-bottom:10px;">
       <h2 style="margin:0;">💬 Chat with your data</h2>
-      <span style="font-size:13px;color:var(--text-muted);">Ask about your captured lessons, mistakes, and rules — answered by Gemini, grounded only in your data.</span>
+      <span style="font-size:13px;color:var(--text-muted);">Ask about your gates, blocks, feedback, and lessons — answered <strong>locally from your own data</strong>, no cloud. (An optional BYO model only kicks in for open-ended questions.)</span>
     </div>
     <div id="chatMessages" style="max-height:360px;overflow-y:auto;margin-bottom:12px;display:none;padding-right:4px;"></div>
     <div style="display:flex;gap:8px;">

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1644,6 +1644,33 @@ function buildEnterpriseChatAnswer(prompt, dashboardData, status) {
   };
 }
 
+// Answer the dashboard "Chat with your data" panel LOCALLY (deterministic, no
+// cloud/LLM) from this install's own per-project dashboard data. Returns true if
+// it sent a response; false if the local snapshot was unavailable (caller then
+// falls through). Shared by the local-first path and the no-model fallback.
+async function trySendLocalDashboardChat(res, parsed, feedbackDir, prompt, suffix) {
+  try {
+    const dashboardResult = await buildLiveDashboardData(parsed, feedbackDir);
+    const localChat = buildEnterpriseChatAnswer(
+      prompt,
+      dashboardResult.data,
+      buildEnterpriseDataChatStatus(),
+    );
+    sendJson(res, 200, {
+      ok: true,
+      answer: suffix ? `${localChat.answer} ${suffix}` : localChat.answer,
+      sources: (localChat.sources || []).map((title) => ({ title })),
+      topic: localChat.topic,
+      provider: 'local-data',
+      llm: 'none',
+      grounded: true,
+    });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 async function answerEnterpriseDataChat({ prompt, feedbackDir, parsed }) {
   const normalizedPrompt = normalizeEnterpriseChatPrompt(prompt);
   if (!normalizedPrompt) {
@@ -7166,32 +7193,17 @@ ${hidden}
         const body = await parseJsonBody(req);
         const question = body.question || body.q || body.message;
         const normalizedChatPrompt = normalizeEnterpriseChatPrompt(question);
+        const chatFeedbackDir = requestFeedbackPaths.FEEDBACK_DIR;
 
+        // Local-first: factual/metric questions (gates, blocks, feedback, cost,
+        // team) are answered deterministically from local data — no cloud/LLM/key.
         if (
           normalizedChatPrompt
           && !containsUnsafeEnterpriseChatInput(normalizedChatPrompt)
           && classifyEnterpriseChatTopic(normalizedChatPrompt) !== 'overview'
+          && await trySendLocalDashboardChat(res, parsed, chatFeedbackDir, normalizedChatPrompt)
         ) {
-          try {
-            const dashboardResult = await buildLiveDashboardData(parsed, requestFeedbackPaths.FEEDBACK_DIR);
-            const localChat = buildEnterpriseChatAnswer(
-              normalizedChatPrompt,
-              dashboardResult.data,
-              buildEnterpriseDataChatStatus(),
-            );
-            sendJson(res, 200, {
-              ok: true,
-              answer: localChat.answer,
-              sources: (localChat.sources || []).map((title) => ({ title })),
-              topic: localChat.topic,
-              provider: 'local-data',
-              llm: 'none',
-              grounded: true,
-            });
-            return;
-          } catch (_) {
-            // Fall through to retrieval if local snapshot is unavailable.
-          }
+          return;
         }
 
         const { answerDataQuestion } = require('../../scripts/dashboard-chat');
@@ -7199,38 +7211,21 @@ ${hidden}
         const projectChatSettings = readProjectChatSettings(req, parsed);
 
         const result = await answerDataQuestion(question, {
-          feedbackDir: requestFeedbackPaths.FEEDBACK_DIR,
+          feedbackDir: chatFeedbackDir,
           model: typeof body.model === 'string' ? body.model : undefined,
           apiKey: projectChatSettings.perplexityKey || projectChatSettings.geminiKey || process.env.PERPLEXITY_API_KEY || process.env.THUMBGATE_PERPLEXITY_API_KEY || process.env.GEMINI_API_KEY || process.env.THUMBGATE_GEMINI_API_KEY || process.env.GOOGLE_API_KEY || '',
           localEndpoint: projectChatSettings.localEndpoint || process.env.THUMBGATE_LOCAL_LLM_ENDPOINT || '',
           localModel: projectChatSettings.localModel || process.env.THUMBGATE_LOCAL_LLM_MODEL || '',
         });
 
-        // Local-first guarantee: if no model is configured (no local endpoint, no
-        // BYO key), never hard-fail with "no_api_key" — fall back to a deterministic
-        // local answer grounded in this install's dashboard data. No question
-        // requires the cloud.
-        if (!result.ok && (result.error === 'no_api_key' || result.error === 'no_model')) {
-          try {
-            const dashboardResult = await buildLiveDashboardData(parsed, requestFeedbackPaths.FEEDBACK_DIR);
-            const localChat = buildEnterpriseChatAnswer(
-              normalizedChatPrompt || question,
-              dashboardResult.data,
-              buildEnterpriseDataChatStatus(),
-            );
-            sendJson(res, 200, {
-              ok: true,
-              answer: `${localChat.answer} (Connect a local model via THUMBGATE_LOCAL_LLM_ENDPOINT for open-ended analysis over your lessons.)`,
-              sources: (localChat.sources || []).map((title) => ({ title })),
-              topic: localChat.topic,
-              provider: 'local-data',
-              llm: 'none',
-              grounded: true,
-            });
-            return;
-          } catch (_) {
-            // fall through to the original error response below
-          }
+        // Local-first guarantee: if no model is configured, never hard-fail with
+        // "no_api_key" — fall back to a deterministic local answer. No cloud required.
+        if (
+          !result.ok
+          && (result.error === 'no_api_key' || result.error === 'no_model')
+          && await trySendLocalDashboardChat(res, parsed, chatFeedbackDir, normalizedChatPrompt || question, '(Connect a local model via THUMBGATE_LOCAL_LLM_ENDPOINT for open-ended analysis over your lessons.)')
+        ) {
+          return;
         }
 
         sendJson(res, result.ok ? 200 : (result.error === 'no_api_key' ? 503 : 400), result);

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -7156,22 +7156,83 @@ ${hidden}
         return;
       }
 
-      // Chat with your data — RAG over this install's captured lessons, answered
-      // by Gemini grounded only in the retrieved context. Powers the dashboard
-      // "Chat with your data" panel.
+      // Chat with your data — LOCAL-FIRST. Powers the dashboard "Chat with your
+      // data" panel. Factual/metric questions (gates, blocks, feedback, token
+      // savings, team) are answered DETERMINISTICALLY from this install's own
+      // dashboard data — no cloud, no LLM, no API key (the local-first thesis).
+      // Only open-ended/qualitative questions fall through to lesson retrieval +
+      // the user's configured LOCAL model (a BYO cloud key is optional, not required).
       if (req.method === 'POST' && pathname === '/v1/chat') {
         const body = await parseJsonBody(req);
+        const question = body.question || body.q || body.message;
+        const normalizedChatPrompt = normalizeEnterpriseChatPrompt(question);
+
+        if (
+          normalizedChatPrompt
+          && !containsUnsafeEnterpriseChatInput(normalizedChatPrompt)
+          && classifyEnterpriseChatTopic(normalizedChatPrompt) !== 'overview'
+        ) {
+          try {
+            const dashboardResult = await buildLiveDashboardData(parsed, requestFeedbackPaths.FEEDBACK_DIR);
+            const localChat = buildEnterpriseChatAnswer(
+              normalizedChatPrompt,
+              dashboardResult.data,
+              buildEnterpriseDataChatStatus(),
+            );
+            sendJson(res, 200, {
+              ok: true,
+              answer: localChat.answer,
+              sources: (localChat.sources || []).map((title) => ({ title })),
+              topic: localChat.topic,
+              provider: 'local-data',
+              llm: 'none',
+              grounded: true,
+            });
+            return;
+          } catch (_) {
+            // Fall through to retrieval if local snapshot is unavailable.
+          }
+        }
+
         const { answerDataQuestion } = require('../../scripts/dashboard-chat');
 
         const projectChatSettings = readProjectChatSettings(req, parsed);
 
-        const result = await answerDataQuestion(body.question || body.q || body.message, {
+        const result = await answerDataQuestion(question, {
           feedbackDir: requestFeedbackPaths.FEEDBACK_DIR,
           model: typeof body.model === 'string' ? body.model : undefined,
           apiKey: projectChatSettings.perplexityKey || projectChatSettings.geminiKey || process.env.PERPLEXITY_API_KEY || process.env.THUMBGATE_PERPLEXITY_API_KEY || process.env.GEMINI_API_KEY || process.env.THUMBGATE_GEMINI_API_KEY || process.env.GOOGLE_API_KEY || '',
           localEndpoint: projectChatSettings.localEndpoint || process.env.THUMBGATE_LOCAL_LLM_ENDPOINT || '',
           localModel: projectChatSettings.localModel || process.env.THUMBGATE_LOCAL_LLM_MODEL || '',
         });
+
+        // Local-first guarantee: if no model is configured (no local endpoint, no
+        // BYO key), never hard-fail with "no_api_key" — fall back to a deterministic
+        // local answer grounded in this install's dashboard data. No question
+        // requires the cloud.
+        if (!result.ok && (result.error === 'no_api_key' || result.error === 'no_model')) {
+          try {
+            const dashboardResult = await buildLiveDashboardData(parsed, requestFeedbackPaths.FEEDBACK_DIR);
+            const localChat = buildEnterpriseChatAnswer(
+              normalizedChatPrompt || question,
+              dashboardResult.data,
+              buildEnterpriseDataChatStatus(),
+            );
+            sendJson(res, 200, {
+              ok: true,
+              answer: `${localChat.answer} (Connect a local model via THUMBGATE_LOCAL_LLM_ENDPOINT for open-ended analysis over your lessons.)`,
+              sources: (localChat.sources || []).map((title) => ({ title })),
+              topic: localChat.topic,
+              provider: 'local-data',
+              llm: 'none',
+              grounded: true,
+            });
+            return;
+          } catch (_) {
+            // fall through to the original error response below
+          }
+        }
+
         sendJson(res, result.ok ? 200 : (result.error === 'no_api_key' ? 503 : 400), result);
         return;
       }

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -3766,11 +3766,15 @@ test('dashboard chat endpoint degrades cleanly when Gemini is not configured', a
       body: JSON.stringify({ question: 'What dashboard mistakes should we avoid?' }),
     });
 
-    assert.equal(res.status, 503);
+    // Local-first: with no Gemini key configured, the chat no longer fails with
+    // "no_api_key" — it answers the data question (topic: feedback/"mistakes")
+    // deterministically from this install's own dashboard data. No cloud required.
+    assert.equal(res.status, 200);
     const body = await res.json();
-    assert.equal(body.ok, false);
-    assert.equal(body.error, 'no_api_key');
-    assert.match(body.message, /GEMINI_API_KEY/);
+    assert.equal(body.ok, true);
+    assert.equal(body.provider, 'local-data');
+    assert.equal(body.llm, 'none');
+    assert.match(body.answer, /feedback|lesson|mistake/i);
     assert.ok(Array.isArray(body.sources));
   } finally {
     if (savedGeminiApiKey === undefined) delete process.env.GEMINI_API_KEY;
@@ -3909,6 +3913,36 @@ test('enterprise data chat endpoint answers from local dashboard data and blocks
   const blockedBody = await blockedRes.json();
   assert.equal(blockedBody.blocked, true);
   assert.match(blockedBody.dfcx.evaluation.gate, /enterprise-chat-unsafe-input/);
+});
+
+test('dashboard /v1/chat answers data questions LOCALLY with no cloud/LLM/API key', async () => {
+  // Factual question → deterministic local answer from this install's own data.
+  const res = await fetch(apiUrl('/v1/chat'), {
+    method: 'POST',
+    headers: authHeader,
+    body: JSON.stringify({ question: 'how many mistakes were blocked today?' }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.provider, 'local-data', 'data questions must be answered locally, not via cloud');
+  assert.equal(body.llm, 'none', 'no LLM should be invoked for a metric question');
+  assert.equal(body.topic, 'gates');
+  assert.match(body.answer, /gates|blocked/i);
+  // No Gemini key is set in this test env — proving the local-first path needs no cloud.
+
+  // Open-ended question with no model configured must STILL return a local answer,
+  // never a hard "no_api_key" failure and never a forced cloud call.
+  const open = await fetch(apiUrl('/v1/chat'), {
+    method: 'POST',
+    headers: authHeader,
+    body: JSON.stringify({ question: 'what is our philosophy of work?' }),
+  });
+  assert.equal(open.status, 200);
+  const openBody = await open.json();
+  assert.equal(openBody.ok, true);
+  assert.equal(openBody.provider, 'local-data');
+  assert.equal(openBody.llm, 'none');
 });
 
 test('legacy enterprise Dialogflow routes remain compatibility aliases', async () => {

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -410,9 +410,13 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // on reliability rollout: packaged runtime dependencies plus public
   // discovery assets weigh ~4.08 MB unpacked, leaving a narrow safety margin.
   // Bumped 4.18 MB -> 4.25 MB (2026-06-03) for the parallel workflow orchestrator.
+  // Bumped 4.25 MB -> 4.30 MB (2026-06-04) for the local-first dashboard chat:
+  // /v1/chat now answers data questions deterministically from local dashboard data
+  // (src/api/server.js) instead of Gemini RAG. Observed ~4.251 MB after the addition;
+  // the bump restores a one-normal-PR headroom buffer.
   assert.ok(
-    manifest.unpackedSize <= 4_250_000,
-    `npm package should stay <= 4.25 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 4_300_000,
+    `npm package should stay <= 4.30 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {


### PR DESCRIPTION
## Why
The dashboard "Chat with your data" panel routed **every** question through **Gemini RAG over lessons only**. Two problems you flagged:
1. It depends on **Gemini cloud** — contradicting ThumbGate's local-first thesis (the UI literally said "answered by Gemini").
2. It **couldn't answer factual questions** ("how many mistakes were blocked today?" → "the lessons do not contain the answer") because block/gate counts live in telemetry, not lessons.

## What
`/v1/chat` is now **local-first**:
- **Data/metric questions** (gates, blocks, feedback, token savings, team) are answered **deterministically from this install's own dashboard data** — no cloud, no LLM, no API key. Reuses the existing local `buildEnterpriseChatAnswer` (completes what #2489 started for the dashboard panel).
- **Open-ended questions** fall through to lesson retrieval + the user's configured **local** model; a BYO cloud key is optional. With no model configured, they still get a **local answer** instead of a hard `no_api_key` error.
- Dashboard subtitle no longer claims "answered by Gemini" — it says answers are local.

## Verification (clean state, no Gemini key)
Live-tested against the branch server with **no `.env`/no Gemini key**:
- `"how many mistakes were blocked today?"` → `{ok:true, provider:"local-data", llm:"none", topic:"gates", answer:"Active gates: 37. Blocked actions recorded: 158…"}`
- open-ended → `{ok:true, provider:"local-data", llm:"none"}` (graceful local fallback)

Tests: new `/v1/chat` local-first test + updated the "degrades cleanly" test to the new contract; api-server chat suite **5/5**, dashboard suite **119/119**, `dashboard-chat` module **9/9** — all clean-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)