### PR TITLE
fix(mcp): stdio server self-exits on stdin EOF/close (stops orphaned thumbgate serve pileup)

### DIFF
--- a/.changeset/stdio-server-exit-on-stdin-eof.md
+++ b/.changeset/stdio-server-exit-on-stdin-eof.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+fix(mcp): stdio server self-exits on stdin EOF/close
+
+stdio MCP server (adapters/mcp/server-stdio.js) now listens to stdin 'end' and 'close' events to exit the process with code 0 when the client disconnects. This prevents orphaned serve processes from accumulating on the host system.

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -1480,6 +1480,19 @@ function startStdioServer() {
   acquireLock();
 
   process.stdin.resume();
+
+  // Self-terminate when the client disconnects (stdin EOF/close). A stdio MCP
+  // server must not outlive its parent: clients spawn it over stdin/stdout and
+  // a well-behaved server exits when that pipe closes. Without this, children
+  // abandoned by a client that exits without killing them linger forever and
+  // accumulate. WHY: on 2026-06-05, 117 orphaned `thumbgate serve` processes
+  // (spawned by a Codex app-server over ~4 days, never reaped) piled up and
+  // helped exhaust a 24GB host. The existing exit handlers (cleanupLock /
+  // cleanupSessionLock registered on 'exit') run via process.exit(0).
+  const exitOnDisconnect = () => process.exit(0);
+  process.stdin.on('end', exitOnDisconnect);
+  process.stdin.on('close', exitOnDisconnect);
+
   let buffer = Buffer.alloc(0);
   // Auto-detect transport from first request and lock it for the session.
   // mcp-proxy (Glama) sends NDJSON and expects NDJSON back.


### PR DESCRIPTION
## Problem
On 2026-06-05, **117 orphaned `thumbgate serve` processes** (spawned by a Codex app-server over ~4 days, never reaped) accumulated on a 24GB Mac mini and helped exhaust its memory/process table — a contributing cause of repeated freezes.

## Root cause
`adapters/mcp/server-stdio.js` calls `process.stdin.resume()` and handles `'data'`, `SIGTERM`, `SIGINT` — but has **no `stdin 'end'/'close'` handler**. A stdio MCP server is spawned by its client over stdin/stdout and must exit when that pipe closes. Without it, a child abandoned by a client that exits without killing it runs forever. The per-session lock **intentionally allows concurrent sessions** (multi-client stdio is valid — confirmed by `server-stdio-lock.test.js`), so nothing reaped them.

`"singleton lock"` would be the **wrong** fix — it would break legitimate concurrent clients. The correct fix is self-termination on disconnect.

## Fix
Add `stdin.on('end')` / `stdin.on('close')` → `process.exit(0)`. Existing `'exit'` handlers run `cleanupLock`/`cleanupSessionLock`. Concurrency behavior is unchanged.

## Verification
- `node --check` clean.
- `node --test tests/server-stdio-lock.test.js` → **7/7 pass** (lock/concurrency behavior intact).

## Note
`adapters/skool/server-stdio.js` appears to have the same shape and likely needs the same handler — flagging as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)