### PR TITLE
dashboard: intent-aware chat answerer (consolidates the chat fix)

### DIFF
--- a/.changeset/dashboard-chat-intent-aware-answerer.md
+++ b/.changeset/dashboard-chat-intent-aware-answerer.md
@@ -1,0 +1,20 @@
+---
+"thumbgate": patch
+---
+
+dashboard: chat answers are now intent-aware and specific, not one canned template
+
+The "Chat with your data" answerer matched a topic and returned a fixed line, so
+different questions ("how many gates were activated" vs "what mistakes were
+blocked") returned the IDENTICAL "Active gates: N. Blocked actions recorded: M."
+output. Now:
+
+- "what / which was blocked" lists the actual gates that fired (from the per-gate
+  breakdown): "Most-blocked: memory-high-risk-default-deny (62x), secret-exfiltration (38x)…"
+- "how many" distinguishes configured gates (active & watching) from the ones that
+  have actually fired, plus actions blocked vs warned — instead of conflating them.
+- Honest "today" handling: counts are cumulative for the install; the answer says
+  so rather than implying a per-day figure that isn't computed yet.
+- Overview gives a real snapshot instead of "ask about X".
+
+Consolidates the dashboard-chat answerer into one canonical implementation.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1567,7 +1567,7 @@ function compactNumber(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
-function buildEnterpriseChatSection(topic, dashboardData, status) {
+function buildEnterpriseChatSection(topic, dashboardData, status, prompt = '') {
   const approval = dashboardData.approval || {};
   const gates = Array.isArray(dashboardData.gates) ? dashboardData.gates : [];
   const gateStats = dashboardData.gateStats || {};
@@ -1575,21 +1575,58 @@ function buildEnterpriseChatSection(topic, dashboardData, status) {
   const tokenSavings = dashboardData.tokenSavings || {};
   const lessonPipeline = dashboardData.lessonPipeline || {};
 
+  // Intent: does the question want a LIST ("what/which was blocked") or a COUNT
+  // ("how many")? This is why two different questions must not return the same
+  // canned line.
+  const q = String(prompt || '').toLowerCase();
+  const wantsList = /\b(what|which|list|show|examples?|kinds?|types?|details?|breakdown|top)\b/.test(q);
+  const mentionsToday = /\b(today|now|currently|this (week|month|day))\b/.test(q);
+  // Gate occurrence counts are cumulative for this install, not per-day — be
+  // honest rather than implying a "today" figure we don't compute yet.
+  const scopeNote = mentionsToday
+    ? ' (cumulative for this install — per-day scoping isn\'t in chat yet)'
+    : '';
+
+  // Real "what was blocked" data: the per-gate blocked breakdown.
+  const byGate = gateStats.byGate && typeof gateStats.byGate === 'object' ? gateStats.byGate : {};
+  const blockedGates = Object.entries(byGate)
+    .map(([id, counts]) => ({ id, blocked: Number((counts && counts.blocked) || 0) }))
+    .filter((g) => g.blocked > 0)
+    .sort((a, b) => b.blocked - a.blocked);
+  const configuredGates = gates.length || compactNumber(gateStats.totalGates);
+  const totalBlocked = compactNumber(gateStats.blocked != null ? gateStats.blocked : (gateStats.totalBlocked || 0));
+  const totalWarned = compactNumber(gateStats.warned != null ? gateStats.warned : (gateStats.totalWarned || 0));
+
   if (topic === 'feedback') {
     return {
       lines: [
-        `Feedback total: ${compactNumber(approval.total)} (${compactNumber(approval.positive)} positive, ${compactNumber(approval.negative)} negative).`,
-        `Lesson pipeline: ${compactNumber(lessonPipeline.lessons || lessonPipeline.generated || 0)} lessons visible in the current dashboard snapshot.`,
+        `Feedback total: ${compactNumber(approval.total)} (${compactNumber(approval.positive)} positive, ${compactNumber(approval.negative)} negative)${scopeNote}.`,
+        `${compactNumber(lessonPipeline.lessons || lessonPipeline.generated || 0)} lessons promoted from that feedback.`,
       ],
       sources: ['feedback log', 'lesson pipeline'],
     };
   }
   if (topic === 'gates') {
+    // "what / which mistakes were blocked" -> list the actual gates that fired.
+    if (wantsList) {
+      if (blockedGates.length === 0) {
+        return {
+          lines: [`No actions have been blocked yet${scopeNote} — ${configuredGates} gates are configured and watching.`],
+          sources: ['gate stats'],
+        };
+      }
+      const top = blockedGates.slice(0, 6).map((g) => `${g.id} (${g.blocked}x)`).join(', ');
+      return {
+        lines: [`${totalBlocked} action(s) blocked across ${blockedGates.length} gate(s)${scopeNote}. Most-blocked: ${top}.`],
+        sources: ['gate stats (per-gate breakdown)'],
+      };
+    }
+    // "how many" -> distinguish configured vs actually-fired vs actions blocked.
     return {
       lines: [
-        `Active gates: ${gates.length || compactNumber(gateStats.totalGates)}.`,
-        `Blocked actions recorded: ${compactNumber(gateStats.blocked || gateStats.denied || gateStats.totalBlocked)}.`,
-        gates[0] ? `Example gate: ${gates[0].name || gates[0].id || 'unnamed gate'}.` : '',
+        `${configuredGates} gates are configured (active and watching); ${blockedGates.length} have actually fired.`,
+        `They've blocked ${totalBlocked} action(s) and warned on ${totalWarned}${scopeNote}.`,
+        gateStats.topBlocked ? `Most-blocked: ${gateStats.topBlocked} (${compactNumber(gateStats.topBlockedCount)}x).` : '',
       ].filter(Boolean),
       sources: ['gate stats'],
     };
@@ -1626,16 +1663,16 @@ function buildEnterpriseChatSection(topic, dashboardData, status) {
   }
   return {
     lines: [
-      'Ask about feedback, lessons, active gates, team rollout, token savings, or Vertex/DFCX readiness.',
-      `Current local snapshot: ${compactNumber(approval.total)} feedback events and ${gates.length || compactNumber(gateStats.totalGates)} active gates.`,
+      `Snapshot: ${compactNumber(approval.total)} feedback (${compactNumber(approval.positive)} positive / ${compactNumber(approval.negative)} negative), ${configuredGates} gates configured, ${totalBlocked} action(s) blocked.`,
+      'Ask "what was blocked", "how many gates fired", "how much feedback", or "token savings" for specifics.',
     ],
-    sources: [],
+    sources: ['local dashboard data'],
   };
 }
 
 function buildEnterpriseChatAnswer(prompt, dashboardData, status) {
   const topic = classifyEnterpriseChatTopic(prompt);
-  const section = buildEnterpriseChatSection(topic, dashboardData, status);
+  const section = buildEnterpriseChatSection(topic, dashboardData, status, prompt);
 
   return {
     topic,

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1567,6 +1567,32 @@ function compactNumber(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
+// "what was blocked" (list the fired gates) vs "how many" (configured vs fired
+// vs blocked) — kept as its own helper so the section dispatcher stays flat.
+function buildGatesChatSection({ wantsList, blockedGates, configuredGates, totalBlocked, totalWarned, gateStats, scopeNote }) {
+  if (wantsList) {
+    if (blockedGates.length === 0) {
+      return {
+        lines: [`No actions have been blocked yet${scopeNote} — ${configuredGates} gates are configured and watching.`],
+        sources: ['gate stats'],
+      };
+    }
+    const top = blockedGates.slice(0, 6).map((g) => `${g.id} (${g.blocked}x)`).join(', ');
+    return {
+      lines: [`${totalBlocked} action(s) blocked across ${blockedGates.length} gate(s)${scopeNote}. Most-blocked: ${top}.`],
+      sources: ['gate stats (per-gate breakdown)'],
+    };
+  }
+  const lines = [
+    `${configuredGates} gates are configured (active and watching); ${blockedGates.length} have actually fired.`,
+    `They've blocked ${totalBlocked} action(s) and warned on ${totalWarned}${scopeNote}.`,
+  ];
+  if (gateStats.topBlocked) {
+    lines.push(`Most-blocked: ${gateStats.topBlocked} (${compactNumber(gateStats.topBlockedCount)}x).`);
+  }
+  return { lines, sources: ['gate stats'] };
+}
+
 function buildEnterpriseChatSection(topic, dashboardData, status, prompt = '') {
   const approval = dashboardData.approval || {};
   const gates = Array.isArray(dashboardData.gates) ? dashboardData.gates : [];
@@ -1607,29 +1633,7 @@ function buildEnterpriseChatSection(topic, dashboardData, status, prompt = '') {
     };
   }
   if (topic === 'gates') {
-    // "what / which mistakes were blocked" -> list the actual gates that fired.
-    if (wantsList) {
-      if (blockedGates.length === 0) {
-        return {
-          lines: [`No actions have been blocked yet${scopeNote} — ${configuredGates} gates are configured and watching.`],
-          sources: ['gate stats'],
-        };
-      }
-      const top = blockedGates.slice(0, 6).map((g) => `${g.id} (${g.blocked}x)`).join(', ');
-      return {
-        lines: [`${totalBlocked} action(s) blocked across ${blockedGates.length} gate(s)${scopeNote}. Most-blocked: ${top}.`],
-        sources: ['gate stats (per-gate breakdown)'],
-      };
-    }
-    // "how many" -> distinguish configured vs actually-fired vs actions blocked.
-    return {
-      lines: [
-        `${configuredGates} gates are configured (active and watching); ${blockedGates.length} have actually fired.`,
-        `They've blocked ${totalBlocked} action(s) and warned on ${totalWarned}${scopeNote}.`,
-        gateStats.topBlocked ? `Most-blocked: ${gateStats.topBlocked} (${compactNumber(gateStats.topBlockedCount)}x).` : '',
-      ].filter(Boolean),
-      sources: ['gate stats'],
-    };
+    return buildGatesChatSection({ wantsList, blockedGates, configuredGates, totalBlocked, totalWarned, gateStats, scopeNote });
   }
   if (topic === 'team') {
     return {
@@ -8943,6 +8947,9 @@ module.exports = {
   createApiServer,
   startServer,
   __test__: {
+    buildEnterpriseChatAnswer,
+    buildEnterpriseChatSection,
+    classifyEnterpriseChatTopic,
     buildCheckoutFallbackUrl,
     createPrivateCoreUnavailableError,
     buildPosthogProxyRequestOptions,

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -3971,6 +3971,52 @@ test('dashboard chat gives DIFFERENT, intent-aware answers (list vs count), not 
   assert.doesNotMatch(countAns.answer, /^Active gates: \d+\. Blocked actions recorded/);
 });
 
+test('chat answerer unit: every branch returns grounded, distinct answers', () => {
+  const { buildEnterpriseChatAnswer } = __test__;
+  const status = { vertex: { configured: false }, dfcx: { liveAgentConfigured: false } };
+  const data = {
+    approval: { total: 10, positive: 6, negative: 4 },
+    gates: Array.from({ length: 37 }, (_, i) => ({ id: `g${i}` })),
+    gateStats: {
+      totalGates: 37, blocked: 8, warned: 5,
+      topBlocked: 'rm-rf-home-or-root', topBlockedCount: 5,
+      byGate: { 'rm-rf-home-or-root': { blocked: 5 }, 'force-push': { blocked: 3 } },
+    },
+    lessonPipeline: { lessons: 7 },
+    tokenSavings: { dollarsSavedDisplay: '$1.50', blockedCalls: 8 },
+    team: { totalAgents: 3, riskyAgents: 1 },
+  };
+
+  // gates LIST (populated) — lists the actual fired gates
+  const list = buildEnterpriseChatAnswer('what mistakes were blocked?', data, status);
+  assert.equal(list.topic, 'gates');
+  assert.match(list.answer, /blocked across 2 gate\(s\)/);
+  assert.match(list.answer, /Most-blocked: rm-rf-home-or-root \(5x\), force-push \(3x\)/);
+
+  // gates COUNT — configured vs fired vs blocked, distinct from the list answer
+  const count = buildEnterpriseChatAnswer('how many gates are configured?', data, status);
+  assert.match(count.answer, /37 gates are configured \(active and watching\); 2 have actually fired/);
+  assert.match(count.answer, /blocked 8 action\(s\) and warned on 5/);
+  assert.notEqual(list.answer, count.answer);
+
+  // gates LIST empty-state
+  const empty = buildEnterpriseChatAnswer('what was blocked?', { ...data, gateStats: { totalGates: 37, byGate: {} } }, status);
+  assert.match(empty.answer, /No actions have been blocked yet/);
+
+  // "today" -> honest cumulative scope note
+  assert.match(buildEnterpriseChatAnswer('what was blocked today?', data, status).answer, /cumulative for this install/);
+
+  // feedback
+  const fb = buildEnterpriseChatAnswer('how much feedback do we have?', data, status);
+  assert.equal(fb.topic, 'feedback');
+  assert.match(fb.answer, /Feedback total: 10 \(6 positive, 4 negative\)/);
+  assert.match(fb.answer, /7 lessons promoted/);
+
+  // cost + overview branches
+  assert.match(buildEnterpriseChatAnswer('what are our token savings?', data, status).answer, /token savings/i);
+  assert.match(buildEnterpriseChatAnswer('give me a general summary', data, status).answer, /Snapshot:/);
+});
+
 test('legacy enterprise Dialogflow routes remain compatibility aliases', async () => {
   const statusRes = await fetch(apiUrl('/v1/enterprise/dialogflow/status'), { headers: authHeader });
   assert.equal(statusRes.status, 200);

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -3945,6 +3945,32 @@ test('dashboard /v1/chat answers data questions LOCALLY with no cloud/LLM/API ke
   assert.equal(openBody.llm, 'none');
 });
 
+test('dashboard chat gives DIFFERENT, intent-aware answers (list vs count), not one canned template', async () => {
+  // The exact bug: "what mistakes were blocked" and "how many gates" used to
+  // return the identical "Active gates: N. Blocked actions recorded: M." line.
+  const ask = async (question) => {
+    const res = await fetch(apiUrl('/v1/chat'), {
+      method: 'POST', headers: authHeader, body: JSON.stringify({ question }),
+    });
+    assert.equal(res.status, 200);
+    return res.json();
+  };
+
+  const listAns = await ask('what mistakes were blocked?');   // LIST intent
+  const countAns = await ask('how many gates are configured?'); // COUNT intent
+
+  assert.equal(listAns.topic, 'gates');
+  assert.equal(countAns.topic, 'gates');
+  // The two answers must NOT be identical (the whole complaint).
+  assert.notEqual(listAns.answer, countAns.answer);
+  // List branch surfaces the per-gate breakdown phrasing (or the empty-state).
+  assert.match(listAns.answer, /blocked across|No actions have been blocked|Most-blocked/i);
+  // Count branch distinguishes configured gates from ones that actually fired.
+  assert.match(countAns.answer, /configured \(active and watching\)/i);
+  // It must not regress to the old conflated single-line template.
+  assert.doesNotMatch(countAns.answer, /^Active gates: \d+\. Blocked actions recorded/);
+});
+
 test('legacy enterprise Dialogflow routes remain compatibility aliases', async () => {
   const statusRes = await fetch(apiUrl('/v1/enterprise/dialogflow/status'), { headers: authHeader });
   assert.equal(statusRes.status, 200);

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -3986,7 +3986,9 @@ test('legacy enterprise Dialogflow routes remain compatibility aliases', async (
   assert.equal(chatRes.status, 200);
   const chat = await chatRes.json();
   assert.equal(chat.ok, true);
-  assert.match(chat.answer, /Active gates/i);
+  // "Which gates are blocking…" is a list-intent question → the answerer lists the
+  // gates that fired (or the empty-state), not a generic "Active gates: N" template.
+  assert.match(chat.answer, /blocked across|Most-blocked|No actions have been blocked|gates are configured/i);
 });
 
 test('renderPackagedLessonsHtml returns html with lessons content', () => {


### PR DESCRIPTION
## Why
"Chat with your data" returned **the same canned line** for different questions — "how many gates were activated" and "what mistakes were blocked" both gave *"Active gates: N. Blocked actions recorded: M."* (CEO screenshot). It matched a topic and dumped a fixed template; it didn't actually answer.

## What
Intent-aware, data-specific answerer:
- **"what / which was blocked"** → lists the actual fired gates from the per-gate breakdown: *"186 blocked across 10 gates. Most-blocked: pr-thread-resolution (67x), memory-high-risk-default-deny (62x), secret-exfiltration (38x), rm-rf-home-or-root (2x)…"*
- **"how many"** → distinguishes **configured** gates (active & watching) from the ones that **actually fired**, plus **blocked vs warned** — no longer conflated.
- **Honest "today"**: counts are cumulative for the install; the answer says so instead of faking a per-day number.
- **Overview** = real snapshot, not "ask about X".

Stays local-first (no cloud/LLM/key — builds on #2501). New test asserts the two question types return **different** answers + don't regress to the old template.

## Verification (live, real gate data)
- "how many gates activated" → "37 configured; 10 have actually fired; blocked 186, warned 166"
- "what mistakes were blocked" → lists the 6 real top gates with counts
- api-server chat suite 6/6, dashboard-chat 9/9, clean-state

## Consolidation
This is the **single canonical** dashboard-chat answerer (CEO-directed). It supersedes the overlapping in-flight chat work (#2509 local-fallback ≈ already-shipped #2501; the intent-aware branches). Recommend closing those once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)