### PR TITLE
fix(billing): fail closed without STRIPE_WEBHOOK_SECRET (security; extracted from #2509)

### DIFF
--- a/.changeset/stripe-webhook-secret-fail-closed.md
+++ b/.changeset/stripe-webhook-secret-fail-closed.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fail closed when live Stripe webhook processing is enabled without `STRIPE_WEBHOOK_SECRET`; unsigned webhook parsing is now test-only opt-in.

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -139,6 +139,10 @@ const IS_TEST = !!(
   process.env.NODE_ENV === 'test'
 );
 
+function allowUnsignedStripeWebhooks() {
+  return IS_TEST && process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS === '1';
+}
+
 function shouldMergeLegacyBillingData() {
   return process.env._TEST_INCLUDE_LEGACY_BILLING_DATA === '1'
     || process.env.THUMBGATE_INCLUDE_LEGACY_BILLING_DATA === '1';
@@ -2901,7 +2905,7 @@ function disableCustomerKeys(customerId) {
 }
 
 function verifyWebhookSignature(rawBody, signature) {
-  if (!CONFIG.STRIPE_WEBHOOK_SECRET) return true;
+  if (!CONFIG.STRIPE_WEBHOOK_SECRET) return allowUnsignedStripeWebhooks();
   if (!signature || !rawBody) return false;
 
   // Stripe signature format: t=<timestamp>,v1=<hmac>,...
@@ -2931,6 +2935,13 @@ function verifyWebhookSignature(rawBody, signature) {
 
 async function handleWebhook(rawBody, signature) {
   if (LOCAL_MODE()) return { handled: false, reason: 'local_mode' };
+  if (!CONFIG.STRIPE_WEBHOOK_SECRET && !allowUnsignedStripeWebhooks()) {
+    return {
+      handled: false,
+      reason: 'invalid_signature',
+      error: 'STRIPE_WEBHOOK_SECRET is required before Stripe webhooks can be processed.',
+    };
+  }
   let event;
   try {
     if (CONFIG.STRIPE_WEBHOOK_SECRET) {

--- a/tests/billing-webhook-email.test.js
+++ b/tests/billing-webhook-email.test.js
@@ -28,6 +28,7 @@ const savedEnv = {
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
   STRIPE_PRICE_ID: process.env.STRIPE_PRICE_ID,
   STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+  THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS: process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS,
   THUMBGATE_PLAUSIBLE_DISABLE: process.env.THUMBGATE_PLAUSIBLE_DISABLE,
 };
 
@@ -41,7 +42,8 @@ function primeEnv(suffix) {
   process.env.STRIPE_SECRET_KEY = 'sk_test_fake_for_webhook_test';
   process.env.STRIPE_PRICE_ID = '';
   process.env.THUMBGATE_PLAUSIBLE_DISABLE = '1';
-  // No webhook secret → constructEvent path skipped; raw body is JSON-parsed.
+  // Test-only unsigned path exercises mailer side effects without real Stripe keys.
+  process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS = '1';
   delete process.env.STRIPE_WEBHOOK_SECRET;
 }
 

--- a/tests/billing.test.js
+++ b/tests/billing.test.js
@@ -693,7 +693,9 @@ describe('billing.js — funnel ledger', () => {
 
   test('stripe webhook provisions and reports skipped activation email when provider is missing', async () => {
     const savedWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    const savedAllowUnsigned = process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS;
     process.env.STRIPE_WEBHOOK_SECRET = '';
+    process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS = '1';
     const billing = requireFreshBilling('sk_test_webhook');
     try {
       const result = await billing.handleWebhook(Buffer.from(JSON.stringify({
@@ -733,6 +735,31 @@ describe('billing.js — funnel ledger', () => {
     } finally {
       if (savedWebhookSecret === undefined) delete process.env.STRIPE_WEBHOOK_SECRET;
       else process.env.STRIPE_WEBHOOK_SECRET = savedWebhookSecret;
+      if (savedAllowUnsigned === undefined) delete process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS;
+      else process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS = savedAllowUnsigned;
+    }
+  });
+
+  test('stripe webhook fails closed when live billing lacks a webhook secret', async () => {
+    const savedWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    const savedAllowUnsigned = process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS;
+    process.env.STRIPE_WEBHOOK_SECRET = '';
+    delete process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS;
+    const billing = requireFreshBilling('sk_test_missing_webhook_secret');
+    try {
+      assert.equal(billing.verifyWebhookSignature(Buffer.from('{"id":"evt_forged"}'), ''), false);
+      const result = await billing.handleWebhook(Buffer.from(JSON.stringify({
+        type: 'checkout.session.completed',
+        data: { object: { id: 'cs_forged', customer_details: { email: 'forged@example.com' } } },
+      })), '');
+      assert.equal(result.handled, false);
+      assert.equal(result.reason, 'invalid_signature');
+      assert.match(result.error, /STRIPE_WEBHOOK_SECRET is required/i);
+    } finally {
+      if (savedWebhookSecret === undefined) delete process.env.STRIPE_WEBHOOK_SECRET;
+      else process.env.STRIPE_WEBHOOK_SECRET = savedWebhookSecret;
+      if (savedAllowUnsigned === undefined) delete process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS;
+      else process.env.THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS = savedAllowUnsigned;
     }
   });
 


### PR DESCRIPTION
## Security: webhook fail-open → fail-closed
`scripts/billing.js` accepted Stripe webhooks **without signature verification when `STRIPE_WEBHOOK_SECRET` was unset** — `verifyWebhookSignature` returned `true`, and `handleWebhook` parsed the raw event directly. A misconfigured/missing secret on the billing server would let an attacker POST **forged** webhook events (fake `payment_succeeded`, refunds, subscription changes). **This fail-open is shipped in published npm 1.27.4.**

## Fix
- Missing secret in **live** mode → **reject** (`reason: 'invalid_signature'`, "STRIPE_WEBHOOK_SECRET is required…"). Fail **closed**.
- Lenient path gated to test only: `allowUnsignedStripeWebhooks()` = `IS_TEST && THUMBGATE_ALLOW_UNSIGNED_STRIPE_WEBHOOKS === '1'`.
- Production already sets the secret, so normal operation is unchanged — this only changes the *missing-secret* path from accept→reject.

## Why a separate PR
The fix (commit `6ca630b8`, with tests) was **trapped inside the 76-file, CONFLICTING/DIRTY #2509 bundle** and never reached npm. Security shouldn't wait on a stuck bundle — extracted here into a focused, mergeable PR.

## Verification
- Billing + webhook suites **67/67** clean-state (`billing.test.js`, `billing-webhook-email.test.js`, `stripe-webhook-route.test.js`, `stripe-webhook-rotation.test.js`).
- Includes its changeset → next release (1.27.5) ships the hardening to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)