### PR TITLE
feat(checkout): sample bypass traffic for objections

### DIFF
--- a/.changeset/checkout-interstitial-sampling.md
+++ b/.changeset/checkout-interstitial-sampling.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add deterministic sampling for the ThumbGate Pro checkout interstitial when direct-to-Stripe bypass is enabled, preserving fast checkout for unsampled visitors while exposing a configured slice of human traffic to buyer-objection feedback capture.

--- a/scripts/telemetry-analytics.js
+++ b/scripts/telemetry-analytics.js
@@ -75,6 +75,13 @@ function normalizeInteger(value) {
   return Number.isFinite(parsed) ? Math.trunc(parsed) : null;
 }
 
+function normalizeRate(value) {
+  if (value === undefined || value === null || value === '') return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.max(0, Math.min(parsed, 1));
+}
+
 function safeRate(num, den) {
   if (!den) return 0;
   return Number((num / den).toFixed(4));
@@ -480,6 +487,8 @@ function sanitizeTelemetryPayload(payload = {}, headers = {}) {
     httpStatus: normalizeInteger(raw.httpStatus),
     userAgent: pickFirstText(raw.userAgent, headers['user-agent']),
     isBot: pickFirstText(raw.isBot),
+    interstitialSampled: pickFirstText(raw.interstitialSampled),
+    interstitialSampleRate: normalizeRate(raw.interstitialSampleRate),
     attributionTagged: Boolean(
       pickFirstText(raw.utmSource, raw.utmMedium, raw.utmCampaign, raw.utmContent, raw.utmTerm)
     ),

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1567,8 +1567,8 @@ function classifyEnterpriseChatTopic(prompt) {
 // today?" with an actual filtered list instead of a canned total.
 function parseChatIntent(prompt) {
   const lower = String(prompt || '').toLowerCase();
-  const terms = lower.split(/[^a-z0-9]+/).filter(Boolean);
-  const hasTerm = (term) => terms.includes(term);
+  const terms = new Set(lower.split(/[^a-z0-9]+/).filter(Boolean));
+  const hasTerm = (term) => terms.has(term);
   const wantsList = lower.includes('tell me about') ||
     ['what', 'which', 'list', 'show', 'example', 'examples'].some(hasTerm);
   let windowMs = null;
@@ -1919,6 +1919,43 @@ function buildLossAnalyticsResponse(data, summaryOptions) {
 
 function createJourneyId(prefix) {
   return createTraceId(prefix).replace(/^trace_/, `${prefix}_`);
+}
+
+function normalizeCheckoutInterstitialSampleRate(value) {
+  const parsed = Number.parseFloat(String(value || '').trim());
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+  if (parsed > 1) {
+    return Math.min(parsed / 100, 1);
+  }
+  return Math.min(parsed, 1);
+}
+
+function stableUnitInterval(value) {
+  const text = String(value || '');
+  let hash = 2166136261;
+  for (const character of text) {
+    hash ^= character.codePointAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4294967296;
+}
+
+function shouldSampleCheckoutInterstitial({ sampleRate, traceId, analyticsMetadata }) {
+  if (sampleRate <= 0) {
+    return false;
+  }
+  if (sampleRate >= 1) {
+    return true;
+  }
+  const seed = [
+    analyticsMetadata?.visitorId,
+    analyticsMetadata?.sessionId,
+    analyticsMetadata?.acquisitionId,
+    traceId,
+  ].filter(Boolean).join(':');
+  return stableUnitInterval(seed || traceId) < sampleRate;
 }
 
 function appendQueryParam(url, key, value) {
@@ -5654,11 +5691,20 @@ async function addContext(){
       // buildCheckoutFallbackUrl. Default-off; bot-deflection still applies
       // (bot + no email hint still falls through to the existing interstitial).
       const interstitialBypassEnabled = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS === '1';
+      const interstitialSampleRate = normalizeCheckoutInterstitialSampleRate(
+        process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE
+      );
+      const interstitialSampled = shouldSampleCheckoutInterstitial({
+        sampleRate: interstitialSampleRate,
+        traceId,
+        analyticsMetadata,
+      });
       if (
         !isConfirmedCheckout
         && interstitialBypassEnabled
         && req.method !== 'POST'
         && botShouldBypass
+        && !interstitialSampled
       ) {
         // Always target the pro Stripe Payment Link directly. The
         // hostedConfig.checkoutFallbackUrl (e.g. https://thumbgate.ai/go/pro)
@@ -5684,6 +5730,7 @@ async function addContext(){
           referrerHost: analyticsMetadata.referrerHost,
           page: '/checkout/pro',
           planId: analyticsMetadata.planId,
+          interstitialSampleRate,
         }, req.headers, 'checkout_interstitial_bypass_redirect');
         res.writeHead(302, {
           ...responseHeaders,
@@ -5750,6 +5797,8 @@ async function addContext(){
           billingCycle: analyticsMetadata.billingCycle,
           landingPath: analyticsMetadata.landingPath,
           isBot: botClassification.isBot ? 'true' : 'false',
+          interstitialSampled: interstitialSampled ? 'true' : 'false',
+          interstitialSampleRate,
           reason: botClassification.reason,
         }, req.headers, eventType);
         const prefilledEmail = parsed?.searchParams?.get('customer_email') || '';

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -260,6 +260,150 @@ describe('/checkout/pro bot guard', () => {
     }
   });
 
+  it('keeps direct-to-Stripe bypass for unsampled human traffic when bypass is enabled', async () => {
+    const previousBypass = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+    const previousSampleRate = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+    const previousProStripeUrl = process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL;
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = '1';
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = '0';
+    process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL = 'https://buy.stripe.com/test-pro';
+
+    try {
+      try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
+      const res = await fetch(`${origin}/checkout/pro?visitor_id=visitor_unsampled`, {
+        redirect: 'manual',
+        headers: {
+          'user-agent': BROWSER_UA,
+          accept: BROWSER_ACCEPT,
+        },
+      });
+      assert.equal(res.status, 302);
+      assert.match(res.headers.get('location') || '', /^https:\/\/buy\.stripe\.com\/test-pro/);
+
+      const events = readFunnelEvents();
+      const event = events.find((entry) =>
+        entry.eventType === 'checkout_interstitial_bypass_redirect' &&
+        entry.visitorId === 'visitor_unsampled'
+      );
+      assert.ok(event, 'expected bypass redirect telemetry for unsampled human traffic');
+      assert.equal(event.interstitialSampleRate, 0);
+    } finally {
+      if (previousBypass === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = previousBypass;
+      if (previousSampleRate === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = previousSampleRate;
+      if (previousProStripeUrl === undefined) delete process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL;
+      else process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL = previousProStripeUrl;
+    }
+  });
+
+  it('samples human bypass traffic into the checkout feedback interstitial', async () => {
+    const previousBypass = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+    const previousSampleRate = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = '1';
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = '1';
+
+    try {
+      try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
+      const res = await fetch(`${origin}/checkout/pro?visitor_id=visitor_sampled`, {
+        redirect: 'manual',
+        headers: {
+          'user-agent': BROWSER_UA,
+          accept: BROWSER_ACCEPT,
+        },
+      });
+      assert.equal(res.status, 200);
+      const body = await res.text();
+      assert.match(body, /aria-label="Checkout feedback"/);
+      assert.match(body, /data-reason="price_unclear"/);
+      assert.match(body, /reason_not_buying/);
+
+      const events = readFunnelEvents();
+      const event = events.find((entry) =>
+        entry.eventType === 'checkout_interstitial_view' &&
+        entry.visitorId === 'visitor_sampled'
+      );
+      assert.ok(event, 'expected interstitial telemetry for sampled human traffic');
+      assert.equal(event.interstitialSampled, 'true');
+      assert.equal(event.interstitialSampleRate, 1);
+    } finally {
+      if (previousBypass === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = previousBypass;
+      if (previousSampleRate === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = previousSampleRate;
+    }
+  });
+
+  it('accepts percentage syntax for checkout interstitial sampling', async () => {
+    const previousBypass = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+    const previousSampleRate = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = '1';
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = '100';
+
+    try {
+      try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
+      const res = await fetch(`${origin}/checkout/pro?visitor_id=visitor_percent_sampled`, {
+        redirect: 'manual',
+        headers: {
+          'user-agent': BROWSER_UA,
+          accept: BROWSER_ACCEPT,
+        },
+      });
+      assert.equal(res.status, 200);
+
+      const events = readFunnelEvents();
+      const event = events.find((entry) =>
+        entry.eventType === 'checkout_interstitial_view' &&
+        entry.visitorId === 'visitor_percent_sampled'
+      );
+      assert.ok(event, 'expected interstitial telemetry for percent sampling');
+      assert.equal(event.interstitialSampled, 'true');
+      assert.equal(event.interstitialSampleRate, 1);
+    } finally {
+      if (previousBypass === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = previousBypass;
+      if (previousSampleRate === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = previousSampleRate;
+    }
+  });
+
+  it('treats invalid checkout interstitial sample rates as zero', async () => {
+    const previousBypass = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+    const previousSampleRate = process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+    const previousProStripeUrl = process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL;
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = '1';
+    process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = 'not-a-rate';
+    process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL = 'https://buy.stripe.com/test-pro';
+
+    try {
+      try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
+      const res = await fetch(`${origin}/checkout/pro?visitor_id=visitor_invalid_sample_rate`, {
+        redirect: 'manual',
+        headers: {
+          'user-agent': BROWSER_UA,
+          accept: BROWSER_ACCEPT,
+        },
+      });
+      assert.equal(res.status, 302);
+      assert.match(res.headers.get('location') || '', /^https:\/\/buy\.stripe\.com\/test-pro/);
+
+      const events = readFunnelEvents();
+      const event = events.find((entry) =>
+        entry.eventType === 'checkout_interstitial_bypass_redirect' &&
+        entry.visitorId === 'visitor_invalid_sample_rate'
+      );
+      assert.ok(event, 'expected bypass telemetry for invalid sampling');
+      assert.equal(event.interstitialSampleRate, 0);
+    } finally {
+      if (previousBypass === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS = previousBypass;
+      if (previousSampleRate === undefined) delete process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE;
+      else process.env.THUMBGATE_CHECKOUT_INTERSTITIAL_SAMPLE_RATE = previousSampleRate;
+      if (previousProStripeUrl === undefined) delete process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL;
+      else process.env.THUMBGATE_CHECKOUT_PRO_STRIPE_URL = previousProStripeUrl;
+    }
+  });
+
   it('shows real browsers the intent interstitial before checkout session creation', async () => {
     try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
     const res = await fetch(`${origin}/checkout/pro`, {

--- a/tests/telemetry-analytics.test.js
+++ b/tests/telemetry-analytics.test.js
@@ -91,6 +91,8 @@ test('sanitizeTelemetryPayload normalizes modern web payloads', () => {
     ctaPlacement: 'pricing',
     planId: 'pro',
     page: '/',
+    interstitialSampled: 'true',
+    interstitialSampleRate: 0.25,
   }, {
     referer: 'https://search.example',
     'user-agent': 'browser-test',
@@ -105,6 +107,8 @@ test('sanitizeTelemetryPayload normalizes modern web payloads', () => {
   assert.equal(entry.referrer, 'https://search.example');
   assert.equal(entry.referrerHost, 'search.example');
   assert.equal(entry.ctaPlacement, 'pricing');
+  assert.equal(entry.interstitialSampled, 'true');
+  assert.equal(entry.interstitialSampleRate, 0.25);
   assert.equal(entry.userAgent, 'browser-test');
   assert.equal(entry.attributionTagged, true);
 });


### PR DESCRIPTION
## Summary
- Add deterministic sampling for `/checkout/pro` when direct-to-Stripe bypass is enabled.
- Preserve the fast Stripe redirect for unsampled human visitors.
- Emit sanitized sampling fields so checkout objection telemetry can be segmented.

## Verification
- `node --test tests/checkout-bot-guard.test.js tests/telemetry-analytics.test.js`
- `node --test tests/api-server.test.js tests/dashboard.test.js tests/sonarcloud-workflow.test.js`
- `npm run changeset:check`
- `git diff --check`
- focused secret scan over `scripts src tests .changeset .github public package.json .env.example`
- pre-commit guards passed
- pre-push guards passed

## Revenue Ops Context
PR #2519 shipped the buyer-objection UI, but production still redirects ordinary human traffic directly to Stripe because `THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS=1`. This patch makes the reason-capture path measurable without removing the high-conversion direct checkout path.