### PR TITLE
feat(seo): auto-include compare pages in sitemap + FAQ schema for AI Overview eligibility

### DIFF
--- a/.changeset/sitemap-compare-autoinclude-faq-schema.md
+++ b/.changeset/sitemap-compare-autoinclude-faq-schema.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+GEO: `/sitemap.xml` now auto-includes every `public/compare/*.html` comparison page (derived from the filesystem instead of a hand-maintained list, so pages can no longer silently fall out of the sitemap), and the ThumbGate-vs-Rein comparison and Agent Manager landing pages gained FAQPage structured data — making them eligible to surface in AI Overviews / AI Mode and discoverable by AI answer engines on their buyer-intent queries.

--- a/.claude/implementation-notes/2026-06-05-geo-ai-overview-eligibility.md
+++ b/.claude/implementation-notes/2026-06-05-geo-ai-overview-eligibility.md
@@ -1,0 +1,60 @@
+# GEO: AI Overview eligibility (2026-06-05)
+
+Trigger: CEO shared Google's "Search Generative AI performance reports in Search Console"
+(2026-06-03) and asked "how does this help us? implement the high-ROI ideas."
+
+## What the blog actually says (VERIFIED via WebSearch across Google + SE Land + SEJ)
+GSC now reports **impressions inside AI Overviews, AI Mode, and Discover AI features**,
+sliced by Pages/Countries/Devices/Dates. Impressions only (no clicks/queries yet),
+rolling out to a subset (UK first). It also ships an opt-out to *block* content from AI answers.
+
+How it helps: it's the first way to **measure** whether ThumbGate appears in Google's AI
+answers — the core GEO goal. Two implementables fall out: (1) don't block AI crawlers,
+(2) be structurally eligible + crawlable for AI Overviews on category/comparison queries.
+
+## What I found (audit, not assumption)
+- robots.txt already explicitly `Allow: /` for Google-Extended, GPTBot, OAI-SearchBot,
+  ClaudeBot/Claude-SearchBot/Claude-User, PerplexityBot, anthropic-ai, Googlebot, Bingbot,
+  + llms.txt/llm-context.md + Sitemap. **No gap — left untouched.**
+- Homepage structured data already rich (FAQPage 12 Q, HowTo, 2× SoftwareApplication).
+- REAL gaps:
+  - `compare/rein.html` and `agent-manager.html` had **no FAQPage schema** → ineligible
+    for AI Overviews on their queries.
+  - **4 comparison pages missing from /sitemap.xml**: agentix-labs,
+    ai-experience-orchestration, heidi, rein. (Corrected from an initial wrong "7 missing"
+    — fallow/mem0/speclock are already covered via seo-gsd.js. The "are you sure?" check
+    caught that I'd only read the hardcoded list, not the spread-in seo entries.)
+
+## Decisions
+- **Root-cause fix, not a patch.** Instead of hand-adding the 4 missing entries,
+  `renderSitemapXml` now derives compare entries from `fs.readdirSync(PUBLIC_DIR/compare)`
+  and de-dupes against entries already declared (so seo-gsd's explicit priorities win).
+  New compare pages are now auto-included forever. Kept the 6 hardcoded entries (preserve
+  the 0.9 priority on anthropic-claude-for-legal; FS-derive skips them via the dedupe set).
+  - Tradeoff: one `readdirSync` per /sitemap.xml request. Negligible (low-traffic crawler
+    route; server already reads files per marketing page). Wrapped in try/catch so a
+    stripped bundle without public/compare falls back to static entries. Files sorted for
+    deterministic output.
+- **FAQ content is grounded in each page's real copy**, not filler — and preserves the
+  honest license hedge on rein.html (Rein's exact license to be verified at reinai.io;
+  secondary source said AGPL, unconfirmed). VERIFIED by reading both pages before writing.
+- **Regression guard** added: `public-static-assets.test.js` asserts every
+  public/compare/*.html is in /sitemap.xml, + that rein/agent-manager expose FAQPage.
+  This is the durable anti-drift mechanism (CEO: "no tech debt").
+
+## Verification (all VERIFIED)
+- public-static-assets.test.js: 62 pass (incl. 2 new guards)
+- api-server.test.js: 136 pass
+- seo-gsd.test.js: 28 pass
+- package-boundary + public-bundle-ratchet: 6 pass (file count 254 unchanged — no new
+  bundle files; HTML edits only add content). Size cap has headroom.
+- JSON-LD in both edited pages parses; 4 FAQ questions each.
+- Changeset added (patch).
+
+## NOT done / out of scope
+- Reading the live GSC gen-AI report for thumbgate.ai — rolling out UK-first/subset, may
+  not be available for our property yet; needs GSC browser access, not a code change.
+- #2511 (chat answerer) is owned by another active session (commits 3 min ago in
+  /tmp/tg-chat2); its duplicate-key S1534 bug was already removed in their latest commit.
+  I stood down — not racing a multi-agent branch.
+- #2512 (webhook fail-closed) merged to main (deb3355e) independently.

--- a/public/agent-manager.html
+++ b/public/agent-manager.html
@@ -28,6 +28,46 @@
   ]
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the Agent Manager role?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Anthropic named it: the Agent Manager is a hybrid PM/engineer single DRI who owns the Claude Code configuration every developer in the org actually feels — the CLAUDE.md hierarchy, the plugin marketplace, the permissions policy, and which skills ship — and is responsible for keeping them current. Without that role, enterprise Claude Code rollouts stall in phase two; with it, the model improving is no longer the bottleneck."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does ThumbGate help the Agent Manager?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ThumbGate is the pre-action enforcement layer underneath what the role owns. It runs PreToolUse hooks at the tool-call boundary, auto-distills prevention rules from real thumbs-down feedback and writes them into CLAUDE.md, provides an org-wide rule library and hosted dashboard, and keeps an adapter matrix current as Claude Code, Cursor, and Codex change — so the role does not have to be the operator themselves. Each block carries the rule that fired and the evidence that triggered it, so the agent can choose a safer plan."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is ThumbGate free for the Agent Manager to start?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. npx thumbgate init in one repo is free and MIT licensed, and the gates work locally without a hosted account. The paid tier adds the hosted dashboard, the org-wide rule library, DPO/HuggingFace export, and 24x7 ops on the adapter matrix — the operational work the role would otherwise have to do itself."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which AI coding agents does ThumbGate cover for an enterprise rollout?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode. One install wires every supported agent, and each adapter is version-pinned and CI-checked against the upstream runtime, so a breaking change to a hook or plugin API does not stall the rollout for a quarter."
+      }
+    }
+  ]
+}
+</script>
 <style>
   *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
   :root { --bg:#0a0a0b; --card:#161618; --border:#222225; --text:#e8e8ec; --muted:#8b8b94; --cyan:#22d3ee; }

--- a/public/compare/rein.html
+++ b/public/compare/rein.html
@@ -35,6 +35,47 @@
 }
 </script>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What's the difference between Rein and ThumbGate?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both intercept an agent's action before it fires — that's the shared category. Rein is a generic in-process Python decorator aimed at production apps in regulated domains (trading, healthcare, legal), where each decision is high-stakes and policies are authored by hand. ThumbGate is the coding-agent specialist for Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode: it intercepts at the out-of-process PreToolUse hook boundary and learns from thumbs-down corrections, auto-promoting them into prevention rules that persist across sessions. Same pre-action thesis, different target user."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use Rein and ThumbGate together?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. They don't conflict and they aren't direct alternatives. Rein governs a production application's agent at the decorated-function boundary; ThumbGate governs your engineering team's coding agents at the PreToolUse boundary. A team running both a regulated production agent and an AI coding workflow can use Rein for the first and ThumbGate for the second."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does ThumbGate require code changes like Rein's decorator?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Rein integrates as a Python decorator you wrap around each tool function. ThumbGate installs with npx thumbgate init, which auto-detects the agent and wires the PreToolUse hooks with zero workflow change. It runs out-of-process at the agent runtime boundary, so dangerous calls are caught before the agent's process even attempts them."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is ThumbGate open source like Rein?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ThumbGate's CLI and hook layer are MIT licensed — open-core, not viral — with commercial licensing for Pro and Team features. Rein's exact license should be confirmed at reinai.io before you make a distribution decision; a secondary source summarized it as AGPL, but we have not independently verified that, so check the primary source."
+      }
+    }
+  ]
+}
+</script>
+
 <link rel="stylesheet" href="/learn/learn.css">
 <style>
   .matrix { width: 100%; border-collapse: collapse; margin: 1.5rem 0; font-size: 0.95rem; }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2951,7 +2951,7 @@ function renderSitemapXml(runtimeConfig) {
   // seo-gsd specs), which keep their explicit priorities.
   const declaredPaths = new Set(entries.map((entry) => entry.path));
   try {
-    const compareFiles = fs.readdirSync(path.join(PUBLIC_DIR, 'compare')).sort();
+    const compareFiles = fs.readdirSync(path.join(PUBLIC_DIR, 'compare')).sort((a, b) => a.localeCompare(b));
     for (const file of compareFiles) {
       if (!file.endsWith('.html')) continue;
       const comparePath = `/compare/${file.replace(/\.html$/, '')}`;

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2943,6 +2943,25 @@ function renderSitemapXml(runtimeConfig) {
     { path: '/compare/anthropic-claude-for-legal', changefreq: 'weekly', priority: '0.9' },
     ...THUMBGATE_SEO_SITEMAP_ENTRIES,
   ];
+  // Auto-include every hand-written comparison page so /sitemap.xml can never
+  // drift out of sync with public/compare/*.html. Crawlers and AI answer engines
+  // (Google AI Overviews/AI Mode, ChatGPT, Perplexity) only surface pages they can
+  // discover, so a comparison page missing from the sitemap is invisible on its
+  // buyer-intent query. De-duped against entries already declared above (e.g. the
+  // seo-gsd specs), which keep their explicit priorities.
+  const declaredPaths = new Set(entries.map((entry) => entry.path));
+  try {
+    const compareFiles = fs.readdirSync(path.join(PUBLIC_DIR, 'compare')).sort();
+    for (const file of compareFiles) {
+      if (!file.endsWith('.html')) continue;
+      const comparePath = `/compare/${file.replace(/\.html$/, '')}`;
+      if (declaredPaths.has(comparePath)) continue;
+      declaredPaths.add(comparePath);
+      entries.push({ path: comparePath, changefreq: 'weekly', priority: '0.85' });
+    }
+  } catch {
+    // public/compare absent in a stripped bundle — fall back to the static entries.
+  }
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -783,3 +783,39 @@ test('GET /docs/connectors/ (trailing slash) also resolves', async () => {
   const res = await fetch(`${origin}/docs/connectors/`);
   assert.equal(res.status, 200);
 });
+
+// Regression guard: every hand-written comparison page must appear in the sitemap.
+// Root cause this prevents: compare pages were enumerated in a hand-maintained list,
+// so new public/compare/*.html files silently fell out of /sitemap.xml and became
+// undiscoverable by crawlers and AI answer engines (Google AI Overviews/AI Mode,
+// ChatGPT, Perplexity) on their buyer-intent queries. renderSitemapXml now derives
+// these from the filesystem; this test pins that contract so it can't drift again.
+test('GET /sitemap.xml lists every public/compare/*.html page', async () => {
+  const comparePages = fs
+    .readdirSync(path.join(publicDir, 'compare'))
+    .filter((file) => file.endsWith('.html'))
+    .map((file) => `/compare/${file.replace(/\.html$/, '')}`);
+
+  assert.ok(comparePages.length >= 13, `expected the full compare catalog, got ${comparePages.length}`);
+
+  const res = await fetch(`${origin}/sitemap.xml`);
+  assert.equal(res.status, 200);
+  const xml = await res.text();
+
+  const missing = comparePages.filter(
+    (p) => !new RegExp(`<loc>[^<]*${p.replace(/[/-]/g, (c) => `\\${c}`)}</loc>`).test(xml),
+  );
+  assert.deepEqual(missing, [], `comparison pages missing from sitemap: ${missing.join(', ')}`);
+});
+
+// GEO: comparison and high-intent landing pages carry FAQPage structured data so they
+// are eligible to be pulled into AI Overviews / AI Mode on their category queries.
+test('comparison and key landing pages expose FAQPage structured data', async () => {
+  for (const pagePath of ['/compare/rein', '/agent-manager']) {
+    const res = await fetch(`${origin}${pagePath}`);
+    assert.equal(res.status, 200, `${pagePath} must serve`);
+    const body = await res.text();
+    assert.match(body, /"@type":\s*"FAQPage"/, `${pagePath} must declare FAQPage schema`);
+    assert.match(body, /"@type":\s*"Question"/, `${pagePath} must include at least one Question`);
+  }
+});


### PR DESCRIPTION
## Why
Google Search Console launched **Generative AI performance reports** (June 2026): impressions inside **AI Overviews / AI Mode / Discover**. To be eligible + discoverable there on buyer-intent/comparison queries, our pages must be (a) in the sitemap and (b) carry FAQ structured data. An audit found gaps in both.

## What
- **Sitemap can no longer drift.** `renderSitemapXml` now derives `/compare/*` entries from `public/compare/*.html` instead of a hand-maintained list. This fixed **4 comparison pages silently missing** from `/sitemap.xml` (agentix-labs, ai-experience-orchestration, heidi, rein) and prevents recurrence. De-duped against declared entries (seo-gsd priorities win); `try/catch` falls back to static entries in stripped bundles; output sorted for determinism.
- **FAQPage schema** added to `compare/rein.html` and `agent-manager.html` (the two high-intent pages that had none), grounded in each page's real copy.
- **Regression guard**: every `public/compare/*.html` must appear in `/sitemap.xml`, and rein/agent-manager must expose FAQPage.

## Verify
Full suite green (clean state): public-static-assets **62**, api-server **136**, seo-gsd **28**, package-boundary + ratchet **6** (254-file bundle count unchanged — content-only HTML edits). JSON-LD validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)