### PR TITLE
ci(release): auto-regenerate codex marketplace pack on version bump

### DIFF
--- a/.changeset/sync-version-codex-pack.md
+++ b/.changeset/sync-version-codex-pack.md
@@ -1,0 +1,24 @@
+---
+"thumbgate": patch
+---
+
+ci: wire codex marketplace pack regeneration into sync-version.js
+
+The codex marketplace pack (`docs/marketing/codex-marketplace-revenue-pack.md`)
+embeds the release version in a `releases/download/v<VERSION>/` URL, but was
+not a `sync-version` target — so every release tripped the
+"checked-in Codex marketplace pack stays in sync with the generator output"
+test (caught on 1.27.3, 1.27.4/1.27.6, would have caught every future bump).
+
+Fix: add a `POST_SYNC_GENERATORS` step that, after the simple field-level
+version sync, invokes registered regenerator scripts (currently just
+`scripts/codex-marketplace-revenue-pack.js --write-docs`). On `--check` the
+generators are skipped (the existing per-generator test catches drift); on a
+real sync they run and re-emit the pack with the new version. Generator
+failures are logged as warnings, never break the version sync — the
+per-generator test is still the source of truth.
+
+Live-verified by simulating 1.27.6 → 1.27.7: pack URL auto-updated from
+`v1.27.6/...zip` to `v1.27.7/...zip` and the codex test passes 10/10.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

--- a/docs/marketing/codex-marketplace-revenue-pack.json
+++ b/docs/marketing/codex-marketplace-revenue-pack.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-03T21:43:39.815Z",
+  "generatedAt": "2026-06-05T21:13:51.793Z",
   "channel": "Codex",
   "objective": "Turn Codex plugin interest into proof-backed installs, Pro checkout starts, and qualified workflow sprint conversations.",
   "canonicalIdentity": {
@@ -29,7 +29,7 @@
       "key": "standalone_bundle",
       "name": "Standalone bundle download",
       "url": "https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-codex-plugin.zip",
-      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.27.2/thumbgate-codex-plugin-v1.27.2.zip",
+      "versionedUrl": "https://github.com/IgorGanapolsky/ThumbGate/releases/download/v1.27.6/thumbgate-codex-plugin-v1.27.6.zip",
       "supportUrl": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/plugins/codex-profile/README.md",
       "evidenceSource": "plugins/codex-profile/README.md",
       "operatorUse": "Portable plugin path for buyers who want a direct asset instead of a repo checkout.",

--- a/docs/marketing/codex-marketplace-revenue-pack.md
+++ b/docs/marketing/codex-marketplace-revenue-pack.md
@@ -1,6 +1,6 @@
 # Codex Operator Revenue Pack
 
-Updated: 2026-06-05T18:44:50.160Z
+Updated: 2026-06-05T21:13:51.793Z
 
 This is a sales operator artifact. It is not proof of installs, revenue, or marketplace approval by itself.
 

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -508,10 +508,38 @@ function syncVersion(opts) {
     targets.push(vscodeExtensionPath);
   }
 
+  // Post-sync generators: targets whose content embeds the version but isn't a
+  // simple string replacement — they have their own generator. Run AFTER the
+  // simple sync so the package.json is at the new version when the generator
+  // reads it. Each entry is { script, label } that gets `node <script>` invoked.
+  // Failures are logged but never fail the version sync — they're picked up by
+  // the per-generator test (e.g. tests/codex-marketplace-revenue-pack.test.js).
+  const POST_SYNC_GENERATORS = [
+    { script: 'scripts/codex-marketplace-revenue-pack.js', args: ['--write-docs'], label: 'codex marketplace pack' },
+  ];
+  const generatorResults = [];
+  if (!checkOnly) {
+    const { execFileSync } = require('node:child_process');
+    for (const gen of POST_SYNC_GENERATORS) {
+      const scriptPath = path.join(PROJECT_ROOT, gen.script);
+      if (!fs.existsSync(scriptPath)) continue;
+      try {
+        execFileSync(process.execPath, [scriptPath, ...gen.args], {
+          cwd: PROJECT_ROOT, stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        generatorResults.push({ label: gen.label, ok: true });
+      } catch (err) {
+        // Surface as a warning, not a failure — the per-generator test catches drift.
+        generatorResults.push({ label: gen.label, ok: false, error: String(err && err.message || err).slice(0, 200) });
+      }
+    }
+  }
+
   return {
     version,
     targets,
     drifted,
+    generators: generatorResults,
     synced: !checkOnly && drifted.length > 0,
     allInSync: drifted.length === 0,
   };
@@ -541,6 +569,10 @@ if (require.main === module) {
   console.log(`✔ Synced ${result.drifted.length} targets to v${result.version}:`);
   result.drifted.forEach((d) => {
     console.log(`  ${d.file} [${d.field}]: ${d.current} → ${result.version}`);
+  });
+  (result.generators || []).forEach((g) => {
+    if (g.ok) console.log(`  ✔ regenerated: ${g.label}`);
+    else console.warn(`  ✗ generator failed: ${g.label} — ${g.error}`);
   });
 }
 


### PR DESCRIPTION
## Why
Every recent release (1.27.3, 1.27.4/1.27.6) hit the same CI failure: the codex marketplace pack embeds `releases/download/v<VERSION>/thumbgate-codex-plugin-v<VERSION>.zip` but isn't a sync-version target. Each release I had to regenerate it manually mid-flight — pure recurrence cost.

## What
Add a `POST_SYNC_GENERATORS` step to `sync-version.js` that, after the simple field-level sync, invokes registered regenerator scripts. Currently just `scripts/codex-marketplace-revenue-pack.js --write-docs`. Extensible for any future version-embedding artifacts.

- On a real sync: generators run after package.json has the new version → pack URL auto-updates → `codex-marketplace-revenue-pack.test.js` passes
- On `--check`: generators are skipped (the per-generator test catches drift)
- Generator failures: logged as warnings, never break the version sync

## Verified locally
Simulated 1.27.6 → 1.27.7:
- pack URL auto-updated v1.27.6 → v1.27.7 ✓
- codex sync test: 10/10 ✓
- `--check` mode unaffected ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)