### PR TITLE
feat(observability): surface checkout objection breakdown + bot-excluded human funnel

### DIFF
--- a/.changeset/observability-objections-qualified-traffic.md
+++ b/.changeset/observability-objections-qualified-traffic.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Observability: surface the checkout objection-reason breakdown (price_unclear / need_more_proof / need_team_plan / not_urgent) and a bot-excluded `qualifiedTraffic` view (human visitors/checkoutStarts after bot/internal/test exclusion) in the billing summary and the `revenue-status` report. This data was already captured but never reported — now we can see *why* buyers bail and read an honest, bot-filtered human funnel instead of the bot-inflated raw counts. Additive only: the existing `trafficMetrics` block is unchanged so no consumer breaks.

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -2234,6 +2234,28 @@ function getBusinessAnalytics(options = {}) {
     newsletterSignups: newsletterSubscribers.length,
   };
 
+  // Bot-excluded human funnel (the honest view) + the WHY-buyers-bail breakdown.
+  // Additive on purpose: trafficMetrics above is left unchanged so existing
+  // consumers/tests don't break; qualifiedTraffic exposes the bot/internal/test-
+  // filtered counts (telemetry.qualified === trafficQuality.external), and
+  // objections surfaces the reason_not_buying breakdown that was captured but
+  // never reported (price_unclear / need_more_proof / need_team_plan / not_urgent).
+  const qualifiedTraffic = {
+    visitors: telemetry.qualified ? telemetry.qualified.uniqueVisitors || 0 : 0,
+    sessions: telemetry.qualified ? telemetry.qualified.uniqueSessions || 0 : 0,
+    pageViews: telemetry.qualified ? telemetry.qualified.pageViews || 0 : 0,
+    checkoutStarts: telemetry.qualified ? telemetry.qualified.checkoutStarts || 0 : 0,
+    uniqueCheckoutStarters: telemetry.qualified ? telemetry.qualified.uniqueCheckoutStarters || 0 : 0,
+    botEvents: telemetry.trafficQuality ? telemetry.trafficQuality.botEvents || 0 : 0,
+    excludedEvents: telemetry.trafficQuality ? telemetry.trafficQuality.excludedEvents || 0 : 0,
+  };
+
+  const objections = {
+    totalSignals: telemetry.buyerLoss ? telemetry.buyerLoss.totalSignals || 0 : 0,
+    byReason: telemetry.buyerLoss ? telemetry.buyerLoss.reasonsByCode || {} : {},
+    topReason: telemetry.buyerLoss ? telemetry.buyerLoss.topReason || null : null,
+  };
+
   const operatorGeneratedAcquisition = {
     totalEvents: acquisitionEvents.filter(isOperatorGeneratedAcquisitionEntry).length,
     uniqueLeads: operatorGeneratedAcquisitionLeadKeys.size,
@@ -2383,6 +2405,8 @@ function getBusinessAnalytics(options = {}) {
       conversionByOfferCode,
     },
     trafficMetrics,
+    qualifiedTraffic,
+    objections,
     ctas: telemetry.ctas || {},
     operatorGeneratedAcquisition,
     dataQuality,
@@ -2470,6 +2494,8 @@ function getBillingSummary(options = {}) {
     newsletter: business.newsletter,
     attribution: business.attribution,
     trafficMetrics: business.trafficMetrics,
+    qualifiedTraffic: business.qualifiedTraffic,
+    objections: business.objections,
     ctas: business.ctas,
     operatorGeneratedAcquisition: business.operatorGeneratedAcquisition,
     dataQuality: business.dataQuality,

--- a/scripts/revenue-status.js
+++ b/scripts/revenue-status.js
@@ -133,6 +133,8 @@ function normalizeWindowSummary(status, payload = {}) {
   return {
     status,
     trafficMetrics: payload.trafficMetrics || {},
+    qualifiedTraffic: payload.qualifiedTraffic || {},
+    objections: payload.objections || {},
     ctas: payload.ctas || {},
     signups: payload.signups || {},
     revenue: payload.revenue || {},
@@ -146,6 +148,8 @@ function windowSnapshot(summary = {}) {
   return {
     status: summary.status,
     trafficMetrics: summary.trafficMetrics || {},
+    qualifiedTraffic: summary.qualifiedTraffic || {},
+    objections: summary.objections || {},
     ctas: summary.ctas || {},
     signups: summary.signups || {},
     revenue: summary.revenue || {},
@@ -251,8 +255,23 @@ function formatWindowBlock(label, summary = {}) {
     ? `, checkoutIntent views ${interstitialViews}, clicks ${interstitialClicks}, stripeConfirms ${proConfirms}, intakeClicks ${workflowClicks}, teamPathClicks ${teamPathClicks}, diagnosticClicks ${diagnosticClicks}, sprintCheckoutClicks ${sprintCheckoutClicks}, botDeflections ${botDeflections}`
     : '';
 
+  // Bot-excluded human funnel (the honest number) — the headline `visitors` above is
+  // bot-inflated; this shows what's left after bot/internal/test exclusion.
+  const qualified = summary.qualifiedTraffic || {};
+  const qualifiedSuffix = (qualified.visitors || qualified.checkoutStarts || qualified.botEvents)
+    ? `, humans(bot-excl) visitors ${qualified.visitors || 0}, checkoutStarts ${qualified.checkoutStarts || 0}, botEvents ${qualified.botEvents || 0}`
+    : '';
+
+  // WHY buyers bail — the reason_not_buying breakdown, previously captured but never shown.
+  const objectionPairs = Object.entries((summary.objections || {}).byReason || {})
+    .filter(([, n]) => Number(n) > 0)
+    .sort((a, b) => Number(b[1]) - Number(a[1]));
+  const objectionsSuffix = objectionPairs.length
+    ? `, objections {${objectionPairs.map(([k, n]) => `${k} ${n}`).join(', ')}}`
+    : '';
+
   return [
-    `${label}: visitors ${traffic.visitors || 0}, pageViews ${traffic.pageViews || 0}, checkoutStarts ${traffic.checkoutStarts || 0}, paidOrders ${revenue.paidOrders || 0}, bookedRevenue ${centsToDollars(revenue.bookedRevenueCents || 0)}, sprintLeads ${sprintLeads.total || 0}, signups ${signups.uniqueLeads || 0}${intentSuffix}`,
+    `${label}: visitors ${traffic.visitors || 0}, pageViews ${traffic.pageViews || 0}, checkoutStarts ${traffic.checkoutStarts || 0}, paidOrders ${revenue.paidOrders || 0}, bookedRevenue ${centsToDollars(revenue.bookedRevenueCents || 0)}, sprintLeads ${sprintLeads.total || 0}, signups ${signups.uniqueLeads || 0}${intentSuffix}${qualifiedSuffix}${objectionsSuffix}`,
   ];
 }
 

--- a/tests/billing.test.js
+++ b/tests/billing.test.js
@@ -1380,6 +1380,60 @@ describe('billing.js — funnel ledger', () => {
     assert.equal(summary.keys.windowed, false);
   });
 
+  test('getBillingSummary surfaces objection breakdown and bot-excluded qualifiedTraffic', () => {
+    const billing = require('../scripts/billing');
+    const telemetryPath = path.join(testFeedbackDir, 'telemetry-pings.jsonl');
+    fs.mkdirSync(testFeedbackDir, { recursive: true });
+    fs.writeFileSync(telemetryPath, [
+      JSON.stringify({
+        receivedAt: '2026-03-19T09:50:00.000Z',
+        eventType: 'landing_page_view',
+        clientType: 'web',
+        acquisitionId: 'acq_obj',
+        visitorId: 'visitor_obj',
+        sessionId: 'session_obj',
+        source: 'website',
+        page: '/pro',
+      }),
+      JSON.stringify({
+        receivedAt: '2026-03-19T09:58:00.000Z',
+        eventType: 'reason_not_buying',
+        clientType: 'web',
+        acquisitionId: 'acq_obj',
+        visitorId: 'visitor_obj',
+        sessionId: 'session_obj',
+        reasonCode: 'price_unclear',
+      }),
+      JSON.stringify({
+        receivedAt: '2026-03-19T09:59:00.000Z',
+        eventType: 'reason_not_buying',
+        clientType: 'web',
+        acquisitionId: 'acq_obj2',
+        visitorId: 'visitor_obj2',
+        sessionId: 'session_obj2',
+        reasonCode: 'need_more_proof',
+      }),
+      '',
+    ].join('\n'));
+
+    const summary = billing.getBillingSummary({
+      window: 'today',
+      timeZone: 'UTC',
+      now: '2026-03-19T18:00:00.000Z',
+    });
+
+    // Objection breakdown: the WHY-buyers-bail data, previously captured but never surfaced.
+    assert.ok(summary.objections, 'objections block must be present');
+    assert.equal(summary.objections.byReason.price_unclear, 1);
+    assert.equal(summary.objections.byReason.need_more_proof, 1);
+    assert.ok(summary.objections.totalSignals >= 2, 'totalSignals counts the loss signals');
+
+    // Bot-excluded human funnel view exists with numeric fields (additive; trafficMetrics untouched).
+    assert.ok(summary.qualifiedTraffic, 'qualifiedTraffic block must be present');
+    assert.ok(summary.qualifiedTraffic.visitors >= 1, 'human visitor counted in qualifiedTraffic');
+    assert.equal(typeof summary.qualifiedTraffic.botEvents, 'number');
+  });
+
   test('getBillingSummaryLive includes Stripe-reconciled historical revenue without claiming money today', async () => {
     process.env._TEST_STRIPE_RECONCILED_REVENUE_EVENTS_JSON = JSON.stringify([
       {


### PR DESCRIPTION
## Why
The data-science pass on our funnel (GSD cycle) found two observability gaps that make decisions unreliable:
1. **We can't see WHY buyers bail.** ~555 real humans reached the buy interstitial; only 2 ever clicked Pay. The `reason_not_buying` objections (price_unclear / need_more_proof / need_team_plan / not_urgent) are captured but **never surfaced** anywhere.
2. **The funnel is bot-inflated.** 62% of lifetime checkout-starts were bot-deflected (802); the headline `visitors`/`signups` counts include bots, so the human funnel is overstated ~2.4×.

## What (additive — no consumer breaks)
- `scripts/billing.js` `getBusinessAnalytics` + `getBillingSummary` now expose:
  - **`objections`** `{ totalSignals, byReason, topReason }` (from `telemetry.buyerLoss`)
  - **`qualifiedTraffic`** `{ visitors, sessions, pageViews, checkoutStarts, uniqueCheckoutStarters, botEvents, excludedEvents }` — the bot/internal/test-excluded human view (`telemetry.qualified` = `trafficQuality.external`)
  - The existing `trafficMetrics` block is **unchanged** (raw, for backward-compat).
- `scripts/revenue-status.js` prints the bot-excluded human funnel + the objection breakdown per window.
- `tests/billing.test.js`: a real, no-mock seeded test locking both new blocks.

## Verify
94 affected tests pass (billing, revenue-status, telemetry-analytics, funnel-invariants, funnel-analytics) incl. the new test. The one full-suite failure (`prove-claim-verification` CLAIM-03) is **pre-existing/environmental** — it fails identically on pristine `origin/main` with these changes stashed, touches zero files in this diff, and main's `test` job is green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)