### PR TITLE
feat(database): add agent safety gate pack

### DIFF
--- a/.changeset/database-agent-safety.md
+++ b/.changeset/database-agent-safety.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a database-agent safety gate pack, harden SQL and migration pre-action checks, and publish a high-intent database safety guide for AI agents.

--- a/public/guides/database-agent-safety.html
+++ b/public/guides/database-agent-safety.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Database Safety for AI Agents | ThumbGate Guide</title>
+  <meta name="description" content="AI agents can write code quickly, but database actions need stricter gates: a hallucinated SQL write, migration, role grant, or production config change can..." />
+  <meta property="og:title" content="Database Safety for AI Agents | ThumbGate Guide" />
+  <meta property="og:description" content="AI agents can write code quickly, but database actions need stricter gates: a hallucinated SQL write, migration, role grant, or production config change can..." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/database-agent-safety" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/database-agent-safety" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
+  <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
+  <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
+  <meta property="og:image" content="/og.png" />
+  <style>
+    :root {
+      --bg: #0a0a0b;
+      --bg-raised: #111113;
+      --bg-card: #161618;
+      --line: #222225;
+      --text: #e8e8ec;
+      --muted: #8b8b96;
+      --cyan: #22d3ee;
+      --green: #4ade80;
+      --red: #f87171;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.65;
+    }
+    a { color: var(--cyan); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .container { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      backdrop-filter: blur(12px);
+      background: rgba(10, 10, 11, 0.88);
+      border-bottom: 1px solid var(--line);
+    }
+    .topbar .container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding-top: 14px;
+      padding-bottom: 14px;
+    }
+    .brand {
+      font-weight: 700;
+      color: var(--text);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+    }
+    .brand .logo-mark { width: 28px; height: 28px; display: block; }
+    .hero { padding: 72px 0 32px; }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(34, 211, 238, 0.22);
+      background: rgba(34, 211, 238, 0.1);
+      color: var(--cyan);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 12px;
+      font-weight: 700;
+    }
+    h1 {
+      font-size: clamp(34px, 5vw, 56px);
+      line-height: 1.06;
+      letter-spacing: -0.04em;
+      margin: 16px 0;
+      max-width: 760px;
+    }
+    .hero p {
+      max-width: 720px;
+      color: var(--muted);
+      font-size: 18px;
+    }
+    .signal-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin: 28px 0 0;
+    }
+    .signal-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--bg-raised);
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .signal-pill.up {
+      border-color: rgba(74, 222, 128, 0.28);
+      color: #b8f7c8;
+      background: rgba(74, 222, 128, 0.1);
+    }
+    .signal-pill.down {
+      border-color: rgba(248, 113, 113, 0.28);
+      color: #ffc0c0;
+      background: rgba(248, 113, 113, 0.1);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+      gap: 24px;
+      padding-bottom: 72px;
+    }
+    .card, .detail-section, .sidebar-card {
+      background: var(--bg-card);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+    }
+    .card { padding: 24px; }
+    .detail-section { padding: 24px; margin-bottom: 18px; }
+    .detail-section h2 { margin: 0 0 12px; font-size: 24px; letter-spacing: -0.03em; }
+    .detail-section p { color: var(--muted); }
+    .detail-section ul, .card ul { padding-left: 18px; color: var(--muted); }
+    .card h2 { margin-top: 0; }
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+    .sidebar-card {
+      padding: 20px;
+    }
+    /* Only the first sidebar card sticks. Stacking multiple stickies at the
+       same top offset makes them overlap each other on scroll. The related-
+       pages card flows normally below. */
+    .sidebar-card:first-child {
+      position: sticky;
+      top: 84px;
+      max-height: calc(100vh - 104px);
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .proof-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 16px;
+    }
+    .cta-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 18px;
+      padding: 12px 16px;
+      border-radius: 10px;
+      background: var(--cyan);
+      color: #071116;
+      font-weight: 700;
+      text-decoration: none;
+    }
+    .paid-sprint-card {
+      border-color: rgba(74, 222, 128, 0.32);
+      background: linear-gradient(180deg, rgba(17, 17, 19, 0.98), rgba(10, 20, 14, 0.96));
+    }
+    .paid-sprint-card p {
+      color: var(--muted);
+      font-size: 14px;
+      line-height: 1.55;
+    }
+    .paid-offers {
+      display: grid;
+      gap: 10px;
+      margin-top: 16px;
+    }
+    .paid-offer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px;
+      border: 1px solid rgba(74, 222, 128, 0.28);
+      border-radius: 10px;
+      color: var(--fg);
+      text-decoration: none;
+      background: rgba(0, 0, 0, 0.22);
+    }
+    .paid-offer strong {
+      color: #9af5b0;
+      white-space: nowrap;
+    }
+    .paid-offer:hover, .paid-offer:focus-visible {
+      border-color: rgba(74, 222, 128, 0.62);
+      outline: none;
+    }
+    .secondary-cta {
+      display: inline-flex;
+      margin-top: 12px;
+      color: var(--cyan);
+      font-size: 14px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+    .faq-item {
+      border-top: 1px solid var(--line);
+      padding: 14px 0;
+    }
+    .faq-item summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .faq-item p {
+      color: var(--muted);
+    }
+    .related-card {
+      display: block;
+      padding: 14px;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: var(--bg-raised);
+      margin-top: 12px;
+      color: var(--text);
+    }
+    .related-label {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 4px;
+    }
+    @media (max-width: 860px) {
+      .grid {
+        grid-template-columns: 1fr;
+      }
+      .sidebar-card:first-child {
+        position: static;
+        max-height: none;
+        overflow: visible;
+      }
+    }
+  </style>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Database Safety for AI Agents",
+  "description": "AI agents can write code quickly, but database actions need stricter gates: a hallucinated SQL write, migration, role grant, or production config change can...",
+  "about": [
+    "claude code masterclass guardrails",
+    "cursor prevent repeated mistakes",
+    "claude code prevent repeated mistakes",
+    "codex cli guardrails"
+  ],
+  "url": "https://thumbgate.ai/guides/database-agent-safety",
+  "publisher": {
+    "@type": "Organization",
+    "name": "ThumbGate",
+    "url": "https://thumbgate.ai"
+  },
+  "mainEntityOfPage": "https://thumbgate.ai/guides/database-agent-safety"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Should AI agents be allowed to run production database migrations?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Only behind an approval gate. Production migrations should require target verification, dry-run output, backup or snapshot evidence, rollback plan, and human approval before the command executes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What database actions should be blocked by default?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "DROP, TRUNCATE, DROP DATABASE, DROP SCHEMA, role or grant changes, unbounded UPDATE or DELETE, and production migrations without rollback and dry-run evidence should be blocked or paused before execution."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is this an AI DBA replacement?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. ThumbGate is the governance layer before an agent touches database tooling. It blocks known-bad actions and requires proof for risky actions; DBAs and platform teams still own database design and operations."
+      }
+    }
+  ]
+}
+  </script>
+</head>
+<body>
+  <div class="topbar">
+    <div class="container">
+      <a class="brand" href="/"><img src="/assets/brand/thumbgate-mark-inline.svg" alt="ThumbGate" class="logo-mark" width="28" height="28"><span class="logo-text">ThumbGate</span></a>
+      <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence</a>
+    </div>
+  </div>
+
+  <main class="container">
+    <section class="hero">
+      <div class="eyebrow">guide | database safety for ai agents</div>
+      <h1>Database Safety for AI Agents</h1>
+      <p>AI agents can write code quickly, but database actions need stricter gates: a hallucinated SQL write, migration, role grant, or production config change can destroy data before review.</p>
+      <div class="signal-row">
+        <div class="signal-pill up">👍 Thumbs up reinforces good behavior</div>
+        <div class="signal-pill down">👎 Thumbs down blocks repeated mistakes</div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div>
+        <div class="card">
+          <h2>Why this page exists</h2>
+          <ul><li>Databases are the highest-blast-radius tool surface for autonomous coding agents.</li><li>The winning pattern is not an AI DBA autopilot alone; it is a pre-action approval boundary before SQL, migrations, and privilege changes run.</li><li>ThumbGate turns repeated database mistakes into rules that block or pause the next risky query before execution.</li></ul>
+        </div>
+
+      <section class="detail-section">
+        <h2>Why database work is the final boss for agents</h2>
+        <p>A bad UI component is visible and usually reversible. A bad production query can delete rows, lock writes, leak data, or change privileges before anyone reviews the pull request.</p><p>That is why database-agent safety belongs at the tool-call boundary. The agent should be stopped before it runs DROP, TRUNCATE, unbounded UPDATE/DELETE, production migrations, or role grants.</p>
+
+      </section>
+      <section class="detail-section">
+        <h2>The high-ROI gate pack</h2>
+
+        <ul><li>Block DROP, TRUNCATE, DROP DATABASE, and DROP SCHEMA unless human approval and rollback evidence are attached.</li><li>Block UPDATE and DELETE without a restrictive WHERE clause, including WHERE 1=1 and WHERE TRUE.</li><li>Require backup, snapshot, or reversible migration proof before production schema changes.</li><li>Require dry-run or EXPLAIN evidence before production writes and migrations.</li><li>Warn on CREATE INDEX without CONCURRENTLY and CROSS JOINs that can create performance incidents.</li><li>Block role creation, role alteration, and broad grants from autonomous agents.</li></ul>
+      </section>
+      <section class="detail-section">
+        <h2>Where ThumbGate fits</h2>
+        <p>ThumbGate is not trying to replace Postgres, MySQL, Prisma, Rails migrations, or a DBA. It is the pre-action control plane that checks the agent before those tools execute.</p><p>The feedback loop matters: when a human gives a thumbs-down on an unsafe migration or query, ThumbGate can promote the failure pattern into a prevention rule so the next agent run cannot repeat it silently.</p>
+
+      </section>
+      <section class="detail-section">
+        <h2>First workflow to gate</h2>
+        <p>Start with one production migration path. Require the agent to show target environment, dry-run output, backup or snapshot evidence, rollback plan, and human approval before it can run the command. That single workflow makes the value visible to engineering leaders immediately.</p>
+
+      </section>
+        <div class="detail-section">
+          <h2>FAQ</h2>
+
+      <details class="faq-item">
+        <summary>Should AI agents be allowed to run production database migrations?</summary>
+        <p>Only behind an approval gate. Production migrations should require target verification, dry-run output, backup or snapshot evidence, rollback plan, and human approval before the command executes.</p>
+      </details>
+      <details class="faq-item">
+        <summary>What database actions should be blocked by default?</summary>
+        <p>DROP, TRUNCATE, DROP DATABASE, DROP SCHEMA, role or grant changes, unbounded UPDATE or DELETE, and production migrations without rollback and dry-run evidence should be blocked or paused before execution.</p>
+      </details>
+      <details class="faq-item">
+        <summary>Is this an AI DBA replacement?</summary>
+        <p>No. ThumbGate is the governance layer before an agent touches database tooling. It blocks known-bad actions and requires proof for risky actions; DBAs and platform teams still own database design and operations.</p>
+      </details>
+        </div>
+      </div>
+
+      <aside class="sidebar">
+
+
+
+
+
+        <div class="sidebar-card">
+          <h2>GSD execution brief</h2>
+          <p>This page was prioritized because it captures high-intent demand around database safety for ai agents and feeds directly into ThumbGate's proof-led conversion path.</p>
+          <p><strong>Opportunity score:</strong> 72</p>
+          <p><strong>Primary persona:</strong> ai-engineer</p>
+          <p><strong>Keyword cluster:</strong> claude code masterclass guardrails, cursor prevent repeated mistakes, claude code prevent repeated mistakes, codex cli guardrails</p>
+          <p><strong>Pricing:</strong> Pro $19/mo or $149/yr. Team $49/seat/mo.</p>
+          <div class="proof-links"><a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Verification evidence</a><a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/proof/automation/report.json" target="_blank" rel="noopener">Automation proof</a><a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub repository</a></div>
+          <a class="cta-button" href="/checkout/pro?utm_source=website&amp;utm_medium=seo_page&amp;utm_campaign=guides_database-agent-safety&amp;cta_placement=seo_brief&amp;plan_id=pro" target="_blank" rel="noopener">Go Pro — $19/mo</a>
+        </div>
+        <div class="sidebar-card">
+          <h2>Related pages</h2>
+
+        <a class="related-card" href="/guides/pre-action-checks">
+          <span class="related-label">Related page</span>
+          <strong>What Are Pre-Action Checks?</strong>
+        </a>
+        <a class="related-card" href="/guides/ai-agent-pre-action-approval-gates">
+          <span class="related-label">Related page</span>
+          <strong>AI agent pre-action approval gates for risky tool calls</strong>
+        </a>
+        <a class="related-card" href="/guides/best-tools-stop-ai-agents-breaking-production">
+          <span class="related-label">Related page</span>
+          <strong>Best Tools to Stop AI Agents From Breaking Production</strong>
+        </a>
+        </div>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/public/learn.html
+++ b/public/learn.html
@@ -22,7 +22,7 @@
   "name": "ThumbGate Learning Hub",
   "description": "Practical guides for AI coding agent safety, pre-action checks, and vibe coding guardrails.",
   "url": "https://thumbgate.ai/learn",
-  "dateModified": "2026-04-20",
+  "dateModified": "2026-06-06",
   "author": {
     "@type": "Person",
     "name": "Igor Ganapolsky",
@@ -177,6 +177,12 @@
         "position": 15,
         "url": "https://thumbgate.ai/guides/ai-deployment-readiness",
         "name": "AI Deployment Readiness Before Production Rollout"
+      },
+      {
+        "@type": "ListItem",
+        "position": 16,
+        "url": "https://thumbgate.ai/guides/database-agent-safety",
+        "name": "Database Safety for AI Agents"
       }
     ]
   }
@@ -423,6 +429,14 @@
   <h2>Popular buyer questions</h2>
   <p class="section-intro">These are the high-intent guides for buyers who already know the pain and want to understand where ThumbGate fits fast.</p>
   <div class="article-grid">
+    <a href="/guides/database-agent-safety" class="article-card">
+      <h3>Database Safety for AI Agents</h3>
+      <p>Block hallucinated SQL writes, migrations, role grants, and production database changes before an agent can touch live data.</p>
+      <span class="article-tag">Database</span>
+      <span class="article-tag">SQL</span>
+      <span class="article-tag">Production Safety</span>
+    </a>
+
     <a href="/guides/ai-deployment-readiness" class="article-card">
       <h3>AI Deployment Readiness Before Production Rollout</h3>
       <p>Use one priority workflow to map tools, data, controls, pre-action gates, and proof before an AI deployment team ships into production.</p>

--- a/scripts/postgres-guard.js
+++ b/scripts/postgres-guard.js
@@ -1,55 +1,165 @@
 'use strict';
 
 /**
- * PostgreSQL Safety Guardrail
+ * Database Safety Guardrail
  *
- * Implements high-ROI safety mechanisms against autonomous AI agents connecting to
- * PostgreSQL databases, directly inspired by the Google DB team's "lean hard on AI
- * but constrain blast radius" mandate.
- *
- * Capabilities:
- * - SQL write-policy enforcement (DROP, mass UPDATE/DELETE)
- * - Schema change approval gates (ALTER TABLE)
- * - Privilege escalation restrictions (GRANT, CREATE ROLE)
+ * High-ROI pre-action checks for autonomous agents touching relational
+ * databases. The core insight: an agent can hallucinate UI safely enough to
+ * review, but a hallucinated SQL write, migration, role change, or production
+ * config tweak can destroy data before review ever happens.
  */
 
-function evaluatePostgresQuery(query) {
+const DANGEROUS_MIGRATION_COMMANDS = [
+  /\bprisma\s+migrate\s+deploy\b/i,
+  /\bprisma\s+migrate\s+reset\b/i,
+  /\bsequelize(?:-cli)?\s+db:migrate\b/i,
+  /\brails\s+db:migrate\b/i,
+  /\bknex\s+migrate:(?:latest|up|rollback)\b/i,
+  /\bflyway\s+migrate\b/i,
+  /\bliquibase\s+update\b/i,
+];
+
+function stripSqlComments(query) {
+  const source = String(query || '');
+  let output = '';
+  let index = 0;
+  let previousWasSpace = true;
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (char === '-' && next === '-') {
+      index += 2;
+      while (index < source.length && source[index] !== '\n' && source[index] !== '\r') {
+        index += 1;
+      }
+      if (!previousWasSpace) {
+        output += ' ';
+        previousWasSpace = true;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      index += 2;
+      while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) {
+        index += 1;
+      }
+      index = Math.min(index + 2, source.length);
+      if (!previousWasSpace) {
+        output += ' ';
+        previousWasSpace = true;
+      }
+      continue;
+    }
+
+    if (char.trim() === '') {
+      if (!previousWasSpace) {
+        output += ' ';
+        previousWasSpace = true;
+      }
+    } else {
+      output += char;
+      previousWasSpace = false;
+    }
+    index += 1;
+  }
+
+  return output.trim();
+}
+
+function normalizeSql(query) {
+  return stripSqlComments(query).toUpperCase();
+}
+
+function isProductionTarget({ env, databaseUrl, command } = {}) {
+  const haystack = [env, databaseUrl, command].filter(Boolean).join(' ').toLowerCase();
+  return /\b(prod|production|primary|railway|rds|aurora|cloudsql|neon\.tech|supabase\.co)\b/.test(haystack);
+}
+
+function hasHumanApproval({ approvalToken, approved, humanApproved } = {}) {
+  return Boolean(approvalToken || approved === true || humanApproved === true);
+}
+
+function hasRollbackEvidence({ hasBackup, backupPath, snapshotId, rollbackPlan, migrationReversible } = {}) {
+  return Boolean(hasBackup || backupPath || snapshotId || rollbackPlan || migrationReversible === true);
+}
+
+function hasDryRunEvidence({ hasDryRun, dryRunOutput, hasExplain, explainPlan } = {}) {
+  return Boolean(hasDryRun || dryRunOutput || hasExplain || explainPlan);
+}
+
+function isUnboundedWhere(normalized) {
+  return /\bWHERE\s+(?:1\s*=\s*1|TRUE)\b/.test(normalized);
+}
+
+function evaluatePostgresQuery(query, options = {}) {
   if (!query || typeof query !== 'string') {
     return { mode: 'allow', reason: 'empty or invalid query' };
   }
 
-  const normalized = query.toUpperCase();
+  const normalized = normalizeSql(query);
+  const production = isProductionTarget(options);
 
-  // 1. Privilege and role restrictions
-  if (normalized.includes('CREATE ROLE') || normalized.includes('ALTER ROLE') || normalized.includes('GRANT ALL')) {
+  if (/\b(CREATE|ALTER)\s+ROLE\b/.test(normalized) || /\bGRANT\s+ALL\b/.test(normalized)) {
     return { mode: 'block', reason: 'Agent is not permitted to create or modify PostgreSQL roles or grants.' };
   }
 
-  // 2. Destructive operations (DROP)
-  if (normalized.includes('DROP TABLE') || normalized.includes('DROP DATABASE') || normalized.includes('DROP SCHEMA')) {
-    return { mode: 'block', reason: 'Destructive DROP operations are blocked for autonomous agents.' };
+  if (/\bDROP\s+(TABLE|DATABASE|SCHEMA)\b/.test(normalized) || /\bTRUNCATE\s+(TABLE\s+)?\w+/i.test(normalized)) {
+    if (production && hasHumanApproval(options) && hasRollbackEvidence(options)) {
+      return { mode: 'warn', reason: 'Destructive production SQL has approval and rollback evidence; require final human review before execution.' };
+    }
+    return { mode: 'block', reason: 'Destructive DROP/TRUNCATE operations are blocked for autonomous agents unless production approval and rollback proof are attached.' };
   }
 
-  // 3. Schema change approval gates
-  if (normalized.includes('ALTER TABLE')) {
+  if (/\bALTER\s+TABLE\b/.test(normalized) || /\bDROP\s+COLUMN\b/.test(normalized)) {
+    if (production && (!hasHumanApproval(options) || !hasRollbackEvidence(options))) {
+      return { mode: 'block', reason: 'Production schema changes require human approval plus backup, snapshot, or rollback evidence.' };
+    }
     return { mode: 'warn', reason: 'Schema modification detected. Requires human review.' };
   }
 
-  // 4. Mass UPDATE/DELETE without restrictive WHERE
-  if (normalized.includes('UPDATE ') || normalized.includes('DELETE FROM ')) {
-    if (!normalized.includes('WHERE ')) {
-      return { mode: 'block', reason: 'Unbounded UPDATE or DELETE without a WHERE clause is blocked.' };
+  if (/\bUPDATE\s+\w+/.test(normalized) || /\bDELETE\s+FROM\s+\w+/.test(normalized)) {
+    if (!/\bWHERE\b/.test(normalized) || isUnboundedWhere(normalized)) {
+      return { mode: 'block', reason: 'Unbounded UPDATE or DELETE without a restrictive WHERE clause is blocked.' };
+    }
+    if (production && !hasDryRunEvidence(options)) {
+      return { mode: 'warn', reason: 'Production write query should include dry-run or EXPLAIN evidence before execution.' };
     }
   }
 
-  // 5. Query-cost and performance protections (Cartesian joins)
-  if (normalized.includes('CROSS JOIN')) {
+  if (/\bCROSS\s+JOIN\b/.test(normalized)) {
     return { mode: 'warn', reason: 'Cartesian join detected. Verify performance cost.' };
+  }
+
+  if (production && /\bCREATE\s+INDEX\b/.test(normalized) && !/\bCONCURRENTLY\b/.test(normalized)) {
+    return { mode: 'warn', reason: 'Production CREATE INDEX without CONCURRENTLY can lock writes; require DBA review.' };
+  }
+
+  return { mode: 'allow', reason: 'safe' };
+}
+
+function evaluateDatabaseAgentAction(action = {}) {
+  const command = String(action.command || '');
+  const query = action.query || action.sql;
+
+  if (query) {
+    return evaluatePostgresQuery(query, action);
+  }
+
+  if (DANGEROUS_MIGRATION_COMMANDS.some((pattern) => pattern.test(command))) {
+    if (isProductionTarget(action) && (!hasHumanApproval(action) || !hasRollbackEvidence(action) || !hasDryRunEvidence(action))) {
+      return { mode: 'block', reason: 'Production database migrations require human approval, rollback evidence, and dry-run proof before an agent can run them.' };
+    }
+    return { mode: 'warn', reason: 'Database migration command detected. Verify target, rollback, and dry-run evidence.' };
   }
 
   return { mode: 'allow', reason: 'safe' };
 }
 
 module.exports = {
+  evaluateDatabaseAgentAction,
   evaluatePostgresQuery,
+  normalizeSql,
 };

--- a/scripts/seo-gsd.js
+++ b/scripts/seo-gsd.js
@@ -170,6 +170,11 @@ const HIGH_ROI_QUERY_SEEDS = [
     95,
     'Bottom-of-funnel query for teams ready to add human approval and evidence requirements before AI agents touch risky tools.',
   ),
+  querySeed(
+    'database safety for ai agents',
+    96,
+    'Fresh database-agent risk query from the 2026 DB/AI conversation: agents can hallucinate UI, but SQL writes, migrations, and role grants can destroy production data.',
+  ),
   {
     query: 'thumbs up thumbs down feedback for ai coding agents',
     businessValue: 95,
@@ -2018,6 +2023,68 @@ const PAGE_BLUEPRINTS = [
       },
     ],
     relatedPaths: ['/guides/pre-action-checks', '/guides/agent-harness-optimization', '/guides/ai-search-topical-presence'],
+  },
+  {
+    query: 'database safety for ai agents',
+    path: '/guides/database-agent-safety',
+    pageType: 'guide',
+    pillar: 'pre-action-checks',
+    title: 'Database Safety for AI Agents | ThumbGate Guide',
+    heroTitle: 'Database Safety for AI Agents',
+    heroSummary: 'AI agents can write code quickly, but database actions need stricter gates: a hallucinated SQL write, migration, role grant, or production config change can destroy data before review.',
+    takeaways: [
+      'Databases are the highest-blast-radius tool surface for autonomous coding agents.',
+      'The winning pattern is not an AI DBA autopilot alone; it is a pre-action approval boundary before SQL, migrations, and privilege changes run.',
+      'ThumbGate turns repeated database mistakes into rules that block or pause the next risky query before execution.',
+    ],
+    sections: [
+      {
+        heading: 'Why database work is the final boss for agents',
+        paragraphs: [
+          'A bad UI component is visible and usually reversible. A bad production query can delete rows, lock writes, leak data, or change privileges before anyone reviews the pull request.',
+          'That is why database-agent safety belongs at the tool-call boundary. The agent should be stopped before it runs DROP, TRUNCATE, unbounded UPDATE/DELETE, production migrations, or role grants.',
+        ],
+      },
+      {
+        heading: 'The high-ROI gate pack',
+        bullets: [
+          'Block DROP, TRUNCATE, DROP DATABASE, and DROP SCHEMA unless human approval and rollback evidence are attached.',
+          'Block UPDATE and DELETE without a restrictive WHERE clause, including WHERE 1=1 and WHERE TRUE.',
+          'Require backup, snapshot, or reversible migration proof before production schema changes.',
+          'Require dry-run or EXPLAIN evidence before production writes and migrations.',
+          'Warn on CREATE INDEX without CONCURRENTLY and CROSS JOINs that can create performance incidents.',
+          'Block role creation, role alteration, and broad grants from autonomous agents.',
+        ],
+      },
+      {
+        heading: 'Where ThumbGate fits',
+        paragraphs: [
+          'ThumbGate is not trying to replace Postgres, MySQL, Prisma, Rails migrations, or a DBA. It is the pre-action control plane that checks the agent before those tools execute.',
+          'The feedback loop matters: when a human gives a thumbs-down on an unsafe migration or query, ThumbGate can promote the failure pattern into a prevention rule so the next agent run cannot repeat it silently.',
+        ],
+      },
+      {
+        heading: 'First workflow to gate',
+        paragraphs: [
+          'Start with one production migration path. Require the agent to show target environment, dry-run output, backup or snapshot evidence, rollback plan, and human approval before it can run the command. That single workflow makes the value visible to engineering leaders immediately.',
+        ],
+      },
+    ],
+    faq: [
+      {
+        question: 'Should AI agents be allowed to run production database migrations?',
+        answer: 'Only behind an approval gate. Production migrations should require target verification, dry-run output, backup or snapshot evidence, rollback plan, and human approval before the command executes.',
+      },
+      {
+        question: 'What database actions should be blocked by default?',
+        answer: 'DROP, TRUNCATE, DROP DATABASE, DROP SCHEMA, role or grant changes, unbounded UPDATE or DELETE, and production migrations without rollback and dry-run evidence should be blocked or paused before execution.',
+      },
+      {
+        question: 'Is this an AI DBA replacement?',
+        answer: 'No. ThumbGate is the governance layer before an agent touches database tooling. It blocks known-bad actions and requires proof for risky actions; DBAs and platform teams still own database design and operations.',
+      },
+    ],
+    relatedPaths: ['/guides/pre-action-checks', '/guides/ai-agent-pre-action-approval-gates', '/guides/best-tools-stop-ai-agents-breaking-production'],
   },
   buildHarnessOptimizationGuide(),
   buildCodeKnowledgeGraphGuardrailsGuide(),

--- a/scripts/skill-packs.js
+++ b/scripts/skill-packs.js
@@ -8,6 +8,25 @@ const BUILTIN_PACKS = {
   'stripe-integration': { name: 'stripe-integration', description: 'Stripe API best practices', triggers: ['stripe', 'payment', 'checkout', 'subscription', 'webhook signature'], rules: ['ALWAYS use idempotency keys on PaymentIntent creation to prevent duplicate charges.', 'NEVER log or store raw card numbers — use Stripe tokens or PaymentMethod IDs.', 'ALWAYS verify webhook signatures with stripe.webhooks.constructEvent() before processing.', 'Use Checkout Sessions instead of raw PaymentIntents for new integrations.', 'ALWAYS handle payment_intent.succeeded AND payment_intent.payment_failed webhooks.'], packTemplate: { namespaces: ['memoryError', 'memoryLearning', 'rules'], maxItems: 8, maxChars: 6000, queryPrefix: 'stripe payment checkout webhook idempotency' } },
   'railway-deploy': { name: 'railway-deploy', description: 'Railway deployment best practices', triggers: ['railway', 'deploy', 'dockerfile', 'health check'], rules: ['ALWAYS verify /health endpoint returns new version after deploy.', 'NEVER say "deployed" without curling the health endpoint and showing version match.', 'ALWAYS check Railway build logs for warnings even when deploy succeeds.', 'Use RAILWAY_VOLUME_MOUNT_PATH for persistent data.', 'ALWAYS wait 2-5 minutes after merge before verifying.'], packTemplate: { namespaces: ['memoryError', 'memoryLearning', 'rules'], maxItems: 8, maxChars: 6000, queryPrefix: 'railway deploy health version dockerfile' } },
   'database-migration': { name: 'database-migration', description: 'Database migration best practices', triggers: ['migration', 'prisma', 'sqlite', 'schema', 'alter table'], rules: ['ALWAYS back up the database before running destructive migrations.', 'NEVER drop columns in production without verifying no code references them.', 'ALWAYS run migrations against a test database first.', 'Use reversible migrations — every up() should have a corresponding down().', 'ALWAYS check for pending migrations before deploying new code.'], packTemplate: { namespaces: ['memoryError', 'rules'], maxItems: 6, maxChars: 5000, queryPrefix: 'migration database schema prisma sqlite' } },
+  'database-agent-safety': {
+    name: 'database-agent-safety',
+    description: 'Pre-action checks for AI agents before they touch production databases.',
+    triggers: ['database', 'postgres', 'mysql', 'sql', 'migration', 'prisma', 'rails db:migrate', 'drop table', 'truncate', 'production database'],
+    rules: [
+      'NEVER allow an autonomous agent to run DROP, TRUNCATE, DROP SCHEMA, or DROP DATABASE without explicit human approval and rollback evidence.',
+      'ALWAYS require a backup, snapshot, or reversible rollback plan before production schema migrations.',
+      'NEVER run UPDATE or DELETE without a restrictive WHERE clause; WHERE 1=1 and WHERE TRUE are not restrictive.',
+      'ALWAYS require dry-run or EXPLAIN evidence before production writes, migrations, or high-cardinality queries.',
+      'NEVER let agents create roles, alter roles, or grant broad privileges in a live database.',
+      'ALWAYS treat database work as a pre-action approval boundary, not a post-hoc review item.',
+    ],
+    packTemplate: {
+      namespaces: ['memoryError', 'memoryLearning', 'rules'],
+      maxItems: 8,
+      maxChars: 6000,
+      queryPrefix: 'database postgres mysql sql migration production drop truncate rollback backup explain',
+    },
+  },
 };
 const registry = new Map(); for (const [id, p] of Object.entries(BUILTIN_PACKS)) registry.set(id, p);
 function ensurePacksDir() { if (!fs.existsSync(SKILL_PACKS_DIR)) fs.mkdirSync(SKILL_PACKS_DIR, { recursive: true }); }

--- a/tests/learn-hub.test.js
+++ b/tests/learn-hub.test.js
@@ -65,6 +65,7 @@ test('learn hub links to core articles and high-intent buyer guides', () => {
   assert.match(html, /\/guides\/browser-automation-safety/);
   assert.match(html, /\/guides\/native-messaging-host-security/);
   assert.match(html, /\/guides\/autoresearch-agent-safety/);
+  assert.match(html, /\/guides\/database-agent-safety/);
 });
 
 test('learn hub has article cards with titles, descriptions, tags, and a buyer-question section', () => {
@@ -87,6 +88,7 @@ test('learn hub has article cards with titles, descriptions, tags, and a buyer-q
   assert.match(html, /Browser Automation Safety for AI Agents/);
   assert.match(html, /Native Messaging Host Security/);
   assert.match(html, /Autoresearch Agent Safety for Self-Improving Coding Agents/);
+  assert.match(html, /Database Safety for AI Agents/);
 });
 
 test('learn hub has CTA with npx install command', () => {
@@ -492,7 +494,7 @@ test('no learn page references version numbers (evergreen content)', () => {
 
 test('no learn page has broken internal links', () => {
   const allFiles = [learnHubPath, ...fs.readdirSync(learnDir).filter(f => f.endsWith('.html')).map(f => path.join(learnDir, f))];
-  const validPaths = ['/learn', '/guide', '/dashboard', '/', '/pricing', '/case-studies', '/compare/rein', '/ai-malpractice-prevention', '/learn/spec-driven-development', '/learn/ai-agent-governance', '/learn/mcp-pre-action-checks-explained', '/learn/vibe-coding-safety-net', '/checkout/pro?utm_source=blog&amp;utm_medium=prototype_to_production&amp;utm_campaign=build_log', '/learn/stop-ai-agent-force-push', '/learn/vibe-coding-safety-net', '/learn/mcp-pre-action-checks-explained', '/learn/agent-harness-pattern', '/learn/agent-swarms-shared-gates', '/learn/background-agent-control-layer', '/learn/claude-code-goal-with-rubrics', '/learn/ai-agent-persistent-memory', '/learn/from-prototype-to-production', '/learn/regulated-agent-execution-boundary', '/learn/ac-dc-runtime-enforcement', '/learn/feedback-loop-vs-decision-layer', '/compare/anthropic-containment', '/learn/learn.css', '/favicon.svg', '/thumbgate-icon.png', '/og.png', '/assets/brand/thumbgate-mark.svg', '/assets/brand/thumbgate-mark-inline.svg', '/guides/stop-repeated-ai-agent-mistakes', '/guides/ai-deployment-readiness', '/guides/browser-automation-safety', '/guides/native-messaging-host-security', '/guides/ai-search-topical-presence', '/guides/relational-knowledge-ai-recommendations', '/guides/cursor-agent-guardrails', '/guides/codex-cli-guardrails', '/guides/gemini-cli-feedback-memory', '/guides/roo-code-alternative-cline', '/guides/autoresearch-agent-safety', '/learn/agentic-enterprise-context-brain', '/learn/deterministic-agent-workflows', '/learn/agentic-os-team-governance', '/learn/codex-role-plugins-need-governance', '/learn/cost-aware-agent-gate-routing', '/codex-plugin', '/learn/pretix-stripe-connect-marketplaces'];
+  const validPaths = ['/learn', '/guide', '/dashboard', '/', '/pricing', '/case-studies', '/compare/rein', '/ai-malpractice-prevention', '/learn/spec-driven-development', '/learn/ai-agent-governance', '/learn/mcp-pre-action-checks-explained', '/learn/vibe-coding-safety-net', '/checkout/pro?utm_source=blog&amp;utm_medium=prototype_to_production&amp;utm_campaign=build_log', '/learn/stop-ai-agent-force-push', '/learn/vibe-coding-safety-net', '/learn/mcp-pre-action-checks-explained', '/learn/agent-harness-pattern', '/learn/agent-swarms-shared-gates', '/learn/background-agent-control-layer', '/learn/claude-code-goal-with-rubrics', '/learn/ai-agent-persistent-memory', '/learn/from-prototype-to-production', '/learn/regulated-agent-execution-boundary', '/learn/ac-dc-runtime-enforcement', '/learn/feedback-loop-vs-decision-layer', '/compare/anthropic-containment', '/learn/learn.css', '/favicon.svg', '/thumbgate-icon.png', '/og.png', '/assets/brand/thumbgate-mark.svg', '/assets/brand/thumbgate-mark-inline.svg', '/guides/stop-repeated-ai-agent-mistakes', '/guides/ai-deployment-readiness', '/guides/database-agent-safety', '/guides/browser-automation-safety', '/guides/native-messaging-host-security', '/guides/ai-search-topical-presence', '/guides/relational-knowledge-ai-recommendations', '/guides/cursor-agent-guardrails', '/guides/codex-cli-guardrails', '/guides/gemini-cli-feedback-memory', '/guides/roo-code-alternative-cline', '/guides/autoresearch-agent-safety', '/learn/agentic-enterprise-context-brain', '/learn/deterministic-agent-workflows', '/learn/agentic-os-team-governance', '/learn/codex-role-plugins-need-governance', '/learn/cost-aware-agent-gate-routing', '/codex-plugin', '/learn/pretix-stripe-connect-marketplaces'];
   for (const file of allFiles) {
     const html = readFile(file);
     const links = html.match(/href="(\/[^"#]*?)"/g) || [];

--- a/tests/metaclaw-features.test.js
+++ b/tests/metaclaw-features.test.js
@@ -94,12 +94,18 @@ test('createDailyDigestSchedule works', () => {
 });
 
 // === Skill Packs ===
-test('3 built-in packs', () => { assert.ok(packs.BUILTIN_PACKS['stripe-integration']); assert.ok(packs.BUILTIN_PACKS['railway-deploy']); assert.ok(packs.BUILTIN_PACKS['database-migration']); });
+test('4 built-in packs include database agent safety', () => {
+  assert.ok(packs.BUILTIN_PACKS['stripe-integration']);
+  assert.ok(packs.BUILTIN_PACKS['railway-deploy']);
+  assert.ok(packs.BUILTIN_PACKS['database-migration']);
+  assert.ok(packs.BUILTIN_PACKS['database-agent-safety']);
+});
 test('listSkillPacks', () => { const l = packs.listSkillPacks(); assert.ok(l.length >= 3); l.forEach((p) => assert.ok(p.ruleCount > 0)); });
 test('getSkillPack by name', () => { assert.ok(packs.getSkillPack('stripe-integration')); });
 test('getSkillPack null for unknown', () => { assert.equal(packs.getSkillPack('nope'), null); });
 test('matchSkillPacks stripe', () => { assert.equal(packs.matchSkillPacks('stripe payment')[0].name, 'stripe-integration'); });
 test('matchSkillPacks railway', () => { assert.equal(packs.matchSkillPacks('deploy railway')[0].name, 'railway-deploy'); });
+test('matchSkillPacks database safety', () => { assert.equal(packs.matchSkillPacks('production database drop table')[0].name, 'database-agent-safety'); });
 test('matchSkillPacks empty for unrelated', () => { assert.equal(packs.matchSkillPacks('quantum physics').length, 0); });
 test('registerSkillPack persists', () => { packs.registerSkillPack({ name: 'test-pack', triggers: ['test'], rules: ['Rule 1'] }); assert.ok(fs.existsSync(path.join(packs.SKILL_PACKS_DIR, 'test-pack.json'))); });
 test('registerSkillPack validates name', () => { assert.throws(() => packs.registerSkillPack({ rules: ['x'] }), /name/); });

--- a/tests/postgres-guard.test.js
+++ b/tests/postgres-guard.test.js
@@ -2,7 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const { evaluatePostgresQuery } = require('../scripts/postgres-guard');
+const { evaluateDatabaseAgentAction, evaluatePostgresQuery, normalizeSql } = require('../scripts/postgres-guard');
 
 test('postgres-guard', async (t) => {
   await t.test('allows safe queries', () => {
@@ -19,7 +19,23 @@ test('postgres-guard', async (t) => {
   await t.test('blocks destructive operations', () => {
     const res = evaluatePostgresQuery('DROP TABLE users;');
     assert.strictEqual(res.mode, 'block');
-    assert.match(res.reason, /Destructive DROP/i);
+    assert.match(res.reason, /Destructive DROP\/TRUNCATE/i);
+  });
+
+  await t.test('blocks truncate operations', () => {
+    const res = evaluatePostgresQuery('TRUNCATE TABLE audit_events;');
+    assert.strictEqual(res.mode, 'block');
+    assert.match(res.reason, /DROP\/TRUNCATE/i);
+  });
+
+  await t.test('allows destructive production SQL only as final-review warning with approval and rollback evidence', () => {
+    const res = evaluatePostgresQuery('DROP TABLE stale_imports;', {
+      env: 'production',
+      approvalToken: 'approved-by-dba',
+      snapshotId: 'snap_123',
+    });
+    assert.strictEqual(res.mode, 'warn');
+    assert.match(res.reason, /approval and rollback evidence/i);
   });
 
   await t.test('warns on schema changes', () => {
@@ -37,5 +53,64 @@ test('postgres-guard', async (t) => {
 
     res = evaluatePostgresQuery('DELETE FROM users WHERE id = 1;');
     assert.strictEqual(res.mode, 'allow');
+  });
+
+  await t.test('blocks WHERE true write queries as unbounded', () => {
+    const res = evaluatePostgresQuery('DELETE FROM users WHERE 1 = 1;');
+    assert.strictEqual(res.mode, 'block');
+    assert.match(res.reason, /restrictive WHERE/i);
+  });
+
+  await t.test('blocks production schema changes without rollback evidence', () => {
+    const res = evaluatePostgresQuery('ALTER TABLE users DROP COLUMN legacy_id;', {
+      env: 'production',
+      approvalToken: 'ticket-123',
+    });
+    assert.strictEqual(res.mode, 'block');
+    assert.match(res.reason, /backup, snapshot, or rollback/i);
+  });
+
+  await t.test('warns production writes without dry-run or explain evidence', () => {
+    const res = evaluatePostgresQuery('UPDATE users SET plan = $1 WHERE id = $2;', {
+      databaseUrl: 'postgres://app@prod-db.example.com/app',
+    });
+    assert.strictEqual(res.mode, 'warn');
+    assert.match(res.reason, /dry-run or EXPLAIN/i);
+  });
+
+  await t.test('warns production CREATE INDEX without CONCURRENTLY', () => {
+    const res = evaluatePostgresQuery('CREATE INDEX idx_events_user_id ON events(user_id);', {
+      env: 'production',
+    });
+    assert.strictEqual(res.mode, 'warn');
+    assert.match(res.reason, /CONCURRENTLY/i);
+  });
+
+  await t.test('blocks production migration commands without approval, rollback, and dry-run proof', () => {
+    const res = evaluateDatabaseAgentAction({
+      command: 'npx prisma migrate deploy',
+      env: 'production',
+      hasBackup: true,
+      approvalToken: 'approved-by-dba',
+    });
+    assert.strictEqual(res.mode, 'block');
+    assert.match(res.reason, /dry-run proof/i);
+  });
+
+  await t.test('warns migration command with full production proof bundle', () => {
+    const res = evaluateDatabaseAgentAction({
+      command: 'npx prisma migrate deploy',
+      env: 'production',
+      approvalToken: 'approved-by-dba',
+      snapshotId: 'snap_123',
+      hasDryRun: true,
+    });
+    assert.strictEqual(res.mode, 'warn');
+    assert.match(res.reason, /Migration command detected/i);
+  });
+
+  await t.test('normalizes SQL comments before matching', () => {
+    assert.equal(normalizeSql('SELECT 1; -- DROP TABLE bait'), 'SELECT 1;');
+    assert.equal(normalizeSql('SELECT /* DROP TABLE bait */ 1;'), 'SELECT 1;');
   });
 });

--- a/tests/seo-gsd.test.js
+++ b/tests/seo-gsd.test.js
@@ -491,6 +491,27 @@ test('AI agent production listicle is discoverable and commercially classified',
   });
 });
 
+test('database agent safety page is discoverable and commercially classified', () => {
+  const page = findSeoPageByPath('/guides/database-agent-safety');
+  const sitemapEntry = THUMBGATE_SEO_SITEMAP_ENTRIES.find((entry) => entry.path === '/guides/database-agent-safety');
+  const html = renderSeoPageHtml(page, { appOrigin: 'https://app.example.com' });
+
+  assert.ok(page);
+  assert.equal(page.query, 'database safety for ai agents');
+  assert.equal(page.pageType, 'guide');
+  assert.equal(page.pillar, 'pre-action-checks');
+  assert.match(html, /Database Safety for AI Agents/);
+  assert.match(html, /DROP, TRUNCATE/);
+  assert.match(html, /production migrations/i);
+  assert.match(html, /dry-run or EXPLAIN evidence/i);
+  assert.match(html, /role grants/i);
+  assert.deepEqual(sitemapEntry, {
+    path: '/guides/database-agent-safety',
+    changefreq: 'monthly',
+    priority: '0.8',
+  });
+});
+
 test('native messaging host security page is discoverable and commercially classified', () => {
   const page = findSeoPageByPath('/guides/native-messaging-host-security');
   const sitemapEntry = THUMBGATE_SEO_SITEMAP_ENTRIES.find((entry) => entry.path === '/guides/native-messaging-host-security');

--- a/tests/seo-guides.test.js
+++ b/tests/seo-guides.test.js
@@ -31,6 +31,7 @@ const GUIDE_FILES = [
   'guides/native-messaging-host-security.html',
   'guides/ai-search-topical-presence.html',
   'guides/best-tools-stop-ai-agents-breaking-production.html',
+  'guides/database-agent-safety.html',
   'guides/relational-knowledge-ai-recommendations.html',
   'guides/ai-mode-ads-agent-governance.html',
   'guides/mcp-tool-governance.html',
@@ -396,5 +397,18 @@ describe('SEO guide and comparison pages', () => {
     assert.ok(mcpGovernance.includes('Tool inventory'), 'MCP guide should describe governance requirements');
     assert.ok(approvalGates.includes('pre-action approval gates for risky tool calls'), 'approval-gates guide should lead with the buyer phrase');
     assert.ok(approvalGates.includes('Block: deny known-bad actions'), 'approval-gates guide should describe gate outcomes');
+  });
+
+  it('database agent safety guide routes database-agent risk into pre-action checks', () => {
+    const html = fs.readFileSync(
+      path.join(PUBLIC_DIR, 'guides/database-agent-safety.html'),
+      'utf-8'
+    );
+
+    assert.ok(html.includes('Database Safety for AI Agents'));
+    assert.ok(html.includes('DROP, TRUNCATE'));
+    assert.ok(html.includes('UPDATE and DELETE without a restrictive WHERE clause'));
+    assert.ok(html.includes('dry-run or EXPLAIN evidence'));
+    assert.ok(html.includes('role creation, role alteration, and broad grants'));
   });
 });


### PR DESCRIPTION
## Summary
- Add a database-agent safety gate pack for production SQL, migrations, grants, and rollback/dry-run proof requirements.
- Harden `postgres-guard` into a broader database pre-action evaluator for destructive SQL, unbounded writes, production schema changes, CREATE INDEX locking risk, and migration commands.
- Publish a new high-intent guide at `/guides/database-agent-safety` and link it from `/learn` for SEO/GEO discovery.

## Why
The New Stack's June 2026 database-agent coverage highlights the exact ThumbGate wedge: agents can recover from many UI/code mistakes, but production database queries, migrations, and privilege changes have immediate blast radius. This turns that market signal into enforceable checks and a discoverable buyer page.

## Validation
- `node --test tests/postgres-guard.test.js tests/metaclaw-features.test.js tests/seo-gsd.test.js tests/seo-guides.test.js tests/learn-hub.test.js` (394/394 passing)
- `npm run test:public-static-assets` (62/62 passing)
- `npm run test:public-package-parity` (5/5 passing)
- `git diff --check`
- Secret-pattern scan over touched files; only benign existing marketing/test uses of "secret" matched
- Pre-commit: package parity + version sync passed
- Pre-push: npm pack dry-run + internal links + regression guards passed
