### PR TITLE
seo(compare): wire all live /compare pages into the hub + homepage

### DIFF
--- a/.changeset/compare-hub-discoverability.md
+++ b/.changeset/compare-hub-discoverability.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+seo: wire all live /compare pages into the comparison hub and homepage
+
+The /compare hub linked to only 4 of 13 live comparison pages, and the homepage compare strip to 4 — both hand-maintained lists that drifted every time a new buyer-intent page shipped. Flagship competitor comparisons (claude-code-hooks, arcjet, bumblebee, anthropic-containment, oak-and-sparrow-gatekeeper, anthropic-claude-for-legal) were live and in the sitemap but unreachable from the hub whose entire job is to list them, and the homepage's only link to the hub was `display:none`. That starves the highest-intent pages of internal link equity from the site's top-authority surfaces — directly counter to the GEO/buyer-intent goal those pages exist for.
+
+This makes the hub a complete index of every live comparison (framing grounded in each page's own subtitle, no overclaim), adds the top buyer-intent links plus a visible "Compare all" hub link to the homepage strip, and pins the contract with a regression test (`/compare` must link to every `public/compare/*.html`) mirroring the existing sitemap-completeness test so it cannot silently drift again.

--- a/public/compare.html
+++ b/public/compare.html
@@ -267,6 +267,24 @@
   <p><a href="/compare/rein" class="cta">Read ThumbGate vs Rein</a></p>
 </div>
 
+<h2>All ThumbGate comparisons</h2>
+<p style="color:var(--muted);">Every head-to-head in one place. ThumbGate is the local-first, learning enforcement layer at the tool-call boundary — most of these tools sit at a different layer and are complementary.</p>
+<ul class="compare-index">
+  <li><a href="/compare/claude-code-hooks">ThumbGate vs claude-code-hooks</a> — hosted sync &amp; learning on top of local shell-script hooks</li>
+  <li><a href="/compare/arcjet">ThumbGate vs Arcjet</a> — agent-outbound gate pairs with an app-inbound firewall</li>
+  <li><a href="/compare/bumblebee">ThumbGate vs Bumblebee</a> — runtime enforcement pairs with static inventory</li>
+  <li><a href="/compare/anthropic-containment">ThumbGate vs Anthropic's Claude Containment</a> — an IDE-agent extension of Anthropic's published architecture</li>
+  <li><a href="/compare/oak-and-sparrow-gatekeeper">ThumbGate vs Gatekeeper (Oak &amp; Sparrow)</a> — agent-action gate pairs with a workforce-input gate</li>
+  <li><a href="/compare/fallow">ThumbGate vs Fallow</a> — static analysis vs agent-action enforcement</li>
+  <li><a href="/compare/heidi">ThumbGate vs HEIDI</a> — behavior enforcement vs supply-chain scanning</li>
+  <li><a href="/compare/rein">ThumbGate vs Rein</a> — coding-agent governance vs generic decorator governance</li>
+  <li><a href="/compare/anthropic-claude-for-legal">ThumbGate vs Claude for Legal</a> — runtime gate pairs with Anthropic's practice-area plugins</li>
+  <li><a href="/compare/mem0">ThumbGate vs Mem0</a> — enforcement vs memory for AI agents</li>
+  <li><a href="/compare/speclock">ThumbGate vs SpecLock</a> — thumbs-feedback enforcement vs manual specs</li>
+  <li><a href="/compare/ai-experience-orchestration">ThumbGate vs AI Experience Orchestration</a> — orchestration vs execution enforcement</li>
+  <li><a href="/compare/agentix-labs">ThumbGate vs Agentix Labs</a> — productized enforcement vs custom AI-agent services</li>
+</ul>
+
 <h2>How It Works</h2>
 <div class="step-grid">
   <div class="step-card">

--- a/public/index.html
+++ b/public/index.html
@@ -1128,9 +1128,14 @@ __GA_BOOTSTRAP__
       <div style="color:var(--cyan);font-weight:700;">Compare ThumbGate with other agent-safety approaches</div>
       <div style="display:flex;flex-wrap:wrap;gap:10px;margin-top:14px;font-size:13px;line-height:1.4;">
         <a href="/learn">Browse the guide library</a>
+        <a href="/compare/claude-code-hooks" title="ThumbGate vs native Claude Code hooks and free community repos">Claude Code hooks</a>
+        <a href="/compare/arcjet">Arcjet</a>
+        <a href="/compare/bumblebee">Bumblebee</a>
+        <a href="/compare/anthropic-containment">Claude Containment</a>
         <a href="/compare/speclock">SpecLock</a>
         <a href="/compare/mem0">Mem0</a>
         <a href="/compare/fallow">Fallow</a>
+        <a href="/compare" style="font-weight:700;color:var(--cyan);">Compare all &rarr;</a>
         <a href="/guides/pre-action-checks">Pre-action checks</a>
         <a href="/guides/agent-harness-optimization">Agent harness optimization</a>
         <a href="/guides/code-knowledge-graph-guardrails">Code graph guardrails</a>

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -808,6 +808,29 @@ test('GET /sitemap.xml lists every public/compare/*.html page', async () => {
   assert.deepEqual(missing, [], `comparison pages missing from sitemap: ${missing.join(', ')}`);
 });
 
+// Root cause this prevents: the /compare hub linked to a hand-maintained subset of the
+// catalog (4 of 13 pages), so flagship buyer-intent comparisons (claude-code-hooks, arcjet,
+// bumblebee, anthropic-containment, ...) were live and in the sitemap but unreachable from
+// the hub whose entire job is to list them — and the homepage strip had the same drift.
+// This test pins the contract: the hub must link to every public/compare/*.html page.
+test('GET /compare hub links to every public/compare/*.html page', async () => {
+  const comparePages = fs
+    .readdirSync(path.join(publicDir, 'compare'))
+    .filter((file) => file.endsWith('.html'))
+    .map((file) => `/compare/${file.replace(/\.html$/, '')}`);
+
+  assert.ok(comparePages.length >= 13, `expected the full compare catalog, got ${comparePages.length}`);
+
+  const res = await fetch(`${origin}/compare`);
+  assert.equal(res.status, 200);
+  const html = await res.text();
+
+  const missing = comparePages.filter(
+    (p) => !new RegExp(`href="${p.replace(/[/-]/g, (c) => `\\${c}`)}"`).test(html),
+  );
+  assert.deepEqual(missing, [], `comparison pages missing from the /compare hub: ${missing.join(', ')}`);
+});
+
 // GEO: comparison and high-intent landing pages carry FAQPage structured data so they
 // are eligible to be pulled into AI Overviews / AI Mode on their category queries.
 test('comparison and key landing pages expose FAQPage structured data', async () => {


### PR DESCRIPTION
## Problem

The `/compare` hub — the page whose entire job is to list ThumbGate's head-to-head comparisons — linked to only **4 of 13 live comparison pages**. The homepage compare strip linked to 4, and its only link to the hub itself was `display:none`.

So these flagship buyer-intent pages were **live and in the sitemap but unreachable from the site's two highest-authority surfaces**:

`claude-code-hooks`, `arcjet`, `bumblebee`, `anthropic-containment`, `oak-and-sparrow-gatekeeper`, `anthropic-claude-for-legal`, `fallow`, `mem0`, `speclock`

That starves exactly the pages we want ranked/cited (the documented buyer-intent + GEO goal) of internal link equity, and the hand-maintained lists drifted further every time a new compare page shipped.

## Change

- **`public/compare.html`** — adds a complete "All ThumbGate comparisons" index of every live page. Framing is grounded in each page's own title-subtitle (no overclaim; keeps the existing 4 featured cards as highlights above it).
- **`public/index.html`** — adds the top buyer-intent links (claude-code-hooks, Arcjet, Bumblebee, Claude Containment) and a **visible** "Compare all →" link to the hub.
- **`tests/public-static-assets.test.js`** — regression test asserting `/compare` links to every `public/compare/*.html`, mirroring the existing sitemap-completeness test so this can't silently drift again.

## Verification

Local: `public-static-assets` (63 ✓, incl. the new test), `landing-page-claims` (23 ✓), `competitive-positioning-marketing` (16 ✓), `package-boundary` (4 ✓), `public-bundle-ratchet` (2 ✓).

## Context

Surfaced while triaging [#2461](https://github.com/IgorGanapolsky/ThumbGate/pull/2461), which I closed as superseded — its `/compare/claude-code-hooks` page was already live in `main` (identical blob); its only genuinely-missing piece was the homepage link, which this PR delivers along with the broader hub fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)