### PR TITLE
chore(deps): combined dependency bumps (unblocks dependabot #2435/#2437/#2438/#2439/#2436)

### DIFF
--- a/.changeset/deps-combined-2026-06-06.md
+++ b/.changeset/deps-combined-2026-06-06.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+chore(deps): bump protobufjs to ^8.5.0 (resolved 8.6.0), @lancedb/lancedb to ^0.30.0, @anthropic-ai/sdk to 0.100.1, @google/genai to 2.7.0, stripe to ^22.2.0
+
+Combined dependency bump consolidating dependabot PRs #2435/#2437/#2438/#2439/#2436 (all five passed targeted tests and were included). Single changeset satisfies the changeset:check gate that blocks lockfile-only dependabot PRs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,19 +20,20 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.96.0",
-        "@google/genai": "1.49.0",
+        "@anthropic-ai/sdk": "0.100.1",
+        "@google/genai": "2.7.0",
         "@huggingface/transformers": "^4.2.0",
-        "@lancedb/lancedb": "^0.27.2",
+        "@lancedb/lancedb": "^0.30.0",
         "apache-arrow": "^18.1.0",
         "better-sqlite3": "^12.9.0",
         "dotenv": "^17.4.2",
         "playwright-core": "^1.59.1",
-        "protobufjs": "^8.4.0",
-        "stripe": "^22.0.2"
+        "protobufjs": "^8.5.0",
+        "stripe": "^22.2.0"
       },
       "bin": {
-        "thumbgate": "bin/cli.js"
+        "thumbgate": "bin/cli.js",
+        "thumbgate-dashboard": "bin/dashboard-cli.js"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
@@ -46,9 +47,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
-      "integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -392,9 +393,10 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.49.0.tgz",
-      "integrity": "sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.7.0.tgz",
+      "integrity": "sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -406,7 +408,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0"
+        "@modelcontextprotocol/sdk": "^1.25.2"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -992,9 +994,9 @@
       }
     },
     "node_modules/@lancedb/lancedb": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.27.2.tgz",
-      "integrity": "sha512-JQpZHV5KzUzDI3flYCjtZcfHlEbL8lM54E0NT+jrRYe29aKYegfavvPsAsuZp0VdcMwFMZcpMkaBhjQMo/fwvg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.30.0.tgz",
+      "integrity": "sha512-d0FoEL6cthqgsulqAc7fck6kRXrSRGMTqlKYbhSGSazHU6vB2GEpD737Mu0HZd7fMyBUdhR9sD1W2C9uQZ5p0Q==",
       "cpu": [
         "x64",
         "arm64"
@@ -1012,22 +1014,22 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@lancedb/lancedb-darwin-arm64": "0.27.2",
-        "@lancedb/lancedb-linux-arm64-gnu": "0.27.2",
-        "@lancedb/lancedb-linux-arm64-musl": "0.27.2",
-        "@lancedb/lancedb-linux-x64-gnu": "0.27.2",
-        "@lancedb/lancedb-linux-x64-musl": "0.27.2",
-        "@lancedb/lancedb-win32-arm64-msvc": "0.27.2",
-        "@lancedb/lancedb-win32-x64-msvc": "0.27.2"
+        "@lancedb/lancedb-darwin-arm64": "0.30.0",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.30.0",
+        "@lancedb/lancedb-linux-arm64-musl": "0.30.0",
+        "@lancedb/lancedb-linux-x64-gnu": "0.30.0",
+        "@lancedb/lancedb-linux-x64-musl": "0.30.0",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.30.0",
+        "@lancedb/lancedb-win32-x64-msvc": "0.30.0"
       },
       "peerDependencies": {
         "apache-arrow": ">=15.0.0 <=18.1.0"
       }
     },
     "node_modules/@lancedb/lancedb-darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-+XM68V/Rou8kKWDnUeKvg9ChKS0zGeQC2sKAop+06Ty4LwIjEGkeYBYrK0vMhZkBN5EFaOjTOp8E8hGQxdFwXA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.30.0.tgz",
+      "integrity": "sha512-x6dmsjRIv0xumELYnFAEfyFDxqcO/n4rHYCJvC27RbRez0UmbByi6OMTgbSoSTatrQSPRCL7JJSa5pwNeawnIg==",
       "cpu": [
         "arm64"
       ],
@@ -1041,11 +1043,14 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.27.2.tgz",
-      "integrity": "sha512-laiTTDeMUTzm7t+t6ME5nNQMDoERjmkeuWAFWekbXiFdmp62Dqu34Lvf2BvpWnKwxLMZ5JcBJFIw32WS8/8Jnw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.30.0.tgz",
+      "integrity": "sha512-CWUex7hRNiLkXFeTQlUGPyy5VktbXoUmQdZuiVCETZ6ggljEC7c7Qvzu2ge+jEZML+UE7tXL2lVC3klRFGczng==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1057,11 +1062,14 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-musl": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.27.2.tgz",
-      "integrity": "sha512-bK5Mc50EvwGZaaiym5CoPu8Y4GNSyEEvTQ0dTC2AUIm83qdQu1rGw6kkYtc/rTH/hbvAvPQot4agHDZfMVxfYw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.30.0.tgz",
+      "integrity": "sha512-2MHmAS4tKePNVbwfgDrjCFj6BVuAgXlL2c9iWk7TfcwL+jcSxo52LFx03O0+ArpVCF2sI6aoDqZaQNre5zMniQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1073,11 +1081,14 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-gnu": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.27.2.tgz",
-      "integrity": "sha512-qe+ML0YmPru0o84f33RBHqoNk6zsHBjiXTLKsEBDiiFYKks/XMsrkKy9NQYcTxShBrg/nx/MLzCzd7dihqgNYw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.30.0.tgz",
+      "integrity": "sha512-0OpDNxsDE4OXD+PIFd7KdE42xhYIE+fZL+jCm1v3dTug4UEhumWBuSgbUIBP7t0yJZHwh62/QivVh/V1cPB2Bg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1089,11 +1100,14 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-musl": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.27.2.tgz",
-      "integrity": "sha512-ZpX6Oxn06qvzAdm+D/gNb3SRp/A9lgRAPvPg6nnMmSQk5XamC/hbGO07uK1wwop7nlqXUH/thk4is2y2ieWdTw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.30.0.tgz",
+      "integrity": "sha512-4Bq7VngQt+lyxIcu79EN8nYJs8gvUnrIT6I/t2MSlpG/BXWHZG2A+PRii1Zq4GCUlRTTG+RlieCv8CBGSPm8bw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1105,9 +1119,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.27.2.tgz",
-      "integrity": "sha512-4ffpFvh49MiUtkdFJOmBytXEbgUPXORphTOuExnJAgT1VAKwQcu4ZzdsgNoK6mumKBaU+pYQU/MedNkgTzx/Lw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.30.0.tgz",
+      "integrity": "sha512-N2DQg2XBWZirn5jS6kRJUxF679t3sKcIxBwP9zY4Idq5OVLAj0yfLueWIKhYxv8en7pBFYWdgw5j9dTS7XajyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1121,9 +1135,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-x64-msvc": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.27.2.tgz",
-      "integrity": "sha512-XlwiI6CK2Gkqq+FFVAStHojao/XjIJpDPTm7Tb9SpLL64IlwGw3yaT2hnWKTm90W4KlSrpfSldPly+s+y4U7JQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.30.0.tgz",
+      "integrity": "sha512-CDgN/ZmYqSlVX2nBJAF2PYEwqBBxotCVORjagmvrd0k5D7RBLlAQUEAR4gDMum2BpYsUkzdTYQpquLjRCVbwbQ==",
       "cpu": [
         "x64"
       ],
@@ -3338,10 +3352,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.0.tgz",
-      "integrity": "sha512-iriNhQ57SYA5Jbdi+41AyPdx6jPPkFO7DODzkOBmqFhgYn/JzX2HxgxYPY18eQAs3CP/AWqtPvkWn8rclRAxdQ==",
-      "hasInstallScript": true,
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.0.tgz",
+      "integrity": "sha512-PIOO89BMGMXGz2333TVv/OqPNVWm7w30ll/4FtLbtLBaonzJMYwTbAZSSlobjIy9MoUgIAxSVUpK7aP7EpTtkg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
@@ -3840,9 +3853,9 @@
       }
     },
     "node_modules/stripe": {
-      "version": "22.1.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
-      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.0.tgz",
+      "integrity": "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -778,16 +778,16 @@
     "node": ">=18.18.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "0.96.0",
-    "@google/genai": "1.49.0",
+    "@anthropic-ai/sdk": "0.100.1",
+    "@google/genai": "2.7.0",
     "@huggingface/transformers": "^4.2.0",
-    "@lancedb/lancedb": "^0.27.2",
+    "@lancedb/lancedb": "^0.30.0",
     "apache-arrow": "^18.1.0",
     "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.2",
     "playwright-core": "^1.59.1",
-    "protobufjs": "^8.4.0",
-    "stripe": "^22.0.2"
+    "protobufjs": "^8.5.0",
+    "stripe": "^22.2.0"
   },
   "overrides": {
     "express@4.22.1": {


### PR DESCRIPTION
## Why this PR exists

Five dependabot PRs (#2435, #2436, #2437, #2438, #2439) are stuck because each fails the required `test` check at the `changeset:check` step (`node scripts/changeset-check.js` exits 1). Root cause: dependabot bumps `package-lock.json` (a release-relevant file under the gate's `RELEASE_RELEVANT_FILES`) but never authors a `.changeset/*.md`, so the gate has nothing valid to consume and blocks the PR.

This single combined PR carries **one** changeset that satisfies the gate, unblocking all five bumps at once.

## Bumps included (all 5 kept — none dropped)

| Package | From | To (range) | Resolved in lockfile |
|---|---|---|---|
| protobufjs | ^8.4.0 | ^8.5.0 | 8.6.0 |
| @lancedb/lancedb | ^0.27.2 | ^0.30.0 | 0.30.0 |
| @anthropic-ai/sdk | 0.96.0 (pinned) | 0.100.1 (pinned) | 0.100.1 |
| @google/genai | 1.49.0 (pinned) | 2.7.0 (pinned) | 2.7.0 — **MAJOR** |
| stripe | ^22.0.2 | ^22.2.0 | 22.2.0 |

Existing range style preserved (carets stay carets; the two pinned deps stay pinned). `protobufjs` resolves to 8.6.0, the newest release inside the `^8.5.0` range — expected caret behavior.

## Test evidence (run in an isolated worktree with the bumped versions actually installed)

All targeted suites green — **120 pass / 0 fail**:

- `test:llm-client` → 11 pass / 0 fail (exercises @anthropic-ai/sdk + @google/genai)
- `test:billing` → 54 pass / 0 fail (stripe)
- `test:stripe-checkout-diagnostic` → 9 pass / 0 fail (stripe)
- `test:lesson-semantic-retrieval` → 8 pass / 0 fail
- `tests/prove-lancedb.test.js` → 1 pass / 0 fail (loads the native @lancedb/lancedb 0.30.0 binary, VEC-01..VEC-04)
- `tests/vector-store.test.js` → 7 pass / 0 fail (lancedb)
- `test:cli-schema` → 30 pass / 0 fail

The @google/genai **major** bump (1.49.0 → 2.7.0) was treated as highest-risk: `test:llm-client` passes, including the Claude→Gemini routing path. (A live Gemini call inside that test logs a 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT — an environment auth-scope condition, not a regression; the test asserts the error-handling/fallback path and that assertion passes.)

Gate verification: `node scripts/changeset-check.js --base=origin/main` → exit 0 ("Found 1 valid changeset file(s) for release-relevant changes.").

## Follow-up worth doing (structural fix)

`scripts/changeset-check.js` should be made **dependabot-aware** — e.g. auto-skip the changeset requirement (or auto-generate a synthetic one) when the PR author is `app/dependabot` and the only release-relevant change is `package.json` + `package-lock.json`. That removes the need to hand-consolidate dependabot PRs every cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
