### PR TITLE
fix(statusline): stop double-counting cached aggregates (1152→727 bug)

### DIFF
--- a/.changeset/statusline-cache-no-double-count.md
+++ b/.changeset/statusline-cache-no-double-count.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix statusline display showing inflated thumbs counts (e.g. 1152↑/747↓ when the true cross-store total was 727↑/600↓). `scripts/statusline-cache-read.js` was summing `thumbs_up`/`thumbs_down` across every per-folder `statusline_cache.json`, but the canonical global aggregate at `~/.thumbgate/statusline_cache.json` is itself written as the cross-store sum (by `feedback-aggregate.js`). Summing the aggregate plus the per-folder caches counted every event twice. The helper now resolves the highest-priority existing cache and returns its content unchanged.

--- a/scripts/statusline-cache-read.js
+++ b/scripts/statusline-cache-read.js
@@ -1,62 +1,24 @@
 #!/usr/bin/env node
 'use strict';
 
+// Resolve the statusline cache to read for display.
+//
+// PRIOR BUG: the earlier version of this script "aggregated" by summing the
+// thumbs_up/down fields across every per-folder statusline_cache.json. That
+// double-counted, because the global aggregate cache at
+// ~/.thumbgate/statusline_cache.json is ITSELF already the cross-store sum
+// (written by feedback-aggregate.js / hook-thumbgate-cache-updater.js). Summing
+// the global aggregate plus per-folder caches counted every event twice or more
+// and produced bogus totals like 1152↑/747↓ when the true aggregate was 727/600.
+//
+// CORRECT BEHAVIOR: pick the highest-priority existing cache from the
+// candidate list (`statusline-cache-path.js` puts the canonical aggregate path
+// first when aggregation is enabled) and return its content unchanged. No
+// summing across files — the upstream aggregator already did that work.
+
 const fs = require('node:fs');
 const path = require('node:path');
 const { getStatuslineCacheCandidates } = require('./statusline-cache-path');
-const { getHomeDir } = require('./feedback-paths');
-
-const ARCHIVE_MARKER = /\.tg-archive(-\d+)?(\/|$)/;
-
-function toNumber(value) {
-  if (value === null || value === undefined) return 0;
-  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
-  const parsed = Number(String(value).trim());
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function uniqueResolved(paths) {
-  const seen = new Set();
-  const out = [];
-  for (const p of paths) {
-    if (!p) continue;
-    const resolved = path.resolve(p);
-    if (seen.has(resolved)) continue;
-    seen.add(resolved);
-    out.push(resolved);
-  }
-  return out;
-}
-
-function listGlobalProjectCaches(options = {}) {
-  const home = getHomeDir(options);
-  if (!home) return [];
-  const projectsRoot = path.join(home, '.thumbgate', 'projects');
-  let entries = [];
-  try {
-    entries = fs.readdirSync(projectsRoot, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  const out = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    out.push(path.join(projectsRoot, entry.name, 'statusline_cache.json'));
-  }
-  return out;
-}
-
-function getAggregationCandidates(options = {}) {
-  const home = getHomeDir(options);
-  const candidates = [
-    ...getStatuslineCacheCandidates(options),
-    home && path.join(home, '.thumbgate', 'statusline_cache.json'),
-    ...listGlobalProjectCaches(options),
-  ];
-  return uniqueResolved(candidates).filter(
-    (candidate) => !ARCHIVE_MARKER.test(candidate)
-  );
-}
 
 function readCacheFile(filePath) {
   try {
@@ -69,87 +31,21 @@ function readCacheFile(filePath) {
   return null;
 }
 
-function aggregateStatuslineCaches(options = {}) {
-  const candidatePaths = getAggregationCandidates(options);
-  const sources = [];
-  let up = 0;
-  let down = 0;
-  let lessons = 0;
-  let total = 0;
-  let latestTs = 0;
-  let latestRecord = null;
-  let latestRecordSource = null;
-
-  for (const candidate of candidatePaths) {
-    if (!fs.existsSync(candidate)) continue;
-    const data = readCacheFile(candidate);
-    if (!data) continue;
-    sources.push(candidate);
-    up += toNumber(data.thumbs_up);
-    down += toNumber(data.thumbs_down);
-    lessons += toNumber(data.lessons);
-    total += toNumber(data.total_feedback);
-    const ts = toNumber(data.updated_at);
-    if (ts > latestTs) {
-      latestTs = ts;
-      latestRecord = data;
-      latestRecordSource = candidate;
-    }
-  }
-
-  if (sources.length === 0) {
-    return null;
-  }
-
-  const denom = up + down;
-  const approvalRate = denom > 0 ? Math.round((up / denom) * 1000) / 10 : 0;
-  const totalFeedback = total > 0 ? total : up + down;
-
-  const aggregated = {
-    thumbs_up: String(up),
-    thumbs_down: String(down),
-    lessons: String(lessons),
-    approval_rate: String(approvalRate),
-    trend: latestRecord?.trend || '?',
-    total_feedback: String(totalFeedback),
-    updated_at: String(latestTs || Math.floor(Date.now() / 1000)),
-    aggregated: true,
-    sources_count: sources.length,
-    sources,
-  };
-
-  if (latestRecord?.last_lesson) {
-    aggregated.last_lesson = latestRecord.last_lesson;
-  }
-  if (latestRecordSource) {
-    aggregated.latest_source = latestRecordSource;
-  }
-
-  return aggregated;
-}
-
 function readResolvedStatuslineCache(options = {}) {
-  const env = options.env || process.env;
-  const aggregateFlag = env.THUMBGATE_STATUSLINE_AGGREGATE;
-  const aggregationEnabled = aggregateFlag !== '0' && aggregateFlag !== 'false';
-
-  if (aggregationEnabled) {
-    const aggregated = aggregateStatuslineCaches(options);
-    if (aggregated) return aggregated;
-  }
-
   const candidates = getStatuslineCacheCandidates(options);
   for (const candidate of candidates) {
     if (!fs.existsSync(candidate)) continue;
     const data = readCacheFile(candidate);
     if (data) {
-      return { ...data, aggregated: false, sources_count: 1, sources: [path.resolve(candidate)] };
+      return { ...data, source: path.resolve(candidate) };
     }
   }
   return null;
 }
 
-if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+const _invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename);
+if (_invokedDirectly) {
   const resolved = readResolvedStatuslineCache();
   if (resolved) {
     process.stdout.write(JSON.stringify(resolved));
@@ -157,7 +53,5 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename
 }
 
 module.exports = {
-  aggregateStatuslineCaches,
-  getAggregationCandidates,
   readResolvedStatuslineCache,
 };

--- a/tests/statusline-cache-aggregate.test.js
+++ b/tests/statusline-cache-aggregate.test.js
@@ -1,23 +1,34 @@
 'use strict';
 
+// This file used to test a cache-layer aggregator that summed thumbs_up/down
+// across every per-folder statusline_cache.json. That implementation
+// double-counted, because the global aggregate cache at
+// ~/.thumbgate/statusline_cache.json is itself written as the cross-store sum
+// (by feedback-aggregate.js / hook-thumbgate-cache-updater.js). Summing the
+// aggregate plus the per-folder caches produced bogus totals like 1152↑/747↓
+// when the true cross-store total was 727/600.
+//
+// The fix: statusline-cache-read.js now only resolves the highest-priority
+// existing cache file and returns its content unchanged. These tests pin that
+// non-summing behavior so the double-count bug cannot return.
+
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const {
-  aggregateStatuslineCaches,
-  getAggregationCandidates,
-  readResolvedStatuslineCache,
-} = require('../scripts/statusline-cache-read');
+const { readResolvedStatuslineCache } = require('../scripts/statusline-cache-read');
 
 function makeSandbox() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-statusline-agg-'));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-statusline-cache-read-'));
   const home = path.join(root, 'home');
   const projects = path.join(home, '.thumbgate', 'projects');
+  const projectDir = path.join(root, 'project');
+  const feedbackDir = path.join(projectDir, '.claude', 'memory', 'feedback');
   fs.mkdirSync(projects, { recursive: true });
-  return { root, home, projects };
+  fs.mkdirSync(feedbackDir, { recursive: true });
+  return { root, home, projects, projectDir, feedbackDir };
 }
 
 function writeCache(dir, payload) {
@@ -27,21 +38,27 @@ function writeCache(dir, payload) {
   return target;
 }
 
-function withHome(home, fn) {
+function withSandbox(sandbox, fn) {
   const prev = {
     HOME: process.env.HOME,
     USERPROFILE: process.env.USERPROFILE,
     THUMBGATE_PROJECT_DIR: process.env.THUMBGATE_PROJECT_DIR,
+    CLAUDE_PROJECT_DIR: process.env.CLAUDE_PROJECT_DIR,
     THUMBGATE_FEEDBACK_DIR: process.env.THUMBGATE_FEEDBACK_DIR,
+    THUMBGATE_FALLBACK_FEEDBACK_DIR: process.env.THUMBGATE_FALLBACK_FEEDBACK_DIR,
+    _TEST_THUMBGATE_FALLBACK_FEEDBACK_DIR: process.env._TEST_THUMBGATE_FALLBACK_FEEDBACK_DIR,
     THUMBGATE_STATUSLINE_AGGREGATE: process.env.THUMBGATE_STATUSLINE_AGGREGATE,
-    INIT_CWD: process.env.INIT_CWD,
+    THUMBGATE_AGGREGATE_FEEDBACK: process.env.THUMBGATE_AGGREGATE_FEEDBACK,
   };
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  delete process.env.THUMBGATE_PROJECT_DIR;
-  delete process.env.THUMBGATE_FEEDBACK_DIR;
+  process.env.HOME = sandbox.home;
+  process.env.USERPROFILE = sandbox.home;
+  process.env.THUMBGATE_PROJECT_DIR = sandbox.projectDir;
+  process.env.CLAUDE_PROJECT_DIR = sandbox.projectDir;
+  process.env.THUMBGATE_FEEDBACK_DIR = sandbox.feedbackDir;
+  process.env.THUMBGATE_FALLBACK_FEEDBACK_DIR = sandbox.feedbackDir;
+  process.env._TEST_THUMBGATE_FALLBACK_FEEDBACK_DIR = sandbox.feedbackDir;
   delete process.env.THUMBGATE_STATUSLINE_AGGREGATE;
-  delete process.env.INIT_CWD;
+  delete process.env.THUMBGATE_AGGREGATE_FEEDBACK;
   try {
     return fn();
   } finally {
@@ -52,124 +69,87 @@ function withHome(home, fn) {
   }
 }
 
-test('aggregateStatuslineCaches sums per-folder caches and recomputes approval rate', () => {
-  const { root, home, projects } = makeSandbox();
+test('readResolvedStatuslineCache returns the canonical aggregate cache verbatim, never sums', () => {
+  const sandbox = makeSandbox();
+  const { home, projectDir } = sandbox;
+  // The canonical global aggregate — this is what feedback-aggregate.js writes.
   writeCache(path.join(home, '.thumbgate'), {
-    thumbs_up: '49',
-    thumbs_down: '188',
-    lessons: '0',
-    total_feedback: '237',
-    updated_at: '1780763504',
+    thumbs_up: '727',
+    thumbs_down: '600',
+    approval_rate: '54.8',
+    trend: 'degrading',
+    total_feedback: '1327',
+    updated_at: '1780777800',
+  });
+  // Per-folder snapshots — must NOT be summed into the result. The 424 here is
+  // a subset already included in the 727 above.
+  writeCache(path.join(home, '.thumbgate', 'projects', 'demo'), {
+    thumbs_up: '424',
+    thumbs_down: '146',
+    updated_at: '1780766800',
+  });
+  writeCache(sandbox.feedbackDir, {
+    thumbs_up: '50',
+    thumbs_down: '50',
+    updated_at: '1780760000',
+  });
+
+  const resolved = withSandbox(sandbox, () => {
+    // The aggregate path is suppressed when THUMBGATE_FEEDBACK_DIR is under
+    // os.tmpdir() (test-isolation guard). For THIS test we are exercising
+    // production semantics, so unset that env to allow the aggregate to win.
+    delete process.env.THUMBGATE_FEEDBACK_DIR;
+    delete process.env.THUMBGATE_FALLBACK_FEEDBACK_DIR;
+    delete process.env._TEST_THUMBGATE_FALLBACK_FEEDBACK_DIR;
+    return readResolvedStatuslineCache({ cwd: projectDir });
+  });
+  assert.ok(resolved, 'expected a resolved cache');
+  assert.equal(resolved.thumbs_up, '727', 'must return canonical aggregate value, NOT the sum');
+  assert.equal(resolved.thumbs_down, '600');
+  assert.equal(resolved.trend, 'degrading');
+  assert.equal(resolved.approval_rate, '54.8');
+  assert.equal(resolved.source, path.join(home, '.thumbgate', 'statusline_cache.json'));
+});
+
+test('readResolvedStatuslineCache falls back to project cache when no canonical aggregate exists', () => {
+  const sandbox = makeSandbox();
+  const { projectDir, feedbackDir } = sandbox;
+  // Only a per-project cache, no global aggregate file.
+  writeCache(feedbackDir, {
+    thumbs_up: '12',
+    thumbs_down: '3',
     trend: 'stable',
-  });
-  writeCache(path.join(projects, 'demo'), {
-    thumbs_up: '23',
-    thumbs_down: '40',
-    lessons: '1',
-    total_feedback: '63',
-    updated_at: '1780764139',
-    trend: 'up',
-    last_lesson: { summary: 'most recent lesson' },
-  });
-  writeCache(path.join(projects, 'other'), {
-    thumbs_up: 8,
-    thumbs_down: 0,
-    lessons: 0,
-    total_feedback: 8,
-    updated_at: '1780700000',
-    trend: 'flat',
+    updated_at: '1780760000',
   });
 
-  const result = withHome(home, () => aggregateStatuslineCaches({ cwd: root }));
-  assert.ok(result, 'expected aggregated payload');
-  assert.equal(result.thumbs_up, '80');
-  assert.equal(result.thumbs_down, '228');
-  assert.equal(result.lessons, '1');
-  assert.equal(result.total_feedback, '308');
-  assert.equal(result.approval_rate, '26');
-  assert.equal(result.trend, 'up');
-  assert.equal(result.updated_at, '1780764139');
-  assert.deepEqual(result.last_lesson, { summary: 'most recent lesson' });
-  assert.equal(result.aggregated, true);
-  assert.equal(result.sources_count, 3);
+  const resolved = withSandbox(sandbox, () => readResolvedStatuslineCache({ cwd: projectDir }));
+  assert.ok(resolved);
+  assert.equal(resolved.thumbs_up, '12');
+  assert.equal(resolved.thumbs_down, '3');
 });
 
-test('aggregateStatuslineCaches skips archive paths', () => {
-  const { root, home } = makeSandbox();
-  writeCache(path.join(home, '.thumbgate'), { thumbs_up: '10', thumbs_down: '0', updated_at: '1' });
-  const archiveDir = path.join(home, '.tg-archive-12345');
-  writeCache(archiveDir, { thumbs_up: '999', thumbs_down: '999', updated_at: '2' });
-  writeCache(path.join(archiveDir, 'projects', 'demo'), { thumbs_up: '999', thumbs_down: '999', updated_at: '3' });
-
-  const candidates = withHome(home, () => getAggregationCandidates({ cwd: root }));
-  for (const candidate of candidates) {
-    assert.ok(!candidate.includes('.tg-archive-'), `archive path leaked into candidates: ${candidate}`);
-  }
-  const result = withHome(home, () => aggregateStatuslineCaches({ cwd: root }));
-  assert.equal(result.thumbs_up, '10', 'archive caches must not contribute to totals');
-  assert.equal(result.thumbs_down, '0');
-});
-
-test('aggregateStatuslineCaches returns null when no caches exist', () => {
-  const { root, home } = makeSandbox();
-  const result = withHome(home, () => aggregateStatuslineCaches({ cwd: root }));
+test('readResolvedStatuslineCache returns null when no cache exists', () => {
+  const sandbox = makeSandbox();
+  const result = withSandbox(sandbox, () => readResolvedStatuslineCache({ cwd: sandbox.projectDir }));
   assert.equal(result, null);
 });
 
-test('aggregateStatuslineCaches handles unparseable files without throwing', () => {
-  const { root, home } = makeSandbox();
-  const globalDir = path.join(home, '.thumbgate');
-  fs.mkdirSync(globalDir, { recursive: true });
-  fs.writeFileSync(path.join(globalDir, 'statusline_cache.json'), '{not json');
-  const projDir = path.join(home, '.thumbgate', 'projects', 'demo');
-  writeCache(projDir, { thumbs_up: '5', thumbs_down: '5', updated_at: '100' });
-
-  const result = withHome(home, () => aggregateStatuslineCaches({ cwd: root }));
-  assert.ok(result, 'should still aggregate from parseable file');
-  assert.equal(result.thumbs_up, '5');
-  assert.equal(result.approval_rate, '50');
-});
-
-test('approval_rate is "0" when no feedback has been captured', () => {
-  const { root, home } = makeSandbox();
-  writeCache(path.join(home, '.thumbgate'), { thumbs_up: '0', thumbs_down: '0', updated_at: '1' });
-  const result = withHome(home, () => aggregateStatuslineCaches({ cwd: root }));
-  assert.equal(result.approval_rate, '0');
-});
-
-test('readResolvedStatuslineCache prefers aggregation by default', () => {
-  const { root, home } = makeSandbox();
-  writeCache(path.join(home, '.thumbgate'), { thumbs_up: '10', thumbs_down: '0', updated_at: '1' });
-  writeCache(path.join(home, '.thumbgate', 'projects', 'demo'), {
-    thumbs_up: '5',
-    thumbs_down: '5',
-    updated_at: '2',
+test('readResolvedStatuslineCache skips unparseable files and uses next candidate', () => {
+  const sandbox = makeSandbox();
+  const { home, projectDir, feedbackDir } = sandbox;
+  // Broken canonical aggregate cache.
+  const broken = path.join(home, '.thumbgate', 'statusline_cache.json');
+  fs.mkdirSync(path.dirname(broken), { recursive: true });
+  fs.writeFileSync(broken, '{not json');
+  // Valid project cache as fallback.
+  writeCache(feedbackDir, {
+    thumbs_up: '99',
+    thumbs_down: '1',
+    updated_at: '1780760000',
   });
-  const resolved = withHome(home, () => readResolvedStatuslineCache({ cwd: root }));
-  assert.equal(resolved.aggregated, true);
-  assert.equal(resolved.thumbs_up, '15');
-  assert.equal(resolved.thumbs_down, '5');
-});
 
-test('readResolvedStatuslineCache honors THUMBGATE_STATUSLINE_AGGREGATE=0', () => {
-  const { root, home } = makeSandbox();
-  writeCache(path.join(home, '.thumbgate'), { thumbs_up: '10', thumbs_down: '0', updated_at: '1' });
-  writeCache(path.join(home, '.thumbgate', 'projects', 'demo'), {
-    thumbs_up: '5',
-    thumbs_down: '5',
-    updated_at: '2',
-  });
-  // Aggregation-off falls back to the project-scoped candidate set, so we
-  // point the project feedback dir at the home cache so something resolves.
-  const feedbackDir = path.join(home, '.thumbgate');
-
-  const resolved = withHome(home, () => {
-    process.env.THUMBGATE_STATUSLINE_AGGREGATE = '0';
-    process.env.THUMBGATE_FEEDBACK_DIR = feedbackDir;
-    return readResolvedStatuslineCache({ cwd: root });
-  });
-  assert.ok(resolved, 'expected a resolved (non-aggregated) cache');
-  assert.equal(resolved.aggregated, false);
-  assert.equal(resolved.sources_count, 1);
-  assert.equal(resolved.thumbs_up, '10', 'should NOT have summed across folders');
+  const resolved = withSandbox(sandbox, () => readResolvedStatuslineCache({ cwd: projectDir }));
+  assert.ok(resolved, 'should fall through to the next valid candidate');
+  assert.equal(resolved.thumbs_up, '99');
+  assert.equal(resolved.thumbs_down, '1');
 });


### PR DESCRIPTION
## TL;DR — the statusline was showing inflated counts because the read helper was summing the global aggregate plus the per-folder caches that were already inside it.

## Symptom

CEO's statusline screenshot showed `1152👍 747👎 ↘`. The real cross-store aggregate is `727👍 / 600👎`. Investigation traced the inflated value to `scripts/statusline-cache-read.js`.

Reproducible on the same host:

```
$ node scripts/statusline-cache-read.js | jq '{thumbs_up, thumbs_down, sources_count}'
{
  "thumbs_up": "1152",
  "thumbs_down": "747",
  "sources_count": 4    ← summed 4 caches where the first IS already the aggregate
}

$ node -e "const m=require('./scripts/feedback-aggregate'); const s=m.computeAggregateFeedbackStats({cwd:process.cwd()}); console.log(s.totalPositive, s.totalNegative)"
727 600                ← the true cross-store total
```

## Root cause

`feedback-aggregate.js` and `hook-thumbgate-cache-updater.js` write the cross-store aggregate to `~/.thumbgate/statusline_cache.json`. That file already contains the correct total. The per-folder caches (`<project>/.thumbgate/statusline_cache.json`) are subsets of it.

`statusline-cache-read.js` was summing `thumbs_up`/`thumbs_down` across all of them, double- and triple-counting every event.

## Fix

`statusline-cache-read.js` now resolves the highest-priority existing cache from the candidate list (which already puts the canonical aggregate first when aggregation is enabled) and returns its content unchanged. No summing — the upstream aggregator already did that work.

## Tests

- Rewritten `tests/statusline-cache-aggregate.test.js` (4 tests) to **pin non-summing behavior**: when both the canonical aggregate and per-folder subsets exist, the resolved value MUST equal the aggregate (727), not the sum (727+subsets).
- The original tests asserted the sum and would have caught nothing. The new tests would have caught the 1152 bug on day one.

## Out of scope (filed separately in the body of this PR)

The launchd dashboard agent runs from the **npm-installed thumbgate v1.27.6**, which predates `feedback-aggregate.js` entirely. It overwrites `~/.thumbgate/statusline_cache.json` with old per-folder values regardless of source-repo state. This PR doesn't change that — **a new npm release is required for end users to see the corrected number in their statusline.** After this lands, suggest `npm version patch && npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)