### PR TITLE
docs(pm): adopt Spec-Driven Development workflow + first dogfood spec

### DIFF
--- a/.changeset/spec-driven-pm.md
+++ b/.changeset/spec-driven-pm.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Adopt Spec-Driven Development as the project-management methodology. Adds `docs/PROJECT_MANAGEMENT.md` (the SDD + eval-gated + agent-orchestration workflow, with hard race-prevention rules for the multi-agent fleet), a reusable 6-element spec template (`specs/TEMPLATE.md`), and the first dogfood spec (`specs/001-threat-model/`) whose acceptance criteria are deterministic commands rather than self-report — turning "done" into a passing check.

--- a/docs/PROJECT_MANAGEMENT.md
+++ b/docs/PROJECT_MANAGEMENT.md
@@ -1,0 +1,73 @@
+# ThumbGate Project Management — Spec-Driven, Eval-Gated, Agent-Orchestrated
+
+Adopted 2026-06-07. This is the operating system for how work gets **defined**, **executed by AI
+agents**, and **verified** at ThumbGate. It is the June-2026 consensus methodology for agentic
+development: **Spec-Driven Development (SDD)** + **eval-driven verification** + **manager-of-agents
+orchestration**.
+
+## Why this exists (the failures it prevents)
+
+ThumbGate is built with heavy use of AI coding agents (Claude Code, Codex, …) that open PRs and
+merge through a Trunk queue. Three failure modes this system must prevent:
+
+1. **Parallel-agent races** — multiple agents editing overlapping files or branches with no shared
+   source of truth, producing duplicate or conflicting changes.
+2. **Overclaim** — agents (and humans) reporting "done / shipped / deployed" before it is verified.
+3. **No single view of work** — nothing showing what every agent is doing right now.
+
+## The pipeline: use-case → milestone → phase → task → execute
+
+Each layer produces a **versioned Markdown artifact** that becomes the next layer's input. Agents
+read structured context, never ad-hoc prompts.
+
+| Layer | Question | Artifact | Owner | Location |
+|---|---|---|---|---|
+| **Use-case** | Why | one-line outcome + principles | CEO | `specs/constitution.md` |
+| **Milestone** | What ships | **Spec** (6 elements incl. acceptance criteria) | CEO drafts, agent refines | `specs/NNN-name/spec.md` |
+| **Phase** | How | **Plan** | Agent, CEO approves | `specs/NNN-name/plan.md` |
+| **Task** | Atomic, one-agent-sized | **Tasks** (each with its own check) | Agent | `specs/NNN-name/tasks.md` |
+| **Execute** | Build | branch → PR → Trunk | Agent | GitHub |
+
+Every spec MUST contain the **6 elements** (see [`specs/TEMPLATE.md`](../specs/TEMPLATE.md)):
+outcomes, scope boundaries, constraints, prior decisions, task breakdown, **verification criteria**.
+
+## The verification gate (anti-overclaim)
+
+"Done" is not a claim — it is a passing check. Acceptance criteria are defined **before** code is
+written. A task is done only when **all three** hold:
+
+1. **Deterministic check** passes (a test / CI job / a command that exits 0), and
+2. **ThumbGate claim-gate** is satisfied (no "done/shipped/deployed" without paired evidence), and
+3. **Human approval** (CEO) for anything outward-facing — public content, external PRs, deploys,
+   account or billing changes.
+
+This mirrors the 2026 eval-driven standard: deterministic checks + model grading + human review.
+
+## Race-prevention rules (hard)
+
+- **One issue = one agent = one branch = one PR.** An in-progress issue is assignment-locked.
+- **Branch from the latest `main` every time** — never from another in-flight branch.
+- **Trunk owns the merge.** Never two writers on one branch.
+- **The board is the single source of truth.** Claim the issue before starting work.
+
+## Tooling
+
+- **Methodology:** GitHub Spec-Kit (SDD CLI, integrates Claude Code) — or the in-repo `specs/`
+  structure that ships with this doc.
+- **Work tracking:** GitHub Issues + Projects now (free, native). Upgrade to **Linear** (agents are
+  assignable workspace members; planning + execution stay synced) when agent volume justifies it.
+- **Orchestration:** Claude Code subagents; one orchestrator splits objectives into independent
+  issues and dispatches agents.
+- **Enforcement:** ThumbGate's own gates — claim-verification, `stateful-helper-script-bypass`,
+  task-scope — *are* the verification layer. We dogfood our product as the PM safety system.
+
+## Roles
+
+- **CEO = orchestrator + approver.** Writes use-cases and specs, approves plans, gates
+  outward-facing actions.
+- **Agents = implementers.** Turn spec → plan → tasks → PR, carrying verification with each task.
+
+## Status values
+
+- Spec: `draft | approved | in-progress | shipped`
+- Task: `todo | in-progress | blocked | done` — where **done = the acceptance check passed.**

--- a/specs/001-threat-model/spec.md
+++ b/specs/001-threat-model/spec.md
@@ -1,0 +1,46 @@
+# Spec: Threat model + indirection-bypass hardening
+
+> First dogfood spec. Authored 2026-06-07 against the methodology in
+> [`docs/PROJECT_MANAGEMENT.md`](../../docs/PROJECT_MANAGEMENT.md).
+
+```yaml
+id: 001
+use_case: Give users and reviewers an honest, verifiable account of what ThumbGate's hook enforces versus what needs an OS sandbox — so the enforcement model can be trusted.
+milestone: Publish a threat model and confirm the stateful-helper-bypass gate covers the documented indirection vectors.
+status: draft        # public-facing wording awaits CEO approval
+owner: CEO
+created: 2026-06-07
+```
+
+## 1. Outcomes
+- `THREAT_MODEL.md` exists at the repo root, stating plainly the **policy layer vs. containment
+  boundary** distinction (a PreToolUse hook is policy + observability, not containment).
+- The gate's coverage of the indirection set — `curl|bash`, `chmod +x`→execute, write-then-run,
+  package-script wrappers — is documented and backed by tests.
+
+## 2. Scope boundaries
+- **In scope:** `THREAT_MODEL.md`; cross-references to the `stateful-helper-script-bypass` gate and
+  its tests.
+- **Out of scope:** building an OS sandbox — containment is the host's job by design; the doc must
+  say so rather than imply the hook provides it.
+
+## 3. Constraints
+- Public-facing wording requires explicit CEO approval before merge.
+- Must **not** overclaim containment the hook cannot provide (honesty is the point of the doc).
+
+## 4. Prior decisions
+- A community review raised the "path around the observed tool" bypass. The
+  `stateful-helper-script-bypass` gate addresses the common chains and shipped already; pairing the
+  policy layer with an OS sandbox is the correct architecture, not a hook-only model.
+
+## 5. Task breakdown
+- [ ] **T1** Add `THREAT_MODEL.md` (CEO-approved wording).
+- [ ] **T2** Link it from `README` and the gate's changeset.
+- [ ] **T3** Confirm `tests/gates-hardening.test.js` covers each documented vector.
+
+## 6. Verification criteria (acceptance)
+- **Outcome 1** → check: `test -f THREAT_MODEL.md && grep -qi 'containment boundary' THREAT_MODEL.md`.
+- **Outcome 2** → check: `npm run test:gates-hardening` passes, and the test file references each
+  documented vector (curl-pipe-shell, package-script, write-then-run).
+
+> "Done" is the two commands above passing — not anyone's say-so.

--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -1,0 +1,37 @@
+# Spec: <short title>
+
+> Copy this file to `specs/NNN-<kebab-name>/spec.md`. A spec is the source of truth for a
+> milestone — **code serves the spec, not the reverse.** See [`docs/PROJECT_MANAGEMENT.md`](../docs/PROJECT_MANAGEMENT.md).
+
+```yaml
+id: NNN
+use_case: <the why — one line>
+milestone: <the shippable outcome>
+status: draft        # draft | approved | in-progress | shipped
+owner: CEO
+created: YYYY-MM-DD
+```
+
+## 1. Outcomes
+What is observably true when this is done. State results, not "implement X."
+
+## 2. Scope boundaries
+- **In scope:** …
+- **Out of scope (explicitly):** … — naming what we will NOT do is half the spec.
+
+## 3. Constraints
+Hard limits: budget, security, gated/approval-required actions, do-not-touch areas, prior
+commitments the work must respect.
+
+## 4. Prior decisions
+Decisions already made + links (memory notes, past PRs) so agents don't relitigate settled ground.
+
+## 5. Task breakdown
+Atomic, one-agent-sized tasks. Each becomes one issue → one branch → one PR.
+- [ ] T1 …
+- [ ] T2 …
+
+## 6. Verification criteria (acceptance)
+How we **prove** each outcome — a deterministic check per outcome. "Done" means this passes; no
+guesswork, no self-report.
+- Outcome A → check: `<command / test / observable that returns pass/fail>`


### PR DESCRIPTION
## Summary
Implements the **Spec-Driven Development** project-management workflow for ThumbGate — the June-2026 consensus for directing AI coding agents (SDD + eval-driven verification + manager-of-agents). Docs/specs only; no code, no runtime impact.

### What's in it
- **`docs/PROJECT_MANAGEMENT.md`** — the workflow: use-case → milestone → phase → task → execute pipeline; an anti-overclaim **verification gate** (deterministic check + ThumbGate claim-gate + human approval); **hard race-prevention rules** (one issue = one agent = one branch; branch from latest main; Trunk owns the merge); tooling (GitHub now, Linear later); roles.
- **`specs/TEMPLATE.md`** — reusable 6-element spec (outcomes, scope, constraints, prior decisions, tasks, **verification criteria**).
- **`specs/001-threat-model/`** — first dogfood spec; its acceptance criteria are deterministic commands (`test -f`, `npm run test:gates-hardening`), so "done" is a passing check, not self-report.

### Notes
- **Public-safety:** deliberately contains no revenue, founder-sentiment, or launch-theater content (verified against the credibility forbidden-pattern guard) — consistent with the post-#2560/#2562 hygiene.
- `docs/` and `specs/` are not in the npm `files[]` allowlist, so the 254-file bundle ratchet is unaffected.
- First dogfood is the threat-model/gate-hardening work (credibility-positive) rather than a GTM spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
