### PR TITLE
test(verification): restore golden tests + fix pre-commit FORBIDDEN_PATTERNS gap

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -30,12 +30,17 @@ FORBIDDEN_PATTERNS=(
   '^\.claude/implementation-notes/'
   '^\.claude/ralph/'
   '^\.ralph/'
-  '^docs/marketing/reddit-posts/'
-  '^docs/marketing/hn-posts/'
-  '^docs/marketing/discord-posts/'
+  # docs/marketing/ was nuked entirely 2026-06-07 (PR #2570) — block ANY path,
+  # not just the three sub-families known at the time of the original cleanup.
+  # The golden test verification/golden_tests/post-reddit-credibility-cleanup/
+  # caught this hole when it tried to stage docs/marketing/golden-redteam-*.md
+  # and the hook allowed it.
+  '^docs/marketing/'
   '^\.github/workflows/ralph-'
   '^\.github/workflows/social-engagement-'
-  '^LAUNCH(_NOW|_POSTS)?\.md$'
+  # Match any LAUNCH-prefix MD, not just LAUNCH.md / LAUNCH_NOW.md / LAUNCH_POSTS.md.
+  # Wave-2 deleted those three by exact name, but the family is the issue.
+  '^LAUNCH.*\.md$'
   '^FIRST_CUSTOMER.*\.md$'
   '^ALL_ENHANCEMENTS.*\.md$'
   '^TEST_EVIDENCE_.*\.md$'

--- a/verification/golden_tests/post-reddit-credibility-cleanup/ci_test_present_on_main.sh
+++ b/verification/golden_tests/post-reddit-credibility-cleanup/ci_test_present_on_main.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Golden test: the CI-level no-internal-orchestration-leaks test must
+# exist on origin/main and must pass when run locally.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd "$REPO_ROOT"
+
+git fetch origin main --quiet
+
+if git cat-file -e "origin/main:tests/no-internal-orchestration-leaks.test.js" 2>/dev/null; then
+  echo "ok: tests/no-internal-orchestration-leaks.test.js present on origin/main"
+else
+  echo "FAIL: tests/no-internal-orchestration-leaks.test.js missing from origin/main"
+  exit 1
+fi
+
+if git cat-file -e "origin/main:tests/public-repo-hygiene.test.js" 2>/dev/null; then
+  echo "ok: tests/public-repo-hygiene.test.js present on origin/main"
+fi
+
+if node --test tests/no-internal-orchestration-leaks.test.js >/dev/null 2>&1; then
+  echo "ok: test passes locally"
+else
+  echo "FAIL: test does not pass locally"
+  exit 1
+fi
+
+echo "PASS"

--- a/verification/golden_tests/post-reddit-credibility-cleanup/pre_commit_blocks_forbidden_paths.sh
+++ b/verification/golden_tests/post-reddit-credibility-cleanup/pre_commit_blocks_forbidden_paths.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Golden test: pre-commit hook must REJECT a commit that contains any
+# of the forbidden-path families, even when staged with `git add -f`.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd "$REPO_ROOT"
+
+FORBIDDEN=(
+  ".claude/implementation-notes/golden-redteam-$(date +%s).md"
+  ".claude/ralph/golden-redteam-$(date +%s).md"
+  "docs/marketing/golden-redteam-$(date +%s).md"
+  "LAUNCH_golden_$(date +%s).md"
+  "FIRST_CUSTOMER_BATTLE_PLAN.md"
+)
+
+pass=1
+for rel in "${FORBIDDEN[@]}"; do
+  mkdir -p "$(dirname "$rel")" 2>/dev/null || true
+  echo "redteam" > "$rel"
+  git add -f "$rel" >/dev/null 2>&1
+  if git -c commit.gpgsign=false -c core.hooksPath=.githooks commit -m "REDTEAM" >/dev/null 2>&1; then
+    echo "FAIL: pre-commit did NOT block $rel"
+    pass=0
+    git reset --soft HEAD^ >/dev/null 2>&1 || true
+  else
+    echo "ok: blocked $rel"
+  fi
+  git restore --staged "$rel" >/dev/null 2>&1 || true
+  rm -f "$rel"
+  rmdir "$(dirname "$rel")" 2>/dev/null || true
+done
+
+[ "$pass" = "1" ] && { echo "PASS"; exit 0; } || { echo "FAIL"; exit 1; }

--- a/verification/golden_tests/post-reddit-credibility-cleanup/reddit_urls_return_404.sh
+++ b/verification/golden_tests/post-reddit-credibility-cleanup/reddit_urls_return_404.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Golden test: the three Reddit-quoted GitHub URLs must return 404 on main.
+set -euo pipefail
+
+URLS=(
+  "https://github.com/IgorGanapolsky/ThumbGate/blob/main/.claude/implementation-notes/2026-05-20-high-roi-items.md"
+  "https://github.com/IgorGanapolsky/ThumbGate/blob/main/.claude/ralph/ATTEMPTS.md"
+  "https://github.com/IgorGanapolsky/ThumbGate/blob/main/.github/workflows/social-engagement-hourly.yml"
+)
+
+fail=0
+for url in "${URLS[@]}"; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+  if [ "$code" != "404" ]; then
+    echo "FAIL: $url returned $code (want 404)"
+    fail=1
+  else
+    echo "ok: $url"
+  fi
+done
+
+exit "$fail"


### PR DESCRIPTION
## Why

PR #2573 (the spec-foundation race that ceded to #2575) carried 3 golden tests for the post-Reddit credibility cleanup. Both PRs were closed (the race lost both sides), so the tests never reached main. This restores **only the golden tests** — they're spec-convention-independent and self-contained.

## The hook bug surfaced

Running the restored `pre_commit_blocks_forbidden_paths.sh` against the current hook surfaced a real gap:

- `^docs/marketing/(reddit-posts|hn-posts|discord-posts)/` only blocked three named subdirs even though [#2570](https://github.com/IgorGanapolsky/ThumbGate/pull/2570) nuked the **entire** `docs/marketing/` directory. Anything else under that path could be committed.
- `^LAUNCH(_NOW|_POSTS)?\.md$` only matched 3 specific files. `LAUNCH_NEW.md` slipped through.

Both fixed in this PR:
- `^docs/marketing/` — any path under the directory
- `^LAUNCH.*\.md$` — any LAUNCH-prefix MD

## Verification

```
$ bash verification/golden_tests/post-reddit-credibility-cleanup/pre_commit_blocks_forbidden_paths.sh
ok: blocked .claude/implementation-notes/golden-redteam-...
ok: blocked .claude/ralph/golden-redteam-...
ok: blocked docs/marketing/golden-redteam-...
ok: blocked LAUNCH_golden_...
ok: blocked FIRST_CUSTOMER_BATTLE_PLAN.md
PASS
```

All 3 golden tests pass locally.

## Discipline note

This commit was preceded by `bash ~/.claude/skills/safe-public-commit/check.sh <paths>` (exit 0, staged set == expected), per the memory rule `feedback_safe_public_commit` that I missed during the original session-of-shame on this surface. Documented in memory entry `feedback_missed_safe_public_commit_skill_2026-06-07`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)