### PR TITLE
fix(ci): skip changeset:check for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,11 @@ jobs:
         run: node scripts/sync-version.js --check
 
       - name: Check changeset coverage for release-relevant PRs
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        # Dependabot PRs don't write changesets; auto-merge is the documented
+        # path (.github/workflows/dependabot-automerge.yml). Skip changeset:check
+        # for those so they're not stuck BLOCKED on `test`. 2026-06-08: surfaced
+        # by #2582-#2585 all failing this exact step.
+        if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: npm run changeset:check
 
       - name: Run budget status gate


### PR DESCRIPTION
## Why
Four dependabot PRs (#2582-#2585) opened overnight 2026-06-08 are all stuck BLOCKED on the same `test` job step: **Check changeset coverage for release-relevant PRs** → exit 1.

Dependabot doesn't write changesets; the documented merge path is dependabot-automerge (workflow already exists). But it can't auto-merge while `test` fails.

## Fix
One-line: skip the changeset:check step when the actor (or PR author) is dependabot. Uses both gates for safety (push vs pull_request contexts).

## Verification
- safe-public-commit check.sh: `OK: staged set == expected (1 files); no leak tokens.`
- After this lands, the 4 stuck dependabot PRs should re-pass CI and auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)