### PR TITLE
fix(health): report the actually-deployed commit (RAILWAY_GIT_COMMIT_SHA)

### DIFF
--- a/.changeset/health-buildsha-railway-git-commit.md
+++ b/.changeset/health-buildsha-railway-git-commit.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+fix(health): report the actually-deployed commit in `/health` `buildSha`. On the Railway GitHub-connected service the baked `config/build-metadata.json` is the committed null placeholder and `RAILWAY_SYNC_VARIABLES` is off, so `THUMBGATE_BUILD_SHA` never updated and `/health` reported a months-old commit while newer code was live — which also made the deploy workflow's build-SHA verification gate fail on every run. `resolveBuildMetadata` now reads Railway's per-deploy `RAILWAY_GIT_COMMIT_SHA` (ground truth for GitHub-connected deploys) ahead of the drift-prone `THUMBGATE_BUILD_SHA`, while a properly baked file SHA still wins when present.

--- a/scripts/build-metadata.js
+++ b/scripts/build-metadata.js
@@ -5,6 +5,11 @@ const PROJECT_ROOT = path.resolve(__dirname, '..');
 const DEFAULT_BUILD_METADATA_PATH = path.join(PROJECT_ROOT, 'config', 'build-metadata.json');
 const BUILD_SHA_ENV_KEY = 'THUMBGATE_BUILD_SHA';
 const BUILD_GENERATED_AT_ENV_KEY = 'THUMBGATE_BUILD_GENERATED_AT';
+// Railway injects this automatically for GitHub-connected deployments: the git
+// SHA of the commit that triggered the deploy. It is the ground truth for what
+// code is actually live, and unlike THUMBGATE_BUILD_SHA it cannot drift (Railway
+// sets it per deploy). https://docs.railway.com/reference/variables
+const RAILWAY_GIT_COMMIT_SHA_ENV_KEY = 'RAILWAY_GIT_COMMIT_SHA';
 
 function normalizeNullableText(value) {
   if (typeof value !== 'string') {
@@ -28,6 +33,7 @@ function resolveBuildMetadata({ env = process.env, filePath } = {}) {
     normalizeNullableText(env.THUMBGATE_BUILD_METADATA_PATH) ||
     DEFAULT_BUILD_METADATA_PATH;
   const envBuildSha = normalizeNullableText(env[BUILD_SHA_ENV_KEY]);
+  const railwayGitSha = normalizeNullableText(env[RAILWAY_GIT_COMMIT_SHA_ENV_KEY]);
   const envGeneratedAt = normalizeNullableText(env[BUILD_GENERATED_AT_ENV_KEY]);
 
   let fileBuildSha = null;
@@ -48,9 +54,23 @@ function resolveBuildMetadata({ env = process.env, filePath } = {}) {
     };
   }
 
-  // No SHA in the file — fall back to env only if an explicit SHA is set.
-  // (Previously a bare GENERATED_AT with no SHA could short-circuit and return
-  // { buildSha: null }, losing both signals; now we require the SHA.)
+  // No SHA baked into the image. Prefer Railway's own per-deploy commit SHA over
+  // THUMBGATE_BUILD_SHA: the latter is set out-of-band by the deploy workflow and
+  // has drifted in prod (stuck reporting an old commit while newer code was live,
+  // because RAILWAY_SYNC_VARIABLES is off and `railway up` stamping is unreliable).
+  // RAILWAY_GIT_COMMIT_SHA is injected by Railway per deploy, so it always matches
+  // the code actually serving traffic on a GitHub-connected service.
+  if (railwayGitSha) {
+    return {
+      path: resolvedPath,
+      buildSha: railwayGitSha,
+      generatedAt: envGeneratedAt,
+    };
+  }
+
+  // Last resort: the workflow-managed env var. Only trust it when an explicit SHA
+  // is set. (Previously a bare GENERATED_AT with no SHA could short-circuit and
+  // return { buildSha: null }, losing both signals; now we require the SHA.)
   if (envBuildSha) {
     return {
       path: resolvedPath,
@@ -124,6 +144,7 @@ if (require.main === module) {
 module.exports = {
   BUILD_GENERATED_AT_ENV_KEY,
   BUILD_SHA_ENV_KEY,
+  RAILWAY_GIT_COMMIT_SHA_ENV_KEY,
   DEFAULT_BUILD_METADATA_PATH,
   resolveBuildMetadata,
   writeBuildMetadataFile,

--- a/tests/build-metadata.test.js
+++ b/tests/build-metadata.test.js
@@ -7,6 +7,7 @@ const os = require('os');
 const {
   BUILD_GENERATED_AT_ENV_KEY,
   BUILD_SHA_ENV_KEY,
+  RAILWAY_GIT_COMMIT_SHA_ENV_KEY,
   resolveBuildMetadata,
   writeBuildMetadataFile,
 } = require('../scripts/build-metadata');
@@ -82,6 +83,45 @@ describe('build-metadata', () => {
     });
     assert.strictEqual(result.buildSha, 'env-only-sha');
     assert.strictEqual(result.generatedAt, '2026-04-08T14:20:00Z');
+  });
+
+  // Railway drift fix (2026-06-08): on the GitHub-connected service the baked
+  // file is the committed null placeholder and RAILWAY_SYNC_VARIABLES is off, so
+  // THUMBGATE_BUILD_SHA never updates and /health reported an old commit while
+  // newer code was live. RAILWAY_GIT_COMMIT_SHA is injected by Railway per deploy
+  // and is the ground truth, so it must beat the drift-prone THUMBGATE_BUILD_SHA.
+  it('resolveBuildMetadata prefers RAILWAY_GIT_COMMIT_SHA over the drift-prone THUMBGATE_BUILD_SHA', () => {
+    const result = resolveBuildMetadata({
+      filePath: '/tmp/nonexistent-build-meta.json',
+      env: {
+        [RAILWAY_GIT_COMMIT_SHA_ENV_KEY]: 'railway-live-sha',
+        [BUILD_SHA_ENV_KEY]: 'stale-workflow-sha',
+        [BUILD_GENERATED_AT_ENV_KEY]: '2026-04-08T14:20:00Z',
+      },
+    });
+    assert.strictEqual(result.buildSha, 'railway-live-sha', 'Railway per-deploy SHA is ground truth');
+  });
+
+  it('resolveBuildMetadata still lets a baked file SHA win over RAILWAY_GIT_COMMIT_SHA', () => {
+    const tmpFile = path.join(os.tmpdir(), `build-meta-railway-vs-file-${Date.now()}.json`);
+    try {
+      writeBuildMetadataFile({ sha: 'file-sha', outputPath: tmpFile, generatedAt: '2026-01-01T00:00:00Z' });
+      const result = resolveBuildMetadata({
+        filePath: tmpFile,
+        env: { [RAILWAY_GIT_COMMIT_SHA_ENV_KEY]: 'railway-live-sha' },
+      });
+      assert.strictEqual(result.buildSha, 'file-sha', 'baked image artifact still wins when present');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('resolveBuildMetadata uses RAILWAY_GIT_COMMIT_SHA when it is the only source', () => {
+    const result = resolveBuildMetadata({
+      filePath: '/tmp/nonexistent-build-meta.json',
+      env: { [RAILWAY_GIT_COMMIT_SHA_ENV_KEY]: 'railway-only-sha' },
+    });
+    assert.strictEqual(result.buildSha, 'railway-only-sha');
   });
 
   it('resolveBuildMetadata does NOT short-circuit to a null SHA when only generatedAt env is set', () => {


### PR DESCRIPTION
## The bug (and why the deploy job goes red)
`/health` has reported `buildSha: b7b0ddac…` for weeks. I assumed that meant production was **stale** — it isn't. Production serves current code; I verified two pages added *after* that commit return HTTP 200:

```
GET /guides/agentic-web-governance  -> 200
GET /guides/database-agent-safety   -> 200   (both new since b7b0ddac)
/health buildSha                    -> b7b0ddac…   (frozen)
```

So the **code deploys fine** (Railway's native GitHub auto-deploy), but the `buildSha` label is frozen. Chain:
1. `config/build-metadata.json` is committed as a null placeholder (`{"buildSha":null}`), so the baked-file path yields nothing.
2. `.github/workflows/deploy-railway.yml` exits the variable-sync step early because `RAILWAY_SYNC_VARIABLES != "true"`, so `THUMBGATE_BUILD_SHA` is **never updated** per deploy.
3. `railway up` stamping is unreliable (it false-fails), so no fresh file gets baked either.
4. `resolveBuildMetadata` falls back to the stale `THUMBGATE_BUILD_SHA` env (last set manually ≈ `b7b0ddac`).
5. The deploy workflow's verification gate compares `/health` buildSha to the merge SHA → can never match → **every deploy run is marked failed** even though the code shipped.

## The fix
`resolveBuildMetadata` now prefers **`RAILWAY_GIT_COMMIT_SHA`** — injected by Railway per deploy on GitHub-connected services ([docs](https://docs.railway.com/reference/variables)), i.e. the commit actually serving traffic — over the drift-prone `THUMBGATE_BUILD_SHA`. A properly baked file SHA still wins when present (preserves the 2026-05-20 anti-drift precedence).

Precedence: baked file → `RAILWAY_GIT_COMMIT_SHA` → `THUMBGATE_BUILD_SHA` → null.

## Verification
- `npm run test:build-metadata` → 10/10 (added 3 precedence tests)
- `npm run test:api` → 955/955
- **Self-verifying in prod:** after merge, `/health` buildSha flips to the real commit if Railway injects the var, or is unchanged otherwise — no regression either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)