### PR TITLE
feat(homepage): answer 'why not write my own hooks?' objection

### DIFF
--- a/.changeset/unblock-2593-homepage-why-not-diy.md
+++ b/.changeset/unblock-2593-homepage-why-not-diy.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add homepage section answering 'why not write my own hooks'; web copy only.

--- a/public/index.html
+++ b/public/index.html
@@ -834,6 +834,14 @@ __GA_BOOTSTRAP__
   </div>
 </section>
 
+<section class="compatibility" id="why-not-diy" aria-label="Why not write your own hooks">
+  <div class="container">
+    <h2>“Why not just write my own PreToolUse hooks?”</h2>
+    <p class="hero-lede" style="max-width:760px;margin:0 auto 18px;">You can — on one machine, for one agent, until the next breaking change. ThumbGate is that idea, maintained: a 👎 becomes a rule that <strong>propagates across every agent</strong> — Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — and every machine, with adapters kept current so you’re not patching shell scripts each release. Hand-written hooks don’t learn, don’t sync, and don’t survive a teammate’s laptop.</p>
+    <p><a href="/compare/claude-code-hooks">See ThumbGate vs. hand-written hooks →</a></p>
+  </div>
+</section>
+
 <section class="compatibility" id="agentic-development-cycle">
   <div class="container">
     <div class="section-label">Agentic Development Cycle</div>


### PR DESCRIPTION
## Summary
The homepage never answered the **#1 buyer objection** — *"why not just write my own PreToolUse hooks?"* — even though `/compare/claude-code-hooks.html` already exists. A grep confirmed **zero** DIY framing on the homepage.

Adds a concise section (reusing the `compatibility` section style) that answers it in the comparison page's own voice — cross-agent propagation, 👎→permanent rule, maintained adapters, survives teammate machines — and links to the full comparison.

## Why
This is the real competitor (free DIY hooks), and it's the exact argument being made in live r/ClaudeCode threads right now. Answering it at the point of objection is the one positioning gap an external funnel audit correctly flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
