### PR TITLE
fix(media): serve static media route and add regression tests

### DIFF
--- a/.changeset/hotfix-media-static-route.md
+++ b/.changeset/hotfix-media-static-route.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Serve static /media/ assets route to fix broken demo GIF in landing pages.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5632,6 +5632,18 @@ async function addContext(){
       return;
     }
 
+    if (isGetLikeRequest && pathname.startsWith('/media/')) {
+      const rel = pathname.slice('/media/'.length);
+      const mediaDir = path.join(PUBLIC_DIR, 'media');
+      const resolved = path.resolve(mediaDir, rel);
+      if (!resolved.startsWith(mediaDir + path.sep) && resolved !== mediaDir) {
+        sendJson(res, 403, { error: 'Forbidden' });
+        return;
+      }
+      serveStaticFile(res, resolved, { headOnly: isHeadRequest });
+      return;
+    }
+
     if (isGetLikeRequest && (
       pathname === '/favicon.ico'
       || pathname === '/thumbgate-logo.png'

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -842,3 +842,21 @@ test('comparison and key landing pages expose FAQPage structured data', async ()
     assert.match(body, /"@type":\s*"Question"/, `${pagePath} must include at least one Question`);
   }
 });
+
+test('GET /media/thumbgate-demo.gif serves the animated demo GIF without an API key', async () => {
+  const res = await fetch(`${origin}/media/thumbgate-demo.gif`);
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('content-type'), 'image/gif');
+  assert.ok(Number(res.headers.get('content-length')) > 0);
+});
+
+test('GET /media/does-not-exist.gif returns 404', async () => {
+  const res = await fetch(`${origin}/media/does-not-exist.gif`);
+  assert.equal(res.status, 404);
+});
+
+test('GET /media/../server.js is rejected (no path traversal)', async () => {
+  const res = await fetch(`${origin}/media/..%2fapi%2fserver.js`);
+  assert.ok([403, 404].includes(res.status));
+  assert.notEqual(res.status, 200);
+});


### PR DESCRIPTION
Hotfix to serve the /media/ static assets route and prevent broken thumbnails on the production landing page.