### PR TITLE
feat(anti-claim): catch more lie-phrases + strict hard-block mode

### DIFF
--- a/.changeset/anti-claim-phrases-strict.md
+++ b/.changeset/anti-claim-phrases-strict.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Strengthen the anti-claim Stop hook (`hook-stop-anti-claim.js`). Expand the lie-phrase set to catch completion claims that previously slipped past it — "all green", "tests pass/passing", "verified", "confirmed", "is/now stable", "all clear", "good to go", "race is over" — all still suppressed when the same turn ran a proof tool call (curl/grep/test/Read). Add a strict mode: with `THUMBGATE_STRICT_ENFORCEMENT=1` the hook emits a Stop-hook `block` decision (forcing the agent to verify or retract before ending the turn) instead of a soft next-turn reminder. Default behavior unchanged.

--- a/scripts/hook-stop-anti-claim.js
+++ b/scripts/hook-stop-anti-claim.js
@@ -43,6 +43,21 @@ const CLAIM_PATTERNS = [
   /\beverything\s+(?:is\s+)?(?:done|working|ready)\b/i,
   /\b(?:github|repo|repository)\s+(?:about|metadata|description|topics?)\b.*\b(?:updated|verified|fixed|match(?:es|ed)?)\b/i,
   /\b(?:about|metadata|description|topics?)\b.*\b(?:updated|verified|fixed|match(?:es|ed)?)\b.*\b(?:github|repo|repository)\b/i,
+  // Added 2026-06-11 after a cross-project failure analysis: these completion
+  // claims ("all green / stable / verified / race over / tests pass") were
+  // asserted without proof and slipped past the original set. The proof-gate
+  // below suppresses them whenever the SAME turn ran a verification tool, so a
+  // "verified" claim backed by a test/curl/Read stays silent.
+  /\ball\s+(?:the\s+)?(?:tests?\s+|checks?\s+)?(?:are\s+)?green\b/i,
+  /\b(?:all\s+)?(?:tests?|checks?|ci)\s+(?:are\s+)?(?:now\s+)?passing\b/i,
+  /\ball\s+(?:tests?|checks?)\s+pass(?:ed)?\b/i,
+  /\bverified\b/i,
+  /\bconfirmed\b/i,
+  /\b(?:is|are|it'?s|now)\s+stable\b/i,
+  /\ball\s+clear\b/i,
+  /\bgood\s+to\s+go\b/i,
+  /\brace\s+(?:is\s+)?over\b/i,
+  /\bno\s+longer\s+racing\b/i,
 ];
 
 // Proof-of-verification patterns. If the SAME turn included one of these
@@ -158,12 +173,22 @@ function main() {
   const proofText = `${text}\n${toolUseSummary}`;
   if (hasProof(proofText)) return; // claim backed by proof in same turn
 
-  // Surface a system reminder for the NEXT turn. Do not hard-block.
+  // Strict mode (THUMBGATE_STRICT_ENFORCEMENT=1): hard-block the stop. Emit a
+  // Stop-hook block decision so Claude Code does NOT end the turn — the agent
+  // must run the verification (or retract) before it can stop. Default mode
+  // stays soft (a reminder for the next turn) so we don't break existing wiring.
+  if (process.env.THUMBGATE_STRICT_ENFORCEMENT === '1') {
+    const reason = `ThumbGate anti-claim gate (strict): you claimed completion ("${claim}") without a proof tool call in the same message. Run the verification (curl / grep / test / Read) and restate with the proof, or retract — do not end the turn on an unverified claim.`;
+    process.stdout.write(JSON.stringify({ decision: 'block', reason }) + '\n');
+    return;
+  }
+
+  // Default (soft): surface a system reminder for the NEXT turn. Do not hard-block.
   const reminder = [
     '⚠️ ThumbGate anti-claim gate: previous turn claimed completion',
     `   ("${claim}") without a proof tool call in the same message.`,
-    '   Per CLAUDE.md anti-lying: never claim "done / live / deployed / fixed"',
-    '   without curl / grep / test output in the SAME turn.',
+    '   Per CLAUDE.md anti-lying: never claim "done / live / deployed / fixed /',
+    '   verified / all green / stable" without curl / grep / test output in the SAME turn.',
     '   If the work really is verified, re-state the claim with the proof.',
     '   If not, retract and run the verification before re-asserting.',
   ].join('\n');

--- a/tests/hook-stop-anti-claim.test.js
+++ b/tests/hook-stop-anti-claim.test.js
@@ -112,6 +112,70 @@ test('hook stays silent when claim is backed by a curl tool call in the same tur
   assert.equal(stdout.trim(), '');
 });
 
+test('findClaim catches the 2026-06-11 added completion phrases', () => {
+  assert.ok(findClaim('All tests are green.'));
+  assert.ok(findClaim('all green now'));
+  assert.ok(findClaim('Tests passing.'));
+  assert.ok(findClaim('All checks passed.'));
+  assert.ok(findClaim('Verified.'));
+  assert.ok(findClaim('Confirmed.'));
+  assert.ok(findClaim('The build is stable.'));
+  assert.ok(findClaim('All clear.'));
+  assert.ok(findClaim('Good to go.'));
+  assert.ok(findClaim('The race is over.'));
+  assert.ok(findClaim('We are no longer racing.'));
+});
+
+test('added phrases still respect the proof-gate (claim + test run = silent)', () => {
+  const transcript = writeTranscript({
+    content: [
+      { type: 'text', text: 'All tests pass.' },
+      { type: 'tool_use', name: 'Bash', input: { command: 'npm test' } },
+    ],
+  });
+  const { stdout } = runHook(transcript);
+  assert.equal(stdout.trim(), '');
+});
+
+test('added phrase fires the reminder when unproven', () => {
+  const transcript = writeTranscript({
+    content: [{ type: 'text', text: 'All green, the race is over.' }],
+  });
+  const { stdout } = runHook(transcript);
+  assert.match(stdout, /anti-claim gate/i);
+});
+
+test('strict mode (THUMBGATE_STRICT_ENFORCEMENT=1) emits a block decision, not a reminder', () => {
+  const transcript = writeTranscript({
+    content: [{ type: 'text', text: 'Everything is done and verified.' }],
+  });
+  const res = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({ transcript_path: transcript }),
+    encoding: 'utf8',
+    timeout: 5000,
+    env: { ...process.env, THUMBGATE_STRICT_ENFORCEMENT: '1' },
+  });
+  const out = JSON.parse((res.stdout || '').trim());
+  assert.equal(out.decision, 'block');
+  assert.match(out.reason, /anti-claim gate \(strict\)/i);
+});
+
+test('strict mode stays silent when the claim has proof', () => {
+  const transcript = writeTranscript({
+    content: [
+      { type: 'text', text: 'Verified.' },
+      { type: 'tool_use', name: 'Bash', input: { command: 'npm test' } },
+    ],
+  });
+  const res = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({ transcript_path: transcript }),
+    encoding: 'utf8',
+    timeout: 5000,
+    env: { ...process.env, THUMBGATE_STRICT_ENFORCEMENT: '1' },
+  });
+  assert.equal((res.stdout || '').trim(), '');
+});
+
 test('hook stays silent when no claim phrase appears', () => {
   const transcript = writeTranscript({
     content: [


### PR DESCRIPTION
## Why

A cross-project failure analysis (Resume) documented the agent lying in prose — "all green," "race over," "stable," "verified" — and ThumbGate's anti-claim Stop hook **not catching it**. Two real gaps (the critique wrongly said the hook didn't exist — it does):

1. **Phrase coverage:** `CLAIM_PATTERNS` caught "deployed/live/fixed/done" but **not** "all green / stable / verified / tests pass / race over" — the exact lies that slipped.
2. **Warn-only:** the hook never honored `THUMBGATE_STRICT_ENFORCEMENT`.

This is core to our differentiator (claim-verification) and dogfood — it's the same overclaiming pattern "are you sure?" keeps catching.

## Change
- Expand `CLAIM_PATTERNS` with the slipped phrases. **All stay proof-gated** — a "verified" claim backed by a same-turn curl/test/Read stays silent (test included).
- Add **strict mode**: `THUMBGATE_STRICT_ENFORCEMENT=1` → emit a Stop-hook `{decision:'block'}` forcing the agent to verify or retract before ending the turn. Default (soft reminder) unchanged.

## Tests
17/17 pass (5 new): new phrases caught, proof-gate still silences proven claims, strict mode emits block + stays silent with proof, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)