### PR TITLE
fix(repo): delete broken skool asset symlinks to unblock deployment

### DIFF
--- a/.changeset/hotfix-delete-broken-symlinks.md
+++ b/.changeset/hotfix-delete-broken-symlinks.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Delete broken skool asset symlinks to unblock Railway deployment.

--- a/public/assets/skool/thumbgate-skool-cover-1084x576.png
+++ b/public/assets/skool/thumbgate-skool-cover-1084x576.png
@@ -1,1 +1,0 @@
-../../../docs/marketing/assets/thumbgate-skool-cover-1084x576.png

--- a/public/assets/skool/thumbgate-skool-icon-128x128.png
+++ b/public/assets/skool/thumbgate-skool-icon-128x128.png
@@ -1,1 +1,0 @@
-../../../docs/marketing/assets/thumbgate-skool-icon-128x128.png


### PR DESCRIPTION
Delete broken skool asset symlinks that cause Railway CLI packaging and deployment to fail with os error 2.