### PR TITLE
Fix Pay  diagnostic CTA navigation

### DIFF
--- a/.changeset/fix-diagnostic-cta-navigation.md
+++ b/.changeset/fix-diagnostic-cta-navigation.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix the sticky Pay $499 diagnostic CTA so Stripe Checkout opens in the current tab instead of a fragile popup/new-tab flow.

--- a/public/js/buyer-intent.js
+++ b/public/js/buyer-intent.js
@@ -257,7 +257,7 @@
       '<p>Use Pro for self-serve proof, or buy the diagnostic when one workflow is already costing time.</p>',
       '<nav>',
       '<a data-assist-cta="assist_pro_checkout" href="' + proHref + '">Get Pro</a>',
-      '<a data-assist-cta="assist_workflow_diagnostic" href="' + diagnosticHref + '" target="_blank" rel="nofollow noopener noreferrer">Pay $499 diagnostic</a>',
+      '<a data-assist-cta="assist_workflow_diagnostic" href="' + diagnosticHref + '" rel="nofollow">Pay $499 diagnostic</a>',
       '<button type="button" data-assist-dismiss>Not now</button>',
       '</nav>'
     ].join('');

--- a/tests/buyer-intent-revenue-assist.test.js
+++ b/tests/buyer-intent-revenue-assist.test.js
@@ -31,6 +31,15 @@ test('buyer intent script exposes paid CTA and abandon reason observability', ()
   assert.match(BUYER_INTENT, /researching/);
 });
 
+test('paid diagnostic assist opens checkout in the current tab', () => {
+  const diagnosticLinkTemplate = BUYER_INTENT.match(/<a data-assist-cta="assist_workflow_diagnostic"[^;]+Pay \$499 diagnostic<\/a>/);
+
+  assert.ok(diagnosticLinkTemplate, 'diagnostic CTA template should exist');
+  assert.match(diagnosticLinkTemplate[0], /href="'\s*\+\s*diagnosticHref\s*\+\s*'"/);
+  assert.doesNotMatch(diagnosticLinkTemplate[0], /target="_blank"/);
+  assert.doesNotMatch(diagnosticLinkTemplate[0], /noopener|noreferrer/);
+});
+
 test('paid revenue assist does not inject on checkout routes', () => {
   assert.match(BUYER_INTENT, /path === '\/checkout\/pro'/);
   assert.match(BUYER_INTENT, /path\.indexOf\('\/go\/pro'\) === 0/);


### PR DESCRIPTION
## Emergency fix
The sticky revenue assist "Pay  diagnostic" CTA opened Stripe Checkout in a new tab via target="_blank". In browser contexts where the popup is backgrounded/blocked/missed, this looks like the checkout is broken.

This keeps the same Stripe Payment Link but navigates in the current tab.

## Verification
- node --test tests/buyer-intent-revenue-assist.test.js
- node --test tests/public-landing.test.js
- Local browser check: CTA has target='' and clicking it navigates the current page to Stripe Checkout.
- Live Stripe URL currently returns HTTP 200.
