### PR TITLE
feat(landing): surface 'self-improving enforcement' positioning

### DIFF
--- a/.changeset/self-improving-positioning.md
+++ b/.changeset/self-improving-positioning.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Surface the self-improving positioning visibly on the landing page (it was only in structured-data before). The "three steps" section now leads with "Self-improving enforcement" and a subhead clarifying the axis — self-improving for *safety*, not capability: every 👎 compiles into a hard rule, and each rule regression-tests itself so it blocks the repeat, never the safe action.

--- a/public/index.html
+++ b/public/index.html
@@ -1234,8 +1234,9 @@ __GA_BOOTSTRAP__
 <!-- HOW IT WORKS -->
 <section class="how-it-works" id="how-it-works">
   <div class="container">
-    <div class="section-label">Current release</div>
+    <div class="section-label">Self-improving enforcement</div>
     <h2 class="section-title">Three steps to stop repeated AI failures</h2>
+    <p class="section-sub" style="max-width:720px;margin:6px auto 22px;text-align:center;color:var(--text-muted);font-size:clamp(16px,1.6vw,18px);">Self-improving — but for safety, not capability: every <code>👎</code> compiles into a hard rule, and each rule regression-tests itself against your history, so it blocks the repeat and never the safe action.</p>
     <div class="steps">
       <div class="step">
         <div class="step-num">1</div>


### PR DESCRIPTION
## Why
Competitors (Hermes/Nous, the whole 2026 'self-improving agent' wave) are loudly claiming a 'built-in learning loop.' ThumbGate genuinely has one — 👎 -> prevention rule (auto-promote-gates) + regression-tested promotion (PR #2610) — but it was only in the page's structured-data, not visible copy. This claims the narrative on **our axis: safety, not capability.**

## Change
One additive subhead on the stable 'Three steps' section (eyebrow -> 'Self-improving enforcement'). **Hero left untouched** — it's being actively edited by parallel sessions, so I avoided the conflict. Every claim is true (deterministic block + regression-test), and the copy explicitly does NOT claim capability-building (Hermes' lane) — only prevention.

Landing-page-claims test stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)