### PR TITLE
fix(landing): route sticky workflow CTA to intake

### DIFF
--- a/.changeset/route-sticky-workflow-intake.md
+++ b/.changeset/route-sticky-workflow-intake.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Route the sticky workflow-help CTA to intake instead of a blind $499 diagnostic checkout.

--- a/public/js/buyer-intent.js
+++ b/public/js/buyer-intent.js
@@ -240,11 +240,11 @@
       cta_placement: placement,
       plan_id: 'pro',
     });
-    var diagnosticHref = appendCampaignParams(settings.diagnosticHref || 'https://buy.stripe.com/00w14neyUcXA5pL5e33sI0e', {
+    var intakeHref = appendCampaignParams(settings.intakeHref || '/#workflow-sprint-intake', {
       utm_source: 'owned_site',
       utm_medium: 'sticky_cta',
       utm_campaign: campaign,
-      cta_id: 'assist_workflow_diagnostic',
+      cta_id: 'assist_workflow_intake',
       cta_placement: placement,
       client_reference_id: 'thumbgate_assist_' + placement,
     });
@@ -254,10 +254,10 @@
     panel.setAttribute('aria-label', 'ThumbGate paid help');
     panel.innerHTML = [
       '<strong>Stop the repeated agent failure?</strong>',
-      '<p>Use Pro for self-serve proof, or buy the diagnostic when one workflow is already costing time.</p>',
+      '<p>Use Pro for self-serve proof, or send the workflow first when one failure is already costing time.</p>',
       '<nav>',
       '<a data-assist-cta="assist_pro_checkout" href="' + proHref + '">Get Pro</a>',
-      '<a data-assist-cta="assist_workflow_diagnostic" href="' + diagnosticHref + '" rel="nofollow">Pay $499 diagnostic</a>',
+      '<a data-assist-cta="assist_workflow_intake" href="' + intakeHref + '">Send workflow first</a>',
       '<button type="button" data-assist-dismiss>Not now</button>',
       '</nav>'
     ].join('');

--- a/tests/buyer-intent-revenue-assist.test.js
+++ b/tests/buyer-intent-revenue-assist.test.js
@@ -31,13 +31,13 @@ test('buyer intent script exposes paid CTA and abandon reason observability', ()
   assert.match(BUYER_INTENT, /researching/);
 });
 
-test('paid diagnostic assist opens checkout in the current tab', () => {
-  const diagnosticLinkTemplate = BUYER_INTENT.match(/<a data-assist-cta="assist_workflow_diagnostic"[^;]+Pay \$499 diagnostic<\/a>/);
+test('revenue assist routes workflow help through intake, not blind diagnostic checkout', () => {
+  const intakeLinkTemplate = BUYER_INTENT.match(/<a data-assist-cta="assist_workflow_intake"[^;]+Send workflow first<\/a>/);
 
-  assert.ok(diagnosticLinkTemplate, 'diagnostic CTA template should exist');
-  assert.match(diagnosticLinkTemplate[0], /href="'\s*\+\s*diagnosticHref\s*\+\s*'"/);
-  assert.doesNotMatch(diagnosticLinkTemplate[0], /target="_blank"/);
-  assert.doesNotMatch(diagnosticLinkTemplate[0], /noopener|noreferrer/);
+  assert.ok(intakeLinkTemplate, 'workflow intake CTA template should exist');
+  assert.match(intakeLinkTemplate[0], /href="'\s*\+\s*intakeHref\s*\+\s*'"/);
+  assert.doesNotMatch(BUYER_INTENT, /Pay \$499 diagnostic/);
+  assert.doesNotMatch(BUYER_INTENT, /assist_workflow_diagnostic/);
 });
 
 test('paid revenue assist does not inject on checkout routes', () => {


### PR DESCRIPTION
## Summary
- Replace the sticky revenue-assist "Pay $499 diagnostic" CTA with "Send workflow first".
- Route workflow-help intent to `/#workflow-sprint-intake` instead of a blind Stripe diagnostic checkout.
- Update the regression test so `Pay $499 diagnostic` and `assist_workflow_diagnostic` cannot return in `public/js/buyer-intent.js`.

## Evidence
- Live production asset before fix contained `Pay $499 diagnostic` in `/js/buyer-intent.js`.
- `node --test tests/buyer-intent-revenue-assist.test.js tests/public-landing.test.js tests/pro-landing.test.js tests/checkout-bot-guard.test.js` -> 81 passing.
- `git diff --check` -> clean.
- Targeted secret scan over changed files -> no matches.
