### PR TITLE
fix(landing): drop off-canon $499 diagnostic CTA from site-wide popup

### DIFF
--- a/.changeset/drop-499-diagnostic-homepage-popup.md
+++ b/.changeset/drop-499-diagnostic-homepage-popup.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Remove the off-canon "$499 diagnostic" CTA from the site-wide revenue-assist popup. The sticky popup injected by `public/js/buyer-intent.js` was showing every anonymous visitor a "Pay $499 diagnostic" button (a one-time consulting SKU that is not part of the Free/Pro/Enterprise pricing and converted 0 times across 7 Stripe sessions). The popup now offers "Get Pro" plus a no-price "Send workflow first" intake link, matching the canonical pricing surface. The guard test now asserts the blind $499 diagnostic checkout CTA is absent.

--- a/public/js/buyer-intent.js
+++ b/public/js/buyer-intent.js
@@ -240,11 +240,11 @@
       cta_placement: placement,
       plan_id: 'pro',
     });
-    var diagnosticHref = appendCampaignParams(settings.diagnosticHref || 'https://buy.stripe.com/00w14neyUcXA5pL5e33sI0e', {
+    var intakeHref = appendCampaignParams(settings.intakeHref || '/#workflow-sprint-intake', {
       utm_source: 'owned_site',
       utm_medium: 'sticky_cta',
       utm_campaign: campaign,
-      cta_id: 'assist_workflow_diagnostic',
+      cta_id: 'assist_workflow_intake',
       cta_placement: placement,
       client_reference_id: 'thumbgate_assist_' + placement,
     });
@@ -254,10 +254,10 @@
     panel.setAttribute('aria-label', 'ThumbGate paid help');
     panel.innerHTML = [
       '<strong>Stop the repeated agent failure?</strong>',
-      '<p>Use Pro for self-serve proof, or buy the diagnostic when one workflow is already costing time.</p>',
+      '<p>Use Pro for self-serve proof, or send the workflow first when one failure is already costing time.</p>',
       '<nav>',
       '<a data-assist-cta="assist_pro_checkout" href="' + proHref + '">Get Pro</a>',
-      '<a data-assist-cta="assist_workflow_diagnostic" href="' + diagnosticHref + '" rel="nofollow">Pay $499 diagnostic</a>',
+      '<a data-assist-cta="assist_workflow_intake" href="' + intakeHref + '">Send workflow first</a>',
       '<button type="button" data-assist-dismiss>Not now</button>',
       '</nav>'
     ].join('');

--- a/tests/buyer-intent-revenue-assist.test.js
+++ b/tests/buyer-intent-revenue-assist.test.js
@@ -31,13 +31,14 @@ test('buyer intent script exposes paid CTA and abandon reason observability', ()
   assert.match(BUYER_INTENT, /researching/);
 });
 
-test('paid diagnostic assist opens checkout in the current tab', () => {
-  const diagnosticLinkTemplate = BUYER_INTENT.match(/<a data-assist-cta="assist_workflow_diagnostic"[^;]+Pay \$499 diagnostic<\/a>/);
+test('revenue assist routes workflow help through intake, not blind diagnostic checkout', () => {
+  const intakeLinkTemplate = BUYER_INTENT.match(/<a data-assist-cta="assist_workflow_intake"[^;]+Send workflow first<\/a>/);
 
-  assert.ok(diagnosticLinkTemplate, 'diagnostic CTA template should exist');
-  assert.match(diagnosticLinkTemplate[0], /href="'\s*\+\s*diagnosticHref\s*\+\s*'"/);
-  assert.doesNotMatch(diagnosticLinkTemplate[0], /target="_blank"/);
-  assert.doesNotMatch(diagnosticLinkTemplate[0], /noopener|noreferrer/);
+  assert.ok(intakeLinkTemplate, 'workflow intake CTA template should exist');
+  assert.match(intakeLinkTemplate[0], /href="'\s*\+\s*intakeHref\s*\+\s*'"/);
+  assert.doesNotMatch(BUYER_INTENT, /Pay \$499 diagnostic/);
+  assert.doesNotMatch(BUYER_INTENT, /assist_workflow_diagnostic/);
+  assert.doesNotMatch(BUYER_INTENT, /https:\/\/buy\.stripe\.com\/00w14neyUcXA5pL5e33sI0e/);
 });
 
 test('paid revenue assist does not inject on checkout routes', () => {


### PR DESCRIPTION
## What
Removes the `Pay $499 diagnostic` button from the site-wide revenue-assist sticky popup (`public/js/buyer-intent.js`). Now shows **Get Pro** + a no-price **Send workflow first** intake link.

## Why (evidence)
- The $499 'Workflow Hardening Diagnostic' is a one-time **consulting SKU outside the canonical Free / Pro ($19·mo) / Enterprise pricing**.
- **0 conversions**: 7 Stripe checkout sessions at $499 ever created → 6 expired, 1 open, **$0 paid**.
- It put a $499 number in front of every anonymous visitor on a page whose job is $19/mo Pro signups.
- The removal was already designed + tested on PR #2590 but is trapped in a 164-file CONFLICTING branch that won't merge. This extracts just the 2-file fix from `main` so it actually ships.

## Scope
- `public/js/buyer-intent.js` — popup CTA
- `tests/buyer-intent-revenue-assist.test.js` — guard test now asserts the blind $499 diagnostic CTA is **absent** (was asserting it present)
- changeset (patch)

Inline `$499` CTAs still exist on ~8 deeper-funnel /guides and /learn pages — follow-up; this PR clears the high-traffic site-wide sticky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)