### PR TITLE
feat(positioning): frame safe Hermes self-evolution

### DIFF
--- a/.changeset/hermes-safe-self-evolution.md
+++ b/.changeset/hermes-safe-self-evolution.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Position Hermes-style self-evolution as safer reviewed rule and skill-change proposals instead of silent instruction overwrites.

--- a/public/guides/hermes-agent-guardrails.html
+++ b/public/guides/hermes-agent-guardrails.html
@@ -312,7 +312,7 @@
     <section class="hero">
       <div class="eyebrow">integration | hermes agent guardrails</div>
       <h1>Hermes Agent can grow with you. ThumbGate keeps the growing agent safe.</h1>
-      <p>Hermes Agent points at the next wave: persistent memory, generated skills, messaging gateways, scheduled automations, and sandboxed execution. ThumbGate is the enforcement layer those workflows need before a remembered mistake becomes another real tool call.</p>
+      <p>Hermes Agent points at the next wave: persistent memory, generated skills, messaging gateways, scheduled automations, and sandboxed execution. ThumbGate is the enforcement layer those workflows need before a remembered mistake becomes another real tool call or a self-evolution loop rewrites stable instructions without proof.</p>
       <div class="signal-row">
         <div class="signal-pill up">👍 Thumbs up reinforces good behavior</div>
         <div class="signal-pill down">👎 Thumbs down blocks repeated mistakes</div>
@@ -323,22 +323,22 @@
       <div>
         <div class="card">
           <h2>Why this page exists</h2>
-          <ul><li>Hermes validates the market shift toward long-running, self-improving agents.</li><li>Memory and generated skills increase leverage, but they also increase the blast radius of repeated mistakes.</li><li>ThumbGate should be positioned as the local-first pre-action firewall for Hermes-style agents, not as a general agent clone.</li></ul>
+          <ul><li>Hermes validates the market shift toward long-running, self-improving agents.</li><li>Memory and generated skills increase leverage, but they also increase the blast radius of repeated mistakes.</li><li>The polarizing feature is automatic self-evolution: fast learning when it works, risky instruction drift when it silently overwrites a stable <code>SKILL.md</code>.</li><li>ThumbGate should be positioned as the local-first pre-action firewall for Hermes-style agents, not as a general agent clone.</li></ul>
         </div>
 
       <section class="detail-section">
         <h2>Why Hermes-style agents need a separate execution gate</h2>
-        <p>A persistent agent can remember projects, generate its own skills, run scheduled automations, and accept instructions from messaging gateways. That is powerful, but it also means one bad habit can persist longer and reach more surfaces.</p><p>The safety problem is not only whether the agent remembers. It is whether remembered lessons can stop the next risky shell command, git action, database write, deploy, browser click, or payment workflow before execution.</p>
+        <p>A persistent agent can remember projects, generate its own skills, run scheduled automations, and accept instructions from messaging gateways. That is powerful, but it also means one bad habit can persist longer and reach more surfaces.</p><p>The safety problem is not only whether the agent remembers. It is whether remembered lessons can stop the next risky shell command, git action, database write, deploy, browser click, or payment workflow before execution.</p><p>The self-evolution problem is similar: automatically rewriting skills can resolve repeated bugs, but it can also mutate working instructions without warning. ThumbGate turns that into a reviewed change path: propose the rule or skill patch from failure evidence, run the relevant proof, and block risky execution until the new behavior is accepted.</p>
 
       </section>
       <section class="detail-section">
         <h2>What ThumbGate adds to Hermes-style workflows</h2>
 
-        <ul><li>Pre-action checks before risky tool calls execute.</li><li>Thumbs-down feedback that becomes explicit prevention rules.</li><li>Evidence requirements for deploys, migrations, API calls, and production-facing changes.</li><li>Audit trails that show which lesson, rule, and workflow context allowed or blocked the action.</li><li>A local-first path for teams that want agent memory without handing every correction to a hosted black box.</li></ul>
+        <ul><li>Pre-action checks before risky tool calls execute.</li><li>Thumbs-down feedback that becomes explicit prevention rules.</li><li>Skill and rule-change proposals that require evidence before stable instructions are modified.</li><li>Evidence requirements for deploys, migrations, API calls, and production-facing changes.</li><li>Audit trails that show which lesson, rule, and workflow context allowed or blocked the action.</li><li>A local-first path for teams that want agent memory without handing every correction to a hosted black box.</li></ul>
       </section>
       <section class="detail-section">
         <h2>The buyer message</h2>
-        <p>Hermes can be the agent that grows with you. ThumbGate is the firewall that makes sure growth does not mean repeating expensive mistakes faster across more surfaces.</p><p>For teams evaluating persistent agents, the practical first step is not another prompt. It is one enforced rule from one real failure, proven locally, then expanded into Pro or a workflow hardening sprint when the risk is recurring.</p>
+        <p>Hermes can be the agent that grows with you. ThumbGate is the firewall that makes sure growth does not mean repeating expensive mistakes faster across more surfaces or silently drifting stable skills.</p><p>For teams evaluating persistent agents, the practical first step is not another prompt. It is one enforced rule from one real failure, proven locally, then expanded into Pro or a workflow hardening sprint when the risk is recurring.</p>
 
       </section>
         <div class="detail-section">

--- a/public/index.html
+++ b/public/index.html
@@ -1032,7 +1032,7 @@ __GA_BOOTSTRAP__
       </a>
       <a class="compat-card seo-card" href="/guides/hermes-agent-guardrails" rel="noopener">
         <h3>☤ Hermes Agent guardrails</h3>
-        <p>Hermes-style agents bring persistent memory, generated skills, messaging gateways, scheduled automations, and sandboxed execution. ThumbGate is the local-first firewall that checks risky actions before the growing agent repeats an expensive mistake.</p>
+        <p>Hermes-style agents bring persistent memory, generated skills, messaging gateways, scheduled automations, and sandboxed execution. ThumbGate adds the safer self-evolution loop: propose rule and skill changes from failures, then gate them with evidence before anything overwrites stable instructions or repeats an expensive action.</p>
         <div class="card-arrow">Read the Hermes guardrails guide →</div>
       </a>
       <a class="compat-card seo-card" href="/guides/agent-context-governance" rel="noopener">

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -37,6 +37,8 @@ ThumbGate is built on Node.js >=18.18.0 and runs locally on each developer's mac
 
 **Autoresearch Safety Pack**: ThumbGate checks self-improving coding loops before they promote a claimed improvement. The `autoresearch-brief` ContextFS template retrieves research history, learned rules, holdout expectations, proof requirements, and reward-hacking failures so the agent can search for better code without grading itself on missing evidence.
 
+**Hermes-Style Self-Evolution Guardrails**: Hermes Agent validates demand for persistent memory and generated skills, but automatic skill rewriting creates instruction-drift risk when stable `SKILL.md` files are overwritten without warning. ThumbGate's wedge is safer self-evolution: failures become explicit rule or skill-change proposals, proof gates verify the change, and pre-action checks block risky execution until the learned behavior is accepted.
+
 **Audit Trail**: Every check decision (blocked, approved, overridden) is logged with a timestamp, the triggering tool call, the matching lesson ID, and the identity of any human who approved an exception. This log is queryable and exportable for compliance reporting.
 
 **Browser Bridge Audit**: `npx thumbgate native-messaging-audit` inspects local browser native messaging manifests, allowed extension origins, missing host binaries, and dormant AI browser bridges so teams can review connector scope before an agent turns a one-off install into a durable local integration.

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -503,6 +503,8 @@ test('public landing page includes compatibility section for AI agent surfaces',
   assert.match(landingPage, /Hermes Agent guardrails/i);
   assert.match(landingPage, /\/guides\/hermes-agent-guardrails/);
   assert.match(landingPage, /persistent memory, generated skills, messaging gateways, scheduled automations, and sandboxed execution/i);
+  assert.match(landingPage, /safer self-evolution loop/i);
+  assert.match(landingPage, /overwrites stable instructions/i);
   assert.match(landingPage, /Context and tool governance/i);
   assert.match(landingPage, /\/guides\/agent-context-governance/);
   assert.match(landingPage, /cleaner working context, approved model routes, isolated execution, tool lockdown, direct pushback, and evidence/i);

--- a/tests/seo-guides.test.js
+++ b/tests/seo-guides.test.js
@@ -321,6 +321,18 @@ describe('SEO guide and comparison pages', () => {
     assert.ok(claudeSkills.includes('skillbook'));
   });
 
+  it('Hermes guide positions ThumbGate as safe self-evolution guardrails', () => {
+    const hermesGuide = fs.readFileSync(
+      path.join(PUBLIC_DIR, 'guides/hermes-agent-guardrails.html'),
+      'utf-8'
+    );
+
+    assert.ok(hermesGuide.includes('stable <code>SKILL.md</code>'));
+    assert.ok(hermesGuide.includes('reviewed change path'));
+    assert.ok(hermesGuide.includes('Skill and rule-change proposals'));
+    assert.ok(hermesGuide.includes('silently drifting stable skills'));
+  });
+
   it('long-running context and reasoning guides expose new research-backed CLI gates', () => {
     const contextGuide = fs.readFileSync(
       path.join(PUBLIC_DIR, 'guides/long-running-agent-context-management.html'),


### PR DESCRIPTION
## Summary
- Strengthen Hermes Agent positioning around the debated self-evolution loop.
- Position ThumbGate as safer reviewed rule/skill-change proposals instead of silent `SKILL.md` overwrites.
- Add the same message to `llm-context.md` for AI answer-engine visibility.

## Evidence
- `node --test tests/public-landing.test.js tests/seo-guides.test.js tests/positioning-contract.test.js tests/learn-hub.test.js` -> 384 passing.
- `npm run changeset:check` -> no local PR base, skipped as expected.
- `git diff --check` -> clean.
- Changed-file scan found no HermiT/Pellet/description-logic implementation claim and no old $499 sticky CTA strings.
