### PR TITLE
fix(revenue): recognize hosted tracking signals

### DIFF
--- a/.changeset/hosted-tracking-revenue-status.md
+++ b/.changeset/hosted-tracking-revenue-status.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Recognize hosted funnel telemetry as implemented tracking in the revenue status report.

--- a/scripts/revenue-status.js
+++ b/scripts/revenue-status.js
@@ -204,13 +204,23 @@ function buildDiagnosis({ publicProbe, hostedAudit }) {
   const runtimePresenceKnown = Boolean(hostedAudit?.runtimePresenceKnown !== false);
   const traffic30 = trailing30?.trafficMetrics || {};
   const revenue30 = trailing30?.revenue || {};
+  const ctas30 = trailing30?.ctas || {};
+  const dataQuality30 = trailing30?.dataQuality || {};
   const lifetimeRevenue = lifetime?.revenue || {};
   const externalCustomerAudit = normalizeExternalCustomerAudit(hostedAudit?.externalCustomerAudit || null);
 
-  const trackingImplemented = Boolean(
+  const publicTrackingDetected = Boolean(
     publicProbe?.root?.signals?.telemetryEndpoint &&
     publicProbe.root.signals.plausibleScript
   );
+  const hostedTrackingDetected = Boolean(
+    Number(dataQuality30.telemetryCoverage || 0) > 0 ||
+    Number(dataQuality30.attributionCoverage || 0) > 0 ||
+    Number(traffic30.checkoutStarts || 0) > 0 ||
+    Number(ctas30.checkoutIntent?.views || 0) > 0 ||
+    Number(ctas30.checkoutIntent?.clicks || 0) > 0
+  );
+  const trackingImplemented = publicTrackingDetected || hostedTrackingDetected;
   const telemetryIngressWorking = Boolean(publicProbe?.telemetryPing?.status === 204);
   const hostedSummaryWorking = Boolean(today?.status === 200 && trailing30?.status === 200);
   const hostedTrafficObserved = Number(traffic30.visitors || 0) > 0 || Number(traffic30.pageViews || 0) > 0;

--- a/tests/revenue-status.test.js
+++ b/tests/revenue-status.test.js
@@ -181,6 +181,51 @@ test('buildDiagnosis reports owner/test-only revenue instead of treating raw lif
   assert.equal(diagnosis.ownerTestRevenueOnly, true);
 });
 
+test('buildDiagnosis treats hosted funnel telemetry as implemented tracking even when root script detection is incomplete', () => {
+  const diagnosis = buildDiagnosis({
+    publicProbe: {
+      root: {
+        signals: {
+          telemetryEndpoint: false,
+          plausibleScript: false,
+        },
+      },
+      telemetryPing: {
+        status: 204,
+      },
+    },
+    hostedAudit: {
+      runtimePresence: {
+        THUMBGATE_GA_MEASUREMENT_ID: true,
+        THUMBGATE_SPRINT_DIAGNOSTIC_CHECKOUT_URL: true,
+        THUMBGATE_WORKFLOW_SPRINT_CHECKOUT_URL: true,
+      },
+      summaries: {
+        today: { status: 200 },
+        '30d': {
+          status: 200,
+          trafficMetrics: { visitors: 127, pageViews: 109, checkoutStarts: 2 },
+          ctas: {
+            checkoutIntent: { views: 2, clicks: 0 },
+          },
+          revenue: { paidOrders: 0, bookedRevenueCents: 0 },
+          dataQuality: {
+            attributionCoverage: 1,
+            telemetryCoverage: 0.9937,
+          },
+        },
+        lifetime: {
+          status: 200,
+          revenue: { paidOrders: 0, bookedRevenueCents: 0 },
+        },
+      },
+    },
+  });
+
+  assert.equal(diagnosis.trackingImplemented, true);
+  assert.equal(diagnosis.primaryIssue, 'conversion_or_pricing_gap');
+});
+
 test('resolveExternalCustomerAudit returns a visible unavailable marker when Railway vars are missing', () => {
   const audit = resolveExternalCustomerAudit({
     repoVars: {},


### PR DESCRIPTION
## Summary
- Treat hosted funnel telemetry and data-quality coverage as proof that revenue tracking is implemented
- Keep external customer revenue separated from owner/test revenue
- Add regression coverage for the production-shaped report where root script detection is incomplete but hosted telemetry exists

## Verification
- node --test tests/revenue-status.test.js tests/external-customer-audit.test.js
- git diff --check
- changed-file secret scan: no hits
