### PR TITLE
Position ThumbGate as governance, not logging

### DIFF
--- a/.changeset/governance-not-logging.md
+++ b/.changeset/governance-not-logging.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Sharpen public positioning so ThumbGate is framed as pre-action governance with reviewable evidence, not self-governance or passive logging.

--- a/public/index.html
+++ b/public/index.html
@@ -337,7 +337,7 @@ __GA_BOOTSTRAP__
       "name": "How does ThumbGate reduce host blast radius for high-risk local runs?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate combines pre-action checks with execution guidance. Workflow Sentinel predicts risky local actions before they execute, and high-risk runs can be routed into Docker Sandboxes instead of running directly on the host. Team workflows also have a signed hosted sandbox lane for isolated automation dispatch."
+        "text": "ThumbGate combines pre-action checks with execution guidance. Workflow Sentinel predicts risky local actions before they execute, and high-risk runs can be routed into Docker Sandboxes instead of running directly on the host. Enterprise workflows also have a signed hosted sandbox lane for isolated automation dispatch."
       }
     },
     {
@@ -1159,7 +1159,7 @@ __GA_BOOTSTRAP__
         <p>Every block explains why: which pattern matched, what evidence triggered it, and whether the rule came from your own corrections.</p>
       </div>
       <div class="agent-card">
-        <h3>📊 Org Dashboard (Team)</h3>
+        <h3>📊 Org Dashboard</h3>
         <p>See which agents are creating review churn, which checks are saving time, and where rollout risk is still concentrated across the shared workflow.</p>
       </div>
       <div class="agent-card">
@@ -1177,6 +1177,28 @@ __GA_BOOTSTRAP__
       <div class="agent-card">
         <h3>🪞 History-Aware Lessons</h3>
         <p>When the current Claude auto-capture hook only gets a vague thumbs-down, ThumbGate can reuse up to 8 prior recorded entries plus the failed tool call, then keep a linked 60-second feedback session open for later corrections instead of creating a dead-end note.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="compatibility" id="governance-not-logging">
+  <div class="container">
+    <div class="section-label">Governance, Not Logging</div>
+    <h2 class="section-title">Logs describe the damage. ThumbGate blocks the risky action before it runs.</h2>
+    <p style="color:var(--text-dim);max-width:820px;margin:0 auto 22px;">Self-governance is an operator writing local rules and keeping local logs. ThumbGate starts there, then turns each correction into a pre-action decision: allow, block, require evidence, or route for approval before the tool call touches code, data, money, or customers.</p>
+    <div class="agent-grid">
+      <div class="agent-card">
+        <h3>Pre-action enforcement</h3>
+        <p>The rule is evaluated at the execution boundary, not after the fact. Repeated failures are stopped before shell commands, PR actions, deploys, refunds, or production writes run.</p>
+      </div>
+      <div class="agent-card">
+        <h3>Reviewable decision trail</h3>
+        <p>Each event records the rule, source lesson, policy version, actor, action, evidence requirement, and reason so reviewers can inspect the decision instead of trusting an agent summary.</p>
+      </div>
+      <div class="agent-card">
+        <h3>Enterprise governance mode</h3>
+        <p>Org-owned policies, reviewer approvals, signed evidence bundles, and export paths turn local corrections into shared controls without giving the agent unilateral authority over the rules.</p>
       </div>
     </div>
   </div>
@@ -1267,7 +1289,7 @@ __GA_BOOTSTRAP__
         </div>
         <div class="autoresearch-card">
           <h3>Ship into CI</h3>
-          <p>Start with templates for <code>npm test</code>, Playwright duration, bundle size, lint, and CI failures, then add Team checks for shared workflows.</p>
+          <p>Start with templates for <code>npm test</code>, Playwright duration, bundle size, lint, and CI failures, then add shared workflow checks for team-owned releases.</p>
         </div>
       </div>
       <div class="autoresearch-cta">
@@ -1510,7 +1532,7 @@ __GA_BOOTSTRAP__
           <li><strong>Audit-ready enforcement proof</strong> — Personal local dashboard for the individual operator with auditable block history</li>
           <li><strong>Ship hardened agents to production</strong> — Model Hardening Advisor plus HuggingFace dataset export</li>
           <li><strong>Hand a PR with proof</strong> — Review-ready workflow support and proof-ready lesson bundles a reviewer can verify in 30 seconds</li>
-          <li><strong>Hand off without re-onboarding</strong> — Team lesson export/import for handoff or migration</li>
+          <li><strong>Hand off without re-onboarding</strong> — Lesson export/import for handoff or migration</li>
         </ul>
         <div style="margin:12px 0 16px;padding:12px;border:1px solid rgba(34,211,238,0.25);border-radius:8px;background:rgba(34,211,238,0.06);">
           <div style="font-size:12px;color:var(--text-muted);margin-bottom:4px;">What your Pro dashboard looks like</div>
@@ -1688,7 +1710,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <button class="faq-q" type="button" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How do we keep high-risk autonomous runs off the host?</button>
-        <div class="faq-a">ThumbGate is the control plane, not just a prompt layer. Workflow Sentinel predicts blast radius before execution, and risky local autonomy can be routed into Docker Sandboxes instead of running directly on the host. Team workflows also have a signed hosted sandbox lane for isolated dispatch when local repo access is not required.</div>
+        <div class="faq-a">ThumbGate is the control plane, not just a prompt layer. Workflow Sentinel predicts blast radius before execution, and risky local autonomy can be routed into Docker Sandboxes instead of running directly on the host. Enterprise workflows also have a signed hosted sandbox lane for isolated dispatch when local repo access is not required.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q" role="button" tabindex="0" aria-expanded="false" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)">How do we trust a new package release?</div>
@@ -2017,7 +2039,7 @@ function copyInstall(el) {
   trackClick('.btn-demo-link', 'demo_click', { source: 'homepage' });
   trackClick('.nav-cta:not([data-revenue-cta])', 'chatgpt_gpt_click', { tier: 'free', source: 'nav' });
 
-  /* Pricing CTA conversion tracking — fires on every Get Started / Pro / Team button click
+  /* Pricing CTA conversion tracking — fires on every Get Started / Pro / Enterprise button click
      with section context so we can distinguish pricing section vs final CTA section clicks */
   document.querySelectorAll('.btn-pro, .btn-gpt-page, .btn-pro-page, .btn-install-hero, .btn-install-link, .btn-team, .btn-free, .btn-demo-link, .nav-cta').forEach(function(el) {
     el.addEventListener('click', function() {

--- a/public/pro.html
+++ b/public/pro.html
@@ -37,7 +37,7 @@ __GA_BOOTSTRAP__
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "FAQPage", "mainEntity": [{ "@type": "Question", "name": "How is Pro different from the free install?", "acceptedAnswer": { "@type": "Answer", "text": "Free keeps local recall, checks, and MCP. Pro adds the personal dashboard, DPO export, auto-connect, and founder support." } }, { "@type": "Question", "name": "Does Pro require a cloud account?", "acceptedAnswer": { "@type": "Answer", "text": "No. Pro stays local-first; Team is the hosted rollout lane for shared lessons, org visibility, and reviews." } }, { "@type": "Question", "name": "What happens after checkout?", "acceptedAnswer": { "@type": "Answer", "text": "You activate Pro, connect the local dashboard, and inspect blocked actions, lessons, and exports." } }, { "@type": "Question", "name": "When should I choose Team instead of Pro?", "acceptedAnswer": { "@type": "Answer", "text": "Choose Team when one correction needs to protect multiple developers or agents across shared repositories." } }]
+  "@type": "FAQPage", "mainEntity": [{ "@type": "Question", "name": "How is Pro different from the free install?", "acceptedAnswer": { "@type": "Answer", "text": "Free keeps local recall, checks, and MCP. Pro adds the personal dashboard, DPO export, auto-connect, and founder support." } }, { "@type": "Question", "name": "Does Pro require a cloud account?", "acceptedAnswer": { "@type": "Answer", "text": "No. Pro stays local-first; Enterprise is the hosted rollout lane for shared lessons, org visibility, and reviews." } }, { "@type": "Question", "name": "What happens after checkout?", "acceptedAnswer": { "@type": "Answer", "text": "You activate Pro, connect the local dashboard, and inspect blocked actions, lessons, and exports." } }, { "@type": "Question", "name": "When should I choose Enterprise instead of Pro?", "acceptedAnswer": { "@type": "Answer", "text": "Choose Enterprise when one correction needs to protect multiple developers or agents across shared repositories." } }]
 }
 </script>
 
@@ -731,7 +731,7 @@ __GA_BOOTSTRAP__
       <h1>Buy the operator loop that proves your AI agent stopped repeating the mistake.</h1>
       <p style="font-size:13px;opacity:0.8;margin-bottom:0.5rem;">Updated: <time datetime="2026-04-20">2026-04-20</time> · by <a href="https://github.com/IgorGanapolsky" style="color:inherit;">Igor Ganapolsky</a></p>
       <p>ThumbGate Pro is for one operator who already hit a repeated AI-agent failure and now needs proof: what was blocked, why it was blocked, and what changed before the next risky run.</p>
-      <p>Start Pro when you want the local dashboard, DPO export, and a single proof lane for the repeated mistake you need to stop. Team diagnostics and custom services are handled through intake, not this buyer path.</p>
+      <p>Start Pro when you want the local dashboard, DPO export, and a single proof lane for the repeated mistake you need to stop. Enterprise diagnostics and custom services are handled through intake, not this buyer path.</p>
       <div class="hero-proof">
         <div class="proof-pill">Personal local dashboard</div>
         <div class="proof-pill">DPO export from real corrections</div>
@@ -951,15 +951,15 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <button class="faq-q" type="button" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)" aria-expanded="false">Does Pro require a cloud account?</button>
-        <div class="faq-a">No. Pro is still local-first for the individual operator lane. Team is the hosted rollout lane for shared lessons, org visibility, and hosted review views.</div>
+        <div class="faq-a">No. Pro is still local-first for the individual operator lane. Enterprise is the hosted rollout lane for shared lessons, org visibility, and hosted review views.</div>
       </div>
       <div class="faq-item">
         <button class="faq-q" type="button" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)" aria-expanded="false">What happens after checkout?</button>
         <div class="faq-a">You activate Pro, connect the personal local dashboard, and your running agents can appear automatically so you can inspect blocked actions, active lessons, and exportable DPO pairs without adding a separate cloud dashboard dependency.</div>
       </div>
       <div class="faq-item">
-        <button class="faq-q" type="button" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)" aria-expanded="false">When should I choose Team instead of Pro?</button>
-        <div class="faq-a">Choose Team when one thumbs-down should protect multiple people or agents across shared repositories, or when you need shared hosted lessons, org dashboard visibility, and a workflow hardening pilot with rollout review views.</div>
+        <button class="faq-q" type="button" onclick="toggleFaq(this)" onkeydown="handleFaqKeydown(event)" aria-expanded="false">When should I choose Enterprise instead of Pro?</button>
+        <div class="faq-a">Choose Enterprise when one thumbs-down should protect multiple people or agents across shared repositories, or when you need shared hosted lessons, org dashboard visibility, and a workflow hardening pilot with rollout review views.</div>
       </div>
     </div>
   </div>
@@ -987,7 +987,7 @@ __GA_BOOTSTRAP__
       <a href="__VERIFICATION_URL__" target="_blank" rel="noopener">Verification Evidence</a>
       <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub</a>
     </div>
-    <div class="footer-copy">ThumbGate Pro for individual operators. Team stays intake-first.</div>
+    <div class="footer-copy">ThumbGate Pro for individual operators. Enterprise stays intake-first.</div>
   </div>
 </footer>
 

--- a/tests/pro-landing.test.js
+++ b/tests/pro-landing.test.js
@@ -79,7 +79,7 @@ test('pro landing page keeps JSON-LD and FAQ structure for SEO and GEO', () => {
   assert.match(proPage, /How is Pro different from the free install\?/);
   assert.match(proPage, /Does Pro require a cloud account\?/);
   assert.match(proPage, /What happens after checkout\?/);
-  assert.match(proPage, /When should I choose Team instead of Pro\?/);
+  assert.match(proPage, /When should I choose Enterprise instead of Pro\?/);
 });
 
 test('pro landing page tracks paid CTAs without unsupported claims', () => {
@@ -95,7 +95,7 @@ test('pro landing page tracks paid CTAs without unsupported claims', () => {
 test('pro landing page keeps services out of the Pro buyer path', () => {
   const proPage = readProPage();
 
-  assert.match(proPage, /Team diagnostics and custom services are handled through intake, not this buyer path/);
+  assert.match(proPage, /Enterprise diagnostics and custom services are handled through intake, not this buyer path/);
   assert.match(proPage, /Book an Enterprise Pilot Call/);
   assert.doesNotMatch(proPage, /data-pro-paid-recovery/);
   assert.doesNotMatch(proPage, /data-first-rule-link/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -76,6 +76,18 @@ test('public landing page maps agentic development cycle to pre-action execution
   assert.match(cycleSection, /agentic_cycle_card_click/);
 });
 
+test('public landing page distinguishes pre-action governance from logging and self-governance', () => {
+  const landingPage = readLandingPage();
+
+  assert.match(landingPage, /Governance, Not Logging/);
+  assert.match(landingPage, /Logs describe the damage\. ThumbGate blocks the risky action before it runs\./);
+  assert.match(landingPage, /Self-governance is an operator writing local rules and keeping local logs\./);
+  assert.match(landingPage, /pre-action decision/);
+  assert.match(landingPage, /Reviewable decision trail/);
+  assert.match(landingPage, /signed evidence bundles/);
+  assert.match(landingPage, /without giving the agent unilateral authority over the rules/);
+});
+
 test('public landing page exposes above-fold paid Pro CTA with canonical revenue analytics', () => {
   const landingPage = readLandingPage();
   const heroStart = landingPage.indexOf('<!-- HERO -->');

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -135,6 +135,19 @@ test('landing pricing section compares plan capabilities and limits clearly', as
   assert.match(html, /Enterprise plans start through intake/);
 });
 
+test('landing page answers governance objections instead of presenting passive logs', async () => {
+  const res = await fetch(`${origin}/`);
+  assert.equal(res.status, 200);
+  const html = await res.text();
+
+  assert.match(html, /Governance, Not Logging/);
+  assert.match(html, /Logs describe the damage\. ThumbGate blocks the risky action before it runs\./);
+  assert.match(html, /pre-action decision/);
+  assert.match(html, /Reviewable decision trail/);
+  assert.match(html, /signed evidence bundles/);
+  assert.doesNotMatch(html, /Org Dashboard \(Team\)/);
+});
+
 test('homepage and pricing surfaces expose canonical and LLM context links', async () => {
   const pages = [
     ['/', `${origin}/`, `${origin}/llm-context.md`],


### PR DESCRIPTION
## Summary
- Add homepage section that directly answers the self-governance/logging objection: ThumbGate blocks risky actions before execution and records reviewable decision evidence.
- Replace stale visible Team wording on homepage/Pro page with Enterprise positioning while leaving internal compatibility IDs untouched.
- Add regression tests that lock the governance-not-logging copy and stale Team wording cleanup.

## Evidence
- `node --test tests/public-landing.test.js tests/pro-landing.test.js tests/public-static-assets.test.js tests/landing-page-claims.test.js tests/competitive-positioning-marketing.test.js tests/public-package-parity.test.js tests/test-suite-parity.test.js` -> 177 pass / 0 fail on clean branch.
- `npm test` -> full repo test chain exited 0 after restoring declared `stripe@22.2.0` dependency locally.
- `CHANGESET_BASE_REF=origin/main npm run changeset:check` -> Found 1 valid changeset file for release-relevant changes.
- `git diff --check` -> pass.
- `git push` pre-push guards -> npm pack dry-run, public HTML link validation, regression-guard tests all passed.

## Notes
- During full test setup, `npm install` restored declared dependencies and reported 0 root vulnerabilities.
- `npm --prefix workers ci` inside full tests reported 2 high severity worker dependency vulnerabilities; worker tests still passed, but this should be handled in a separate dependency PR.
