### PR TITLE
Fix Railway deploy scope for worker maintenance

### DIFF
--- a/.changeset/railway-worker-scope.md
+++ b/.changeset/railway-worker-scope.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Keep Cloudflare Worker maintenance changes out of the Railway deploy scope while preserving Railway deploys for root runtime dependency and serving-surface changes.

--- a/scripts/deploy-scope.sh
+++ b/scripts/deploy-scope.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|workers/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
+DEPLOYABLE_PATTERN='^(src/|scripts/.*\.(js|mjs|cjs)$|config/|adapters/.*\.(js|mjs|cjs|json|ya?ml|toml)$|public/|\.well-known/|openapi/|\.github/workflows/deploy-railway\.yml$|Dockerfile$|railway\.json$|package\.json$|package-lock\.json$)'
 
 BEFORE_SHA="${BEFORE_SHA:-}"
 HEAD_SHA="${HEAD_SHA:-${GITHUB_SHA:-}}"
@@ -10,16 +10,16 @@ CHANGED_FILES=''
 SHOULD_DEPLOY=true
 SCOPE_REASON='default_deploy'
 
-if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
   SHOULD_DEPLOY=true
   SCOPE_REASON='workflow_dispatch'
-elif [ "$EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]]; then
   if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
     CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$HEAD_SHA" | sed '/^$/d')"
-    if [ -n "$CHANGED_FILES" ] && ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
+    if [[ -n "$CHANGED_FILES" ]] && ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
       SHOULD_DEPLOY=false
       SCOPE_REASON='non_runtime_changes'
-    elif [ -n "$CHANGED_FILES" ]; then
+    elif [[ -n "$CHANGED_FILES" ]]; then
       SHOULD_DEPLOY=true
       SCOPE_REASON='deployable_changes'
     else
@@ -42,7 +42,7 @@ echo "deployable_pattern=$DEPLOYABLE_PATTERN"
 echo "should_deploy=$SHOULD_DEPLOY"
 echo "scope_reason=$SCOPE_REASON"
 
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
     echo "changed_files<<EOF"
     printf '%s\n' "$CHANGED_FILES"
@@ -53,7 +53,7 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   } >> "$GITHUB_OUTPUT"
 fi
 
-if [ -n "${DEPLOY_SCOPE_OUTPUT_JSON:-}" ]; then
+if [[ -n "${DEPLOY_SCOPE_OUTPUT_JSON:-}" ]]; then
   node - "$DEPLOY_SCOPE_OUTPUT_JSON" "$BEFORE_SHA" "$HEAD_SHA" "$EVENT_NAME" "$SHOULD_DEPLOY" "$SCOPE_REASON" "$DEPLOYABLE_PATTERN" "$CHANGED_FILES" <<'NODE'
 const fs = require('fs');
 const [

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -449,6 +449,10 @@ test('Deploy to Railway workflow skips non-runtime pushes and only deploys when 
     !scopeScript.includes('|adapters/|'),
     'scope script should not treat adapter Markdown docs as deployable',
   );
+  assert.ok(
+    !scopeScript.includes('|workers/|'),
+    'Railway deploy scope should not treat Cloudflare Worker changes as Railway runtime deploys',
+  );
   assert.match(scopeScript, /! printf '%s\\n' "\$CHANGED_FILES" \| grep -Eq "\$DEPLOYABLE_PATTERN"/);
   assert.match(scopeScript, /should_deploy=\$SHOULD_DEPLOY/);
   assert.match(scopeScript, /SHOULD_DEPLOY=true/);
@@ -467,6 +471,21 @@ test('deploy-scope script decides from the actual push range and writes reusable
   assert.equal(runtimeChange.shouldDeploy, true);
   assert.equal(runtimeChange.scopeReason, 'deployable_changes');
   assert.deepEqual(runtimeChange.changedFiles, ['src/runtime-change.js']);
+
+  const rootPackageLockChange = runDeployScopeFixture('package-lock.json');
+  assert.equal(rootPackageLockChange.shouldDeploy, true);
+  assert.equal(rootPackageLockChange.scopeReason, 'deployable_changes');
+  assert.deepEqual(rootPackageLockChange.changedFiles, ['package-lock.json']);
+
+  const workerPackageLockChange = runDeployScopeFixture('workers/package-lock.json');
+  assert.equal(workerPackageLockChange.shouldDeploy, false);
+  assert.equal(workerPackageLockChange.scopeReason, 'non_runtime_changes');
+  assert.deepEqual(workerPackageLockChange.changedFiles, ['workers/package-lock.json']);
+
+  const workerRuntimeChange = runDeployScopeFixture('workers/src/index.ts');
+  assert.equal(workerRuntimeChange.shouldDeploy, false);
+  assert.equal(workerRuntimeChange.scopeReason, 'non_runtime_changes');
+  assert.deepEqual(workerRuntimeChange.changedFiles, ['workers/src/index.ts']);
 
   const manualDeploy = runDeployScopeFixture('docs/manual-note.md', 'workflow_dispatch');
   assert.equal(manualDeploy.shouldDeploy, true);


### PR DESCRIPTION
## Summary
- remove Cloudflare Worker files from the Railway deploy-scope pattern
- add regression coverage proving worker package/source changes skip Railway deploys
- keep root package-lock and Railway runtime surfaces deployable

## Evidence
- npm run test:deployment: 111 tests passed
- npm audit --audit-level=low: found 0 vulnerabilities
- npm --prefix workers audit --audit-level=low: found 0 vulnerabilities
- CHANGESET_BASE_REF=refs/remotes/origin/main npm run changeset:check: no release-relevant changes detected
- git diff --check: clean

## Context
PR #2654 fixed the worker npm audit vulnerability and merged cleanly, but the post-merge Railway deploy workflow failed because the deploy scope treated Cloudflare Worker maintenance as a Railway runtime deploy and then hit the stale STRIPE_WEBHOOK_SECRET deploy-policy gate. This PR fixes that scope bug. The stale Stripe webhook secret still needs real rotation; this change prevents unrelated worker maintenance from forcing a Railway deploy.