### PR TITLE
fix(api): constrain checkout HTML attribution

### DIFF
--- a/.changeset/checkout-html-xss-followup.md
+++ b/.changeset/checkout-html-xss-followup.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Constrain checkout interstitial hidden attribution to an allowlist so arbitrary request query parameters cannot be reflected into server-rendered HTML.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2095,17 +2095,58 @@ function buildCheckoutIntentHref(baseUrl, metadata = {}, overrides = {}) {
   });
 }
 
+const CHECKOUT_HIDDEN_ATTRIBUTION_KEYS = Object.freeze([
+  'trace_id',
+  'acquisition_id',
+  'visitor_id',
+  'session_id',
+  'visitor_session_id',
+  'install_id',
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'creator',
+  'community',
+  'post_id',
+  'comment_id',
+  'campaign_variant',
+  'offer_code',
+  'cta_id',
+  'cta_placement',
+  'plan_id',
+  'billing_cycle',
+  'seat_count',
+  'landing_path',
+  'referrer_host',
+]);
+
+function normalizeHiddenAttributionValue(value) {
+  const normalized = normalizeNullableText(value);
+  if (!normalized) return '';
+  return normalized.slice(0, 512);
+}
+
+function buildCheckoutHiddenAttributionInputs(parsed = null) {
+  if (!parsed?.searchParams) return '';
+
+  const inputs = [];
+  for (const key of CHECKOUT_HIDDEN_ATTRIBUTION_KEYS) {
+    const value = normalizeHiddenAttributionValue(parsed.searchParams.get(key));
+    if (value) {
+      inputs.push(`<input type="hidden" name="${key}" value="${escapeHtmlAttribute(value)}">`);
+    }
+  }
+  return inputs.join('');
+}
+
 function renderCheckoutIntentPage(prefilledEmail = '', parsed = null, options = {}) {
   const plausibleDomain = escapeHtmlAttribute(resolvePlausibleDataDomain({ host: 'thumbgate.ai' }));
   const includeHiddenAttribution = options.includeHiddenAttribution === true;
-  let hiddenInputs = '';
-  if (includeHiddenAttribution && parsed?.searchParams) {
-    for (const [key, value] of parsed.searchParams.entries()) {
-      if (key !== 'confirm' && key !== 'customer_email') {
-        hiddenInputs += `<input type="hidden" name="${escapeHtmlAttribute(key)}" value="${escapeHtmlAttribute(value)}">`;
-      }
-    }
-  }
+  const hiddenInputs = includeHiddenAttribution
+    ? buildCheckoutHiddenAttributionInputs(parsed)
+    : '';
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -2301,17 +2342,6 @@ function normalizeCheckoutCustomerEmail(value) {
   if (!email || email.length > 254 || atIndex <= 0 || atIndex !== email.lastIndexOf('@') || !domain || !domain.includes('.') || domain.startsWith('.') || domain.endsWith('.') || domain.includes('..')) return null;
   for (const ch of email) if (ch <= ' ' || ch === '<' || ch === '>' || ch === '"') return null;
   return email;
-}
-
-function renderCheckoutIntentGate(parsed, responseHeaders = {}) {
-  let hiddenInputs = '';
-  for (const [key, value] of parsed.searchParams.entries()) {
-    if (key !== 'confirm' && key !== 'customer_email') hiddenInputs += `<input type=hidden name=${escapeHtmlAttribute(key)} value=${escapeHtmlAttribute(value)}>`;
-  }
-  return {
-    html: `<!doctype html><h1>Email for Stripe receipt</h1><form action=/checkout/pro>${hiddenInputs}<input type=hidden name=confirm value=1><input name=customer_email type=email required><button>Continue</button></form>`,
-    headers: responseHeaders,
-  };
 }
 
 function normalizeTrackedLinkSlug(value) {

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1782,7 +1782,7 @@ test('checkout bootstrap route preserves attribution and records first-party tel
 // render the interstitial; only POST or ?confirm=1 triggers a Stripe session.
 
 test('checkout interstitial: GET without confirm=1 (human UA) renders the interstitial HTML, no Stripe session', async () => {
-  const res = await fetch(apiUrl('/checkout/pro?plan_id=pro&billing_cycle=monthly'), {
+  const res = await fetch(apiUrl('/checkout/pro?plan_id=pro&billing_cycle=monthly&utm_campaign=%3Cimg%20src=x%20onerror=alert(1)%3E&not_allowed=%3Csvg%20onload=alert(1)%3E'), {
     redirect: 'manual',
     headers: {
       'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -1799,6 +1799,10 @@ test('checkout interstitial: GET without confirm=1 (human UA) renders the inters
   assert.match(body, /name="confirm" value="1"/);
   assert.match(body, /name="plan_id" value="pro"/, 'human interstitial should preserve checkout attribution through submit');
   assert.match(body, /name="billing_cycle" value="monthly"/, 'human interstitial should preserve billing cycle through submit');
+  assert.match(body, /name="utm_campaign" value="&lt;img src=x onerror=alert\(1\)&gt;"/);
+  assert.doesNotMatch(body, /not_allowed/);
+  assert.doesNotMatch(body, /<img src=x onerror=alert\(1\)>/);
+  assert.doesNotMatch(body, /<svg onload=alert\(1\)>/);
   assert.doesNotMatch(body, /name="customer_email"[^>]*required/, 'email should be optional because Stripe collects it');
   assert.match(body, /Stripe can collect your email/);
   assert.match(body, /Not sure yet\? Send the workflow first/);


### PR DESCRIPTION
## Summary
- Replace raw checkout query-param hidden-input reflection with an allowlist of attribution keys
- Delete unused checkout intent gate renderer that looped over arbitrary query params into HTML
- Add regression coverage for escaped allowlisted attribution and dropped non-allowlisted XSS probes

## Evidence
- node --test --test-concurrency=1 --test-name-pattern "checkout interstitial: GET without confirm|loss analytics JSON response neutralizes" tests/api-server.test.js
- npm run test:api -> 963 pass, 0 fail
- git diff --check && npm audit --audit-level=low && npm --prefix workers audit --audit-level=low -> found 0 vulnerabilities twice
- CHANGESET_BASE_REF=refs/remotes/origin/main npm run changeset:check -> No release-relevant changes detected. Changeset not required.
