### PR TITLE
fix(api): allowlist public html routes

### DIFF
--- a/.changeset/public-html-route-allowlist.md
+++ b/.changeset/public-html-route-allowlist.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Route public HTML detail pages through server-built slug allowlists and sanitize forwarded hosts before rendering HTML or OpenAPI metadata.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -244,6 +244,10 @@ const COMPARE_DIR = path.resolve(__dirname, '../../public/compare');
 const USE_CASES_DIR = path.resolve(__dirname, '../../public/use-cases');
 const PUBLIC_DIR = path.resolve(__dirname, '../../public');
 const PUBLIC_ASSETS_DIR = path.resolve(__dirname, '../../public/assets');
+const LEARN_PAGE_PATHS_BY_SLUG = buildPublicHtmlFileMap(LEARN_DIR);
+const GUIDE_PAGE_PATHS_BY_SLUG = buildPublicHtmlFileMap(GUIDES_DIR);
+const COMPARE_PAGE_PATHS_BY_SLUG = buildPublicHtmlFileMap(COMPARE_DIR);
+const USE_CASE_PAGE_PATHS_BY_SLUG = buildPublicHtmlFileMap(USE_CASES_DIR);
 const BUYER_INTENT_SCRIPT_PATH = path.resolve(__dirname, '../../public/js/buyer-intent.js');
 const STATIC_MIME_BY_EXT = Object.freeze({
   '.png': 'image/png',
@@ -2354,6 +2358,27 @@ function normalizePublicPageSlug(value) {
     .replace(/[^a-z0-9-]/g, '');
 }
 
+function buildPublicHtmlFileMap(directory) {
+  const entries = new Map();
+  try {
+    for (const fileName of fs.readdirSync(directory)) {
+      if (!/^[a-z0-9-]+\.html$/i.test(fileName)) continue;
+      const slug = normalizePublicPageSlug(fileName);
+      if (!slug) continue;
+      entries.set(slug, path.join(directory, fileName));
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  return entries;
+}
+
+function resolvePublicHtmlFile(publicPageMap, rawSlug) {
+  const slug = normalizePublicPageSlug(rawSlug);
+  if (!slug) return null;
+  return publicPageMap.get(slug) || null;
+}
+
 function getTrackedLinkTarget(slug) {
   const normalizedSlug = normalizeTrackedLinkSlug(slug);
   return TRACKED_LINK_TARGETS[normalizedSlug]
@@ -2613,8 +2638,9 @@ function chatgptActionEventType(integration, suffix) {
 }
 
 function getPublicOrigin(req) {
-  const proto = String(req.headers['x-forwarded-proto'] || '').split(',')[0].trim() || 'http';
-  const host = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim() || 'localhost';
+  const rawProto = String(req.headers['x-forwarded-proto'] || '').split(',')[0].trim().toLowerCase();
+  const proto = rawProto === 'https' ? 'https' : 'http';
+  const host = getSafePublicRequestHost(req) || 'localhost';
   return `${proto}://${host}`;
 }
 
@@ -2631,6 +2657,29 @@ function getRequestHostHeader(req) {
     return forwardedHost[0] || req.headers.host || '';
   }
   return forwardedHost || req.headers.host || '';
+}
+
+function normalizePublicRequestHost(value) {
+  const rawHost = String(value || '').split(',')[0].trim().toLowerCase();
+  if (!rawHost || rawHost.length > 253) return '';
+
+  const hostWithoutPort = rawHost.startsWith('[')
+    ? rawHost.slice(1).split(']')[0]
+    : rawHost.split(':')[0];
+  const port = rawHost.startsWith('[')
+    ? rawHost.split(']:')[1] || ''
+    : rawHost.split(':')[1] || '';
+
+  if (!/^(localhost|[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*|\d{1,3}(?:\.\d{1,3}){3}|::1)$/.test(hostWithoutPort)) {
+    return '';
+  }
+  if (port && !/^\d{1,5}$/.test(port)) return '';
+  if (port && Number(port) > 65535) return '';
+  return port ? `${hostWithoutPort}:${port}` : hostWithoutPort;
+}
+
+function getSafePublicRequestHost(req) {
+  return normalizePublicRequestHost(getRequestHostHeader(req));
 }
 
 function isLoopbackHost(hostValue) {
@@ -2687,7 +2736,7 @@ function normalizePublicMarketingHtml(html, runtimeConfig, requestHost) {
   let output = String(html);
   output = output.replaceAll(DEFAULT_PUBLIC_APP_ORIGIN, appOrigin);
   try {
-    const host = requestHost || new URL(appOrigin).host;
+    const host = normalizePublicRequestHost(requestHost) || new URL(appOrigin).host;
     const plausibleDomain = resolvePlausibleDataDomain({ host });
     output = output.replaceAll(
       'data-domain="thumbgate-production.up.railway.app"',
@@ -3560,7 +3609,7 @@ function servePublicMarketingPage({
     }, req.headers, 'seo_landing_view');
   }
 
-  const requestHost = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim();
+  const requestHost = getSafePublicRequestHost(req);
   const html = renderHtml(hostedConfig, {
     serverVisitorId: journeyState.visitorId,
     serverSessionId: journeyState.sessionId,
@@ -5748,13 +5797,12 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname.startsWith('/learn/')) {
       try {
-        const slug = normalizePublicPageSlug(pathname.replace('/learn/', ''));
-        const articlePath = path.join(LEARN_DIR, `${slug}.html`);
-        if (!articlePath.startsWith(LEARN_DIR)) {
-          sendJson(res, 403, { error: 'Forbidden' });
+        const articlePath = resolvePublicHtmlFile(LEARN_PAGE_PATHS_BY_SLUG, pathname.replace('/learn/', ''));
+        if (!articlePath) {
+          sendJson(res, 404, { error: 'Article not found' });
           return;
         }
-        const requestHost = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim();
+        const requestHost = getSafePublicRequestHost(req);
         const html = normalizePublicMarketingHtml(fs.readFileSync(articlePath, 'utf-8'), hostedConfig, requestHost);
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
       } catch {
@@ -5765,10 +5813,9 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname.startsWith('/guides/')) {
       try {
-        const slug = normalizePublicPageSlug(pathname.replace('/guides/', ''));
-        const guidePath = path.join(GUIDES_DIR, `${slug}.html`);
-        if (!guidePath.startsWith(GUIDES_DIR)) { sendJson(res, 403, { error: 'Forbidden' }); return; }
-        const requestHost = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim();
+        const guidePath = resolvePublicHtmlFile(GUIDE_PAGE_PATHS_BY_SLUG, pathname.replace('/guides/', ''));
+        if (!guidePath) { sendJson(res, 404, { error: 'Guide not found' }); return; }
+        const requestHost = getSafePublicRequestHost(req);
         const html = normalizePublicMarketingHtml(fs.readFileSync(guidePath, 'utf-8'), hostedConfig, requestHost);
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
       } catch { sendJson(res, 404, { error: 'Guide not found' }); }
@@ -5777,10 +5824,9 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname.startsWith('/compare/') && pathname !== '/compare') {
       try {
-        const slug = normalizePublicPageSlug(pathname.replace('/compare/', ''));
-        const comparePath = path.join(COMPARE_DIR, `${slug}.html`);
-        if (!comparePath.startsWith(COMPARE_DIR)) { sendJson(res, 403, { error: 'Forbidden' }); return; }
-        const requestHost = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim();
+        const comparePath = resolvePublicHtmlFile(COMPARE_PAGE_PATHS_BY_SLUG, pathname.replace('/compare/', ''));
+        if (!comparePath) { sendJson(res, 404, { error: 'Comparison not found' }); return; }
+        const requestHost = getSafePublicRequestHost(req);
         const html = normalizePublicMarketingHtml(fs.readFileSync(comparePath, 'utf-8'), hostedConfig, requestHost);
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
       } catch { sendJson(res, 404, { error: 'Comparison not found' }); }
@@ -5789,10 +5835,9 @@ async function addContext(){
 
     if (isGetLikeRequest && pathname.startsWith('/use-cases/')) {
       try {
-        const slug = normalizePublicPageSlug(pathname.replace('/use-cases/', ''));
-        const useCasePath = path.join(USE_CASES_DIR, `${slug}.html`);
-        if (!useCasePath.startsWith(USE_CASES_DIR)) { sendJson(res, 403, { error: 'Forbidden' }); return; }
-        const requestHost = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim();
+        const useCasePath = resolvePublicHtmlFile(USE_CASE_PAGE_PATHS_BY_SLUG, pathname.replace('/use-cases/', ''));
+        if (!useCasePath) { sendJson(res, 404, { error: 'Use case not found' }); return; }
+        const requestHost = getSafePublicRequestHost(req);
         const html = normalizePublicMarketingHtml(fs.readFileSync(useCasePath, 'utf-8'), hostedConfig, requestHost);
         sendHtml(res, 200, html, {}, { headOnly: isHeadRequest });
       } catch { sendJson(res, 404, { error: 'Use case not found' }); }
@@ -6295,7 +6340,7 @@ async function addContext(){
       // Public-facing broker lead-flow audit landing page. Wedge for the
       // real-estate broker outreach. Static HTML served from src/api/static.
       try {
-        const host = String(req.headers['x-forwarded-host'] || req.headers.host || '').split(',')[0].trim();
+        const host = getSafePublicRequestHost(req);
         const html = normalizePublicMarketingHtml(fillTemplate(fs.readFileSync(
           path.resolve(__dirname, '../../assets/static/broker-audit.html'),
           'utf8'

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1001,6 +1001,20 @@ test('public openapi yaml advertises forwarded https origin for hosted imports',
   assert.match(body, /servers:\n  - url: https:\/\/thumbgate-production\.up\.railway\.app/);
 });
 
+test('public openapi yaml ignores markup in forwarded host headers', async () => {
+  const res = await fetch(apiUrl('/openapi.yaml'), {
+    headers: {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': '<img src=x onerror=alert(1)>',
+    },
+  });
+  assert.equal(res.status, 200);
+
+  const body = await res.text();
+  assert.doesNotMatch(body, /<img src=x onerror=alert\(1\)>/);
+  assert.match(body, /servers:\n  - url: https:\/\/localhost/);
+});
+
 test('public server card exposes MCP tool schemas for directory scanners', async () => {
   const res = await fetch(apiUrl('/.well-known/mcp/server-card.json'));
   assert.equal(res.status, 200);
@@ -1473,6 +1487,22 @@ test('SEO comparison pages serve HTML, reuse journey cookies, and record page-sp
   assert.ok(seoEvent);
   assert.equal(seoEvent.pageType, 'comparison');
   assert.equal(seoEvent.seoQuery, 'thumbgate vs speclock');
+});
+
+test('public comparison pages do not reflect malicious slug or forwarded host markup', async () => {
+  const missingRes = await fetch(apiUrl('/compare/%3Cimg%20src=x%20onerror=alert(1)%3E'));
+  assert.equal(missingRes.status, 404);
+  assert.match(String(missingRes.headers.get('content-type')), /application\/json/);
+  assert.doesNotMatch(await missingRes.text(), /<img src=x onerror=alert\(1\)>/);
+
+  const hostedRes = await fetch(apiUrl('/compare/speclock'), {
+    headers: {
+      'x-forwarded-host': '<svg onload=alert(1)>',
+    },
+  });
+  assert.equal(hostedRes.status, 200);
+  const body = await hostedRes.text();
+  assert.doesNotMatch(body, /<svg onload=alert\(1\)>/);
 });
 
 test('robots and sitemap endpoints publish crawl metadata for the canonical app origin', async () => {

--- a/tests/learn-hub.test.js
+++ b/tests/learn-hub.test.js
@@ -405,10 +405,11 @@ test('server.js has /learn/* article route handler', () => {
   assert.ok(src.includes("pathname.startsWith('/learn/')"), '/learn/* route missing from server.js');
 });
 
-test('server.js /learn/* route sanitizes slug (no path traversal)', () => {
+test('server.js /learn/* route uses an allowlisted slug resolver (no path traversal)', () => {
   const src = readFile(serverPath);
   assert.ok(src.includes('.replace(/[^a-z0-9-]/g'), 'slug sanitization missing — path traversal risk');
-  assert.ok(src.includes('.startsWith(LEARN_DIR)'), 'path prefix check missing — path traversal risk');
+  assert.ok(src.includes('LEARN_PAGE_PATHS_BY_SLUG'), 'learn page allowlist missing — path traversal risk');
+  assert.ok(src.includes('resolvePublicHtmlFile(LEARN_PAGE_PATHS_BY_SLUG'), 'learn route must resolve files through the allowlist');
 });
 
 test('server.js API discovery includes /learn endpoint', () => {


### PR DESCRIPTION
## Summary
- route public learn/guide/compare/use-case HTML through server-built slug allowlists
- sanitize forwarded public host values before rendering HTML analytics metadata or OpenAPI server origins
- add regression tests for malicious slug and forwarded-host markup

## Evidence
- node --test --test-concurrency=1 --test-name-pattern "public openapi yaml ignores markup|public comparison pages do not reflect|SEO comparison pages serve HTML" tests/api-server.test.js
- npm run test:api
- CHANGESET_BASE_REF=refs/remotes/origin/main npm run changeset:check
- git diff --check && npm audit --audit-level=low && npm --prefix workers audit --audit-level=low