### PR TITLE
fix(api): escape OAuth consent token attribute

### DIFF
--- a/.changeset/oauth-consent-token-attribute.md
+++ b/.changeset/oauth-consent-token-attribute.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Escape the OAuth consent nonce before rendering it into the hidden form attribute so the hosted connector authorization page remains explicit about its HTML boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,3 +128,5 @@ Rules:
 
 - **Rule [auto-promoted-mqf6zaon-0]**: NEVER repeated problem context string
 - **Rule [auto-manual-ingest-markdown-migration]**: Auto-promoted repeated pattern: "MISTAKE: This is a test failure" (1 occurrences in 30 days)
+- **Rule [auto-entity-customer-evidence-first-honesty-revenue-str]**: Auto-promoted repeated pattern: "User is angry because I implied ThumbGate was fixed while Stripe production billing remained blocked by an expired live " (1 occurrences in 30 days)
+- **Rule [auto-autonomy-entity-customer-revenue-stripe-thumbs-dow]**: Auto-promoted repeated pattern: "User provided valid live Stripe key and was angry I stopped for confirmation despite full authorization to fix productio" (1 occurrences in 30 days)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,3 +22,5 @@ Key: Always dogfood the latest local changes before publishing.
 
 - **Rule [auto-promoted-mqf6zaon-0]**: NEVER repeated problem context string
 - **Rule [auto-manual-ingest-markdown-migration]**: Auto-promoted repeated pattern: "MISTAKE: This is a test failure" (1 occurrences in 30 days)
+- **Rule [auto-entity-customer-evidence-first-honesty-revenue-str]**: Auto-promoted repeated pattern: "User is angry because I implied ThumbGate was fixed while Stripe production billing remained blocked by an expired live " (1 occurrences in 30 days)
+- **Rule [auto-autonomy-entity-customer-revenue-stripe-thumbs-dow]**: Auto-promoted repeated pattern: "User provided valid live Stripe key and was angry I stopped for confirmation despite full authorization to fix productio" (1 occurrences in 30 days)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4142,9 +4142,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -6464,7 +6464,7 @@ button{width:100%;padding:11px;border-radius:8px;border:0;background:#10b981;col
 a{color:#8b9}</style></head><body><form class="card" method="post" action="/oauth/authorize">
 <h2>Authorize Claude → ThumbGate</h2>
 <p>Paste your ThumbGate API key to let this connector act as you. Get one with <code>npx thumbgate init</code> or from your <a href="/dashboard">dashboard</a>.</p>
-<input type="hidden" name="auth_request_token" value="${authRequestToken}">
+<input type="hidden" name="auth_request_token" value="${escapeHtmlAttribute(authRequestToken)}">
 <input type="password" name="api_key" placeholder="ThumbGate API key" autocomplete="off" required>
 <button type="submit" name="approve" value="yes">Approve</button>
 </form></body></html>`;

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -3,6 +3,7 @@ const http = require('http');
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('node:crypto');
 const { EventEmitter } = require('node:events');
 const pkg = require('../../package.json');
 const {
@@ -1772,10 +1773,11 @@ function buildFeedbackSection({ ctx, intent, feedbackDir, approval, lessonPipeli
   const windowNeg = windowed.filter((r) => r.signal === 'negative').length;
   const entries = buildFeedbackEntries(windowed, signal);
 
-  const lines = [];
-  lines.push(intent.windowMs
+  const lines = [
+    intent.windowMs
     ? `Feedback ${intent.windowLabel}: ${windowed.length} (${windowPos} positive, ${windowNeg} negative).`
-    : `Feedback total: ${compactNumber(approval.total)} (${compactNumber(approval.positive)} positive, ${compactNumber(approval.negative)} negative).`);
+    : `Feedback total: ${compactNumber(approval.total)} (${compactNumber(approval.positive)} positive, ${compactNumber(approval.negative)} negative).`,
+  ];
 
   if (intent.wantsList) {
     appendFeedbackListLines(lines, { entries, signal, intent });
@@ -2157,7 +2159,7 @@ function prunePendingOauthAuthorizeRequests(now = Date.now()) {
 
 function createPendingOauthAuthorizeRequest(params, now = Date.now()) {
   prunePendingOauthAuthorizeRequests(now);
-  const token = require('crypto').randomBytes(32).toString('base64url');
+  const token = crypto.randomBytes(32).toString('base64url');
   pendingOauthAuthorizeRequests.set(token, {
     params,
     expiresAt: now + OAUTH_AUTHORIZE_REQUEST_TTL_MS,
@@ -2725,12 +2727,30 @@ function normalizePublicRequestHost(value) {
     ? rawHost.split(']:')[1] || ''
     : rawHost.split(':')[1] || '';
 
-  if (!/^(localhost|[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*|\d{1,3}(?:\.\d{1,3}){3}|::1)$/.test(hostWithoutPort)) {
+  if (!isAllowedPublicHostName(hostWithoutPort)) {
     return '';
   }
   if (port && !/^\d{1,5}$/.test(port)) return '';
   if (port && Number(port) > 65535) return '';
   return port ? `${hostWithoutPort}:${port}` : hostWithoutPort;
+}
+
+function isAllowedPublicHostName(hostname) {
+  return hostname === 'localhost'
+    || hostname === '::1'
+    || isIpv4Host(hostname)
+    || isDnsHostName(hostname);
+}
+
+function isIpv4Host(hostname) {
+  const parts = hostname.split('.');
+  return parts.length === 4 && parts.every((part) => /^\d{1,3}$/.test(part));
+}
+
+function isDnsHostName(hostname) {
+  return hostname
+    .split('.')
+    .every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label));
 }
 
 function getSafePublicRequestHost(req) {


### PR DESCRIPTION
## Summary\n- Escape the OAuth consent auth_request_token before writing it into the hidden HTML attribute\n- Keeps the server-side nonce flow from PR #2669 while making the final attribute sink explicit for CodeQL\n\n## Verification\n- node --test tests/mcp-oauth-flow.test.js tests/mcp-oauth-reviewer.test.js tests/public-html-security.test.js\n- node --test tests/public-package-parity.test.js tests/test-suite-parity.test.js tests/landing-page-claims.test.js\n- npm run test:api\n- npm audit --audit-level=moderate\n- node scripts/secret-scanner.js\n- git diff --check

----
## Summary by Gitar

- **Security enhancements:**
  - Added `escapeHtmlAttribute` to `auth_request_token` in `server.js` to prevent HTML injection.
- **Documentation updates:**
  - Updated `GEMINI.md` and `AGENTS.md` with new self-harness prevention rules regarding customer evidence and revenue workflows.

<sub>This will update automatically on new commits.</sub>