### PR TITLE
Add MCPMarket seller pack

### DIFF
--- a/docs/channels/mcpmarket-seller-pack.json
+++ b/docs/channels/mcpmarket-seller-pack.json
@@ -1,0 +1,54 @@
+{
+  "updated": "2026-06-15",
+  "source": "https://mcpmarket.com/sell-skills",
+  "status": "early_access_ready_not_approved",
+  "listing": {
+    "name": "ThumbGate Agent Failure Firewall",
+    "category": "Developer Tools / AI Agent Governance",
+    "shortDescription": "Stop AI coding agents from repeating the same dangerous tool mistake. ThumbGate packages local-first feedback memory, MCP wiring checks, and pre-action governance into installable Agent Skills.",
+    "priceTest": {
+      "skillPackUsd": 49,
+      "proMonthlyUsd": 19,
+      "proAnnualUsd": 149
+    },
+    "urls": {
+      "product": "https://thumbgate.ai",
+      "repository": "https://github.com/IgorGanapolsky/ThumbGate",
+      "docs": "https://github.com/IgorGanapolsky/ThumbGate/tree/main/skills",
+      "proof": "https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md",
+      "support": "https://github.com/IgorGanapolsky/ThumbGate/issues"
+    }
+  },
+  "skills": [
+    {
+      "name": "thumbgate-doctor",
+      "path": "skills/thumbgate-doctor/SKILL.md",
+      "buyerPain": "Are my agent guardrails actually installed and connected?"
+    },
+    {
+      "name": "thumbgate-guard",
+      "path": "skills/thumbgate-guard/SKILL.md",
+      "buyerPain": "How do I stop this repeated tool mistake before it runs again?"
+    },
+    {
+      "name": "thumbgate-protect",
+      "path": "skills/thumbgate-protect/SKILL.md",
+      "buyerPain": "How do I grant one narrow exception without disabling governance?"
+    },
+    {
+      "name": "evidence-first-answer",
+      "path": ".claude/skills/evidence-first-answer/SKILL.md",
+      "buyerPain": "How do I prevent false completion claims without proof?"
+    }
+  ],
+  "trackedCtas": {
+    "install": "https://thumbgate.ai/go/pro?utm_source=mcpmarket&utm_medium=skill_listing&utm_campaign=agent_failure_firewall&utm_content=install&cta_id=mcpmarket_skill_install",
+    "proUpgrade": "https://thumbgate.ai/checkout/pro?utm_source=mcpmarket&utm_medium=skill_listing&utm_campaign=agent_failure_firewall&utm_content=pro_upgrade&cta_id=mcpmarket_skill_pro",
+    "workflowSprint": "https://thumbgate.ai/?utm_source=mcpmarket&utm_medium=skill_listing&utm_campaign=agent_failure_firewall&utm_content=workflow_sprint&cta_id=mcpmarket_skill_sprint#workflow-sprint-intake"
+  },
+  "guardrails": [
+    "Do not claim MCPMarket approval until it is granted.",
+    "Do not claim marketplace revenue until Stripe or marketplace payout evidence exists.",
+    "Do not disclose private-core implementation details in listing copy."
+  ]
+}

--- a/docs/channels/mcpmarket-seller-pack.md
+++ b/docs/channels/mcpmarket-seller-pack.md
@@ -1,0 +1,109 @@
+# MCPMarket Seller Pack
+
+Updated: 2026-06-15
+
+This is a sales operator artifact. It is not proof of MCPMarket approval, marketplace revenue, or paid installs.
+
+## Why This Channel Matters
+
+MCPMarket's sell-skills page says skill selling is "Coming Soon" and positions the channel as a way to sell Agent Skills to developers and AI teams using Claude, ChatGPT, and Codex. The high-ROI move is to enter early with a clear paid skill bundle, not wait for the marketplace to become crowded.
+
+Source checked: https://mcpmarket.com/sell-skills
+
+## Primary Offer
+
+- Listing name: ThumbGate Agent Failure Firewall
+- Category: Developer Tools / AI Agent Governance
+- Buyer: solo developers, staff engineers, platform teams, and AI consultancies running coding agents
+- Promise: turn repeated AI-agent mistakes into local pre-action checks before the next tool call runs
+- Price test: $49 one-time skill pack, with Pro upsell at $19/mo or $149/yr
+- Team path: workflow hardening sprint for buyers with one repeated production-risk workflow and an accountable owner
+- Fulfillment: existing ThumbGate CLI, MCP server, and skills; no custom consulting required for the first purchase
+
+## What Buyers Get
+
+1. ThumbGate Doctor Skill
+   - Checks whether MCP, hooks, lesson storage, and runtime enforcement are actually wired.
+   - Best for buyers asking, "Are my agent guardrails installed correctly?"
+
+2. ThumbGate Guard Skill
+   - Captures a repeated mistake and promotes it into a prevention rule.
+   - Best for buyers asking, "How do I stop my agent from doing that again?"
+
+3. ThumbGate Protect Skill
+   - Shows branch/release governance and grants narrow, expiring approvals only when explicitly requested.
+   - Best for teams that need exceptions without disabling the guardrail system.
+
+4. Evidence-First Answer Skill
+   - Forces status claims, file references, and completion claims to be backed by proof.
+   - Best for buyers who have been burned by "done" claims that were not verified.
+
+## Listing Copy
+
+### Short Description
+
+Stop AI coding agents from repeating the same dangerous tool mistake. ThumbGate packages local-first feedback memory, MCP wiring checks, and pre-action governance into installable Agent Skills.
+
+### Long Description
+
+ThumbGate Agent Failure Firewall gives developers a practical control layer for Claude, ChatGPT, Codex, Cursor, and MCP-compatible coding agents. Instead of relying on static prompt rules, the skill pack helps agents check whether ThumbGate is wired, capture explicit thumbs-up/down feedback, convert repeated failures into prevention rules, and require evidence before claiming a task is finished.
+
+Use it when your agent keeps making the same mistake: force-pushing before review, editing protected files without scope, claiming "all green" without test output, skipping checkout verification, or ignoring prior feedback. ThumbGate keeps the enforcement local-first and action-oriented: the valuable unit is not another memory note, it is a gate that fires before a risky action runs.
+
+### Proof Bullets
+
+- Works through the existing ThumbGate CLI and MCP server instead of a hosted black box.
+- Includes doctor/wiring checks so buyers can verify hooks and MCP are live.
+- Turns explicit feedback into durable prevention rules and audit-friendly evidence.
+- Fits Claude, ChatGPT, Codex, Cursor, and other MCP-compatible agent workflows.
+- Keeps Pro upsell separate from the paid skill pack: buy the skill, then upgrade if unlimited local enforcement is valuable.
+
+### Buyer Pain Bullets
+
+- "My agent says it verified things, but it did not."
+- "The same bad command or edit keeps happening."
+- "We need exceptions without turning off governance."
+- "Our agent memory is full of lessons that never become enforcement."
+- "We need local guardrails before tools run, not just logs after damage."
+
+## Submission Fields
+
+- Product URL: https://thumbgate.ai
+- Docs URL: https://github.com/IgorGanapolsky/ThumbGate/tree/main/skills
+- Install URL: https://thumbgate.ai/go/pro?utm_source=mcpmarket&utm_medium=skill_listing&utm_campaign=agent_failure_firewall&utm_content=install
+- Proof URL: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md
+- Support URL: https://github.com/IgorGanapolsky/ThumbGate/issues
+- Repository URL: https://github.com/IgorGanapolsky/ThumbGate
+
+## Tracked CTAs
+
+- Listing install: https://thumbgate.ai/go/pro?utm_source=mcpmarket&utm_medium=skill_listing&utm_campaign=agent_failure_firewall&utm_content=install&cta_id=mcpmarket_skill_install
+- Pro upgrade: https://thumbgate.ai/checkout/pro?utm_source=mcpmarket&utm_medium=skill_listing&utm_campaign=agent_failure_firewall&utm_content=pro_upgrade&cta_id=mcpmarket_skill_pro
+- Workflow sprint: https://thumbgate.ai/?utm_source=mcpmarket&utm_medium=skill_listing&utm_campaign=agent_failure_firewall&utm_content=workflow_sprint&cta_id=mcpmarket_skill_sprint#workflow-sprint-intake
+
+## Early Access Submission Note
+
+Hi MCPMarket team,
+
+I would like to list ThumbGate Agent Failure Firewall as an early paid Agent Skill bundle. It helps developers running Claude, ChatGPT, Codex, Cursor, and MCP-compatible coding agents convert explicit feedback into local pre-action gates, verify MCP/hook wiring, and enforce evidence-first completion claims.
+
+The core buyer pain is repeated agent failure: the same risky command, file edit, checkout mistake, or false "done" claim keeps recurring because normal memory and prompt rules do not block actions before they run. ThumbGate packages doctor, guard, protect, and evidence-first skills around an existing open-source MCP/CLI runtime so buyers can verify the system locally.
+
+Listing draft: https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/marketing/mcpmarket-seller-pack.md
+Product: https://thumbgate.ai
+Repo: https://github.com/IgorGanapolsky/ThumbGate
+
+## Operator Queue
+
+1. Submit early access with the note above.
+2. Post one LinkedIn/X thread: "Agent skills should not just remember mistakes; they should block the repeat before the next tool call."
+3. DM MCP/agent developers who publish skills: offer a free wiring audit and point them to the paid pack when they name one repeated failure.
+4. Track `utm_source=mcpmarket` visits, checkout starts, and sprint intake submissions.
+5. If any buyer asks for marketplace-native packaging, convert `skills/thumbgate-doctor`, `skills/thumbgate-guard`, `skills/thumbgate-protect`, and `.claude/skills/evidence-first-answer` into the exact MCPMarket upload format once MCPMarket publishes it.
+
+## Guardrails
+
+- Do not claim MCPMarket approval until it is granted.
+- Do not claim marketplace revenue until Stripe or marketplace payout evidence exists.
+- Do not promise hosted enforcement; position ThumbGate as local-first with paid Pro and sprint upsells.
+- Do not give away private-core implementation details in the listing.


### PR DESCRIPTION
## Summary
- Add MCPMarket early-access seller pack for ThumbGate Agent Failure Firewall
- Include marketplace listing copy, pricing test, tracked CTAs, operator queue, and guardrails
- Add machine-readable listing JSON tied to existing skill paths

## Verification
- Parsed docs/channels/mcpmarket-seller-pack.json with Node
- Verified all referenced skill paths exist
- git diff --check