### PR TITLE
Add Headroom and sovereign coding model guardrail pages

### DIFF
--- a/.changeset/context-compression-sovereign-guardrails.md
+++ b/.changeset/context-compression-sovereign-guardrails.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add public Headroom context-compression and sovereign coding model guardrail guides, plus LLM discovery links, so buyers comparing token compression or local coding models can find ThumbGate's pre-action enforcement layer.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -64,6 +64,8 @@ npx thumbgate init --agent claude-code
 - Agent discovery: https://thumbgate.ai/.well-known/mcp.json
 - Progressive tool index: https://thumbgate.ai/.well-known/mcp/tools.json
 - Context footprint report: https://thumbgate.ai/.well-known/mcp/footprint.json
+- Headroom context compression guardrails: https://thumbgate.ai/guides/headroom-context-compression-guardrails
+- Sovereign coding model guardrails: https://thumbgate.ai/guides/sovereign-coding-model-guardrails
 - Agentic web governance: https://thumbgate.ai/guides/agentic-web-governance
 - AI Mode ads and agent governance: https://thumbgate.ai/guides/ai-mode-ads-agent-governance
 - MCP tool governance: https://thumbgate.ai/guides/mcp-tool-governance

--- a/public/guides/headroom-context-compression-guardrails.html
+++ b/public/guides/headroom-context-compression-guardrails.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Headroom Guardrails | Context Compression Is Not Governance</title>
+  <meta name="description" content="Headroom compresses agent context before it reaches the LLM. ThumbGate complements that by gating risky tool calls, file edits, deploys, and proof claims before they execute." />
+  <meta property="og:title" content="Headroom Guardrails | Context Compression Is Not Governance" />
+  <meta property="og:description" content="Headroom compresses agent context before it reaches the LLM. ThumbGate complements that by gating risky tool calls, file edits, deploys, and proof claims before they execute." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/headroom-context-compression-guardrails" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/headroom-context-compression-guardrails" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
+  <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#151518; --line:#29292f; --text:#ececf1; --muted:#a0a0aa; --cyan:#22d3ee; --green:#4ade80; }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:var(--bg); color:var(--text); line-height:1.65; }
+    a { color:var(--cyan); text-decoration:none; } a:hover { text-decoration:underline; }
+    .wrap { max-width:1040px; margin:0 auto; padding:0 24px; }
+    header { border-bottom:1px solid var(--line); background:rgba(10,10,11,.9); position:sticky; top:0; z-index:2; }
+    header .wrap { display:flex; justify-content:space-between; align-items:center; padding-top:14px; padding-bottom:14px; }
+    .brand { color:var(--text); font-weight:800; }
+    .hero { padding:70px 0 34px; }
+    .eyebrow { color:var(--cyan); text-transform:uppercase; font-size:12px; font-weight:800; letter-spacing:.08em; }
+    h1 { font-size:clamp(34px,5vw,58px); line-height:1.05; max-width:820px; margin:14px 0; }
+    .lead { color:var(--muted); font-size:18px; max-width:760px; }
+    .grid { display:grid; grid-template-columns:minmax(0,2fr) minmax(280px,1fr); gap:22px; padding-bottom:72px; }
+    section, aside > div { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:22px; margin-bottom:18px; }
+    h2 { margin:0 0 10px; font-size:24px; }
+    p, li { color:var(--muted); }
+    .cta { display:inline-flex; margin-top:12px; padding:12px 15px; border-radius:10px; background:var(--cyan); color:#051014; font-weight:800; }
+    .offer { display:block; border:1px solid rgba(74,222,128,.34); border-radius:10px; padding:12px; margin-top:10px; color:var(--text); }
+    .offer strong { color:var(--green); }
+    @media (max-width: 860px) { .grid { grid-template-columns:1fr; } }
+  </style>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Headroom Context Compression Guardrails",
+  "description": "Headroom compresses agent context before it reaches the LLM. ThumbGate complements that by gating risky tool calls, file edits, deploys, and proof claims before they execute.",
+  "about": ["Headroom", "context compression", "AI agent governance", "token compression", "pre-action checks"],
+  "url": "https://thumbgate.ai/guides/headroom-context-compression-guardrails",
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
+  "mainEntityOfPage": "https://thumbgate.ai/guides/headroom-context-compression-guardrails"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Headroom a ThumbGate competitor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Headroom is competitor-adjacent, not a direct replacement. It compresses context before the LLM. ThumbGate gates actions before tools, files, deploys, payments, and completion claims execute."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should teams use compression without governance?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Compression can reduce token cost and noise, but it can also hide missing evidence. Risky actions still need pre-action checks, proof requirements, and rollback evidence."
+      }
+    }
+  ]
+}
+  </script>
+</head>
+<body>
+  <header><div class="wrap"><a class="brand" href="/">ThumbGate</a><a href="/pricing">Pro $19/mo or $149/yr. Enterprise for org-wide enforcement.</a></div></header>
+  <main class="wrap">
+    <div class="hero">
+      <div class="eyebrow">Context Compression Guardrails</div>
+      <h1>Headroom can reduce tokens. It still needs an action firewall.</h1>
+      <p class="lead">Headroom's useful idea is compressing tool outputs, logs, files, RAG chunks, and conversation history before they reach the LLM. ThumbGate's job starts where compression stops: blocking risky agent actions before they run.</p>
+    </div>
+    <div class="grid">
+      <div>
+        <section>
+          <h2>How this helps ThumbGate</h2>
+          <p>Headroom validates the same buyer pain we sell into: long-running coding agents get expensive, noisy, and confused. Our wedge is sharper: compression saves tokens; ThumbGate prevents the repeated mistake from executing.</p>
+          <ul>
+            <li>Use Headroom-style compression as an optional context budget lane.</li>
+            <li>Require ThumbGate proof before trusting compressed outputs for deploy, billing, file, git, or database actions.</li>
+            <li>Position ThumbGate as complementary: the deterministic gate underneath compression, memory, and model-routing tools.</li>
+          </ul>
+        </section>
+        <section>
+          <h2>The risk in compressed context</h2>
+          <p>Compression can remove exactly the evidence an agent needs to avoid a false status claim. If logs, test output, or RAG chunks are summarized, the next tool call should be gated by proof requirements, not model confidence.</p>
+          <ul>
+            <li>Block "done", "verified", or "all green" claims unless test output or deployment evidence is attached.</li>
+            <li>Require original-context retrieval before destructive actions when the compressed view omits file paths, stack traces, secrets, or failing assertions.</li>
+            <li>Record compression ratio, original pointer, verifier result, and action decision in the audit trail.</li>
+          </ul>
+        </section>
+        <section>
+          <h2>Recommended architecture</h2>
+          <p>Run compression before model context assembly. Run ThumbGate before execution. That keeps token efficiency out of the enforcement hot path and prevents "cheap context" from becoming unsafe action.</p>
+          <ul>
+            <li>Context layer: Headroom or similar compressor cleans logs, files, and RAG chunks.</li>
+            <li>Reasoning layer: Claude, Codex, Cursor, OpenCode, or a local model proposes the next step.</li>
+            <li>Execution layer: ThumbGate checks the proposed shell, file, git, deploy, API, or customer-system action before it runs.</li>
+          </ul>
+        </section>
+      </div>
+      <aside>
+        <div>
+          <h2>Turn this into money</h2>
+          <p>Use this page when buyers ask about Headroom, token compression, context optimization, or cheaper coding agents.</p>
+          <a class="cta" href="/checkout/pro?utm_source=headroom_guide&utm_medium=guide&utm_campaign=context_compression_guardrails&utm_content=pro">Go Pro</a>
+          <a class="offer" href="/?utm_source=headroom_guide&utm_medium=guide&utm_campaign=context_compression_guardrails&utm_content=workflow_sprint#workflow-sprint-intake"><strong>Enterprise:</strong> scope one compressed-agent workflow and gate its risky actions.</a>
+        </div>
+        <div>
+          <h2>Related</h2>
+          <p><a href="/guides/reasoning-compression-guardrails">Reasoning compression guardrails</a></p>
+          <p><a href="/guides/long-running-agent-context-management">Long-running agent context management</a></p>
+          <p><a href="/guides/agent-context-governance">Agent context governance</a></p>
+        </div>
+      </aside>
+    </div>
+  </main>
+</body>
+</html>

--- a/public/guides/sovereign-coding-model-guardrails.html
+++ b/public/guides/sovereign-coding-model-guardrails.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sovereign Coding Model Guardrails | Local AI Still Needs Gates</title>
+  <meta name="description" content="Cohere North Mini Code and other sovereign coding models make local agent workflows more practical. ThumbGate gates local model tool calls before they touch files, terminals, deploys, or production systems." />
+  <meta property="og:title" content="Sovereign Coding Model Guardrails | Local AI Still Needs Gates" />
+  <meta property="og:description" content="Cohere North Mini Code and other sovereign coding models make local agent workflows more practical. ThumbGate gates local model tool calls before they touch files, terminals, deploys, or production systems." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://thumbgate.ai/guides/sovereign-coding-model-guardrails" />
+  <link rel="canonical" href="https://thumbgate.ai/guides/sovereign-coding-model-guardrails" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
+  <link rel="icon" type="image/svg+xml" href="/thumbgate-icon.png" />
+  <style>
+    :root { --bg:#0a0a0b; --panel:#151518; --line:#29292f; --text:#ececf1; --muted:#a0a0aa; --cyan:#22d3ee; --green:#4ade80; }
+    * { box-sizing:border-box; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:var(--bg); color:var(--text); line-height:1.65; }
+    a { color:var(--cyan); text-decoration:none; } a:hover { text-decoration:underline; }
+    .wrap { max-width:1040px; margin:0 auto; padding:0 24px; }
+    header { border-bottom:1px solid var(--line); background:rgba(10,10,11,.9); position:sticky; top:0; z-index:2; }
+    header .wrap { display:flex; justify-content:space-between; align-items:center; padding-top:14px; padding-bottom:14px; }
+    .brand { color:var(--text); font-weight:800; }
+    .hero { padding:70px 0 34px; }
+    .eyebrow { color:var(--cyan); text-transform:uppercase; font-size:12px; font-weight:800; letter-spacing:.08em; }
+    h1 { font-size:clamp(34px,5vw,58px); line-height:1.05; max-width:820px; margin:14px 0; }
+    .lead { color:var(--muted); font-size:18px; max-width:760px; }
+    .grid { display:grid; grid-template-columns:minmax(0,2fr) minmax(280px,1fr); gap:22px; padding-bottom:72px; }
+    section, aside > div { background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:22px; margin-bottom:18px; }
+    h2 { margin:0 0 10px; font-size:24px; }
+    p, li { color:var(--muted); }
+    .cta { display:inline-flex; margin-top:12px; padding:12px 15px; border-radius:10px; background:var(--cyan); color:#051014; font-weight:800; }
+    .offer { display:block; border:1px solid rgba(74,222,128,.34); border-radius:10px; padding:12px; margin-top:10px; color:var(--text); }
+    .offer strong { color:var(--green); }
+    @media (max-width: 860px) { .grid { grid-template-columns:1fr; } }
+  </style>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "Sovereign Coding Model Guardrails for Local AI Agents",
+  "description": "Cohere North Mini Code and other sovereign coding models make local agent workflows more practical. ThumbGate gates local model tool calls before they touch files, terminals, deploys, or production systems.",
+  "about": ["Cohere North Mini Code", "sovereign AI", "local coding agents", "OpenCode", "pre-action checks"],
+  "url": "https://thumbgate.ai/guides/sovereign-coding-model-guardrails",
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
+  "mainEntityOfPage": "https://thumbgate.ai/guides/sovereign-coding-model-guardrails"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Do local coding models remove the need for agent governance?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Local and sovereign coding models reduce vendor dependency and can improve cost control, but they still propose shell commands, file edits, deploys, and API calls that need pre-action checks."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where should ThumbGate sit with Cohere North Mini Code or OpenCode?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ThumbGate should sit at the execution boundary: after the local model proposes an action and before the terminal, file system, git remote, deployment target, payment system, or production connector receives it."
+      }
+    }
+  ]
+}
+  </script>
+</head>
+<body>
+  <header><div class="wrap"><a class="brand" href="/">ThumbGate</a><a href="/pricing">Pro $19/mo or $149/yr. Enterprise for org-wide enforcement.</a></div></header>
+  <main class="wrap">
+    <div class="hero">
+      <div class="eyebrow">Sovereign Coding Model Guardrails</div>
+      <h1>Local coding models are cheaper to run. They are not safer by default.</h1>
+      <p class="lead">Cohere North Mini Code makes sovereign, on-prem, and local coding agents more credible. That increases the need for local enforcement: ThumbGate checks what the agent is about to do before it touches your machine or production systems.</p>
+    </div>
+    <div class="grid">
+      <div>
+        <section>
+          <h2>Why North Mini Code helps the market</h2>
+          <p>Cohere's North Mini Code is positioned for agentic coding, terminal tasks, long context, local deployment, and OpenCode-style workflows. That means more teams will run capable coding agents outside hosted SaaS control planes.</p>
+          <ul>
+            <li>More local agents means more local tool calls.</li>
+            <li>More terminal automation means more blast radius.</li>
+            <li>More sovereign deployment means teams need local proof and audit trails.</li>
+          </ul>
+        </section>
+        <section>
+          <h2>The governance gap</h2>
+          <p>A model can be open-source, efficient, and on-prem while still generating an unsafe command. The question is not only "where do the weights run?" It is "what happens before the action executes?"</p>
+          <ul>
+            <li>Gate shell commands before they run.</li>
+            <li>Gate file writes before protected paths change.</li>
+            <li>Gate deploy, publish, payment, and production connector actions before they leave the machine.</li>
+            <li>Gate completion claims before humans trust the summary.</li>
+          </ul>
+        </section>
+        <section>
+          <h2>Recommended architecture</h2>
+          <p>Keep local models and local governance separate. Use North Mini Code, OpenCode, vLLM, or other self-hosted runtimes for generation. Use ThumbGate for deterministic pre-action enforcement.</p>
+          <ul>
+            <li>Model lane: fast local coding and terminal reasoning.</li>
+            <li>Context lane: optional compression or retrieval for long sessions.</li>
+            <li>Governance lane: ThumbGate blocks repeated mistakes and requires evidence before risky execution.</li>
+          </ul>
+        </section>
+      </div>
+      <aside>
+        <div>
+          <h2>Buyer path</h2>
+          <p>Use this page for teams adopting Cohere North Mini Code, OpenCode, vLLM, on-prem coding agents, or sovereign AI developer stacks.</p>
+          <a class="cta" href="/checkout/pro?utm_source=cohere_north_guide&utm_medium=guide&utm_campaign=sovereign_coding_guardrails&utm_content=pro">Go Pro</a>
+          <a class="offer" href="/?utm_source=cohere_north_guide&utm_medium=guide&utm_campaign=sovereign_coding_guardrails&utm_content=workflow_sprint#workflow-sprint-intake"><strong>Enterprise:</strong> harden one local-agent workflow before rollout.</a>
+        </div>
+        <div>
+          <h2>Related</h2>
+          <p><a href="/guides/vllm-serving-guardrails">vLLM serving guardrails</a></p>
+          <p><a href="/guides/codex-cli-guardrails">Codex CLI guardrails</a></p>
+          <p><a href="/guides/headroom-context-compression-guardrails">Headroom context compression guardrails</a></p>
+        </div>
+      </aside>
+    </div>
+  </main>
+</body>
+</html>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -41,6 +41,10 @@ ThumbGate is built on Node.js >=18.18.0 and runs locally on each developer's mac
 
 **vLLM Serving Guardrails**: vLLM validates demand for high-throughput self-hosted inference through PagedAttention, continuous batching, chunked prefill, prefix caching, broad Hugging Face model support, and optimized kernels. ThumbGate should not move deterministic PreToolUse checks into the model-serving batch. Its wedge is runtime rollout governance: require p95 latency, queue-time, cache-isolation, benchmark, model-compatibility, and rollback proof before agent traffic routes through a vLLM lane.
 
+**Headroom Context Compression Guardrails**: Headroom validates demand for token and context compression around tool outputs, logs, files, RAG chunks, code search results, and conversation history. ThumbGate's position is complementary: compression reduces context cost, but pre-action checks still govern shell commands, file writes, git operations, deploys, payment actions, API calls, and completion claims before execution. Compressed context should carry original pointers, verifier evidence, and rollback receipts before risky actions proceed.
+
+**Sovereign Coding Model Guardrails**: Cohere North Mini Code and similar local or on-prem coding models make sovereign developer agents more practical, especially inside OpenCode, vLLM, and terminal-based workflows. Local weights reduce vendor dependency, but they do not make generated actions safe by default. ThumbGate sits at the execution boundary: after the model proposes an action and before the terminal, file system, git remote, deployment target, payment system, or production connector receives it.
+
 **Audit Trail**: Every check decision (blocked, approved, overridden) is logged with a timestamp, the triggering tool call, the matching lesson ID, and the identity of any human who approved an exception. This log is queryable and exportable for compliance reporting.
 
 **Browser Bridge Audit**: `npx thumbgate native-messaging-audit` inspects local browser native messaging manifests, allowed extension origins, missing host binaries, and dormant AI browser bridges so teams can review connector scope before an agent turns a one-off install into a durable local integration.
@@ -256,6 +260,8 @@ npx thumbgate dashboard --open
 - AI search topical presence guide: https://thumbgate.ai/guides/ai-search-topical-presence
 - Agentic web governance guide: https://thumbgate.ai/guides/agentic-web-governance
 - GPT-5.5 model evaluation guide: https://thumbgate.ai/guides/gpt-5-5-model-evaluation
+- Headroom context compression guardrails guide: https://thumbgate.ai/guides/headroom-context-compression-guardrails
+- Sovereign coding model guardrails guide: https://thumbgate.ai/guides/sovereign-coding-model-guardrails
 - vLLM serving guardrails guide: https://thumbgate.ai/guides/vllm-serving-guardrails
 - Best tools to stop AI agents from breaking production: https://thumbgate.ai/guides/best-tools-stop-ai-agents-breaking-production
 - Relational knowledge guide: https://thumbgate.ai/guides/relational-knowledge-ai-recommendations

--- a/tests/seo-guides.test.js
+++ b/tests/seo-guides.test.js
@@ -22,7 +22,9 @@ const GUIDE_FILES = [
   'guides/claude-code-skills-guardrails.html',
   'guides/long-running-agent-context-management.html',
   'guides/reasoning-compression-guardrails.html',
+  'guides/headroom-context-compression-guardrails.html',
   'guides/deepseek-v4-runtime-guardrails.html',
+  'guides/sovereign-coding-model-guardrails.html',
   'guides/vllm-serving-guardrails.html',
   'guides/background-agent-governance.html',
   'guides/ai-agent-workflow-migration-checklist.html',
@@ -350,6 +352,34 @@ describe('SEO guide and comparison pages', () => {
     assert.ok(contextGuide.includes('Director journals'));
     assert.ok(reasoningGuide.includes('npx thumbgate reasoning-efficiency-guardrails'));
     assert.ok(reasoningGuide.includes('Step-Level Verifier Checks'));
+  });
+
+  it('Headroom context compression guide positions compression as complementary to enforcement', () => {
+    const html = fs.readFileSync(
+      path.join(PUBLIC_DIR, 'guides/headroom-context-compression-guardrails.html'),
+      'utf-8'
+    );
+
+    assert.ok(html.includes('Headroom can reduce tokens'));
+    assert.ok(html.includes('Context Compression Is Not Governance'));
+    assert.ok(html.includes('compression saves tokens; ThumbGate prevents the repeated mistake from executing'));
+    assert.ok(html.includes('Run compression before model context assembly. Run ThumbGate before execution.'));
+    assert.ok(html.includes('utm_source=headroom_guide'));
+    assert.ok(html.includes('Pro $19/mo or $149/yr. Enterprise for org-wide enforcement.'));
+  });
+
+  it('sovereign coding model guide routes Cohere North Mini Code demand into local gates', () => {
+    const html = fs.readFileSync(
+      path.join(PUBLIC_DIR, 'guides/sovereign-coding-model-guardrails.html'),
+      'utf-8'
+    );
+
+    assert.ok(html.includes('Sovereign Coding Model Guardrails'));
+    assert.ok(html.includes('Cohere North Mini Code'));
+    assert.ok(html.includes('Local coding models are cheaper to run. They are not safer by default.'));
+    assert.ok(html.includes('Use North Mini Code, OpenCode, vLLM, or other self-hosted runtimes for generation. Use ThumbGate for deterministic pre-action enforcement.'));
+    assert.ok(html.includes('utm_source=cohere_north_guide'));
+    assert.ok(html.includes('Pro $19/mo or $149/yr. Enterprise for org-wide enforcement.'));
   });
 
   it('DeepSeek V4 runtime guide exposes sparse-attention guardrails', () => {


### PR DESCRIPTION
## Summary
- add a Headroom context-compression guide that positions compression as complementary to ThumbGate pre-action enforcement
- add a sovereign coding model guide for Cohere North Mini Code / local coding-agent demand
- expose both pages in llms.txt and public LLM context, with SEO regression tests

## Verification
- node --test tests/seo-guides.test.js tests/public-static-assets.test.js tests/positioning-contract.test.js
- git diff --check
- focused credential scan over changed files