### PR TITLE
revert(brand): restore original TG gate monogram logo to match Stripe

### DIFF
--- a/.changeset/revert-brand-logo-to-monogram.md
+++ b/.changeset/revert-brand-logo-to-monogram.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Revert the brand logo assets to the original TG gate monogram design to align with the branding displayed on Stripe checkout pages.

--- a/public/assets/brand/thumbgate-logo-transparent.svg
+++ b/public/assets/brand/thumbgate-logo-transparent.svg
@@ -13,14 +13,17 @@
   <g filter="url(#tg-logo-transparent-glow)">
     <rect x="66" y="66" width="228" height="228" rx="54" fill="#061015" fill-opacity="0.78"/>
     <g transform="translate(66, 66) scale(3.5625)">
-      <!-- Outer Shield / Gate -->
-      <path d="M32 9 C20 13 15 20 15 33 C15 45 26 53 32 56 C38 53 49 45 49 33 C49 20 44 13 32 9 Z" 
-            fill="#0b1820" stroke="url(#tg-logo-transparent-frame)" stroke-width="3.5" stroke-linejoin="round"/>
-            
-      <!-- Proportional Thumbs Up -->
-      <g transform="translate(19, 17) scale(1.1)" stroke="#8cf5d1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
-        <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
-      </g>
+      <!-- Outer Gate Frame (Transparent background) -->
+      <rect x="9" y="9" width="46" height="46" rx="12" fill="none" stroke="url(#tg-logo-transparent-frame)" stroke-width="3"/>
+      
+      <!-- Gate Arch -->
+      <path d="M19 44V25c0-5.5 4.5-10 10-10h6c5.5 0 10 4.5 10 10v19" fill="none" stroke="#8cf5d1" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+      
+      <!-- TG Monogram -->
+      <text x="32" y="39" text-anchor="middle" fill="#e7fbff" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif" font-size="19" font-weight="900">TG</text>
+      
+      <!-- Bottom Bar -->
+      <rect x="18" y="44" width="28" height="4" rx="2" fill="#22d3ee"/>
     </g>
   </g>
   <text x="340" y="178" fill="#f4fdff" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif" font-size="82" font-weight="900">ThumbGate</text>

--- a/public/assets/brand/thumbgate-mark-inline-v2.svg
+++ b/public/assets/brand/thumbgate-mark-inline-v2.svg
@@ -1,18 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="tg-inline-title tg-inline-desc">
   <title id="tg-inline-title">ThumbGate</title>
-  <desc id="tg-inline-desc">ThumbGate premium shield and thumbs-up mark for inline use in site headers.</desc>
+  <desc id="tg-inline-desc">ThumbGate TG gate monogram, transparent background for inline use in site headers.</desc>
   <defs>
     <linearGradient id="tg-inline-frame" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#8cf5d1"/>
       <stop offset="1" stop-color="#22d3ee"/>
     </linearGradient>
   </defs>
-  <!-- Outer Shield / Gate (Transparent background fill, thicker gradient frame) -->
-  <path d="M32 9 C20 13 15 20 15 33 C15 45 26 53 32 56 C38 53 49 45 49 33 C49 20 44 13 32 9 Z" 
-        fill="none" stroke="url(#tg-inline-frame)" stroke-width="4.5" stroke-linejoin="round"/>
-        
-  <!-- Proportional Thumbs Up in Center (Enlarged and Bolder for high-contrast header visibility) -->
-  <g transform="translate(17, 16) scale(1.25)" stroke="#8cf5d1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none">
-    <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
-  </g>
+  <!-- Transparent clean outer frame using the gradient stroke -->
+  <rect x="9" y="9" width="46" height="46" rx="12" fill="none" stroke="url(#tg-inline-frame)" stroke-width="3"/>
+  
+  <!-- Gate Arch -->
+  <path d="M19 44V25c0-5.5 4.5-10 10-10h6c5.5 0 10 4.5 10 10v19" fill="none" stroke="#8cf5d1" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+  
+  <!-- TG Monogram -->
+  <text x="32" y="39" text-anchor="middle" fill="#e7fbff" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif" font-size="19" font-weight="900">TG</text>
+  
+  <!-- Bottom Bar -->
+  <rect x="18" y="44" width="28" height="4" rx="2" fill="#22d3ee"/>
 </svg>

--- a/public/assets/brand/thumbgate-mark.svg
+++ b/public/assets/brand/thumbgate-mark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
   <title id="title">ThumbGate mark</title>
-  <desc id="desc">A crisp shield and thumbs-up mark for ThumbGate.</desc>
+  <desc id="desc">A crisp TG gate monogram for ThumbGate.</desc>
   <defs>
     <linearGradient id="tg-frame" x1="96" y1="96" x2="416" y2="416" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#8cf5d1"/>
@@ -8,14 +8,8 @@
     </linearGradient>
   </defs>
   <rect width="512" height="512" rx="112" fill="#061015"/>
-  <g transform="translate(78, 78) scale(5.5625)">
-    <!-- Outer Shield / Gate -->
-    <path d="M32 9 C20 13 15 20 15 33 C15 45 26 53 32 56 C38 53 49 45 49 33 C49 20 44 13 32 9 Z" 
-          fill="#0b1820" stroke="url(#tg-frame)" stroke-width="3.5" stroke-linejoin="round"/>
-          
-    <!-- Proportional Thumbs Up -->
-    <g transform="translate(19, 17) scale(1.1)" stroke="#8cf5d1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
-      <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
-    </g>
-  </g>
+  <rect x="78" y="78" width="356" height="356" rx="84" fill="#0b1820" stroke="url(#tg-frame)" stroke-width="18"/>
+  <path d="M146 354V192c0-36 29-65 65-65h90c36 0 65 29 65 65v162" fill="none" stroke="#8cf5d1" stroke-width="28" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="256" y="310" text-anchor="middle" fill="#e7fbff" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif" font-size="132" font-weight="900" letter-spacing="-8">TG</text>
+  <rect x="140" y="344" width="232" height="28" rx="14" fill="#22d3ee"/>
 </svg>

--- a/tests/brand-assets.test.js
+++ b/tests/brand-assets.test.js
@@ -31,8 +31,8 @@ test('ThumbGate inline mark SVG exists with transparent backdrop for header use'
   const svg = fs.readFileSync(inlineMarkPath, 'utf8');
   assert.match(svg, /<svg/);
   assert.match(svg, /viewBox="0 0 \d+ \d+"/);
-  assert.match(svg, /stroke="#8cf5d1"/, 'inline mark must stroke with standard color');
-  assert.match(svg, /premium shield and thumbs-up mark/, 'inline mark accessible description should name the premium shield and thumbs-up');
+  assert.match(svg, />TG</, 'inline mark must render the TG monogram in header-sized contexts');
+  assert.match(svg, /TG gate monogram/, 'inline mark accessible description should name the TG gate monogram');
   assert.match(svg, /<\/svg>/);
   assert.doesNotMatch(svg, /gate-and-signal|signal sweep|Status LEDs/i);
   // Guard: inline mark must NOT contain a full-canvas opaque rounded-rect tile. That tile


### PR DESCRIPTION
Restores the brand logo SVGs to the TG monogram format to match the Stripe checkout pages branding. Also adds a changeset.