### PR TITLE
ci: make test suite hermetic against the npm-registry publish probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,14 @@ jobs:
 
       - name: Run tests
         if: steps.ci-scope.outputs.mode != 'web'
+        # Hermetic suite: short-circuit the npm-registry publish probe in
+        # scripts/mcp-config.js (isVersionPublished -> `npm view thumbgate@<v>`),
+        # which several CLI/statusline tests exercise indirectly. Without this,
+        # the suite depends on npm-registry reachability and intermittently
+        # stalls in CI. The probe and its 5s timeout stay intact for real users.
+        env:
+          THUMBGATE_PUBLISH_STATE: unpublished
+          THUMBGATE_PUBLISHED_CLI_STATE: unavailable
         run: npm test
 
       - name: Run gate-eval regression suite
@@ -166,6 +174,10 @@ jobs:
 
       - name: Run coverage
         if: steps.ci-scope.outputs.mode != 'web'
+        # Same hermetic override as "Run tests" — coverage re-runs the suite.
+        env:
+          THUMBGATE_PUBLISH_STATE: unpublished
+          THUMBGATE_PUBLISHED_CLI_STATE: unavailable
         run: npm run test:coverage
 
       - name: Check congruence (branding, tech stack, version across all surfaces)


### PR DESCRIPTION
## Problem
`main` CI was red — run [28113154974](https://github.com/IgorGanapolsky/ThumbGate/actions/runs/28113154974) failed on the **Run tests** step. Every subtest showed `# fail 0` (no assertion failures); the failure signature was orphaned `npm view thumbgate@1.27.15 version` / `npm run test:cli` processes being force-terminated.

**Re-running the same commit passed** ([rerun](https://github.com/IgorGanapolsky/ThumbGate/actions/runs/28113154974)) → the failure was flaky/environmental, not a regression.

## Root cause
`scripts/mcp-config.js` `isVersionPublished()` shells out to `npm view thumbgate@<version> version` when no publish-state override is set. Several `cli` / `statusline` / `install-shim` / `perplexity-command-center` tests exercise that path indirectly, so the suite depended on **npm-registry reachability** and stalled when the registry was slow.

The product code is fine — it already has a 5s timeout, a per-version cache, a graceful `try/catch` fallback, and the `THUMBGATE_PUBLISH_STATE` override. The only gap: the CI suite steps don't set the override, so tests hit the live registry.

## Fix
Set `THUMBGATE_PUBLISH_STATE=unpublished` / `THUMBGATE_PUBLISHED_CLI_STATE=unavailable` on the two suite-running steps (**Run tests**, **Run coverage**). This uses the existing override to skip the network probe deterministically. The in-dev version is genuinely unpublished, so this matches the real result **and** the local-source MCP entry the tests assert (`command = "node"`).

- Probe + its 5s timeout unchanged for real users.
- Live publish checks (`test:congruence:live`) untouched.
- `mcp-config.test.js` (which sets its own per-case override) unaffected.

## Verification
- `node --test cli mcp-config statusline install-shim perplexity-command-center` with the override → **147/147 pass, 0 fail**.
- An earlier attempt with `published`/`available` was caught failing `cli.test.js:2768` (it forced the published `sh` path), which is why the value is `unpublished`.
- `ci.yml` YAML validated; diff is the 2 env blocks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
