### PR TITLE
fix: require checkout email for recovery

### DIFF
--- a/.changeset/checkout-email-recovery-gate.md
+++ b/.changeset/checkout-email-recovery-gate.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Require a valid buyer email before creating Pro Stripe Checkout Sessions so abandoned checkouts keep a recoverable contact path instead of generating unpaid no-contact sessions.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2246,8 +2246,8 @@ a{display:block;text-decoration:none}a.secondary{border:1px solid #374151;color:
 <form action="/checkout/pro" method="GET" data-i="pro_checkout_confirmed">
 ${hiddenInputs}
 <input type="hidden" name="confirm" value="1">
-<input type="email" name="customer_email" value="${escapeHtmlAttribute(prefilledEmail)}" placeholder="you@company.com" autocomplete="email">
-<p class="email-note">Optional. Stripe can collect your email on the secure checkout page.</p>
+<input type="email" name="customer_email" value="${escapeHtmlAttribute(prefilledEmail)}" placeholder="you@company.com" autocomplete="email" required>
+<p class="email-note">Required for your Stripe receipt and checkout recovery link.</p>
 <button type="submit" class="primary">Pay $19/mo with Stripe →</button>
 </form>
 <a class="secondary" data-i="workflow_sprint_intake" href="/#workflow-sprint-intake">Not sure yet? Send the workflow first</a>
@@ -6021,16 +6021,25 @@ async function addContext(){
       // (form submission JS-less bots don't do), (b) a `customer_email`
       // query param treats the request as confirmed even from a bot UA,
       // because no real crawler appends customer_email to discovered URLs.
+      const rawCheckoutEmail = normalizeNullableText(bootstrapBody.customerEmail);
+      const normalizedCheckoutEmail = normalizeCheckoutCustomerEmail(rawCheckoutEmail);
       const hasCustomerEmailHint = !!parsed?.searchParams?.has('customer_email');
-      const botShouldBypass = !botClassification.isBot || hasCustomerEmailHint;
+      const hasValidCustomerEmailHint = !!normalizedCheckoutEmail;
+      const botShouldBypass = !botClassification.isBot || hasValidCustomerEmailHint;
       // 2026-06-04 audit: after the POST-401 fix, 3 of 4 fresh /checkout/pro
       // sessions had customer_email=null in Stripe (zombie sessions with no
       // recovery surface). Root cause: POSTs were auto-confirmed regardless of
       // whether the email query param was present. Require email on POSTs too
       // so emails-less POSTs fall through to the interstitial form instead of
       // creating an un-recoverable Stripe session.
-      const isConfirmedCheckout = (req.method === 'POST' && hasCustomerEmailHint)
-        || (hasConfirmFlag && botShouldBypass);
+      //
+      // 2026-06-28 live Stripe audit: expired live Checkout Sessions still had
+      // customer_email=null, customer_details=null, and payment_status=unpaid.
+      // Stripe generated recovery URLs, but we had no contact surface for the
+      // buyer. Require a valid email before creating the Stripe Session.
+      const isConfirmedCheckout = ((req.method === 'POST') || hasConfirmFlag)
+        && botShouldBypass
+        && hasValidCustomerEmailHint;
       // 2026-06-05 revenue bypass: env-gated direct-to-Stripe redirect.
       // Live 30d billing showed 254 interstitial views → 1 Stripe click-through
       // → 0 paid. When THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS=1 is set we
@@ -6124,6 +6133,7 @@ async function addContext(){
         const eventType = botClassification.isBot
           ? 'checkout_bot_deflected'
           : 'checkout_interstitial_view';
+        const missingConfirmedEmail = hasConfirmFlag && !hasValidCustomerEmailHint;
         appendBestEffortTelemetry(FEEDBACK_DIR, {
           eventType,
           clientType: 'web',
@@ -6147,7 +6157,10 @@ async function addContext(){
           isBot: botClassification.isBot ? 'true' : 'false',
           interstitialSampled: interstitialSampled ? 'true' : 'false',
           interstitialSampleRate,
-          reason: botClassification.reason,
+          reason: missingConfirmedEmail
+            ? (hasCustomerEmailHint ? 'invalid_customer_email' : 'missing_customer_email')
+            : botClassification.reason,
+          confirmEmailRequired: missingConfirmedEmail ? 'true' : 'false',
         }, req.headers, eventType);
         const prefilledEmail = parsed?.searchParams?.get('customer_email') || '';
         const html = renderCheckoutIntentPage(prefilledEmail, parsed, {
@@ -6157,19 +6170,7 @@ async function addContext(){
         return;
       }
 
-      const rawCheckoutEmail = normalizeNullableText(bootstrapBody.customerEmail);
-      const normalizedCheckoutEmail = normalizeCheckoutCustomerEmail(rawCheckoutEmail);
-      if (!normalizedCheckoutEmail) {
-        appendBestEffortTelemetry(FEEDBACK_DIR, {
-          eventType: 'checkout_email_deferred_to_stripe',
-          clientType: 'web',
-          traceId,
-          page: '/checkout/pro',
-          planId: analyticsMetadata.planId,
-          reason: rawCheckoutEmail ? 'invalid_customer_email' : 'missing_customer_email',
-        }, req.headers, 'checkout_email_deferred_to_stripe');
-      }
-      bootstrapBody.customerEmail = normalizedCheckoutEmail || undefined;
+      bootstrapBody.customerEmail = normalizedCheckoutEmail;
 
       appendBestEffortTelemetry(FEEDBACK_DIR, {
         eventType: 'checkout_bootstrap',

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1833,8 +1833,8 @@ test('checkout interstitial: GET without confirm=1 (human UA) renders the inters
   assert.doesNotMatch(body, /not_allowed/);
   assert.doesNotMatch(body, /<img src=x onerror=alert\(1\)>/);
   assert.doesNotMatch(body, /<svg onload=alert\(1\)>/);
-  assert.doesNotMatch(body, /name="customer_email"[^>]*required/, 'email should be optional because Stripe collects it');
-  assert.match(body, /Stripe can collect your email/);
+  assert.match(body, /name="customer_email"[^>]*required/, 'email is required before Stripe session creation so abandoned sessions remain recoverable');
+  assert.match(body, /Required for your Stripe receipt and checkout recovery link/);
   assert.match(body, /Not sure yet\? Send the workflow first/);
   assert.doesNotMatch(body, /Pay \$1 first rule/);
   assert.doesNotMatch(body, /Pay \$99 teardown/);

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -240,8 +240,8 @@ describe('/checkout/pro bot guard', () => {
     assert.match(body, /<form action="\/checkout\/pro"/);
     assert.match(body, /name="confirm" value="1"/);
     assert.match(body, /name="customer_email"/);
-    assert.doesNotMatch(body, /name="customer_email"[^>]*required/);
-    assert.match(body, /Stripe can collect your email/);
+    assert.match(body, /name="customer_email"[^>]*required/);
+    assert.match(body, /Required for your Stripe receipt and checkout recovery link/);
     assert.doesNotMatch(body, /<a[^>]+confirm=1/, 'confirm=1 must not be in a crawlable anchor');
   });
 
@@ -433,7 +433,7 @@ describe('/checkout/pro bot guard', () => {
     );
   });
 
-  it('lets confirmed real browsers proceed while Stripe collects the email', async () => {
+  it('keeps confirmed real browsers on the interstitial until email is captured', async () => {
     try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
     const res = await fetch(`${origin}/checkout/pro?confirm=1`, {
       redirect: 'manual',
@@ -442,17 +442,20 @@ describe('/checkout/pro bot guard', () => {
         accept: BROWSER_ACCEPT,
       },
     });
-    assert.ok(res.status >= 300 && res.status < 400, `expected checkout redirect, got ${res.status}`);
-    assert.match(res.headers.get('location') || '', /\/success\?/);
+    assert.equal(res.status, 200, `expected email interstitial, got ${res.status}`);
+    const body = await res.text();
+    assert.match(body, /Start ThumbGate Pro/);
+    assert.match(body, /name="customer_email"[^>]*required/);
 
     const events = readFunnelEvents();
     assert.ok(
-      events.some((e) => e.eventType === 'checkout_email_deferred_to_stripe'),
-      'missing email should be tracked as delegated to Stripe collection',
+      events.some((e) => e.eventType === 'checkout_interstitial_view' && e.reasonCode === 'missing_customer_email'),
+      'missing email should be tracked before creating a Stripe session',
     );
-    assert.ok(
-      events.some((e) => e.eventType === 'checkout_bootstrap'),
-      'confirmed browsers should create a checkout session without our email gate',
+    assert.equal(
+      events.filter((e) => e.eventType === 'checkout_bootstrap').length,
+      0,
+      'confirmed browsers without email must not create an unrecoverable checkout session',
     );
   });
 

--- a/tests/checkout-pro-confirmation-gate.test.js
+++ b/tests/checkout-pro-confirmation-gate.test.js
@@ -86,8 +86,8 @@ describe('/checkout/pro confirmation gate (closes 0/50 conversion leak)', () => 
     assert.match(body, /Start ThumbGate Pro/);
     assert.match(body, /Pay \$19\/mo with Stripe/);
     assert.match(body, /name="confirm" value="1"/, 'interstitial must include the confirm field as the primary CTA');
-    assert.doesNotMatch(body, /name="customer_email"[^>]*required/, 'email must be optional; Stripe should collect it if absent');
-    assert.match(body, /Stripe can collect your email/);
+    assert.match(body, /name="customer_email"[^>]*required/, 'email is required before Stripe session creation so abandoned sessions remain recoverable');
+    assert.match(body, /Required for your Stripe receipt and checkout recovery link/);
     assert.match(body, /Not sure yet\? Send the workflow first/);
     assert.doesNotMatch(body, /Pay \$1 first rule/);
     assert.doesNotMatch(body, /Pay \$99 teardown/);
@@ -108,23 +108,43 @@ describe('/checkout/pro confirmation gate (closes 0/50 conversion leak)', () => 
     );
   });
 
-  it('real-browser GET WITH ?confirm=1 → 302 toward checkout (preserves frictionless path for already-seen offer)', async () => {
+  it('real-browser GET WITH ?confirm=1 but no email → 200 interstitial, NO Stripe session created', async () => {
     clearTelemetry();
     const res = await fetch(`${origin}/checkout/pro?confirm=1`, {
       redirect: 'manual',
       headers: { 'user-agent': BROWSER_UA, accept: BROWSER_ACCEPT },
     });
-    assert.ok(res.status >= 300 && res.status < 400, `confirmed checkout must 302, got ${res.status}`);
-    const location = res.headers.get('location') || '';
+    assert.equal(res.status, 200, `confirmed checkout without email must render interstitial, got ${res.status}`);
+    const body = await res.text();
+    assert.match(body, /Start ThumbGate Pro/);
+    assert.match(body, /name="customer_email"[^>]*required/);
+
+    const events = readTelemetry();
     assert.ok(
-      /\/success\?/.test(location) || /checkout\.stripe\.com/.test(location),
-      `confirmed checkout must redirect to Stripe or success, got ${location}`,
+      events.some((e) => e.eventType === 'checkout_interstitial_view' && e.reasonCode === 'missing_customer_email'),
+      'missing email should be tracked before creating a Stripe session',
     );
+    assert.equal(
+      events.filter((e) => e.eventType === 'checkout_bootstrap').length,
+      0,
+      'confirm=1 without email must NOT create a Stripe session',
+    );
+  });
+
+  it('real-browser GET WITH ?confirm=1 and email → 302 toward checkout', async () => {
+    clearTelemetry();
+    const res = await fetch(`${origin}/checkout/pro?confirm=1&customer_email=buyer%40example.com`, {
+      redirect: 'manual',
+      headers: { 'user-agent': BROWSER_UA, accept: BROWSER_ACCEPT },
+    });
+    assert.ok(res.status >= 300 && res.status < 400, `confirmed checkout with email must 302, got ${res.status}`);
+    const location = res.headers.get('location') || '';
+    assert.ok(/\/success\?/.test(location) || /checkout\.stripe\.com/.test(location), `confirmed checkout must redirect to Stripe or success, got ${location}`);
 
     const events = readTelemetry();
     assert.ok(
       events.some((e) => e.eventType === 'checkout_bootstrap'),
-      'confirmed checkout should reach the bootstrap path',
+      'confirmed checkout with email should reach the bootstrap path',
     );
   });
 


### PR DESCRIPTION
## Summary
- require a valid `customer_email` before `/checkout/pro` creates a Stripe Checkout Session
- make the Pro checkout interstitial email field required and update copy to explain receipt/recovery
- keep `confirm=1&customer_email=...` as the fast path to Stripe, including for bot-safe explicit email cases
- add a patch changeset

## Stripe Evidence
- Stripe Workbench showed `checkout.session.expired` events with `amount_total=1900`, `payment_status=unpaid`, `status=expired`, and `customer_email=null` / `customer_details=null`.
- Stripe Shell read-only query `stripe checkout sessions list --limit=100 --status=expired` returned `data=[100 items]` and `has_more=true`, so there are at least 100 expired checkout sessions in the account.
- The first inspected event had `after_expiration.recovery.enabled=true` and a recovery URL, but no customer contact field.

## Verification
- PASS: `node --test tests/checkout-pro-confirmation-gate.test.js tests/checkout-bot-guard.test.js tests/api-server.test.js` (160 tests passed)
- PASS: `node --test tests/changeset-check.test.js` (15 tests passed)
- PASS: `git diff --check`
- PASS: pre-commit guards
- PASS: pre-push guards

## Known Blocker
- Full `npm test` is not green in this local environment: `tests/rate-limiter.test.js` has 3 pre-existing free-tier assertions failing because the local environment is treated as Pro/entitled. This also reproduces when running `node --test tests/rate-limiter.test.js` in isolation and is unrelated to the checkout email change.
