### PR TITLE
[codex] Reduce Pro checkout email friction

### DIFF
--- a/.changeset/checkout-email-optional-before-stripe.md
+++ b/.changeset/checkout-email-optional-before-stripe.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Reduce Pro checkout friction by letting confirmed human clicks reach Stripe without requiring an email on the ThumbGate interstitial, while keeping bot deflection and adding a revenue doctor guard for deployed required-email drift.

--- a/config/post-deploy-marketing-pages.json
+++ b/config/post-deploy-marketing-pages.json
@@ -13,6 +13,15 @@
       "description": "Pro landing page"
     },
     {
+      "route": "/checkout/pro",
+      "sentinel": "Optional. Stripe can collect your email on the secure checkout page.",
+      "mustNotContain": [
+        "Required for your Stripe receipt and checkout recovery link."
+      ],
+      "userAgent": "curl/8.0.0",
+      "description": "Pro checkout interstitial must not require email before Stripe"
+    },
+    {
       "route": "/dashboard",
       "sentinel": "ThumbGate Dashboard",
       "description": "Dashboard demo (already enforced by /dashboard step; included here for symmetry with PR comment surface)"

--- a/scripts/revenue-observability-doctor.js
+++ b/scripts/revenue-observability-doctor.js
@@ -119,10 +119,13 @@ async function probePublicFunnel({ appOrigin, fetchImpl = globalThis.fetch, time
     const rootSignals = parseHtmlSignals(root.text || '');
     const checkoutHasFocusedProCta = /Pay \$19\/mo with Stripe/.test(checkoutBody);
     const checkoutHasFallback = /Send the workflow first/.test(checkoutBody);
+    const checkoutHasEmailInput = /name=["']customer_email["']/i.test(checkoutBody);
+    const checkoutRequiresEmailBeforeStripe = /name=["']customer_email["'][^>]*\brequired\b/i.test(checkoutBody);
+    const checkoutEmailOptionalBeforeStripe = checkoutHasEmailInput && !checkoutRequiresEmailBeforeStripe;
     const checkoutLeaksServiceLinks = /https:\/\/buy\.stripe\.com\/|Pay \$1 first rule|Pay \$99 teardown|Book \$499 diagnostic|Start \$1500 sprint/.test(checkoutBody);
 
     return {
-      ok: root.ok && checkout.ok && checkoutHasFocusedProCta && checkoutHasFallback && !checkoutLeaksServiceLinks,
+      ok: root.ok && checkout.ok && checkoutHasFocusedProCta && checkoutHasFallback && checkoutEmailOptionalBeforeStripe && !checkoutLeaksServiceLinks,
       root: {
         status: root.status,
         ok: root.ok,
@@ -134,6 +137,9 @@ async function probePublicFunnel({ appOrigin, fetchImpl = globalThis.fetch, time
         ok: checkout.ok,
         focusedProCta: checkoutHasFocusedProCta,
         workflowFallback: checkoutHasFallback,
+        emailInputPresent: checkoutHasEmailInput,
+        emailOptionalBeforeStripe: checkoutEmailOptionalBeforeStripe,
+        requiresEmailBeforeStripe: checkoutRequiresEmailBeforeStripe,
         leaksServiceLinks: checkoutLeaksServiceLinks,
         plausibleDomains: extractPlausibleDataDomains(checkoutBody),
       },
@@ -229,6 +235,13 @@ async function buildRevenueObservabilityDoctor({
       'critical',
       'Public home, Pro interstitial, and confirmed checkout route must be healthy and focused.',
       publicFunnel
+    ),
+    buildCheck(
+      'checkout_email_optional_before_stripe',
+      publicFunnel.checkout?.emailOptionalBeforeStripe === true,
+      'critical',
+      'Pro checkout interstitial must not require email before Stripe; Stripe can collect email on the secure checkout page.',
+      publicFunnel.checkout || {}
     ),
   ];
 

--- a/scripts/verify-marketing-pages-deployed.js
+++ b/scripts/verify-marketing-pages-deployed.js
@@ -9,8 +9,9 @@
  * against the live production URL (default
  * https://thumbgate-production.up.railway.app, overridable via
  * THUMBGATE_PROD_URL env or --prod-url=…). Each response body must
- * contain the configured sentinel string. Any mismatch fails the run
- * and the route is included in the failure summary.
+ * contain the configured sentinel string and must not contain any configured
+ * `mustNotContain` strings. Any mismatch fails the run and the route is
+ * included in the failure summary.
  *
  * Intended to run as a workflow step in .github/workflows/deploy-verify.yml
  * after the version sentinel check, so the marketing surface is verified
@@ -67,11 +68,19 @@ function loadManifest(manifestPath) {
     if (typeof entry.sentinel !== 'string' || entry.sentinel.length === 0) {
       throw new Error(`Invalid sentinel for route ${entry.route}`);
     }
+    if (entry.mustNotContain != null) {
+      if (!Array.isArray(entry.mustNotContain) || entry.mustNotContain.some((value) => typeof value !== 'string' || value.length === 0)) {
+        throw new Error(`Invalid mustNotContain for route ${entry.route}`);
+      }
+    }
+    if (entry.userAgent != null && (typeof entry.userAgent !== 'string' || entry.userAgent.length === 0)) {
+      throw new Error(`Invalid userAgent for route ${entry.route}`);
+    }
   }
   return parsed;
 }
 
-async function probePage({ prodUrl, route, sentinel, fetchImpl = globalThis.fetch, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+async function probePage({ prodUrl, route, sentinel, mustNotContain = [], userAgent, fetchImpl = globalThis.fetch, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   if (typeof fetchImpl !== 'function') {
     return { route, ok: false, error: 'fetch_unavailable' };
   }
@@ -82,20 +91,24 @@ async function probePage({ prodUrl, route, sentinel, fetchImpl = globalThis.fetc
     const res = await fetchImpl(url, {
       signal: controller.signal,
       headers: {
-        // A real browser-shaped UA so any bot-deflection interstitials
-        // do NOT trigger; we are probing the real visitor's surface.
-        'User-Agent': 'thumbgate-deploy-verify/1.0 (+https://github.com/IgorGanapolsky/ThumbGate)',
+        // A real browser-shaped UA so bot-deflection interstitials do not
+        // trigger; this probe is meant to verify the buyer-facing surface.
+        'User-Agent': userAgent || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
         Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
       },
     });
     const body = await res.text().catch(() => '');
     const sentinelPresent = body.includes(sentinel);
+    const forbiddenPresent = Array.isArray(mustNotContain)
+      ? mustNotContain.filter((value) => body.includes(value))
+      : [];
     return {
       route,
       url,
       status: res.status,
-      ok: res.ok && sentinelPresent,
+      ok: res.ok && sentinelPresent && forbiddenPresent.length === 0,
       sentinelPresent,
+      forbiddenPresent,
       bytes: body.length,
     };
   } catch (error) {
@@ -120,6 +133,8 @@ async function runVerification({ prodUrl, manifestPath, fetchImpl = globalThis.f
       prodUrl,
       route: entry.route,
       sentinel: entry.sentinel,
+      mustNotContain: entry.mustNotContain,
+      userAgent: entry.userAgent,
       fetchImpl,
       timeoutMs,
     });
@@ -149,6 +164,8 @@ function renderHuman(report, { quiet = false } = {}) {
         lines.push(`❌ ${r.route.padEnd(20)}  ERROR ${r.error}`);
       } else if (!r.sentinelPresent) {
         lines.push(`❌ ${r.route.padEnd(20)}  HTTP ${r.status}  sentinel MISSING (expected: ${JSON.stringify(r.sentinel)})`);
+      } else if (Array.isArray(r.forbiddenPresent) && r.forbiddenPresent.length > 0) {
+        lines.push(`❌ ${r.route.padEnd(20)}  HTTP ${r.status}  forbidden content PRESENT (${r.forbiddenPresent.map((value) => JSON.stringify(value)).join(', ')})`);
       } else {
         lines.push(`❌ ${r.route.padEnd(20)}  HTTP ${r.status}`);
       }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2246,8 +2246,8 @@ a{display:block;text-decoration:none}a.secondary{border:1px solid #374151;color:
 <form action="/checkout/pro" method="GET" data-i="pro_checkout_confirmed">
 ${hiddenInputs}
 <input type="hidden" name="confirm" value="1">
-<input type="email" name="customer_email" value="${escapeHtmlAttribute(prefilledEmail)}" placeholder="you@company.com" autocomplete="email" required>
-<p class="email-note">Required for your Stripe receipt and checkout recovery link.</p>
+<input type="email" name="customer_email" value="${escapeHtmlAttribute(prefilledEmail)}" placeholder="you@company.com" autocomplete="email">
+<p class="email-note">Optional. Stripe can collect your email on the secure checkout page.</p>
 <button type="submit" class="primary">Pay $19/mo with Stripe →</button>
 </form>
 <a class="secondary" data-i="workflow_sprint_intake" href="/#workflow-sprint-intake">Not sure yet? Send the workflow first</a>
@@ -6026,20 +6026,15 @@ async function addContext(){
       const hasCustomerEmailHint = !!parsed?.searchParams?.has('customer_email');
       const hasValidCustomerEmailHint = !!normalizedCheckoutEmail;
       const botShouldBypass = !botClassification.isBot || hasValidCustomerEmailHint;
-      // 2026-06-04 audit: after the POST-401 fix, 3 of 4 fresh /checkout/pro
-      // sessions had customer_email=null in Stripe (zombie sessions with no
-      // recovery surface). Root cause: POSTs were auto-confirmed regardless of
-      // whether the email query param was present. Require email on POSTs too
-      // so emails-less POSTs fall through to the interstitial form instead of
-      // creating an un-recoverable Stripe session.
-      //
-      // 2026-06-28 live Stripe audit: expired live Checkout Sessions still had
-      // customer_email=null, customer_details=null, and payment_status=unpaid.
-      // Stripe generated recovery URLs, but we had no contact surface for the
-      // buyer. Require a valid email before creating the Stripe Session.
-      const isConfirmedCheckout = ((req.method === 'POST') || hasConfirmFlag)
-        && botShouldBypass
-        && hasValidCustomerEmailHint;
+      // 2026-06-29 conversion audit: requiring email before Stripe gave us a
+      // recoverable abandoned-session theory, but the hosted funnel showed
+      // traffic with 0 checkout starts. Let confirmed human clicks reach
+      // Stripe; Stripe can collect email on the secure checkout page. Bots
+      // still need a valid email hint to bypass deflection.
+      const isConfirmedCheckout = (
+        (req.method === 'POST' && hasValidCustomerEmailHint)
+        || hasConfirmFlag
+      ) && botShouldBypass;
       // 2026-06-05 revenue bypass: env-gated direct-to-Stripe redirect.
       // Live 30d billing showed 254 interstitial views → 1 Stripe click-through
       // → 0 paid. When THUMBGATE_CHECKOUT_INTERSTITIAL_BYPASS=1 is set we
@@ -6170,7 +6165,17 @@ async function addContext(){
         return;
       }
 
-      bootstrapBody.customerEmail = normalizedCheckoutEmail;
+      if (!normalizedCheckoutEmail) {
+        appendBestEffortTelemetry(FEEDBACK_DIR, {
+          eventType: 'checkout_email_deferred_to_stripe',
+          clientType: 'web',
+          traceId,
+          page: '/checkout/pro',
+          planId: analyticsMetadata.planId,
+          reason: rawCheckoutEmail ? 'invalid_customer_email' : 'missing_customer_email',
+        }, req.headers, 'checkout_email_deferred_to_stripe');
+      }
+      bootstrapBody.customerEmail = normalizedCheckoutEmail || undefined;
 
       appendBestEffortTelemetry(FEEDBACK_DIR, {
         eventType: 'checkout_bootstrap',

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1833,8 +1833,10 @@ test('checkout interstitial: GET without confirm=1 (human UA) renders the inters
   assert.doesNotMatch(body, /not_allowed/);
   assert.doesNotMatch(body, /<img src=x onerror=alert\(1\)>/);
   assert.doesNotMatch(body, /<svg onload=alert\(1\)>/);
-  assert.match(body, /name="customer_email"[^>]*required/, 'email is required before Stripe session creation so abandoned sessions remain recoverable');
-  assert.match(body, /Required for your Stripe receipt and checkout recovery link/);
+  const emailInputMatch = body.match(/<input[^>]+name="customer_email"[^>]*>/i);
+  assert.ok(emailInputMatch, 'email input should remain visible for buyers who want checkout recovery');
+  assert.doesNotMatch(emailInputMatch[0], /\srequired(?:\s|=|>)/i, 'email must stay optional before Stripe so confirmed buyers can reach checkout');
+  assert.match(body, /Stripe can collect your email on the secure checkout page/);
   assert.match(body, /Not sure yet\? Send the workflow first/);
   assert.doesNotMatch(body, /Pay \$1 first rule/);
   assert.doesNotMatch(body, /Pay \$99 teardown/);

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -240,8 +240,8 @@ describe('/checkout/pro bot guard', () => {
     assert.match(body, /<form action="\/checkout\/pro"/);
     assert.match(body, /name="confirm" value="1"/);
     assert.match(body, /name="customer_email"/);
-    assert.match(body, /name="customer_email"[^>]*required/);
-    assert.match(body, /Required for your Stripe receipt and checkout recovery link/);
+    assert.doesNotMatch(body, /name="customer_email"[^>]*required/);
+    assert.match(body, /Stripe can collect your email on the secure checkout page/);
     assert.doesNotMatch(body, /<a[^>]+confirm=1/, 'confirm=1 must not be in a crawlable anchor');
   });
 
@@ -433,7 +433,7 @@ describe('/checkout/pro bot guard', () => {
     );
   });
 
-  it('keeps confirmed real browsers on the interstitial until email is captured', async () => {
+  it('lets confirmed real browsers reach checkout and defer email capture to Stripe', async () => {
     try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
     const res = await fetch(`${origin}/checkout/pro?confirm=1`, {
       redirect: 'manual',
@@ -442,20 +442,23 @@ describe('/checkout/pro bot guard', () => {
         accept: BROWSER_ACCEPT,
       },
     });
-    assert.equal(res.status, 200, `expected email interstitial, got ${res.status}`);
-    const body = await res.text();
-    assert.match(body, /Start ThumbGate Pro/);
-    assert.match(body, /name="customer_email"[^>]*required/);
+    assert.ok(res.status >= 300 && res.status < 400, `expected checkout redirect, got ${res.status}`);
+    const location = res.headers.get('location') || '';
+    assert.ok(/\/success\?/.test(location) || /checkout\.stripe\.com/.test(location), `expected Stripe or success redirect, got ${location}`);
 
     const events = readFunnelEvents();
-    assert.ok(
-      events.some((e) => e.eventType === 'checkout_interstitial_view' && e.reasonCode === 'missing_customer_email'),
-      'missing email should be tracked before creating a Stripe session',
-    );
     assert.equal(
-      events.filter((e) => e.eventType === 'checkout_bootstrap').length,
+      events.filter((e) => e.eventType === 'checkout_interstitial_view' && e.reasonCode === 'missing_customer_email').length,
       0,
-      'confirmed browsers without email must not create an unrecoverable checkout session',
+      'confirmed browsers without email must not be bounced back to the interstitial',
+    );
+    assert.ok(
+      events.some((e) => e.eventType === 'checkout_email_deferred_to_stripe'),
+      'missing email should be tracked as deferred to Stripe',
+    );
+    assert.ok(
+      events.some((e) => e.eventType === 'checkout_bootstrap'),
+      'confirmed browsers without email should create a checkout session',
     );
   });
 

--- a/tests/checkout-pro-confirmation-gate.test.js
+++ b/tests/checkout-pro-confirmation-gate.test.js
@@ -86,8 +86,8 @@ describe('/checkout/pro confirmation gate (closes 0/50 conversion leak)', () => 
     assert.match(body, /Start ThumbGate Pro/);
     assert.match(body, /Pay \$19\/mo with Stripe/);
     assert.match(body, /name="confirm" value="1"/, 'interstitial must include the confirm field as the primary CTA');
-    assert.match(body, /name="customer_email"[^>]*required/, 'email is required before Stripe session creation so abandoned sessions remain recoverable');
-    assert.match(body, /Required for your Stripe receipt and checkout recovery link/);
+    assert.doesNotMatch(body, /name="customer_email"[^>]*required/, 'email must be optional before Stripe so the interstitial does not block checkout starts');
+    assert.match(body, /Stripe can collect your email/);
     assert.match(body, /Not sure yet\? Send the workflow first/);
     assert.doesNotMatch(body, /Pay \$1 first rule/);
     assert.doesNotMatch(body, /Pay \$99 teardown/);
@@ -108,26 +108,25 @@ describe('/checkout/pro confirmation gate (closes 0/50 conversion leak)', () => 
     );
   });
 
-  it('real-browser GET WITH ?confirm=1 but no email → 200 interstitial, NO Stripe session created', async () => {
+  it('real-browser GET WITH ?confirm=1 but no email → 302 toward checkout and defers email to Stripe', async () => {
     clearTelemetry();
     const res = await fetch(`${origin}/checkout/pro?confirm=1`, {
       redirect: 'manual',
       headers: { 'user-agent': BROWSER_UA, accept: BROWSER_ACCEPT },
     });
-    assert.equal(res.status, 200, `confirmed checkout without email must render interstitial, got ${res.status}`);
-    const body = await res.text();
-    assert.match(body, /Start ThumbGate Pro/);
-    assert.match(body, /name="customer_email"[^>]*required/);
+    assert.ok(res.status >= 300 && res.status < 400, `confirmed checkout without email must 302, got ${res.status}`);
+    const location = res.headers.get('location') || '';
+    assert.ok(/\/success\?/.test(location) || /checkout\.stripe\.com/.test(location), `confirmed checkout must redirect to Stripe or success, got ${location}`);
 
     const events = readTelemetry();
-    assert.ok(
-      events.some((e) => e.eventType === 'checkout_interstitial_view' && e.reasonCode === 'missing_customer_email'),
-      'missing email should be tracked before creating a Stripe session',
-    );
     assert.equal(
-      events.filter((e) => e.eventType === 'checkout_bootstrap').length,
+      events.filter((e) => e.eventType === 'checkout_interstitial_view' && e.reasonCode === 'missing_customer_email').length,
       0,
-      'confirm=1 without email must NOT create a Stripe session',
+      'missing email must not bounce a confirmed human click back to the interstitial',
+    );
+    assert.ok(
+      events.some((e) => e.eventType === 'checkout_bootstrap'),
+      'confirm=1 without email should create a checkout session',
     );
   });
 

--- a/tests/revenue-observability-doctor.test.js
+++ b/tests/revenue-observability-doctor.test.js
@@ -60,19 +60,40 @@ test('probePublicFunnel passes when Pro checkout is focused; confirm-path probe 
       if (pathname === '/') {
         return response('<script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.js"></script><script>fetch("/v1/telemetry/ping")</script>');
       }
-      return response('Start ThumbGate Pro <a>Pay $19/mo with Stripe</a><a>Not sure yet? Send the workflow first</a>');
+      return response('Start ThumbGate Pro <input name="customer_email"><a>Pay $19/mo with Stripe</a><a>Not sure yet? Send the workflow first</a>');
     },
   });
 
   assert.equal(result.ok, true);
   assert.equal(result.checkout.focusedProCta, true);
   assert.equal(result.checkout.workflowFallback, true);
+  assert.equal(result.checkout.emailInputPresent, true);
+  assert.equal(result.checkout.emailOptionalBeforeStripe, true);
+  assert.equal(result.checkout.requiresEmailBeforeStripe, false);
   assert.equal(result.checkout.leaksServiceLinks, false);
   assert.equal(result.confirm.probeDisabled, true);
   assert.equal(result.confirm.redirects, null);
   // Exactly 2 fetches (root + /checkout/pro). Was 3 before — the third was
   // the confirm=1 GET that's now disabled.
   assert.equal(calls.length, 2);
+});
+
+test('probePublicFunnel fails when Pro checkout requires email before Stripe', async () => {
+  const result = await probePublicFunnel({
+    appOrigin: 'https://thumbgate.test',
+    async fetchImpl(url) {
+      const parsed = new URL(String(url));
+      if (parsed.pathname === '/') {
+        return response('<script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.js"></script><script>fetch("/v1/telemetry/ping")</script>');
+      }
+      return response('Start ThumbGate Pro <input name="customer_email" required><a>Pay $19/mo with Stripe</a><a>Not sure yet? Send the workflow first</a>');
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.checkout.emailInputPresent, true);
+  assert.equal(result.checkout.emailOptionalBeforeStripe, false);
+  assert.equal(result.checkout.requiresEmailBeforeStripe, true);
 });
 
 test('probePublicFunnel fails when service links leak into Pro checkout interstitial', async () => {
@@ -108,7 +129,7 @@ test('doctor blocks revenue claims when Stripe and hosted auth are missing', asy
       if (parsed.pathname === '/' || parsed.search.includes('confirm=1')) {
         return response('', { status: parsed.search.includes('confirm=1') ? 302 : 200 });
       }
-      return response('Start ThumbGate Pro Pay $19/mo with Stripe Not sure yet? Send the workflow first');
+      return response('Start ThumbGate Pro <input name="customer_email"> Pay $19/mo with Stripe Not sure yet? Send the workflow first');
     },
   });
 
@@ -117,6 +138,33 @@ test('doctor blocks revenue claims when Stripe and hosted auth are missing', asy
   assert.equal(report.canProveVisitorBehavior, false);
   assert.ok(report.nextActions.some((line) => /Stripe secret key/.test(line)));
   assert.ok(formatDoctorReport(report).includes('Revenue Observability Doctor: BLOCKED'));
+});
+
+test('doctor blocks when deployed checkout requires email before Stripe', async () => {
+  const report = await buildRevenueObservabilityDoctor({
+    env: {
+      THUMBGATE_OPERATOR_KEY: 'operator',
+      STRIPE_SECRET_KEY: 'sk_live_x',
+      PLAUSIBLE_API_KEY: 'plausible',
+      PLAUSIBLE_SITE_ID: 'thumbgate.ai',
+      POSTHOG_PERSONAL_API_KEY: 'phx',
+      POSTHOG_PROJECT_ID: '123',
+    },
+    appOrigin: 'https://thumbgate.test',
+    async fetchImpl(url) {
+      const parsed = new URL(String(url));
+      if (parsed.pathname === '/') {
+        return response('<script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.js"></script><script>fetch("/v1/telemetry/ping")</script>');
+      }
+      return response('Start ThumbGate Pro <input name="customer_email" required> Pay $19/mo with Stripe Not sure yet? Send the workflow first');
+    },
+  });
+
+  const check = report.checks.find((entry) => entry.id === 'checkout_email_optional_before_stripe');
+  assert.equal(report.verdict, 'blocked');
+  assert.equal(check.ok, false);
+  assert.equal(check.evidence.requiresEmailBeforeStripe, true);
+  assert.ok(report.nextActions.some((line) => /must not require email before Stripe/.test(line)));
 });
 
 test('doctor blocks when live markup emits thumbgate.ai but Plausible registration only covers Railway', async () => {
@@ -135,7 +183,7 @@ test('doctor blocks when live markup emits thumbgate.ai but Plausible registrati
       if (parsed.pathname === '/') {
         return response('<script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.js"></script><script>fetch("/v1/telemetry/ping")</script>');
       }
-      return response('Start ThumbGate Pro Pay $19/mo with Stripe Not sure yet? Send the workflow first');
+      return response('Start ThumbGate Pro <input name="customer_email"> Pay $19/mo with Stripe Not sure yet? Send the workflow first');
     },
   });
 
@@ -163,7 +211,7 @@ test('doctor is ready when proof access and focused public funnel are present', 
       if (parsed.pathname === '/' || parsed.search.includes('confirm=1')) {
         return response('', { status: parsed.search.includes('confirm=1') ? 302 : 200 });
       }
-      return response('Start ThumbGate Pro Pay $19/mo with Stripe Not sure yet? Send the workflow first');
+      return response('Start ThumbGate Pro <input name="customer_email"> Pay $19/mo with Stripe Not sure yet? Send the workflow first');
     },
   });
 

--- a/tests/verify-marketing-pages-deployed.test.js
+++ b/tests/verify-marketing-pages-deployed.test.js
@@ -75,6 +75,13 @@ test('loadManifest: accepts a well-formed manifest', () => {
   assert.equal(m.version, 1);
 });
 
+test('loadManifest: rejects invalid route-specific user agents', () => {
+  const { file } = writeManifest([
+    { route: '/checkout/pro', sentinel: 'Checkout', userAgent: '' },
+  ]);
+  assert.throws(() => loadManifest(file), /Invalid userAgent/);
+});
+
 test('probePage: ok=true when status 200 + sentinel present', async () => {
   const r = await probePage({
     prodUrl: 'https://x.test',
@@ -97,6 +104,30 @@ test('probePage: ok=false when sentinel missing', async () => {
   assert.equal(r.ok, false);
   assert.equal(r.status, 200);
   assert.equal(r.sentinelPresent, false);
+});
+
+test('probePage: ok=false when forbidden content is present', async () => {
+  const r = await probePage({
+    prodUrl: 'https://x.test',
+    route: '/checkout/pro',
+    sentinel: 'Optional. Stripe can collect your email on the secure checkout page.',
+    mustNotContain: ['Required for your Stripe receipt and checkout recovery link.'],
+    fetchImpl: async () => response('Optional. Stripe can collect your email on the secure checkout page. Required for your Stripe receipt and checkout recovery link.'),
+  });
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.forbiddenPresent, ['Required for your Stripe receipt and checkout recovery link.']);
+});
+
+test('probePage: ok=true when sentinel is present and forbidden content is absent', async () => {
+  const r = await probePage({
+    prodUrl: 'https://x.test',
+    route: '/checkout/pro',
+    sentinel: 'Optional. Stripe can collect your email on the secure checkout page.',
+    mustNotContain: ['Required for your Stripe receipt and checkout recovery link.'],
+    fetchImpl: async () => response('Optional. Stripe can collect your email on the secure checkout page.'),
+  });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.forbiddenPresent, []);
 });
 
 test('probePage: ok=false when HTTP status is non-2xx', async () => {
@@ -202,6 +233,30 @@ test('renderHuman: shows per-route pass + fail lines and a summary', () => {
   assert.match(out, /verdict: FAIL/);
 });
 
+test('renderHuman: shows forbidden content failures', () => {
+  const report = {
+    prodUrl: 'https://x.test',
+    totalRoutes: 1,
+    passedCount: 0,
+    failedCount: 1,
+    verdict: 'fail',
+    results: [
+      {
+        route: '/checkout/pro',
+        status: 200,
+        bytes: 100,
+        ok: false,
+        sentinelPresent: true,
+        sentinel: 'Optional. Stripe can collect your email on the secure checkout page.',
+        forbiddenPresent: ['Required for your Stripe receipt and checkout recovery link.'],
+      },
+    ],
+  };
+  const out = renderHuman(report);
+  assert.match(out, /forbidden content PRESENT/);
+  assert.match(out, /Required for your Stripe receipt and checkout recovery link/);
+});
+
 test('renderHuman: --quiet suppresses per-route lines but keeps summary', () => {
   const report = {
     prodUrl: 'https://x.test',
@@ -230,4 +285,9 @@ test('manifest contract: shipped config/post-deploy-marketing-pages.json is vali
   const home = m.pages.find((p) => p.route === '/');
   assert.ok(home, 'manifest must include /');
   assert.ok(home.sentinel.length > 0);
+  const checkout = m.pages.find((p) => p.route === '/checkout/pro');
+  assert.ok(checkout, 'manifest must include the revenue-critical Pro checkout route');
+  assert.match(checkout.sentinel, /Stripe can collect your email/);
+  assert.ok(checkout.mustNotContain.includes('Required for your Stripe receipt and checkout recovery link.'));
+  assert.equal(checkout.userAgent, 'curl/8.0.0');
 });


### PR DESCRIPTION
## Visual summary

```mermaid
flowchart LR
  A["Live traffic to /checkout/pro"] --> B["Email required before Stripe"]
  B --> C["Doctor blocks: requiresEmailBeforeStripe true"]
  C --> D["0 checkout starts today / 0 paid orders"]
  E["This PR"] --> F["Confirmed human click reaches Stripe"]
  F --> G["Stripe collects email on secure checkout"]
  E --> H["Revenue doctor guards optional-email requirement"]
  H --> I["Deploy verification catches stale checkout friction"]
```

## Business impact

This removes a live Pro checkout conversion bottleneck: confirmed human buyers no longer have to enter an email on the ThumbGate interstitial before reaching Stripe. Stripe can collect the email in the secure checkout flow, while the interstitial still prevents unconfirmed/browser-bot GETs from creating sessions.

## Revenue or sales impact

Live proof before deploy shows the production funnel is still blocked: `node scripts/revenue-observability-doctor.js --app-origin=https://thumbgate.ai --json` reports `checkout_email_optional_before_stripe.ok=false`, `requiresEmailBeforeStripe=true`, and `emailOptionalBeforeStripe=false`. The latest revenue truth also showed traffic with no checkout starts or paid orders, so this is the highest-ROI conversion fix in the path to paid orders.

## Cost impact

No paid infrastructure changes. The change adds a small telemetry event when email is deferred to Stripe and expands the existing local revenue doctor checks.

## Risk impact

Bot and accidental-session protection remains in place: a plain `/checkout/pro` GET still renders the interstitial and creates no Stripe session, Googlebot still receives the interstitial, and confirmed human clicks can proceed without local email collection. The revenue doctor now blocks deployed drift if the interstitial becomes required-email again.

## Linked issues

No issue linked. This addresses the live ThumbGate monetization blocker discovered in the June 29 revenue proof run.

## Verification

- `npm run test:checkout-pro-confirmation-gate` -> pass, 4/4
- `npm run test:revenue-observability-doctor` -> pass, 9/9
- `node --test tests/public-static-assets.test.js tests/pricing-page-telemetry.test.js tests/revenue-observability-doctor.test.js tests/checkout-pro-confirmation-gate.test.js` -> pass, 88/88
- `npm run test:deployment` -> pass, 111/111
- `git diff --check` -> clean
- Pre-commit guard -> package parity pass; landing-page claims pass
- Pre-push guard -> npm pack dry-run, public HTML links, regression guard tests pass
- Local `npm run deploy:policy -- --profiles=billing,deploy` correctly fails closed because this shell does not have `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`, `RAILWAY_HEALTHCHECK_URL`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, or `RAILWAY_TOKEN`.
