### PR TITLE
[codex] Add diagnostic conversion page

### DIFF
--- a/.changeset/diagnostic-conversion-page.md
+++ b/.changeset/diagnostic-conversion-page.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a focused Workflow Hardening Diagnostic page with a tracked $499 diagnostic checkout path and deploy-gated route verification.

--- a/config/post-deploy-marketing-pages.json
+++ b/config/post-deploy-marketing-pages.json
@@ -22,6 +22,11 @@
       "description": "Pro checkout interstitial must not require email before Stripe"
     },
     {
+      "route": "/diagnostic",
+      "sentinel": "Workflow Hardening Diagnostic",
+      "description": "Workflow Hardening Diagnostic intake page for high-intent warm traffic"
+    },
+    {
       "route": "/dashboard",
       "sentinel": "ThumbGate Dashboard",
       "description": "Dashboard demo (already enforced by /dashboard step; included here for symmetry with PR comment surface)"

--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "public/codex-plugin.html",
     "public/compare.html",
     "public/dashboard.html",
+    "public/diagnostic.html",
     "public/federal.html",
     "public/guide.html",
     "public/index.html",

--- a/public/diagnostic.html
+++ b/public/diagnostic.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ThumbGate Workflow Hardening Diagnostic</title>
+<meta name="description" content="A focused diagnostic for one repeated AI-agent workflow failure. ThumbGate maps the failure taxonomy, block/warn/human-review split, and proof checklist before rollout.">
+<link rel="canonical" href="__APP_ORIGIN__/diagnostic">
+<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
+<meta property="og:title" content="ThumbGate Workflow Hardening Diagnostic">
+<meta property="og:description" content="Send one repeated AI-agent workflow failure. Get the gate/review split and proof checklist before implementation.">
+<meta property="og:url" content="__APP_ORIGIN__/diagnostic">
+<meta property="og:type" content="website">
+<style>
+:root {
+  color-scheme: dark;
+  --bg: #05080a;
+  --panel: #0d1418;
+  --panel-2: #12181d;
+  --line: #24323a;
+  --text: #eef7f9;
+  --muted: #a9b7bd;
+  --cyan: #28d5ee;
+  --green: #48dd83;
+  --red: #ff7676;
+  --white: #ffffff;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+a { color: inherit; }
+header, main, footer { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 0;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+.mark {
+  width: 28px;
+  height: 28px;
+  border: 2px solid var(--cyan);
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  color: var(--cyan);
+}
+nav { display: flex; gap: 18px; color: var(--muted); font-size: 14px; }
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(340px, 0.95fr);
+  gap: 36px;
+  align-items: start;
+  padding: 54px 0 40px;
+}
+.eyebrow {
+  color: var(--cyan);
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+}
+h1 {
+  margin: 14px 0 18px;
+  max-width: 720px;
+  font-size: clamp(42px, 6vw, 76px);
+  line-height: .92;
+  letter-spacing: 0;
+}
+.lede {
+  max-width: 650px;
+  margin: 0 0 26px;
+  color: var(--muted);
+  font-size: 20px;
+}
+.actions { display: flex; flex-wrap: wrap; gap: 12px; }
+.button {
+  min-height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  text-decoration: none;
+  font-weight: 800;
+  color: var(--text);
+}
+.button.primary {
+  border-color: var(--cyan);
+  background: var(--cyan);
+  color: #031014;
+}
+.proof-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 34px;
+}
+.proof {
+  min-height: 90px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 8px;
+}
+.proof strong { display: block; font-size: 20px; }
+.proof span { color: var(--muted); font-size: 14px; }
+.intake-card {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 8px;
+  padding: 24px;
+}
+.intake-card h2 { margin: 0 0 10px; font-size: 24px; }
+.intake-card p { color: var(--muted); margin: 0 0 18px; }
+label {
+  display: block;
+  margin: 14px 0 7px;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 750;
+}
+input, textarea, select {
+  width: 100%;
+  border: 1px solid #32424a;
+  border-radius: 7px;
+  background: #070b0d;
+  color: var(--text);
+  padding: 12px;
+  font: inherit;
+}
+textarea { min-height: 116px; resize: vertical; }
+button {
+  width: 100%;
+  min-height: 50px;
+  margin-top: 18px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--cyan);
+  color: #031014;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+.hint { font-size: 13px; color: var(--muted); }
+section {
+  padding: 40px 0;
+  border-top: 1px solid var(--line);
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+.box {
+  min-height: 170px;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-2);
+}
+.box h3 { margin: 0 0 8px; }
+.box p { margin: 0; color: var(--muted); }
+footer { padding: 32px 0 44px; color: var(--muted); }
+@media (max-width: 860px) {
+  header { align-items: flex-start; flex-direction: column; }
+  .hero, .grid, .proof-strip { grid-template-columns: 1fr; }
+  h1 { font-size: 42px; }
+}
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "name": "ThumbGate Workflow Hardening Diagnostic",
+  "provider": {
+    "@type": "Organization",
+    "name": "ThumbGate",
+    "url": "__APP_ORIGIN__"
+  },
+  "description": "A focused diagnostic for one repeated AI-agent workflow failure, including failure taxonomy, block/warn/human-review split, and proof checklist.",
+  "offers": {
+    "@type": "Offer",
+    "price": "__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock",
+    "url": "__APP_ORIGIN__/diagnostic"
+  }
+}
+</script>
+</head>
+<body>
+<header>
+  <a class="brand" href="/">
+    <span class="mark">T</span>
+    <span>ThumbGate</span>
+  </a>
+  <nav aria-label="Primary">
+    <a href="/pro">Pro</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/llm-context.md">LLM Context</a>
+  </nav>
+</header>
+<main>
+  <div class="hero">
+    <div>
+      <div class="eyebrow">Workflow Hardening Diagnostic</div>
+      <h1>Turn one repeated AI-agent failure into a gate you can prove.</h1>
+      <p class="lede">Send the workflow that keeps failing. ThumbGate maps what should block, warn, or route to human review before an agent writes, sends, deploys, or spends.</p>
+      <div class="actions">
+        <a class="button primary" href="/go/diagnostic?utm_source=diagnostic_page&amp;utm_medium=onsite&amp;utm_campaign=workflow_hardening_diagnostic&amp;utm_content=hero_paid_diagnostic" data-revenue-cta data-cta-id="diagnostic_hero_paid" data-cta-placement="hero">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
+        <a class="button" href="#intake" data-revenue-cta data-cta-id="diagnostic_hero_intake" data-cta-placement="hero">Send workflow first</a>
+      </div>
+      <div class="proof-strip" aria-label="Diagnostic proof points">
+        <div class="proof"><strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</strong><span>Credited toward a sprint when implementation follows.</span></div>
+        <div class="proof"><strong>One workflow</strong><span>Scoped tightly so the proof is shippable.</span></div>
+        <div class="proof"><strong>Fit fallback</strong><span>Use the intake if the workflow needs scoping first.</span></div>
+      </div>
+    </div>
+    <form id="intake" class="intake-card" action="/v1/intake/workflow-sprint" method="POST" data-team-intake-form data-diagnostic-intake-form>
+      <h2>Submit for diagnostic scope</h2>
+      <p>Use this when an AI-assisted workflow has already caused rework, review drag, or release risk.</p>
+      <input type="hidden" name="ctaId" value="diagnostic_page_intake">
+      <input type="hidden" name="ctaPlacement" value="diagnostic_page">
+      <input type="hidden" name="utmMedium" value="diagnostic_intake">
+      <input type="hidden" name="utmCampaign" value="workflow_hardening_diagnostic">
+      <input type="hidden" name="planId" value="diagnostic">
+      <input type="hidden" name="page" value="/diagnostic">
+      <label for="name">Name</label>
+      <input id="name" name="name" autocomplete="name" required>
+      <label for="email">Work email</label>
+      <input id="email" name="email" type="email" autocomplete="email" required>
+      <label for="company">Company or project</label>
+      <input id="company" name="company" autocomplete="organization">
+      <label for="workflow">What workflow keeps failing?</label>
+      <textarea id="workflow" name="workflow" required placeholder="Example: agent opens PRs without the right proof, sends the wrong customer update, or deploys before approvals are clear."></textarea>
+      <label for="urgency">Urgency</label>
+      <select id="urgency" name="urgency">
+        <option>Repeated failure already cost us time</option>
+        <option>We are about to roll this workflow out</option>
+        <option>We need an independent proof checklist first</option>
+      </select>
+      <button type="submit" data-revenue-cta data-cta-id="diagnostic_page_submit" data-cta-placement="intake">Submit for diagnostic scope</button>
+      <p class="hint">Ready to pay now? Use the $499 diagnostic checkout above. If the workflow needs fit review first, submit it here and we will route you to the diagnostic or sprint only when the scope is real.</p>
+    </form>
+  </div>
+  <section>
+    <div class="grid">
+      <div class="box">
+        <h3>Failure taxonomy</h3>
+        <p>Classify the repeated action: bad context, missing approval, unsafe write, wrong target, or proof gap.</p>
+      </div>
+      <div class="box">
+        <h3>Gate split</h3>
+        <p>Define what should block automatically, warn the operator, or route to human review with evidence attached.</p>
+      </div>
+      <div class="box">
+        <h3>Proof checklist</h3>
+        <p>Leave with the verification steps needed to prove the next similar action is caught before execution.</p>
+      </div>
+    </div>
+  </section>
+  <section>
+    <h2>Use this for real agent workflows</h2>
+    <div class="grid">
+      <div class="box">
+        <h3>Code and PR agents</h3>
+        <p>Repeated bad diffs, missing tests, unsafe merges, or unclear ownership around generated changes.</p>
+      </div>
+      <div class="box">
+        <h3>Browser and ops agents</h3>
+        <p>Agents clicking, posting, updating CRMs, or moving money without the right boundary proof.</p>
+      </div>
+      <div class="box">
+        <h3>Customer-visible automation</h3>
+        <p>Email, support, billing, or publishing workflows where a repeat mistake costs trust.</p>
+      </div>
+    </div>
+  </section>
+</main>
+<footer>
+  ThumbGate is local-first agent governance. Use <a href="/pro">Pro</a> for self-serve operator proof, or submit one workflow above for a diagnostic.
+</footer>
+<script>
+(function () {
+  const search = new URLSearchParams(window.location.search);
+  const form = document.querySelector('[data-diagnostic-intake-form]');
+  if (form) {
+    for (const [key, value] of search.entries()) {
+      if (!/^utm_|^(source|campaign|content|term)$/i.test(key)) continue;
+      let input = form.querySelector(`input[name="${CSS.escape(key)}"]`);
+      if (!input) {
+        input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = key;
+        form.appendChild(input);
+      }
+      input.value = value;
+    }
+  }
+
+  function telemetry(eventName, props) {
+    try {
+      navigator.sendBeacon && navigator.sendBeacon('/v1/telemetry/event', JSON.stringify({
+        event: eventName,
+        page: '/diagnostic',
+        source: 'diagnostic_page',
+        props
+      }));
+    } catch (_) {}
+  }
+
+  document.addEventListener('click', function (event) {
+    const cta = event.target.closest('[data-revenue-cta]');
+    if (!cta) return;
+    telemetry('diagnostic_cta_click', {
+      ctaId: cta.getAttribute('data-cta-id'),
+      ctaPlacement: cta.getAttribute('data-cta-placement'),
+      planId: cta.getAttribute('data-cta-id') === 'diagnostic_secondary_pro' ? 'pro' : 'diagnostic'
+    });
+  });
+
+  document.addEventListener('submit', function (event) {
+    if (!event.target.matches('[data-diagnostic-intake-form]')) return;
+    telemetry('workflow_sprint_intake_submit_attempted', {
+      ctaId: 'diagnostic_page_submit',
+      ctaPlacement: 'diagnostic_page',
+      planId: 'diagnostic'
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -241,6 +241,7 @@ const NUMBERS_PAGE_PATH = path.resolve(__dirname, '../../public/numbers.html');
 const FEDERAL_PAGE_PATH = path.resolve(__dirname, '../../public/federal.html');
 const PRICING_PAGE_PATH = path.resolve(__dirname, '../../public/pricing.html');
 const ABOUT_PAGE_PATH = path.resolve(__dirname, '../../public/about.html');
+const DIAGNOSTIC_PAGE_PATH = path.resolve(__dirname, '../../public/diagnostic.html');
 const LEARN_DIR = path.resolve(__dirname, '../../public/learn');
 const GUIDES_DIR = path.resolve(__dirname, '../../public/guides');
 const COMPARE_DIR = path.resolve(__dirname, '../../public/compare');
@@ -2878,6 +2879,10 @@ function loadProPageHtml(runtimeConfig, pageContext = {}) {
   return loadPublicMarketingTemplateHtml(PRO_PAGE_PATH, runtimeConfig, pageContext);
 }
 
+function loadDiagnosticPageHtml(runtimeConfig, pageContext = {}) {
+  return loadPublicMarketingTemplateHtml(DIAGNOSTIC_PAGE_PATH, runtimeConfig, pageContext);
+}
+
 function loadPricingPageHtml(runtimeConfig, pageContext = {}) {
   return loadPublicMarketingTemplateHtml(PRICING_PAGE_PATH, runtimeConfig, pageContext);
 }
@@ -3511,6 +3516,8 @@ function renderSitemapXml(runtimeConfig) {
   const entries = [
     { path: '/', changefreq: 'weekly', priority: '1.0' },
     { path: '/pro', changefreq: 'weekly', priority: '0.9' },
+    { path: '/diagnostic', changefreq: 'weekly', priority: '0.9' },
+    { path: '/workflow-hardening-sprint', changefreq: 'weekly', priority: '0.9' },
     { path: '/agent-manager', changefreq: 'weekly', priority: '0.9' },
     { path: '/llm-context.md', changefreq: 'weekly', priority: '0.8' },
     { path: '/chatgpt-app', changefreq: 'weekly', priority: '0.85' },
@@ -5704,13 +5711,16 @@ async function addContext(){
       return;
     }
 
-    // Natural marketing URLs for the Workflow Hardening Sprint. Outbound
-    // messages, social posts, and word-of-mouth all refer to "the sprint"
-    // or "workflow hardening" — recipients who type or paste the natural
-    // URLs currently hit the generic API 401 JSON error and bounce.
-    // Redirect them to the canonical intake anchor instead.
+    // Natural marketing URLs for the Workflow Hardening Diagnostic/Sprint.
+    // High-intent outreach refers to "the diagnostic", "the sprint", or
+    // "workflow hardening"; serve a focused buyer page instead of sending
+    // qualified traffic to the generic homepage anchor.
     if (isGetLikeRequest && (
-      pathname === '/sprint'
+      pathname === '/diagnostic'
+      || pathname === '/diagnostic.html'
+      || pathname === '/workflow-diagnostic'
+      || pathname === '/workflow-diagnostic.html'
+      || pathname === '/sprint'
       || pathname === '/sprint.html'
       || pathname === '/workflow-hardening'
       || pathname === '/workflow-hardening.html'
@@ -5719,11 +5729,21 @@ async function addContext(){
       || pathname === '/workflow-sprint'
       || pathname === '/workflow-sprint.html'
     )) {
-      res.writeHead(302, {
-        Location: '/#workflow-sprint-intake',
-        'Cache-Control': 'no-store',
-      });
-      res.end();
+      try {
+        servePublicMarketingPage({
+          req,
+          res,
+          parsed,
+          hostedConfig,
+          isHeadRequest,
+          renderHtml: loadDiagnosticPageHtml,
+          extraTelemetry: {
+            pageType: 'diagnostic',
+          },
+        });
+      } catch (err) {
+        sendText(res, 500, err.message || 'Diagnostic page unavailable');
+      }
       return;
     }
 

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -515,6 +515,34 @@ test('/pro serves the Pro landing page instead of redirecting to the homepage', 
   assert.match(html, /\/checkout\/pro\?plan_id=pro&billing_cycle=monthly/);
 });
 
+test('/diagnostic serves the focused Workflow Hardening Diagnostic intake page', async () => {
+  const res = await fetch(apiUrl('/diagnostic?utm_source=reddit&utm_campaign=workflow_diagnostic'), { redirect: 'manual' });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') || '', /text\/html/);
+  const html = await res.text();
+  assert.match(html, /Workflow Hardening Diagnostic/);
+  assert.match(html, /Submit for diagnostic scope/);
+  assert.match(html, /action="\/v1\/intake\/workflow-sprint"/);
+  assert.match(html, /name="planId" value="diagnostic"/);
+  assert.match(html, /name="ctaId" value="diagnostic_page_intake"/);
+  assert.match(html, /workflow_sprint_intake_submit_attempted/);
+  assert.match(html, /Pay \$499 diagnostic/);
+  assert.match(html, /\/go\/diagnostic\?utm_source=diagnostic_page&amp;utm_medium=onsite&amp;utm_campaign=workflow_hardening_diagnostic/);
+  assert.match(html, /data-cta-id="diagnostic_hero_paid"/);
+  assert.doesNotMatch(html, /No cold payment link/);
+});
+
+test('/workflow-hardening-sprint and diagnostic aliases serve the focused diagnostic page', async () => {
+  for (const route of ['/workflow-diagnostic', '/sprint', '/workflow-hardening-sprint']) {
+    const res = await fetch(apiUrl(route), { redirect: 'manual' });
+    assert.equal(res.status, 200, `${route} should render`);
+    assert.match(res.headers.get('content-type') || '', /text\/html/);
+    const html = await res.text();
+    assert.match(html, /Workflow Hardening Diagnostic/);
+    assert.match(html, /<link rel="canonical" href="https:\/\/app\.example\.com\/diagnostic"/);
+  }
+});
+
 test('startServer accepts an explicit bind host', async () => {
   const explicit = await startServer({ port: 0, host: '127.0.0.1' });
   try {

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -326,9 +326,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 321 -> 324 (2026-06-16) to ship the Guardian/Ethicore policy-engine
   // adapter and commercial-truth claim gate as public runtime enforcement.
   // Bumped 324 -> 326 (2026-06-22) to ship the new transparent brand logo SVG.
+  // Bumped 326 -> 327 (2026-06-29) to ship public/diagnostic.html, the
+  // focused Workflow Hardening Diagnostic conversion page for warm traffic.
   assert.ok(
-    manifest.fileCount <= 326,
-    `npm package should stay <= 326 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 327,
+    `npm package should stay <= 327 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing
@@ -448,9 +450,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 4.60 MB -> 4.65 MB (2026-06-11) for tool contract validator.
   // Bumped 4.65 MB -> 4.70 MB (2026-06-11) for Letta adapter and evaluation scripts.
   // Bumped 4.70 MB -> 4.75 MB (2026-06-12) for Core AI provider and main merges.
+  // Bumped 4.75 MB -> 4.80 MB (2026-06-29) for public/diagnostic.html,
+  // the focused Workflow Hardening Diagnostic conversion page.
   assert.ok(
-    manifest.unpackedSize <= 4_750_000,
-    `npm package should stay <= 4.75 MB unpacked, got ${manifest.unpackedSize}`
+    manifest.unpackedSize <= 4_800_000,
+    `npm package should stay <= 4.80 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -88,7 +88,9 @@ const path = require('node:path');
 // 321 → 324: 2026-06-16 Guardian/Ethicore policy-engine adapter and
 // commercial-truth claim gate added as public runtime enforcement.
 // 324 → 326: 2026-06-22 ship new transparent brand logo SVG.
-const BASELINE_FILE_COUNT = 326;
+// 326 → 327: 2026-06-29 ship public/diagnostic.html, the focused Workflow
+// Hardening Diagnostic conversion page for warm traffic.
+const BASELINE_FILE_COUNT = 327;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -158,8 +158,11 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // Bumped 321 -> 324 (2026-06-16) to ship the Guardian/Ethicore policy-engine
   // adapter and commercial-truth claim gate as public-shell enforcement.
   // Bumped 324 -> 326 (2026-06-22) to ship the new transparent brand logo SVG.
+  // Bumped 326 -> 327 (2026-06-29) to ship public/diagnostic.html, the
+  // buyer-facing Workflow Hardening Diagnostic conversion page and deploy-gated
+  // route for the $499 diagnostic checkout path.
   const files = npmPackFiles();
-  const CEILING = 326;
+  const CEILING = 327;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -153,6 +153,7 @@ test('homepage and pricing surfaces expose canonical and LLM context links', asy
     ['/', `${origin}/`, `${origin}/llm-context.md`],
     ['/pricing', `${origin}/pricing`, `${origin}/llm-context.md`],
     ['/pro', `${origin}/pro`, `${origin}/llm-context.md`],
+    ['/diagnostic', `${origin}/diagnostic`, `${origin}/llm-context.md`],
   ];
 
   for (const [pathname, canonicalUrl, contextUrl] of pages) {
@@ -161,6 +162,60 @@ test('homepage and pricing surfaces expose canonical and LLM context links', asy
     const html = await res.text();
     assert.match(html, new RegExp(`<link rel="canonical" href="${canonicalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
     assert.match(html, new RegExp(`<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="${contextUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+  }
+});
+
+test('GET /diagnostic serves the Workflow Hardening Diagnostic intake page', async () => {
+  const res = await fetch(`${origin}/diagnostic`);
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') || '', /text\/html/);
+  const html = await res.text();
+  assert.match(html, /Workflow Hardening Diagnostic/);
+  assert.match(html, /Submit for diagnostic scope/);
+  assert.match(html, /action="\/v1\/intake\/workflow-sprint"/);
+  assert.match(html, /data-diagnostic-intake-form/);
+  assert.match(html, /diagnostic_page_submit/);
+  assert.match(html, /Pay \$499 diagnostic/);
+  assert.match(html, /\/go\/diagnostic\?utm_source=diagnostic_page&amp;utm_medium=onsite&amp;utm_campaign=workflow_hardening_diagnostic/);
+  assert.match(html, /data-cta-id="diagnostic_hero_paid"/);
+  assert.doesNotMatch(html, /No cold payment link/);
+});
+
+test('workflow diagnostic aliases serve the focused diagnostic page', async () => {
+  const paths = [
+    '/diagnostic.html',
+    '/workflow-diagnostic',
+    '/workflow-diagnostic.html',
+    '/sprint',
+    '/sprint.html',
+    '/workflow-hardening',
+    '/workflow-hardening.html',
+    '/workflow-hardening-sprint',
+    '/workflow-hardening-sprint.html',
+    '/workflow-sprint',
+    '/workflow-sprint.html',
+  ];
+
+  for (const pathname of paths) {
+    const res = await fetch(`${origin}${pathname}`, { redirect: 'manual' });
+    assert.equal(res.status, 200, `${pathname} should render diagnostic page`);
+    assert.match(res.headers.get('content-type') || '', /text\/html/);
+    const html = await res.text();
+    assert.match(html, /Workflow Hardening Diagnostic/);
+    assert.match(html, /Submit for diagnostic scope/);
+    assert.match(html, /<link rel="canonical" href="[^"]+\/diagnostic"/);
+  }
+});
+
+test('GET /sitemap.xml includes /diagnostic and /workflow-hardening-sprint at priority 0.9', async () => {
+  const res = await fetch(`${origin}/sitemap.xml`);
+  assert.equal(res.status, 200);
+  const xml = await res.text();
+  for (const route of ['/diagnostic', '/workflow-hardening-sprint']) {
+    assert.match(xml, new RegExp(`<loc>[^<]*${route}<\\/loc>`), `sitemap must list ${route}`);
+    const entry = xml.match(new RegExp(`<url>\\s*<loc>[^<]*${route}<\\/loc>[\\s\\S]*?<\\/url>`));
+    assert.ok(entry, `${route} <url> block must exist`);
+    assert.match(entry[0], /<priority>0\.9<\/priority>/);
   }
 });
 
@@ -278,14 +333,6 @@ test('public marketing directory aliases redirect to canonical pages', async () 
     ['/guides.html', '/learn'],
     ['/services', '/#workflow-sprint-intake'],
     ['/services.html', '/#workflow-sprint-intake'],
-    ['/sprint', '/#workflow-sprint-intake'],
-    ['/sprint.html', '/#workflow-sprint-intake'],
-    ['/workflow-hardening', '/#workflow-sprint-intake'],
-    ['/workflow-hardening.html', '/#workflow-sprint-intake'],
-    ['/workflow-hardening-sprint', '/#workflow-sprint-intake'],
-    ['/workflow-hardening-sprint.html', '/#workflow-sprint-intake'],
-    ['/workflow-sprint', '/#workflow-sprint-intake'],
-    ['/workflow-sprint.html', '/#workflow-sprint-intake'],
   ];
 
   for (const [pathname, expectedLocation] of cases) {


### PR DESCRIPTION
## Summary

- Adds a focused `/diagnostic` Workflow Hardening Diagnostic page for high-intent warm traffic.
- Serves `/diagnostic`, `/workflow-diagnostic`, `/sprint`, `/workflow-hardening`, `/workflow-hardening-sprint`, and `/workflow-sprint` aliases as the diagnostic page instead of sending buyers to the generic homepage anchor.
- Adds a visible `$499` diagnostic CTA through the first-party `/go/diagnostic` router while preserving intake fallback and attribution.
- Adds `/diagnostic` and `/workflow-hardening-sprint` to sitemap and post-deploy marketing-page verification.

## Revenue Impact

- Converts the currently-live `/diagnostic` 404 into a buyer page with a paid diagnostic path.
- Keeps Stripe checkout URLs configurable through existing hosted config/link router.
- Gives warm outreach a concrete higher-ticket destination instead of only the $19 self-serve Pro checkout.

## Validation

- `node --check src/api/server.js`
- `node --test tests/public-static-assets.test.js tests/verify-marketing-pages-deployed.test.js` — 96/96 pass
- `node --test tests/api-server.test.js --test-name-pattern="diagnostic|workflow-hardening-sprint|/go/diagnostic|/pro serves"` — 144/144 pass
- `npm run test:public-package-parity` — 5/5 pass
- `node --test tests/package-boundary.test.js tests/public-bundle-ratchet.test.js` — 6/6 pass
- `git diff --check origin/main...HEAD`
- `git push` pre-push guard passed: npm pack dry-run, public HTML link validation, regression-guard tests

## Live Baseline Before Deploy

- `https://thumbgate.ai/health` is healthy at build `8c7cb497240a42f078cacda5f64d743bfe392b59`.
- `https://thumbgate.ai/checkout/pro` is reachable.
- `https://thumbgate.ai/diagnostic` currently returns 404, which this PR fixes after merge/deploy.
- Stripe live today remains `$0` / `0` charges at time of PR creation; this is a conversion-path improvement, not a claimed revenue win yet.
