### PR TITLE
fix(diagnostic): replace placeholder letter-T logo with the real brand mark

### DIFF
--- a/.changeset/diagnostic-real-logo.md
+++ b/.changeset/diagnostic-real-logo.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix the `/diagnostic` page header logo. It rendered a placeholder CSS letter-"T" monogram (`<span class="mark">T</span>`) — the only page on the site doing so — which read as unfinished on the paid $499 diagnostic landing page. Replace it with the real brand mark (`/assets/brand/thumbgate-mark-inline-v3.svg`), matching every other page, and simplify the `.mark` style to a self-framed 28×28 image.

--- a/public/diagnostic.html
+++ b/public/diagnostic.html
@@ -53,11 +53,7 @@ header {
 .mark {
   width: 28px;
   height: 28px;
-  border: 2px solid var(--cyan);
-  border-radius: 7px;
-  display: grid;
-  place-items: center;
-  color: var(--cyan);
+  display: block;
 }
 nav { display: flex; gap: 18px; color: var(--muted); font-size: 14px; }
 .hero {
@@ -207,7 +203,7 @@ footer { padding: 32px 0 44px; color: var(--muted); }
 <body>
 <header>
   <a class="brand" href="/">
-    <span class="mark">T</span>
+    <img class="mark" src="/assets/brand/thumbgate-mark-inline-v3.svg" alt="ThumbGate" width="28" height="28" />
     <span>ThumbGate</span>
   </a>
   <nav aria-label="Primary">


### PR DESCRIPTION
## The bug
`https://thumbgate.ai/diagnostic` rendered its header logo as a CSS letter-**T** in a cyan box (`<span class="mark">T</span>`) — it looked cheap/placeholder on a paid ($499) buyer-facing page. It was the **only** page on the site using that monogram; every other page (index, pro, dashboard, pricing, learn, lessons, federal, chatgpt-app) uses the real brand mark.

## The fix (single file, +2/−6)
- Swap the monogram for the standard `/assets/brand/thumbgate-mark-inline-v3.svg` (shield + thumbs-up, brand gradient), matching the rest of the site.
- Simplify `.mark` to a 28×28 block (the SVG is self-framed, so the bordered box is removed — no double-frame).

## Verified
- Asset resolves 200 (`image/svg+xml`) and renders as the proper brand mark (confirmed visually).
- Markup is identical to the 7 other pages already using this logo.

## Notes
- Branched from current `origin/main` (`92b7f41`, = the live deploy). Goes live on merge + deploy.
- CI `test-suite-parity` is red on `main` itself (pre-existing unwired `tests/*zernio*`), unrelated to this one-file HTML change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)