### PR TITLE
feat(retrieval): Memora-style nucleus (top-P) stop for lesson retrieval

### DIFF
--- a/.changeset/nucleus-lesson-retrieval.md
+++ b/.changeset/nucleus-lesson-retrieval.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add Memora-style nucleus (top-P) "decide when to stop" filtering to per-action lesson retrieval. Operators can set `THUMBGATE_RETRIEVAL_TOP_P` (or pass `options.topP`) to trim the low-relevance tail so a single dominant lesson isn't padded out to `maxResults` — fewer tokens stuffed into each PreToolUse warning and `retrieve_lessons` call. Off by default (`topP=1.0` is a no-op, so existing behaviour is unchanged). Also fixes the previously dead, mis-normalized `filterTopP` (now scale-free with a `minKeep` floor) and removes a duplicate `calculateRetrievalEntropy` definition.

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -2785,7 +2785,7 @@ function buildRecentCorrectiveActionsContext(options = {}) {
 function buildRelevantLessonContext(toolName, toolInput) {
   if (!toolName) return null;
 
-  const { retrieveRelevantLessons, calculateRetrievalEntropy, filterTopP } = loadOptionalModule("./lesson-retrieval", () => ({ retrieveRelevantLessons: () => [], calculateRetrievalEntropy: () => 0, filterTopP: (l) => l }));
+  const { retrieveRelevantLessons, calculateRetrievalEntropy } = loadOptionalModule("./lesson-retrieval", () => ({ retrieveRelevantLessons: () => [], calculateRetrievalEntropy: () => 0 }));
 
   // Extract a searchable action context from the tool input
   const actionContext = extractActionContext(toolName, toolInput);

--- a/scripts/lesson-retrieval.js
+++ b/scripts/lesson-retrieval.js
@@ -47,7 +47,11 @@ function retrieveRelevantLessons(toolName, actionContext, options = {}) {
     toolName,
   });
 
-  return reranked.map((m) => ({
+  // Stage 3 (opt-in) — Memora-style nucleus stop: trim the low-mass tail so a
+  // dominant lesson isn't padded out to maxResults. No-op unless topP < 1.
+  const selected = filterTopP(reranked, resolveTopP(options), { minKeep: options.minKeep });
+
+  return selected.map((m) => ({
     id: m.id,
     title: m.title,
     content: m.content,
@@ -177,7 +181,7 @@ async function retrieveRelevantLessonsAsync(toolName, actionContext, options = {
     // Short-circuit: skip embedding/dense search completely
     const { rerankLessons } = require('./lesson-reranker');
     const reranked = rerankLessons(actionContext, lexicalScored.slice(0, RERANK_CANDIDATE_POOL), { topK: maxResults, toolName });
-    return reranked.map(shapeLesson);
+    return filterTopP(reranked, resolveTopP(options), { minKeep: options.minKeep }).map(shapeLesson);
   }
 
   // WHERE-clause pruning: filter memories before vector search to only include
@@ -241,7 +245,7 @@ async function retrieveRelevantLessonsAsync(toolName, actionContext, options = {
 
   const { rerankLessons } = require('./lesson-reranker');
   const reranked = rerankLessons(actionContext, candidates, { topK: maxResults, toolName });
-  return reranked.map(shapeLesson);
+  return filterTopP(reranked, resolveTopP(options), { minKeep: options.minKeep }).map(shapeLesson);
 }
 
 function buildActionSignature(toolName, actionContext) {
@@ -325,37 +329,63 @@ function tokenize(text) {
   return (text || '').split(/[\s.,;:!?()\[\]{}"'`]+/).filter((t) => t.length > 3);
 }
 
-function calculateRetrievalEntropy(lessons) {
-  if (!Array.isArray(lessons) || lessons.length === 0) return 0;
-  let pW = 0, nW = 0, tW = 0;
-  for (const l of lessons) {
-    const w = l.relevanceScore || 0.1;
-    if (l.signal === "positive") pW += w; else nW += w;
-    tW += w;
-  }
-  if (tW === 0) return 0;
-  const pPos = pW / tW, pNeg = nW / tW;
-  const entropy = (pPos > 0 ? -pPos * Math.log2(pPos) : 0) + (pNeg > 0 ? -pNeg * Math.log2(pNeg) : 0);
-  return Number(entropy.toFixed(4));
+/**
+ * Resolve the nucleus (top-P) cutoff for a retrieval call. Precedence:
+ *   options.topP (finite, 0 < p <= 1)  →  env THUMBGATE_RETRIEVAL_TOP_P  →  1.0 (off).
+ * 1.0 is a no-op (returns the full reranked top-K), so retrieval behaviour is
+ * unchanged unless an operator explicitly opts in.
+ */
+function resolveTopP(options = {}) {
+  const fromOption = Number(options && options.topP);
+  if (Number.isFinite(fromOption) && fromOption > 0 && fromOption <= 1) return fromOption;
+  const fromEnv = Number(process.env.THUMBGATE_RETRIEVAL_TOP_P);
+  if (Number.isFinite(fromEnv) && fromEnv > 0 && fromEnv <= 1) return fromEnv;
+  return 1.0;
 }
-
 
 /**
- * Filter lessons using Top-P (nucleus) sampling logic.
- * Keeps lessons that contribute to the top cumulative relevance mass.
+ * Nucleus (top-P) filter over a ranked lesson list — the lightweight realization of
+ * Memora's "policy-guided retriever decides when to stop" (ICML 2026). Instead of a
+ * fixed top-K, keep the smallest prefix whose NORMALIZED relevance mass covers `topP`.
+ *
+ * Scores are normalized into a probability distribution first, so the cutoff is
+ * scale-free: it behaves the same on raw bi-encoder scores (0..~1.5) and on blended
+ * rerank scores. When one or two lessons dominate the distribution, fewer lessons are
+ * returned (less context stuffed into the prompt, fewer tokens); when relevance is
+ * spread out, more are kept.
+ *
+ * Guarantees:
+ *   - never returns more lessons than the input (purely subtractive);
+ *   - always returns at least `minKeep` (default 1) when the input is non-empty;
+ *   - topP >= 1 (or non-positive/NaN) is a no-op: returns the input, order preserved.
+ *
+ * @param {Array<object>} lessons - ranked lessons (each with rerankedScore or relevanceScore)
+ * @param {number} [topP=1.0] - cumulative normalized mass to cover, in (0, 1]
+ * @param {object} [options]
+ * @param {number} [options.minKeep=1] - hard floor on lessons returned
+ * @returns {Array<object>} the retained prefix, highest score first
  */
-function filterTopP(lessons, topP = 0.9) {
+function filterTopP(lessons, topP = 1.0, options = {}) {
   if (!Array.isArray(lessons) || lessons.length === 0) return [];
-  if (topP >= 1.0) return lessons;
-  const sorted = [...lessons].sort((a, b) => (b.relevanceScore || 0) - (a.relevanceScore || 0));
+  const minKeep = Math.max(1, Math.floor(options && options.minKeep) || 1);
+  if (!(topP > 0) || topP >= 1) return lessons.slice();
+
+  const scoreOf = (l) => {
+    const s = l && (l.rerankedScore ?? l.relevanceScore);
+    return Number.isFinite(s) && s > 0 ? s : 0;
+  };
+  const sorted = [...lessons].sort((a, b) => scoreOf(b) - scoreOf(a));
+  const total = sorted.reduce((sum, l) => sum + scoreOf(l), 0);
+  if (total <= 0) return sorted.slice(0, Math.min(minKeep, sorted.length));
+
   let cumulative = 0;
-  const filtered = [];
-  for (const l of sorted) {
-    filtered.push(l);
-    cumulative += (l.relevanceScore || 0);
-    if (cumulative >= topP) break;
+  const kept = [];
+  for (const lesson of sorted) {
+    kept.push(lesson);
+    cumulative += scoreOf(lesson) / total;
+    if (kept.length >= minKeep && cumulative >= topP) break;
   }
-  return filtered;
+  return kept;
 }
 
 function calculateRetrievalEntropy(lessons) {
@@ -372,7 +402,7 @@ function calculateRetrievalEntropy(lessons) {
   return Number(entropy.toFixed(4));
 }
 
-module.exports = { calculateRetrievalEntropy, filterTopP,  calculateRetrievalEntropy, 
+module.exports = {
   retrieveRelevantLessons,
   retrieveRelevantLessonsAsync,
   reciprocalRankFusion,
@@ -380,4 +410,7 @@ module.exports = { calculateRetrievalEntropy, filterTopP,  calculateRetrievalEnt
   buildActionSignature,
   textBigrams,
   bigramJaccard,
+  calculateRetrievalEntropy,
+  filterTopP,
+  resolveTopP,
 };

--- a/tests/lesson-retrieval.test.js
+++ b/tests/lesson-retrieval.test.js
@@ -233,3 +233,123 @@ test('scoreRelevance boosts fuzzy matches via n-gram similarity', () => {
   assert.ok(similarScore > unrelatedScore,
     `Fuzzy match should boost similar content: ${similarScore} vs ${unrelatedScore}`);
 });
+
+// ---------------------------------------------------------------------------
+// Nucleus (top-P) "decide when to stop" filtering — Memora-style retrieval.
+// ---------------------------------------------------------------------------
+
+test('filterTopP is a no-op at topP >= 1 (default behaviour unchanged)', () => {
+  const { filterTopP } = require('../scripts/lesson-retrieval');
+  const lessons = [
+    { id: 'a', relevanceScore: 0.5 },
+    { id: 'b', relevanceScore: 0.3 },
+    { id: 'c', relevanceScore: 0.2 },
+  ];
+  assert.deepStrictEqual(filterTopP(lessons, 1.0).map((l) => l.id), ['a', 'b', 'c']);
+  assert.deepStrictEqual(filterTopP(lessons, 2).map((l) => l.id), ['a', 'b', 'c']);
+  // default arg is 1.0 → no-op
+  assert.deepStrictEqual(filterTopP(lessons).map((l) => l.id), ['a', 'b', 'c']);
+});
+
+test('filterTopP keeps the smallest prefix covering the normalized mass', () => {
+  const { filterTopP } = require('../scripts/lesson-retrieval');
+  // normalized distribution: 0.60, 0.25, 0.15
+  const lessons = [
+    { id: 'a', relevanceScore: 0.6 },
+    { id: 'b', relevanceScore: 0.25 },
+    { id: 'c', relevanceScore: 0.15 },
+  ];
+  assert.deepStrictEqual(filterTopP(lessons, 0.5).map((l) => l.id), ['a']); // 0.60 >= 0.50
+  assert.deepStrictEqual(filterTopP(lessons, 0.8).map((l) => l.id), ['a', 'b']); // 0.85 >= 0.80
+  assert.deepStrictEqual(filterTopP(lessons, 0.99).map((l) => l.id), ['a', 'b', 'c']);
+});
+
+test('filterTopP normalizes, so raw score scale does not matter', () => {
+  const { filterTopP } = require('../scripts/lesson-retrieval');
+  // Same distribution as above but scaled 100x — must produce identical cuts.
+  const lessons = [
+    { id: 'a', relevanceScore: 60 },
+    { id: 'b', relevanceScore: 25 },
+    { id: 'c', relevanceScore: 15 },
+  ];
+  assert.deepStrictEqual(filterTopP(lessons, 0.5).map((l) => l.id), ['a']);
+  assert.deepStrictEqual(filterTopP(lessons, 0.8).map((l) => l.id), ['a', 'b']);
+});
+
+test('filterTopP honors the minKeep floor', () => {
+  const { filterTopP } = require('../scripts/lesson-retrieval');
+  const lessons = [
+    { id: 'a', relevanceScore: 0.9 },
+    { id: 'b', relevanceScore: 0.07 },
+    { id: 'c', relevanceScore: 0.03 },
+  ];
+  // topP 0.5 alone would keep only 'a'; minKeep 2 forces a second lesson.
+  assert.deepStrictEqual(filterTopP(lessons, 0.5, { minKeep: 2 }).map((l) => l.id), ['a', 'b']);
+});
+
+test('filterTopP prefers rerankedScore over relevanceScore', () => {
+  const { filterTopP } = require('../scripts/lesson-retrieval');
+  const lessons = [
+    { id: 'a', relevanceScore: 0.1, rerankedScore: 0.05 },
+    { id: 'b', relevanceScore: 0.1, rerankedScore: 0.95 },
+  ];
+  assert.deepStrictEqual(filterTopP(lessons, 0.5).map((l) => l.id), ['b']);
+});
+
+test('filterTopP handles empty, null, and all-zero inputs safely', () => {
+  const { filterTopP } = require('../scripts/lesson-retrieval');
+  assert.deepStrictEqual(filterTopP([], 0.5), []);
+  assert.deepStrictEqual(filterTopP(null, 0.5), []);
+  // all-zero scores → no usable distribution → fall back to minKeep floor (never empty)
+  const zero = [{ id: 'a', relevanceScore: 0 }, { id: 'b', relevanceScore: 0 }];
+  assert.strictEqual(filterTopP(zero, 0.5).length, 1);
+});
+
+test('resolveTopP precedence: option > env > default(1.0)', () => {
+  const { resolveTopP } = require('../scripts/lesson-retrieval');
+  const saved = process.env.THUMBGATE_RETRIEVAL_TOP_P;
+  try {
+    delete process.env.THUMBGATE_RETRIEVAL_TOP_P;
+    assert.strictEqual(resolveTopP({}), 1.0);
+    assert.strictEqual(resolveTopP({ topP: 0.8 }), 0.8);
+    assert.strictEqual(resolveTopP({ topP: 5 }), 1.0); // out-of-range option ignored
+
+    process.env.THUMBGATE_RETRIEVAL_TOP_P = '0.7';
+    assert.strictEqual(resolveTopP({}), 0.7); // env used
+    assert.strictEqual(resolveTopP({ topP: 0.8 }), 0.8); // option still wins
+    assert.strictEqual(resolveTopP({ topP: 9 }), 0.7); // bad option → env
+
+    process.env.THUMBGATE_RETRIEVAL_TOP_P = 'nonsense';
+    assert.strictEqual(resolveTopP({}), 1.0); // unparseable env → default
+  } finally {
+    if (saved === undefined) delete process.env.THUMBGATE_RETRIEVAL_TOP_P;
+    else process.env.THUMBGATE_RETRIEVAL_TOP_P = saved;
+  }
+});
+
+test('retrieveRelevantLessons: topP trims the tail, never empties, no-op at 1.0', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lesson-ret-nucleus-'));
+  const now = new Date().toISOString();
+  writeJsonl(path.join(tmpDir, 'memory-log.jsonl'), [
+    { id: 'm1', title: 'bash git push', content: 'never force push to main', tags: ['negative'], timestamp: now },
+    { id: 'm2', title: 'bash push', content: 'verify before you push to remote', tags: ['negative'], timestamp: now },
+    { id: 'm3', title: 'git workflow', content: 'commit then push to remote branch', tags: ['positive'], timestamp: now },
+    { id: 'm4', title: 'bash deploy', content: 'deploy to production carefully after push', tags: ['negative'], timestamp: now },
+    { id: 'm5', title: 'read lesson', content: 'read before editing files', tags: ['negative'], timestamp: now },
+  ]);
+
+  const { retrieveRelevantLessons } = require('../scripts/lesson-retrieval');
+  const opts = { maxResults: 5, feedbackDir: tmpDir };
+
+  const full = retrieveRelevantLessons('Bash', 'git push to remote', opts);
+  const noop = retrieveRelevantLessons('Bash', 'git push to remote', { ...opts, topP: 1.0 });
+  const trimmed = retrieveRelevantLessons('Bash', 'git push to remote', { ...opts, topP: 0.01 });
+
+  assert.ok(full.length >= 1, 'baseline returns at least one lesson');
+  assert.deepStrictEqual(noop.map((l) => l.id), full.map((l) => l.id), 'topP=1.0 is identical to default');
+  assert.ok(trimmed.length >= 1, 'nucleus never empties the result');
+  assert.ok(trimmed.length <= full.length, 'nucleus is purely subtractive');
+  assert.strictEqual(trimmed.length, 1, 'a tiny topP keeps only the single top lesson');
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## What

Wires Memora-style **nucleus (top-P) "decide when to stop"** filtering into per-action lesson retrieval, so a recall returns only as many lessons as the relevance distribution justifies instead of always padding to `maxResults`. Fewer tokens per PreToolUse warning and `retrieve_lessons` call — directly on ThumbGate's token-savings thesis.

Source idea: [Memora — Microsoft Research, ICML 2026](https://www.microsoft.com/en-us/research/blog/memora-a-harmonic-memory-representation-balancing-abstraction-and-specificity/). Its policy-guided retriever "iteratively refines its query … and decides when to stop." This is the lightweight realization of that stop condition over the existing rerank scores.

## Why this scope (and not the rest of Memora)

Grounded against the actual lesson store before writing code:
- **Consolidation-on-write** (Memora's de-fragmentation) — already implemented (3-layer dedup: exact → canonical-hash → Jaccard synthesis, + Bayesian pruning + `compactLessons`). Not rebuilt.
- **Abstraction-keyed / cue-anchor retrieval** — partially covered by the existing `title` embedding + `tags`; going further is a recall-quality gamble with no eval behind it. Deferred.
- **Stop-when-enough** — genuinely missing. `filterTopP` existed but was **dead code** (exported, never called) and **mathematically wrong** (summed raw, un-normalized scores → would truncate to 1 result).

## Changes
- `scripts/lesson-retrieval.js`
  - Fix `filterTopP` → true normalized nucleus filter: scores normalized to a distribution before accumulation (scale-free), `minKeep` floor, `topP >= 1` is a no-op.
  - Add `resolveTopP(options)` precedence: `options.topP` → `THUMBGATE_RETRIEVAL_TOP_P` → `1.0`.
  - Wire into both `retrieveRelevantLessons` and `retrieveRelevantLessonsAsync` (incl. the conclusive short-circuit path).
  - Remove the duplicate `calculateRetrievalEntropy` definition; clean up exports.
- `scripts/gates-engine.js` — remove the dead `filterTopP` import.
- `tests/lesson-retrieval.test.js` — 8 new tests, added to the already-wired suite (no test-suite-parity change).

## Default behavior unchanged
`topP` defaults to `1.0` (no-op). With no env/option set, retrieval is byte-for-byte identical to before — **zero recall regression**. Opt in with `THUMBGATE_RETRIEVAL_TOP_P=0.9` (or `options.topP`). Flipping the default on is intentionally a follow-up, pending a retrieval eval.

## Verification
- `tests/lesson-retrieval.test.js`: **21/21** pass (13 existing + 8 new)
- Blast radius (entropy dedup, gates-engine, semantic/async + multi-hop retrieval): **203/203** pass
- Changeset included (`scripts/` changes require one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)