### PR TITLE
fix(gates): never block read-only observability tools on PR-thread gate

### DIFF
--- a/.changeset/readonly-tools-exempt-pr-thread-gate.md
+++ b/.changeset/readonly-tools-exempt-pr-thread-gate.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Never block read-only observability tools on the pending PR-thread-resolution gate. After any PR-branch commit, the gate previously denied every subsequent tool call — including pure reads like `get_business_metrics`, `dashboard`, and `describe_semantic_entity` — with "a git commit was made on a PR branch." That blinded operators to their own revenue/metrics mid-PR while doing nothing for safety (a read cannot advance a readiness claim or mutate state). Read-only tools (sourced from the canonical `readonly` MCP profile) are now exempt; mutating tools and file edits stay gated.

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -1163,9 +1163,47 @@ function isThreadResolutionEvidenceAction(toolName, toolInput = {}) {
   return /\b(?:gate-satisfy|satisfy_gate|track_action|gh\s+pr\s+(?:view|checks|status)|gh\s+api\b.*(?:reviewThreads|reviews|comments|threads)|git\s+(?:status|diff|show))\b/i.test(command);
 }
 
+// Read-only observability/metrics MCP tools must NEVER be blocked by the pending
+// PR-thread-resolution gate. Reading revenue, the dashboard, gate stats, or a
+// semantic entity cannot advance a "done" claim or mutate any state, so gating it
+// only blinds the operator to their own numbers. This is the exact failure the CEO
+// hit on 2026-06-30: `get_business_metrics` denied with "a git commit was made on a
+// PR branch" — a governance gate eating the observability path. The exempt set is
+// sourced from the canonical `readonly` MCP profile (config/mcp-allowlists.json) so
+// it cannot drift from the product's own definition of "safe to read"; the hard-coded
+// fallback guarantees the core observability tools stay readable even if that policy
+// file is unreadable at runtime.
+const READ_ONLY_TOOL_FALLBACK = new Set([
+  'get_business_metrics', 'describe_semantic_entity', 'describe_reliability_entity',
+  'get_reliability_rules', 'dashboard', 'org_dashboard', 'gate_stats', 'feedback_stats',
+  'feedback_summary', 'session_report', 'generate_operator_artifact', 'settings_status',
+  'get_scope_state', 'get_branch_governance', 'context_provenance', 'native_messaging_audit',
+  'list_harnesses', 'list_intents', 'list_imported_documents', 'get_imported_document',
+  'check_operational_integrity', 'workflow_sentinel', 'recall', 'search_lessons',
+  'retrieve_lessons', 'search_thumbgate', 'unified_context', 'verify_claim',
+]);
+let readOnlyToolCache = null;
+function getReadOnlyToolNames() {
+  if (readOnlyToolCache) return readOnlyToolCache;
+  const names = new Set(READ_ONLY_TOOL_FALLBACK);
+  try {
+    const { getAllowedTools } = require('./mcp-policy');
+    for (const tool of getAllowedTools('readonly')) names.add(tool);
+  } catch (_) {
+    // Policy file missing/malformed — the fallback set still covers the core
+    // observability tools, so the operator can always read state.
+  }
+  readOnlyToolCache = names;
+  return names;
+}
+function isReadOnlyObservabilityTool(toolName) {
+  return Boolean(toolName) && getReadOnlyToolNames().has(toolName);
+}
+
 function evaluatePendingPrThreadResolutionGate(toolName, toolInput = {}) {
   if (!hasAction(PR_THREAD_RESOLUTION_ACTION)) return null;
   if (isThreadResolutionSatisfied()) return null;
+  if (isReadOnlyObservabilityTool(toolName)) return null;
   if (isThreadResolutionEvidenceAction(toolName, toolInput)) return null;
 
   const message = 'A git commit was made on a PR branch. Verify review threads are resolved before the next tool call.';
@@ -3335,6 +3373,7 @@ module.exports = {
   evaluateBoostedRiskTagGuard,
   registerPrThreadResolutionClaimGate,
   evaluatePendingPrThreadResolutionGate,
+  isReadOnlyObservabilityTool,
   getLocalOnlyScopeSources,
   isRemoteSideEffectCommand,
   evaluateLocalOnlyRemoteSideEffectGate,

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -50,6 +50,7 @@ const {
   verifyClaimEvidence,
   evaluateBoostedRiskTagGuard,
   evaluatePendingPrThreadResolutionGate,
+  isReadOnlyObservabilityTool,
   getLocalOnlyScopeSources,
   isRemoteSideEffectCommand,
   evaluateLocalOnlyRemoteSideEffectGate,
@@ -1966,6 +1967,55 @@ test('git commit on PR branch registers thread-resolution claim gate and blocks 
 
     satisfyCondition('pr_threads_checked', 'reviewThreads first:50 returned 0 unresolved');
     assert.equal(evaluatePendingPrThreadResolutionGate('Read', { file_path: 'README.md' }), null);
+  } finally {
+    fs.rmSync(tmpConfig, { force: true });
+    cleanupStateFiles();
+  }
+});
+
+test('pending PR-thread gate never blocks read-only observability tools (operator can always read revenue)', () => {
+  cleanupStateFiles();
+  const tmpConfig = makeTempPath('pr-commit-readonly-exempt.json');
+  try {
+    setTaskScope({
+      allowedPaths: ['README.md'],
+      summary: 'Keep the read-only-exemption test isolated from the caller worktree.',
+    });
+    fs.writeFileSync(tmpConfig, JSON.stringify({ version: 1, gates: [] }));
+
+    // A PR-branch commit arms the pending thread-resolution gate.
+    const commitResult = evaluateGates('Bash', {
+      command: 'git commit -m "fix review feedback"',
+      branchName: 'fix/review-feedback',
+      prNumber: 123,
+      changedFiles: ['README.md'],
+    }, tmpConfig);
+    assert.equal(commitResult, null);
+    assert.ok(hasAction(PR_THREAD_RESOLUTION_ACTION));
+
+    // The gate still bites for a plain file Read (design intent preserved)...
+    const blockedRead = evaluatePendingPrThreadResolutionGate('Read', { file_path: 'README.md' });
+    assert.ok(blockedRead && blockedRead.decision === 'deny', 'file Read stays gated until threads verified');
+
+    // ...but read-only observability MCP tools must pass through so the operator can
+    // always read revenue/metrics/dashboard mid-PR. Regression guard for 2026-06-30:
+    // `get_business_metrics` was denied "a git commit was made on a PR branch".
+    for (const tool of [
+      'get_business_metrics', 'dashboard', 'describe_semantic_entity',
+      'generate_operator_artifact', 'gate_stats', 'session_report',
+    ]) {
+      assert.equal(
+        evaluatePendingPrThreadResolutionGate(tool, {}),
+        null,
+        `${tool} must not be blocked by the pending PR-thread gate`,
+      );
+      assert.equal(isReadOnlyObservabilityTool(tool), true, `${tool} classified read-only`);
+    }
+
+    // A mutating MCP tool is NOT read-only and stays gated.
+    assert.equal(isReadOnlyObservabilityTool('capture_feedback'), false);
+    const blockedMutation = evaluatePendingPrThreadResolutionGate('import_document', { title: 'x' });
+    assert.ok(blockedMutation && blockedMutation.decision === 'deny', 'mutating MCP tool stays gated');
   } finally {
     fs.rmSync(tmpConfig, { force: true });
     cleanupStateFiles();


### PR DESCRIPTION
## Problem

Reading ThumbGate's own revenue via the MCP was **blocked by ThumbGate's own gate**. Any `get_business_metrics`, `dashboard`, or `describe_semantic_entity` call returned:

> `Action blocked by Semantic Firewall: A git commit was made on a PR branch. Verify review threads are resolved before the next tool call.`

## Root cause

`evaluatePendingPrThreadResolutionGate` (`scripts/gates-engine.js`) arms after any PR-branch commit and then **denies every subsequent tool call** outside a tiny evidence allowlist (`isThreadResolutionEvidenceAction`: git commit / recall / search_lessons / verify_claim / satisfy_gate / track_action). Read-only observability tools aren't on that list, so they got denied.

The tracked action **persists across sessions** (within its TTL), so a commit from a *prior* swarm session blocks reads in a later session that never committed anything — which is exactly what happened.

Blocking a read here has **zero safety value**: a metrics read cannot advance a "done"/readiness claim or mutate any state. It only blinds the operator to their own numbers.

## Fix

Exempt read-only tools from this gate. The exempt set is sourced from the canonical `readonly` MCP profile in `config/mcp-allowlists.json` (so it can't drift from the product's own definition of "safe to read"), with a hard-coded observability fallback if that file is unreadable at runtime.

**The gate keeps its teeth:** mutating MCP tools (e.g. `import_document`), file `Edit`/`Write`, and `Bash` still stay gated until review threads are verified.

## Verification

- New regression test in `tests/gates-engine.test.js` asserts read-only tools pass through while `Read`/mutating tools stay denied.
- Full `gates-engine` suite green (**173/173**).
- Verified against **live persisted gate state**: the PR-thread action was actually armed; post-fix `get_business_metrics` + `dashboard` → PASS, `Edit` → still DENY.

> Note: the running local MCP server and Railway prod pick this up on next restart/redeploy; the fix is proven at the code + state level here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
