### PR TITLE
fix(diagnostic): ship upgraded $499 workflow-hardening buyer page

### DIFF
--- a/.changeset/ship-diagnostic-buyer-page.md
+++ b/.changeset/ship-diagnostic-buyer-page.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Ship upgraded $499 Workflow Hardening Diagnostic buyer page (intake form, scope/proof sections, wired /go/diagnostic + /checkout CTAs); replaces the thinner page currently live at /diagnostic.

--- a/public/diagnostic.html
+++ b/public/diagnostic.html
@@ -1,345 +1,467 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>ThumbGate Workflow Hardening Diagnostic</title>
-<meta name="description" content="A focused diagnostic for one repeated AI-agent workflow failure. ThumbGate maps the failure taxonomy, block/warn/human-review split, and proof checklist before rollout.">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+__GOOGLE_SITE_VERIFICATION_META__
+<title>ThumbGate Workflow Hardening Diagnostic | Turn one repeated agent failure into a gate</title>
+<meta name="description" content="Submit one repeated AI-agent workflow failure for a $499 ThumbGate Workflow Hardening Diagnostic. Get a failure taxonomy, block/warn/review split, and proof checklist before rollout.">
+<meta property="og:title" content="ThumbGate Workflow Hardening Diagnostic">
+<meta property="og:description" content="One workflow, one repeated failure, one owner. Turn agent mistakes into pre-action gates with proof.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="__APP_ORIGIN__/diagnostic">
+<meta property="og:image" content="/og.png">
 <link rel="canonical" href="__APP_ORIGIN__/diagnostic">
 <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
-<meta property="og:title" content="ThumbGate Workflow Hardening Diagnostic">
-<meta property="og:description" content="Send one repeated AI-agent workflow failure. Get the gate/review split and proof checklist before implementation.">
-<meta property="og:url" content="__APP_ORIGIN__/diagnostic">
-<meta property="og:type" content="website">
-<style>
-:root {
-  color-scheme: dark;
-  --bg: #05080a;
-  --panel: #0d1418;
-  --panel-2: #12181d;
-  --line: #24323a;
-  --text: #eef7f9;
-  --muted: #a9b7bd;
-  --cyan: #28d5ee;
-  --green: #48dd83;
-  --red: #ff7676;
-  --white: #ffffff;
-}
-* { box-sizing: border-box; }
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: var(--bg);
-  color: var(--text);
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  line-height: 1.5;
-}
-a { color: inherit; }
-header, main, footer { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 24px 0;
-}
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-weight: 800;
-  letter-spacing: 0;
-}
-.mark {
-  width: 28px;
-  height: 28px;
-  display: block;
-}
-nav { display: flex; gap: 18px; color: var(--muted); font-size: 14px; }
-.hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(340px, 0.95fr);
-  gap: 36px;
-  align-items: start;
-  padding: 54px 0 40px;
-}
-.eyebrow {
-  color: var(--cyan);
-  font-size: 13px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-}
-h1 {
-  margin: 14px 0 18px;
-  max-width: 720px;
-  font-size: clamp(42px, 6vw, 76px);
-  line-height: .92;
-  letter-spacing: 0;
-}
-.lede {
-  max-width: 650px;
-  margin: 0 0 26px;
-  color: var(--muted);
-  font-size: 20px;
-}
-.actions { display: flex; flex-wrap: wrap; gap: 12px; }
-.button {
-  min-height: 48px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 18px;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  text-decoration: none;
-  font-weight: 800;
-  color: var(--text);
-}
-.button.primary {
-  border-color: var(--cyan);
-  background: var(--cyan);
-  color: #031014;
-}
-.proof-strip {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 34px;
-}
-.proof {
-  min-height: 90px;
-  padding: 16px;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  border-radius: 8px;
-}
-.proof strong { display: block; font-size: 20px; }
-.proof span { color: var(--muted); font-size: 14px; }
-.intake-card {
-  border: 1px solid var(--line);
-  background: var(--panel);
-  border-radius: 8px;
-  padding: 24px;
-}
-.intake-card h2 { margin: 0 0 10px; font-size: 24px; }
-.intake-card p { color: var(--muted); margin: 0 0 18px; }
-label {
-  display: block;
-  margin: 14px 0 7px;
-  color: var(--text);
-  font-size: 14px;
-  font-weight: 750;
-}
-input, textarea, select {
-  width: 100%;
-  border: 1px solid #32424a;
-  border-radius: 7px;
-  background: #070b0d;
-  color: var(--text);
-  padding: 12px;
-  font: inherit;
-}
-textarea { min-height: 116px; resize: vertical; }
-button {
-  width: 100%;
-  min-height: 50px;
-  margin-top: 18px;
-  border: 0;
-  border-radius: 7px;
-  background: var(--cyan);
-  color: #031014;
-  font: inherit;
-  font-weight: 900;
-  cursor: pointer;
-}
-.hint { font-size: 13px; color: var(--muted); }
-section {
-  padding: 40px 0;
-  border-top: 1px solid var(--line);
-}
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 16px;
-}
-.box {
-  min-height: 170px;
-  padding: 20px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel-2);
-}
-.box h3 { margin: 0 0 8px; }
-.box p { margin: 0; color: var(--muted); }
-footer { padding: 32px 0 44px; color: var(--muted); }
-@media (max-width: 860px) {
-  header { align-items: flex-start; flex-direction: column; }
-  .hero, .grid, .proof-strip { grid-template-columns: 1fr; }
-  h1 { font-size: 42px; }
-}
-</style>
+<link rel="icon" type="image/png" href="/thumbgate-icon.png">
+<link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
+
+<script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.js"></script>
+__GA_BOOTSTRAP__
+
+<script>
+  const gaMeasurementId = '__GA_MEASUREMENT_ID__';
+  const serverVisitorId = '__SERVER_VISITOR_ID__';
+  const serverSessionId = '__SERVER_SESSION_ID__';
+  const serverAcquisitionId = '__SERVER_ACQUISITION_ID__';
+  const serverTelemetryCaptured = '__SERVER_TELEMETRY_CAPTURED__' === 'true';
+</script>
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Service",
   "name": "ThumbGate Workflow Hardening Diagnostic",
+  "description": "A focused diagnostic for one repeated AI-agent workflow failure. ThumbGate maps the failure taxonomy, block/warn/human-review split, and proof checklist before rollout.",
   "provider": {
     "@type": "Organization",
     "name": "ThumbGate",
-    "url": "__APP_ORIGIN__"
+    "url": "__APP_ORIGIN__/"
   },
-  "description": "A focused diagnostic for one repeated AI-agent workflow failure, including failure taxonomy, block/warn/human-review split, and proof checklist.",
+  "url": "__APP_ORIGIN__/diagnostic",
   "offers": {
     "@type": "Offer",
     "price": "__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__",
     "priceCurrency": "USD",
     "availability": "https://schema.org/InStock",
-    "url": "__APP_ORIGIN__/diagnostic"
+    "url": "__APP_ORIGIN__/go/diagnostic"
+  },
+  "audience": {
+    "@type": "Audience",
+    "audienceType": "AI-agent workflow owners, platform teams, founders, and engineering leaders"
   }
 }
 </script>
+
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  :root {
+    --bg: #090b0f;
+    --surface: #11151c;
+    --surface-2: #161b24;
+    --line: #27313d;
+    --text: #f1f5f9;
+    --muted: #9ba8b6;
+    --cyan: #22d3ee;
+    --green: #4ade80;
+    --amber: #fbbf24;
+    --red: #fb7185;
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+  }
+  body {
+    margin: 0;
+    font-family: var(--font);
+    background: linear-gradient(180deg, #090b0f 0%, #0e131a 48%, #090b0f 100%);
+    color: var(--text);
+    line-height: 1.55;
+  }
+  a { color: inherit; }
+  .container { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: rgba(9, 11, 15, 0.88);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(39, 49, 61, 0.9);
+  }
+  nav .container {
+    min-height: 68px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 20px;
+  }
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text);
+    text-decoration: none;
+    font-weight: 800;
+  }
+  .brand img { width: 28px; height: 28px; }
+  .brand span { color: var(--cyan); }
+  .nav-links { display: flex; gap: 18px; align-items: center; flex-wrap: wrap; }
+  .nav-links a { color: var(--muted); text-decoration: none; font-size: 13px; }
+  .nav-links a:hover { color: var(--text); }
+  .nav-cta, .btn-primary, .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    border-radius: 8px;
+    padding: 0 18px;
+    font-weight: 800;
+    text-decoration: none;
+    border: 1px solid transparent;
+  }
+  .nav-cta, .btn-primary {
+    background: var(--cyan);
+    color: #06121a;
+  }
+  .btn-secondary {
+    color: var(--text);
+    background: rgba(17, 21, 28, 0.82);
+    border-color: var(--line);
+  }
+  header.hero {
+    padding: 72px 0 54px;
+  }
+  .hero-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.04fr) minmax(340px, 0.96fr);
+    gap: 28px;
+    align-items: start;
+  }
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    padding: 7px 11px;
+    border: 1px solid rgba(34, 211, 238, 0.28);
+    border-radius: 999px;
+    color: var(--cyan);
+    background: rgba(34, 211, 238, 0.1);
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  h1 {
+    margin: 18px 0 16px;
+    font-size: clamp(36px, 6vw, 58px);
+    line-height: 1.02;
+    letter-spacing: -0.045em;
+  }
+  .lede {
+    margin: 0;
+    color: var(--muted);
+    font-size: 18px;
+    max-width: 720px;
+  }
+  .hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 26px;
+  }
+  .proof-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 28px;
+  }
+  .proof {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 13px;
+    background: rgba(17, 21, 28, 0.74);
+  }
+  .proof strong { display: block; color: var(--text); font-size: 14px; }
+  .proof span { display: block; color: var(--muted); font-size: 12px; margin-top: 3px; }
+  .intake-panel {
+    border: 1px solid rgba(34, 211, 238, 0.3);
+    border-radius: 8px;
+    background: linear-gradient(180deg, rgba(17, 21, 28, 0.98), rgba(22, 27, 36, 0.98));
+    box-shadow: 0 22px 70px rgba(0, 0, 0, 0.28);
+    padding: 24px;
+  }
+  .price {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 18px;
+    margin-bottom: 14px;
+  }
+  .price strong { font-size: 34px; letter-spacing: -0.04em; }
+  .price span { color: var(--muted); font-size: 13px; text-align: right; }
+  form { display: grid; gap: 12px; }
+  label { display: grid; gap: 5px; color: var(--muted); font-size: 12px; font-weight: 700; }
+  input, textarea, select {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: #0c1016;
+    color: var(--text);
+    padding: 11px 12px;
+    font: inherit;
+  }
+  textarea { min-height: 92px; resize: vertical; }
+  .two { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .payment-handoff {
+    display: grid;
+    gap: 4px;
+    margin: 0 0 16px;
+    border: 1px solid rgba(74, 222, 128, 0.32);
+    border-radius: 8px;
+    padding: 12px;
+    background: rgba(74, 222, 128, 0.08);
+  }
+  .payment-handoff strong { color: var(--green); font-size: 13px; }
+  .payment-handoff span { color: var(--muted); font-size: 12px; }
+  .hint { color: var(--muted); font-size: 12px; margin: 10px 0 0; }
+  section { border-top: 1px solid var(--line); padding: 52px 0; }
+  h2 { font-size: 30px; line-height: 1.12; letter-spacing: -0.03em; margin: 0 0 14px; }
+  .section-lede { color: var(--muted); max-width: 760px; margin: 0 0 24px; }
+  .grid-3 { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+  .item {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface);
+    padding: 18px;
+  }
+  .item h3 { margin: 0 0 8px; font-size: 16px; color: var(--cyan); }
+  .item p { margin: 0; color: var(--muted); font-size: 14px; }
+  .timeline { display: grid; gap: 12px; }
+  .step {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    gap: 14px;
+    align-items: start;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 16px;
+    background: var(--surface);
+  }
+  .num {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    background: rgba(34, 211, 238, 0.12);
+    color: var(--cyan);
+    font-weight: 900;
+  }
+  .step strong { display: block; }
+  .step span { display: block; color: var(--muted); margin-top: 4px; }
+  footer { color: var(--muted); padding: 40px 0 70px; text-align: center; font-size: 13px; }
+  footer a { color: var(--cyan); text-decoration: none; }
+  @media (max-width: 820px) {
+    .hero-grid, .grid-3, .proof-row, .two { grid-template-columns: 1fr; }
+    nav .container { align-items: flex-start; flex-direction: column; padding-top: 16px; padding-bottom: 16px; }
+  }
+</style>
 </head>
 <body>
-<header>
-  <a class="brand" href="/">
-    <img class="mark" src="/assets/brand/thumbgate-mark-inline-v3.svg" alt="ThumbGate" width="28" height="28" />
-    <span>ThumbGate</span>
-  </a>
-  <nav aria-label="Primary">
-    <a href="/pro">Pro</a>
-    <a href="/pricing">Pricing</a>
-    <a href="/llm-context.md">LLM Context</a>
-  </nav>
-</header>
-<main>
-  <div class="hero">
-    <div>
-      <div class="eyebrow">Workflow Hardening Diagnostic</div>
-      <h1>Turn one repeated AI-agent failure into a gate you can prove.</h1>
-      <p class="lede">Send the workflow that keeps failing. ThumbGate maps what should block, warn, or route to human review before an agent writes, sends, deploys, or spends.</p>
-      <div class="actions">
-        <a class="button primary" href="/go/diagnostic?utm_source=diagnostic_page&amp;utm_medium=onsite&amp;utm_campaign=workflow_hardening_diagnostic&amp;utm_content=hero_paid_diagnostic" data-revenue-cta data-cta-id="diagnostic_hero_paid" data-cta-placement="hero">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
-        <a class="button" href="#intake" data-revenue-cta data-cta-id="diagnostic_hero_intake" data-cta-placement="hero">Send workflow first</a>
-      </div>
-      <div class="proof-strip" aria-label="Diagnostic proof points">
-        <div class="proof"><strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</strong><span>Credited toward a sprint when implementation follows.</span></div>
-        <div class="proof"><strong>One workflow</strong><span>Scoped tightly so the proof is shippable.</span></div>
-        <div class="proof"><strong>Fit fallback</strong><span>Use the intake if the workflow needs scoping first.</span></div>
-      </div>
+<nav>
+  <div class="container">
+    <a class="brand" href="/">
+      <img src="/assets/brand/thumbgate-mark-inline-v3.svg" alt="">
+      ThumbGate <span>/ diagnostic</span>
+    </a>
+    <div class="nav-links">
+      <a href="#scope">Scope</a>
+      <a href="#proof">Proof</a>
+      <a href="#intake">Intake</a>
+      <a class="nav-cta" href="#intake">Send workflow</a>
     </div>
-    <form id="intake" class="intake-card" action="/v1/intake/workflow-sprint" method="POST" data-team-intake-form data-diagnostic-intake-form>
-      <h2>Submit for diagnostic scope</h2>
-      <p>Use this when an AI-assisted workflow has already caused rework, review drag, or release risk.</p>
-      <input type="hidden" name="ctaId" value="diagnostic_page_intake">
-      <input type="hidden" name="ctaPlacement" value="diagnostic_page">
-      <input type="hidden" name="utmMedium" value="diagnostic_intake">
-      <input type="hidden" name="utmCampaign" value="workflow_hardening_diagnostic">
-      <input type="hidden" name="planId" value="diagnostic">
-      <input type="hidden" name="page" value="/diagnostic">
-      <label for="name">Name</label>
-      <input id="name" name="name" autocomplete="name" required>
-      <label for="email">Work email</label>
-      <input id="email" name="email" type="email" autocomplete="email" required>
-      <label for="company">Company or project</label>
-      <input id="company" name="company" autocomplete="organization">
-      <label for="workflow">What workflow keeps failing?</label>
-      <textarea id="workflow" name="workflow" required placeholder="Example: agent opens PRs without the right proof, sends the wrong customer update, or deploys before approvals are clear."></textarea>
-      <label for="urgency">Urgency</label>
-      <select id="urgency" name="urgency">
-        <option>Repeated failure already cost us time</option>
-        <option>We are about to roll this workflow out</option>
-        <option>We need an independent proof checklist first</option>
-      </select>
-      <button type="submit" data-revenue-cta data-cta-id="diagnostic_page_submit" data-cta-placement="intake">Submit for diagnostic scope</button>
-      <p class="hint">Ready to pay now? Use the $499 diagnostic checkout above. If the workflow needs fit review first, submit it here and we will route you to the diagnostic or sprint only when the scope is real.</p>
-    </form>
   </div>
-  <section>
-    <div class="grid">
-      <div class="box">
+</nav>
+
+<header class="hero">
+  <div class="container hero-grid">
+    <div>
+      <span class="eyebrow">Workflow Hardening Diagnostic</span>
+      <h1>Turn one repeated AI-agent failure into a pre-action gate.</h1>
+      <p class="lede">
+        For teams already using Claude Code, Codex, Cursor, Gemini, Amp, Cline, or browser agents. ThumbGate maps one real failed action into a failure taxonomy, a block/warn/human-review split, and the proof checklist for the next similar action.
+      </p>
+      <div class="hero-actions">
+        <a class="btn-primary" href="/go/diagnostic?utm_source=diagnostic_page&utm_medium=onsite&utm_campaign=diagnostic_paid_start&utm_content=hero_primary" data-revenue-cta data-cta-id="diagnostic_hero_paid_start" data-cta-placement="hero">Book $499 diagnostic</a>
+        <a class="btn-secondary" href="#intake" data-revenue-cta data-cta-id="diagnostic_hero_intake" data-cta-placement="hero">Send workflow first</a>
+        <a class="btn-secondary" href="/checkout/pro?utm_source=diagnostic_page&utm_medium=onsite&utm_campaign=diagnostic_secondary_pro&utm_content=hero_secondary" data-revenue-cta data-cta-id="diagnostic_secondary_pro" data-cta-placement="hero">Need self-serve Pro?</a>
+      </div>
+      <div class="proof-row">
+        <div class="proof"><strong>One workflow</strong><span>Keep scope concrete enough to prove.</span></div>
+        <div class="proof"><strong>One owner</strong><span>Someone reviews the gate decision.</span></div>
+        <div class="proof"><strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</strong><span>Credited toward a sprint.</span></div>
+      </div>
+    </div>
+
+    <aside class="intake-panel" id="intake">
+      <div class="price">
+        <strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</strong>
+        <span>Pay now if scope is clear.<br>Send workflow first if it is not.</span>
+      </div>
+      <div class="payment-handoff" data-diagnostic-payment-handoff>
+        <strong>Ready buyers can start now.</strong>
+        <span>Book the $499 diagnostic now, or submit the workflow first if scope is unclear. Stripe or PayPal attribution is preserved through the paid-start path.</span>
+        <a class="btn-primary" href="/go/diagnostic?utm_source=diagnostic_page&utm_medium=onsite&utm_campaign=diagnostic_paid_start&utm_content=intake_panel" data-diagnostic-paid-start data-revenue-cta data-cta-id="diagnostic_panel_paid_start" data-cta-placement="intake_panel">Book $499 diagnostic</a>
+      </div>
+      <form action="/v1/intake/workflow-sprint" method="POST" data-team-intake-form data-diagnostic-intake-form>
+        <input type="hidden" name="ctaId" value="diagnostic_page_intake">
+        <input type="hidden" name="ctaPlacement" value="diagnostic_page">
+        <input type="hidden" name="utmMedium" value="diagnostic_intake">
+        <input type="hidden" name="utmCampaign" value="workflow_hardening_diagnostic">
+        <input type="hidden" name="planId" value="diagnostic">
+        <input type="hidden" name="page" value="/diagnostic">
+        <label>
+          Work email
+          <input type="email" name="email" autocomplete="email" required placeholder="you@company.com">
+        </label>
+        <label>
+          Company or project
+          <input type="text" name="company" autocomplete="organization" required placeholder="Team, repo, or product">
+        </label>
+        <div class="two">
+          <label>
+            Agent/runtime
+            <select name="runtime" required>
+              <option value="">Choose one</option>
+              <option>Claude Code</option>
+              <option>Codex</option>
+              <option>Cursor</option>
+              <option>Gemini CLI</option>
+              <option>Amp</option>
+              <option>Browser agent</option>
+              <option>Other</option>
+            </select>
+          </label>
+          <label>
+            Owner
+            <input type="text" name="owner" required placeholder="Who reviews proof?">
+          </label>
+        </div>
+        <label>
+          Workflow
+          <input type="text" name="workflow" required placeholder="PR merge, browser posting, checkout deploy, CRM update">
+        </label>
+        <label>
+          Repeated failure or rollout blocker
+          <textarea name="blocker" required placeholder="What action keeps going wrong, and what should have blocked or routed to review?"></textarea>
+        </label>
+        <label>
+          Notes
+          <textarea name="note" placeholder="Paste context, repo URL, screenshot link, or what proof would convince the owner."></textarea>
+        </label>
+        <button class="btn-primary" type="submit" data-revenue-cta data-cta-id="diagnostic_page_submit" data-cta-placement="intake">Submit for diagnostic scope</button>
+      </form>
+      <p class="hint">If the workflow is already clear, use the paid-start button. If scope is unclear, submit the workflow first; the diagnostic is credited toward a $1500 hardening sprint.</p>
+    </aside>
+  </div>
+</header>
+
+<section id="scope">
+  <div class="container">
+    <h2>What the diagnostic produces</h2>
+    <p class="section-lede">This is intentionally smaller than a platform project. It produces enough proof to decide whether to harden the workflow now.</p>
+    <div class="grid-3">
+      <div class="item">
         <h3>Failure taxonomy</h3>
-        <p>Classify the repeated action: bad context, missing approval, unsafe write, wrong target, or proof gap.</p>
+        <p>The repeated mistake is reduced to concrete signatures: command shape, page state, file scope, tool boundary, approval boundary, and expected evidence.</p>
       </div>
-      <div class="box">
+      <div class="item">
         <h3>Gate split</h3>
-        <p>Define what should block automatically, warn the operator, or route to human review with evidence attached.</p>
+        <p>Each case is labeled block, warn, or route to human review. Novel failures stay reviewable instead of turning into broad prompt rules.</p>
       </div>
-      <div class="box">
+      <div class="item">
         <h3>Proof checklist</h3>
-        <p>Leave with the verification steps needed to prove the next similar action is caught before execution.</p>
+        <p>The next similar action must show the gate fired or the review handoff happened before the tool touched production, public posting, billing, or customer data.</p>
       </div>
     </div>
-  </section>
-  <section>
-    <h2>Use this for real agent workflows</h2>
-    <div class="grid">
-      <div class="box">
-        <h3>Code and PR agents</h3>
-        <p>Repeated bad diffs, missing tests, unsafe merges, or unclear ownership around generated changes.</p>
-      </div>
-      <div class="box">
-        <h3>Browser and ops agents</h3>
-        <p>Agents clicking, posting, updating CRMs, or moving money without the right boundary proof.</p>
-      </div>
-      <div class="box">
-        <h3>Customer-visible automation</h3>
-        <p>Email, support, billing, or publishing workflows where a repeat mistake costs trust.</p>
-      </div>
+  </div>
+</section>
+
+<section id="proof">
+  <div class="container">
+    <h2>The buyer fit</h2>
+    <div class="timeline">
+      <div class="step"><span class="num">1</span><div><strong>You already have an AI-assisted workflow.</strong><span>Claude Code, Codex, Cursor, Gemini, Amp, browser automation, or adjacent agent tooling is already touching real work.</span></div></div>
+      <div class="step"><span class="num">2</span><div><strong>The failure has business impact.</strong><span>Bad deploys, wrong sends, stale claims, missing tests, broken checkout, or risky tool use are costing time, trust, or revenue.</span></div></div>
+      <div class="step"><span class="num">3</span><div><strong>One owner can review proof.</strong><span>The diagnostic is useful only when someone can say whether the proposed gate is acceptable before implementation.</span></div></div>
     </div>
-  </section>
-</main>
+  </div>
+</section>
+
 <footer>
-  ThumbGate is local-first agent governance. Use <a href="/pro">Pro</a> for self-serve operator proof, or submit one workflow above for a diagnostic.
+  <div class="container">
+    ThumbGate is local-first agent governance. Use <a href="/pro">Pro</a> for self-serve operator proof, or submit one workflow above for a diagnostic.
+  </div>
 </footer>
+
 <script>
-(function () {
-  const search = new URLSearchParams(window.location.search);
-  const form = document.querySelector('[data-diagnostic-intake-form]');
-  if (form) {
-    for (const [key, value] of search.entries()) {
-      if (!/^utm_|^(source|campaign|content|term)$/i.test(key)) continue;
-      let input = form.querySelector(`input[name="${CSS.escape(key)}"]`);
-      if (!input) {
-        input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = key;
-        form.appendChild(input);
-      }
+  function copySearchParamsToForm() {
+    const form = document.querySelector('[data-diagnostic-intake-form]');
+    if (!form) return;
+    const params = new URLSearchParams(window.location.search);
+    const passthrough = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'creator', 'community', 'post_id', 'comment_id'];
+    const fieldNames = {
+      utm_source: 'utmSource',
+      utm_medium: 'utmMedium',
+      utm_campaign: 'utmCampaign',
+      utm_content: 'utmContent',
+      utm_term: 'utmTerm',
+      post_id: 'postId',
+      comment_id: 'commentId'
+    };
+    for (const key of passthrough) {
+      const value = params.get(key);
+      if (!value) continue;
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = fieldNames[key] || key;
       input.value = value;
+      form.appendChild(input);
     }
   }
-
-  function telemetry(eventName, props) {
+  function sendFirstPartyTelemetry(eventType, props) {
     try {
-      navigator.sendBeacon && navigator.sendBeacon('/v1/telemetry/event', JSON.stringify({
-        event: eventName,
+      navigator.sendBeacon && navigator.sendBeacon('/v1/telemetry/ping', JSON.stringify({
+        eventType,
         page: '/diagnostic',
         source: 'diagnostic_page',
-        props
+        visitorId: serverVisitorId,
+        sessionId: serverSessionId,
+        acquisitionId: serverAcquisitionId,
+        properties: props || {}
       }));
     } catch (_) {}
   }
-
-  document.addEventListener('click', function (event) {
+  copySearchParamsToForm();
+  document.addEventListener('click', function(event) {
     const cta = event.target.closest('[data-revenue-cta]');
     if (!cta) return;
-    telemetry('diagnostic_cta_click', {
+    const props = {
       ctaId: cta.getAttribute('data-cta-id'),
       ctaPlacement: cta.getAttribute('data-cta-placement'),
       planId: cta.getAttribute('data-cta-id') === 'diagnostic_secondary_pro' ? 'pro' : 'diagnostic'
-    });
+    };
+    try { window.plausible && window.plausible('pricing_cta_click', { props }); } catch (_) {}
+    sendFirstPartyTelemetry('diagnostic_cta_click', props);
+    if (typeof gtag === 'function') {
+      try { gtag('event', 'generate_lead', props); } catch (_) {}
+    }
   });
-
-  document.addEventListener('submit', function (event) {
+  document.addEventListener('submit', function(event) {
     if (!event.target.matches('[data-diagnostic-intake-form]')) return;
-    telemetry('workflow_sprint_intake_submit_attempted', {
+    sendFirstPartyTelemetry('workflow_sprint_intake_submit_attempted', {
       ctaId: 'diagnostic_page_submit',
       ctaPlacement: 'diagnostic_page',
       planId: 'diagnostic'
     });
   });
-})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## What
Ships the upgraded `/diagnostic` ($499 Workflow Hardening Diagnostic) buyer page — intake form, `#scope`/`#proof` sections, wired `/go/diagnostic` + `/checkout/pro` CTAs.

## Why
The `/diagnostic` route and an older, thinner page were already on `main` and live in prod. The richer intake-form version was stranded **untracked** in a working tree — never committed, never deployed — so buyers were hitting the weaker page. This commits the upgrade so the full offer page ships.

## Scope
Single page + changeset. No route/server change (route already on main). `public/diagnostic.html` +409/-282.

## Verify after merge + deploy
- `curl -s -o /dev/null -w "%{http_code}" https://thumbgate.ai/diagnostic` → `200`
- Body contains `#intake` form and `$499`

🤖 Generated with [Claude Code](https://claude.com/claude-code)