### PR TITLE
fix(deploy): catch-up deploy when prod drifts behind main HEAD

### DIFF
--- a/.changeset/deploy-scope-prod-drift.md
+++ b/.changeset/deploy-scope-prod-drift.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix deploy-scope silently skipping deploys when production has drifted behind main. A push with no runtime-serving file changes now still triggers a catch-up deploy when the live `/health` build SHA is positively confirmed behind HEAD; unknown/unreachable preserves the historical skip (fail-safe). Prevents production freezing many commits behind main (root cause of the `/diagnostic` 404 — prod was sitting 86 commits behind).

--- a/scripts/deploy-scope.sh
+++ b/scripts/deploy-scope.sh
@@ -10,6 +10,28 @@ CHANGED_FILES=''
 SHOULD_DEPLOY=true
 SCOPE_REASON='default_deploy'
 
+# Positively determine production's currently-deployed commit SHA, if we can.
+# Order: explicit override (tests / pre-fetched) then the live /health buildSha.
+# Prints the SHA on success; prints nothing when unknown/unreachable. Always exits 0
+# so `set -e` never trips on a transient health blip.
+get_deployed_sha() {
+  if [[ -n "${DEPLOY_SCOPE_DEPLOYED_SHA:-}" ]]; then
+    printf '%s' "$DEPLOY_SCOPE_DEPLOYED_SHA"
+    return 0
+  fi
+  local url="${RAILWAY_HEALTHCHECK_URL:-}"
+  if [[ -z "$url" ]]; then
+    return 0
+  fi
+  local body
+  body="$(curl -fsS --max-time 10 "$url" 2>/dev/null || true)"
+  if [[ -z "$body" ]]; then
+    return 0
+  fi
+  printf '%s' "$body" | node -e 'let s="";process.stdin.on("data",(d)=>{s+=d;}).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).buildSha||""));}catch(_){process.stdout.write("");}});' 2>/dev/null || true
+  return 0
+}
+
 if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
   SHOULD_DEPLOY=true
   SCOPE_REASON='workflow_dispatch'
@@ -17,8 +39,21 @@ elif [[ "$EVENT_NAME" == "push" && -n "$BEFORE_SHA" && "$BEFORE_SHA" != "0000000
   if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
     CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$HEAD_SHA" | sed '/^$/d')"
     if [[ -n "$CHANGED_FILES" ]] && ! printf '%s\n' "$CHANGED_FILES" | grep -Eq "$DEPLOYABLE_PATTERN"; then
-      SHOULD_DEPLOY=false
-      SCOPE_REASON='non_runtime_changes'
+      # No runtime-serving files changed in this push, so normally we skip the deploy.
+      # BUT only skip if production is already serving HEAD. If we can positively confirm
+      # the live build SHA is behind HEAD, an earlier deploy was skipped or failed and prod
+      # has drifted behind main — force a catch-up deploy so main HEAD actually ships.
+      # When the deployed SHA is unknown/unreachable we preserve the historical skip
+      # (fail-safe: never block a merge on a health blip).
+      DEPLOYED_SHA="$(get_deployed_sha || true)"
+      if [[ -n "$DEPLOYED_SHA" && "$DEPLOYED_SHA" != "$HEAD_SHA" ]]; then
+        SHOULD_DEPLOY=true
+        SCOPE_REASON='prod_behind_head'
+        echo "::notice::Deploy forced: live build ${DEPLOYED_SHA} is behind main HEAD ${HEAD_SHA}; catching up despite a non-runtime push."
+      else
+        SHOULD_DEPLOY=false
+        SCOPE_REASON='non_runtime_changes'
+      fi
     elif [[ -n "$CHANGED_FILES" ]]; then
       SHOULD_DEPLOY=true
       SCOPE_REASON='deployable_changes'

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -33,7 +33,7 @@ function deployUrl(pathname = '/') {
   return new URL(pathname, deployOrigin).toString();
 }
 
-function runDeployScopeFixture(changePath, eventName = 'push', beforeShaOverride = null) {
+function runDeployScopeFixture(changePath, eventName = 'push', beforeShaOverride = null, deployedSha = null) {
   const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-deploy-scope-'));
   const githubOutput = path.join(repoDir, 'github-output.txt');
   const jsonOutput = path.join(repoDir, 'deploy-scope.json');
@@ -54,6 +54,7 @@ function runDeployScopeFixture(changePath, eventName = 'push', beforeShaOverride
     execFileSync('git', ['add', '.'], { cwd: repoDir });
     execFileSync('git', ['commit', '-m', `change ${changePath}`], { cwd: repoDir, stdio: 'ignore' });
     const headSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repoDir, encoding: 'utf8' }).trim();
+    const resolvedDeployedSha = deployedSha === '__HEAD__' ? headSha : (deployedSha || '');
 
     execFileSync('bash', [DEPLOY_SCOPE_SCRIPT], {
       cwd: repoDir,
@@ -64,6 +65,10 @@ function runDeployScopeFixture(changePath, eventName = 'push', beforeShaOverride
         EVENT_NAME: eventName,
         GITHUB_OUTPUT: githubOutput,
         DEPLOY_SCOPE_OUTPUT_JSON: jsonOutput,
+        // Hermetic: never let the real /health be curled during unit tests.
+        // Empty = "deployed SHA unknown" (preserves historical skip behaviour).
+        RAILWAY_HEALTHCHECK_URL: '',
+        DEPLOY_SCOPE_DEPLOYED_SHA: resolvedDeployedSha,
       },
       stdio: 'pipe',
     });
@@ -457,8 +462,30 @@ test('Deploy to Railway workflow skips non-runtime pushes and only deploys when 
   assert.match(scopeScript, /should_deploy=\$SHOULD_DEPLOY/);
   assert.match(scopeScript, /SHOULD_DEPLOY=true/);
   assert.match(scopeScript, /SHOULD_DEPLOY=false/);
+  // Drift guard: a non-runtime push must still deploy when prod is behind main HEAD.
+  assert.match(scopeScript, /get_deployed_sha/);
+  assert.match(scopeScript, /DEPLOY_SCOPE_DEPLOYED_SHA/);
+  assert.match(scopeScript, /prod_behind_head/);
   assert.match(workflow, /Railway deploy skipped: no runtime-serving files changed in this push range\./);
   assert.doesNotMatch(workflow, /Railway deploy skipped: deploy-scope disabled this run\./);
+});
+
+test('deploy-scope forces a catch-up deploy when production has drifted behind main HEAD', () => {
+  // Non-runtime push, but the live build SHA is behind HEAD -> must deploy to catch up.
+  const behind = runDeployScopeFixture('docs/only-a-note.md', 'push', null, '0000000000000000000000000000000000000000');
+  assert.equal(behind.shouldDeploy, true);
+  assert.equal(behind.scopeReason, 'prod_behind_head');
+
+  // Non-runtime push AND production already serving HEAD -> safe to skip.
+  const current = runDeployScopeFixture('docs/only-a-note.md', 'push', null, '__HEAD__');
+  assert.equal(current.shouldDeploy, false);
+  assert.equal(current.scopeReason, 'non_runtime_changes');
+
+  // Non-runtime push, deployed SHA unknown (no override / no reachable health) ->
+  // preserve historical skip so a health blip never blocks a merge.
+  const unknown = runDeployScopeFixture('docs/only-a-note.md');
+  assert.equal(unknown.shouldDeploy, false);
+  assert.equal(unknown.scopeReason, 'non_runtime_changes');
 });
 
 test('deploy-scope script decides from the actual push range and writes reusable evidence', () => {


### PR DESCRIPTION
## Problem
`deploy-scope.sh` skipped the Railway deploy — while reporting the job **green** — whenever a push touched no runtime-serving files, *even when production was already behind main* from earlier skipped/failed deploys. main HEAD then silently accumulated undeployed commits.

**Real impact:** production sat **86 commits behind main**, so `/diagnostic` (merged in #2721) returned 404 in prod — the paid buyer page was live in code but never deployed.

## Fix
A non-runtime push now still triggers a catch-up deploy **when the live `/health` build SHA is positively confirmed behind HEAD**. When the deployed SHA is unknown/unreachable, it preserves the historical skip (fail-safe — a health blip never blocks a merge). Runtime-file pushes and `workflow_dispatch` are unchanged.

## Tests
`tests/deployment.test.js`: behind → `prod_behind_head` (deploys); current → `non_runtime_changes` (skips); unknown → `non_runtime_changes` (skips). Verified locally across all cases + `bash -n` + `shellcheck -S error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)