### PR TITLE
feat(retrieval): drop superseded/contradictory lessons before selection

### DIFF
--- a/.changeset/lesson-supersede-filter.md
+++ b/.changeset/lesson-supersede-filter.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a retrieval-time superseding filter to lesson retrieval. Same-topic lessons are now collapsed before final selection: duplicates drop to the higher-ranked one, and contradictions (opposite signal on the same rule/topic) keep the most recent — which supersedes the stale one. This prevents "context poisoning," where an agent could be handed two contradictory lessons (e.g. "never force-push" and "force-push is fine") at equal relevance. Conservative by design (distinct lessons are never merged); affects only lesson retrieval, not the hard gate rules.

--- a/scripts/lesson-retrieval.js
+++ b/scripts/lesson-retrieval.js
@@ -49,7 +49,8 @@ function retrieveRelevantLessons(toolName, actionContext, options = {}) {
 
   // Stage 3 (opt-in) — Memora-style nucleus stop: trim the low-mass tail so a
   // dominant lesson isn't padded out to maxResults. No-op unless topP < 1.
-  const selected = filterTopP(reranked, resolveTopP(options), { minKeep: options.minKeep });
+  const deduped = dedupeSupersededLessons(reranked);
+  const selected = filterTopP(deduped, resolveTopP(options), { minKeep: options.minKeep });
 
   return selected.map((m) => ({
     id: m.id,
@@ -181,7 +182,7 @@ async function retrieveRelevantLessonsAsync(toolName, actionContext, options = {
     // Short-circuit: skip embedding/dense search completely
     const { rerankLessons } = require('./lesson-reranker');
     const reranked = rerankLessons(actionContext, lexicalScored.slice(0, RERANK_CANDIDATE_POOL), { topK: maxResults, toolName });
-    return filterTopP(reranked, resolveTopP(options), { minKeep: options.minKeep }).map(shapeLesson);
+    return filterTopP(dedupeSupersededLessons(reranked), resolveTopP(options), { minKeep: options.minKeep }).map(shapeLesson);
   }
 
   // WHERE-clause pruning: filter memories before vector search to only include
@@ -245,7 +246,7 @@ async function retrieveRelevantLessonsAsync(toolName, actionContext, options = {
 
   const { rerankLessons } = require('./lesson-reranker');
   const reranked = rerankLessons(actionContext, candidates, { topK: maxResults, toolName });
-  return filterTopP(reranked, resolveTopP(options), { minKeep: options.minKeep }).map(shapeLesson);
+  return filterTopP(dedupeSupersededLessons(reranked), resolveTopP(options), { minKeep: options.minKeep }).map(shapeLesson);
 }
 
 function buildActionSignature(toolName, actionContext) {
@@ -388,6 +389,73 @@ function filterTopP(lessons, topP = 1.0, options = {}) {
   return kept;
 }
 
+/**
+ * Drop superseded / contradictory lessons before final selection.
+ *
+ * Retrieval can surface two lessons on the SAME topic at near-equal relevance —
+ * a stale one and a newer correction. Handing an agent contradictory guidance
+ * ("never force-push" AND "force-push is fine") poisons its decision and wastes
+ * tokens — the "context poisoning" failure mode. This collapses same-topic
+ * lessons on the reranked list:
+ *   - same topic + SAME signal     → duplicate: keep the higher-ranked, drop rest
+ *   - same topic + OPPOSITE signal → contradiction: keep the most RECENT (it
+ *                                    supersedes), drop the older
+ *
+ * "Same topic" = identical/near-identical structured-rule trigger (the strong
+ * signal), else high character-bigram similarity of title+content. Conservative
+ * by design: distinct lessons are never merged, and survivor order is preserved.
+ * Affects only lesson RETRIEVAL — never the hard gate rules.
+ *
+ * @param {Array<object>} lessons - reranked lessons/memories, best-first
+ * @param {object} [options]
+ * @param {number} [options.similarityThreshold=0.82] - bigram-Jaccard cutoff for "same topic"
+ * @returns {Array<object>} deduped list, order preserved
+ */
+function dedupeSupersededLessons(lessons, options = {}) {
+  if (!Array.isArray(lessons) || lessons.length <= 1) {
+    return Array.isArray(lessons) ? lessons.slice() : [];
+  }
+  const threshold = Number.isFinite(options.similarityThreshold) ? options.similarityThreshold : 0.82;
+  const signalOf = (x) => x.signal || (x.tags?.includes('negative') ? 'negative' : 'positive');
+  const topicSignature = (x) => {
+    const rule = x.rule || x.structuredRule;
+    const cond = rule && (rule.trigger?.condition || rule.if);
+    if (cond && String(cond).trim().length >= 3) return String(cond).toLowerCase().trim();
+    return `${x.title || ''} ${x.content || ''}`.toLowerCase().trim();
+  };
+  const timeOf = (x) => {
+    const t = x.timestamp ? new Date(x.timestamp).getTime() : NaN;
+    return Number.isFinite(t) ? t : -Infinity;
+  };
+  const sigs = lessons.map(topicSignature);
+  const grams = sigs.map((s) => textBigrams(s));
+  const sameTopic = (i, j) => {
+    if (!sigs[i] || !sigs[j]) return false;
+    if (sigs[i] === sigs[j]) return true;
+    return bigramJaccard(grams[i], grams[j]) >= threshold;
+  };
+
+  const kept = []; // indices into `lessons`, best-first
+  for (let i = 0; i < lessons.length; i++) {
+    let collapsed = false;
+    for (let k = 0; k < kept.length; k++) {
+      const j = kept[k];
+      if (!sameTopic(i, j)) continue;
+      if (signalOf(lessons[i]) === signalOf(lessons[j])) {
+        collapsed = true; // duplicate → keep the already-kept (higher-ranked)
+      } else if (timeOf(lessons[i]) > timeOf(lessons[j])) {
+        kept[k] = i; // contradiction → newer supersedes, take the slot
+        collapsed = true;
+      } else {
+        collapsed = true; // contradiction, incoming is older → drop it
+      }
+      break;
+    }
+    if (!collapsed) kept.push(i);
+  }
+  return kept.map((idx) => lessons[idx]);
+}
+
 function calculateRetrievalEntropy(lessons) {
   if (!Array.isArray(lessons) || lessons.length === 0) return 0;
   let pW = 0, nW = 0, tW = 0;
@@ -413,4 +481,5 @@ module.exports = {
   calculateRetrievalEntropy,
   filterTopP,
   resolveTopP,
+  dedupeSupersededLessons,
 };

--- a/tests/lesson-retrieval.test.js
+++ b/tests/lesson-retrieval.test.js
@@ -353,3 +353,54 @@ test('retrieveRelevantLessons: topP trims the tail, never empties, no-op at 1.0'
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
+
+// ---------------------------------------------------------------------------
+// Superseding / contradiction filter — the "context poisoning" fix.
+// Same-topic contradictory or duplicate lessons must not surface together.
+// ---------------------------------------------------------------------------
+
+test('dedupeSupersededLessons keeps the newest of two contradictory same-rule lessons', () => {
+  const { dedupeSupersededLessons } = require('../scripts/lesson-retrieval');
+  const older = { id: 'old', title: 'x', content: 'never force push', tags: ['negative'], structuredRule: { if: 'git push --force' }, timestamp: '2026-01-01T00:00:00Z', relevanceScore: 0.9 };
+  const newer = { id: 'new', title: 'y', content: 'force push ok on personal branches', tags: ['positive'], structuredRule: { if: 'git push --force' }, timestamp: '2026-06-01T00:00:00Z', relevanceScore: 0.7 };
+  const out = dedupeSupersededLessons([older, newer]);
+  assert.strictEqual(out.length, 1, 'contradiction collapsed to one');
+  assert.strictEqual(out[0].id, 'new', 'the newer lesson supersedes the older');
+});
+
+test('dedupeSupersededLessons drops a duplicate same-signal lesson and keeps the higher-ranked', () => {
+  const { dedupeSupersededLessons } = require('../scripts/lesson-retrieval');
+  const a = { id: 'a', title: 'force push', content: 'never force push to main', tags: ['negative'], timestamp: '2026-06-02T00:00:00Z', relevanceScore: 0.9 };
+  const b = { id: 'b', title: 'force push', content: 'never force push to main', tags: ['negative'], timestamp: '2026-06-01T00:00:00Z', relevanceScore: 0.5 };
+  const out = dedupeSupersededLessons([a, b]);
+  assert.strictEqual(out.length, 1, 'duplicate collapsed');
+  assert.strictEqual(out[0].id, 'a', 'higher-ranked (first) kept, order preserved');
+});
+
+test('dedupeSupersededLessons never merges distinct topics', () => {
+  const { dedupeSupersededLessons } = require('../scripts/lesson-retrieval');
+  const a = { id: 'a', title: 'git', content: 'never force push to main branch', tags: ['negative'], timestamp: '2026-06-01T00:00:00Z' };
+  const b = { id: 'b', title: 'auth', content: 'validate the jwt before trusting its claims', tags: ['negative'], timestamp: '2026-06-01T00:00:00Z' };
+  const out = dedupeSupersededLessons([a, b]);
+  assert.strictEqual(out.length, 2, 'distinct topics are both preserved');
+});
+
+test('dedupeSupersededLessons handles empty, null, and single inputs safely', () => {
+  const { dedupeSupersededLessons } = require('../scripts/lesson-retrieval');
+  assert.deepStrictEqual(dedupeSupersededLessons([]), []);
+  assert.deepStrictEqual(dedupeSupersededLessons(null), []);
+  assert.strictEqual(dedupeSupersededLessons([{ id: 'x', title: 't', content: 'c', tags: [] }]).length, 1);
+});
+
+test('retrieveRelevantLessons does not surface both sides of a same-rule contradiction', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lesson-supersede-'));
+  writeJsonl(path.join(tmpDir, 'memory-log.jsonl'), [
+    { id: 'old', title: 'bash git push', content: 'never force push to main', tags: ['negative'], structuredRule: { if: 'git push --force' }, timestamp: '2026-01-01T00:00:00Z' },
+    { id: 'new', title: 'bash git push', content: 'force push allowed on personal branches now', tags: ['positive'], structuredRule: { if: 'git push --force' }, timestamp: new Date().toISOString() },
+  ]);
+  const { retrieveRelevantLessons } = require('../scripts/lesson-retrieval');
+  const ids = retrieveRelevantLessons('Bash', 'git push --force to main', { maxResults: 5, feedbackDir: tmpDir }).map((l) => l.id);
+  assert.ok(!(ids.includes('old') && ids.includes('new')), `contradictory lessons surfaced together: ${ids.join(',')}`);
+  assert.ok(ids.length >= 1, 'still returns the surviving lesson');
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Problem (context poisoning)
Lesson retrieval fuses lexical + dense candidates via RRF and reranks them, but **never removes same-topic contradictions**. An agent could be handed two conflicting lessons — e.g. `never force-push` (negative) and `force-push is fine` (positive) — at near-equal relevance, poisoning its decision and wasting tokens. This is exactly the failure mode flagged by the kdnuggets RAG critique ("contradictory versions") and the pattern Elastic Atlas solves with explicit superseding.

## Fix
New pure helper `dedupeSupersededLessons(lessons)` applied **before `filterTopP`** in all three retrieval return paths (sync, async-conclusive, async-fused):
- **same topic + same signal** → duplicate: keep the higher-ranked, drop the rest
- **same topic + opposite signal** → contradiction: keep the **most recent** (it supersedes), drop the stale one

"Same topic" = identical/near-identical **structured-rule trigger** (strong signal), else ≥0.82 character-bigram similarity of title+content (reuses the file’s existing `textBigrams`/`bigramJaccard`). Conservative: **distinct lessons are never merged**, survivor order preserved. **Only touches lesson retrieval — hard gate rules are unaffected.**

## Tests
`tests/lesson-retrieval.test.js` +5 cases (contradiction→newest, duplicate→higher-ranked, distinct-never-merged, empty/null/single, end-to-end "not both sides"). Full suite **26/26 green locally** (21 existing unchanged + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)