### PR TITLE
feat(gates): opt-in autonomous fail-closed for approval gates

### DIFF
--- a/.changeset/autonomous-fail-closed-gates.md
+++ b/.changeset/autonomous-fail-closed-gates.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Add opt-in autonomous fail-closed mode for approval gates. When `THUMBGATE_AUTONOMOUS=1`, an `approve` (human-in-the-loop) gate now fails CLOSED (deny) instead of deferring — because in an autonomous agent loop there is no human to sign off, and the actions that most need approval must not slip through unattended. Interactive and existing CI behavior is unchanged (opt-in only); applies to both the sync and async evaluation paths.

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -2029,6 +2029,19 @@ async function checkMetricCondition(metricCondition) {
   return true;
 }
 
+/**
+ * Whether this run is autonomous — i.e. no human is present to resolve an
+ * `approve` (human-in-the-loop) gate. Opt-in ONLY via THUMBGATE_AUTONOMOUS=1
+ * (or "true"); interactive and existing CI behavior is unchanged unless an
+ * operator explicitly sets it. In an autonomous agent loop an approval gate has
+ * nobody to sign off, so it must fail CLOSED (deny) rather than defer forever or
+ * slip through — a guardrail has to guard precisely when it is unattended.
+ */
+function isAutonomousRun() {
+  const raw = String(process.env.THUMBGATE_AUTONOMOUS || '').trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
 async function evaluateGatesAsync(toolName, toolInput, configPath) {
   let config;
   try {
@@ -2183,6 +2196,15 @@ async function evaluateGatesAsync(toolName, toolInput, configPath) {
     if (gate.action === 'approve') {
       const approvalEnabled = process.env.THUMBGATE_APPROVAL_GATES !== '0';
       if (approvalEnabled) {
+        if (isAutonomousRun()) {
+          // Autonomous run: no human to approve. Fail CLOSED so the actions that
+          // most need sign-off cannot slip through unattended.
+          const failClosedMessage = `[autonomous run — no approver present, failing closed] ${message}`;
+          recordStat(gate.id, 'block', gate, { toolName, toolInput });
+          const failClosedAudit = recordAuditEvent({ toolName, toolInput, decision: 'deny', gateId: gate.id, message: failClosedMessage, severity: gate.severity, source: 'gates-engine', autonomousFailClosed: true });
+          auditToFeedback(failClosedAudit);
+          return { decision: 'deny', gate: gate.id, message: failClosedMessage, severity: gate.severity, reasoning, requiresApproval: true, failedClosed: true };
+        }
         recordStat(gate.id, 'approve', gate, { toolName, toolInput });
         const result = { decision: 'approve', gate: gate.id, message, severity: gate.severity, reasoning, requiresApproval: true };
         const auditRecord = recordAuditEvent({ toolName, toolInput, decision: 'approve', gateId: gate.id, message, severity: gate.severity, source: 'gates-engine' });
@@ -2387,6 +2409,15 @@ function evaluateGates(toolName, toolInput, configPath) {
     if (gate.action === 'approve') {
       const approvalEnabled = process.env.THUMBGATE_APPROVAL_GATES !== '0';
       if (approvalEnabled) {
+        if (isAutonomousRun()) {
+          // Autonomous run: no human to approve. Fail CLOSED so the actions that
+          // most need sign-off cannot slip through unattended.
+          const failClosedMessage = `[autonomous run — no approver present, failing closed] ${message}`;
+          recordStat(gate.id, 'block', gate, { toolName, toolInput });
+          const failClosedAudit = recordAuditEvent({ toolName, toolInput, decision: 'deny', gateId: gate.id, message: failClosedMessage, severity: gate.severity, source: 'gates-engine', autonomousFailClosed: true });
+          auditToFeedback(failClosedAudit);
+          return { decision: 'deny', gate: gate.id, message: failClosedMessage, severity: gate.severity, reasoning, requiresApproval: true, failedClosed: true };
+        }
         recordStat(gate.id, 'approve', gate, { toolName, toolInput });
         const result = { decision: 'approve', gate: gate.id, message, severity: gate.severity, reasoning, requiresApproval: true };
         const auditRecord = recordAuditEvent({ toolName, toolInput, decision: 'approve', gateId: gate.id, message, severity: gate.severity, source: 'gates-engine' });
@@ -3332,6 +3363,7 @@ module.exports = {
   matchesGate,
   evaluateGates,
   evaluateGatesAsync,
+  isAutonomousRun,
   computeExecutableHash,
   formatOutput,
   isApprovalGatesEnabled,

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -1505,6 +1505,55 @@ test('evaluateGatesAsync skips metric gates for recall tool', async () => {
   }
 });
 
+test('evaluateGates: approval gate fails CLOSED (deny) in an autonomous run', () => {
+  const tmpConfig = makeTempPath('autonomous-approve.json');
+  fs.writeFileSync(tmpConfig, JSON.stringify({
+    version: 1,
+    gates: [{
+      id: 'needs-human-approval',
+      pattern: '.*',
+      action: 'approve',
+      message: 'This action needs human sign-off',
+      severity: 'high',
+    }],
+  }));
+  const orig = process.env.THUMBGATE_AUTONOMOUS;
+  try {
+    // Interactive (default): defer to a human — decision 'approve'.
+    delete process.env.THUMBGATE_AUTONOMOUS;
+    const interactive = evaluateGates('Bash', { command: 'deploy to production' }, tmpConfig);
+    assert.equal(interactive && interactive.decision, 'approve', 'interactive run should defer to human approval');
+    assert.equal(interactive.requiresApproval, true);
+
+    // Autonomous run: no human present → must fail CLOSED (deny), not slip through.
+    process.env.THUMBGATE_AUTONOMOUS = '1';
+    const autonomous = evaluateGates('Bash', { command: 'deploy to production' }, tmpConfig);
+    assert.equal(autonomous && autonomous.decision, 'deny', 'autonomous run must fail closed on an approval gate');
+    assert.equal(autonomous.failedClosed, true);
+  } finally {
+    if (orig === undefined) delete process.env.THUMBGATE_AUTONOMOUS;
+    else process.env.THUMBGATE_AUTONOMOUS = orig;
+    fs.rmSync(tmpConfig, { force: true });
+  }
+});
+
+test('isAutonomousRun is opt-in via THUMBGATE_AUTONOMOUS (off by default)', () => {
+  const orig = process.env.THUMBGATE_AUTONOMOUS;
+  try {
+    delete process.env.THUMBGATE_AUTONOMOUS;
+    assert.equal(gatesEngine.isAutonomousRun(), false);
+    process.env.THUMBGATE_AUTONOMOUS = '1';
+    assert.equal(gatesEngine.isAutonomousRun(), true);
+    process.env.THUMBGATE_AUTONOMOUS = 'true';
+    assert.equal(gatesEngine.isAutonomousRun(), true);
+    process.env.THUMBGATE_AUTONOMOUS = '0';
+    assert.equal(gatesEngine.isAutonomousRun(), false);
+  } finally {
+    if (orig === undefined) delete process.env.THUMBGATE_AUTONOMOUS;
+    else process.env.THUMBGATE_AUTONOMOUS = orig;
+  }
+});
+
 test('evaluateGatesAsync does NOT skip metric gates for non-skip tools', async () => {
   // Mock semantic-layer to return a metric value that violates the gate
   const semanticLayerPath = require.resolve('../scripts/semantic-layer');


### PR DESCRIPTION
## Why
In the autonomous agent-loop era (CodeRabbit "loop engineering", "the year of agent harnesses"), a guardrail has to hold when **no human is present**. Today an `approve` (human-in-the-loop) gate returns `requiresApproval` and defers — but in an unattended loop there is nobody to sign off, so the actions that most need approval can slip through. A guardrail that stops guarding the moment it is unattended is the wrong default for that world.

## What
`isAutonomousRun()` — **opt-in** via `THUMBGATE_AUTONOMOUS=1` (or `true`). When set, an `approve` gate **fails CLOSED (deny)** at both the sync (`evaluateGates`) and async (`evaluateGatesAsync`) paths, with `failedClosed: true` + an `autonomousFailClosed` audit marker, instead of deferring. 

**Zero change to current behavior:** nothing sets the flag today, so interactive and existing CI runs are identical. Escape hatch preserved (`THUMBGATE_APPROVAL_GATES=0` still downgrades to warn).

## Tests
`tests/gates-engine.test.js` +2: integration (approve gate → `deny`/`failedClosed` under autonomous; `approve` when interactive) and unit (`isAutonomousRun` opt-in semantics). Full gates-engine suite green locally (0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)