### PR TITLE
docs(readme): maintainer hire-me section (Option-C lead-gen)

### DIFF
--- a/.changeset/readme-hiring-cta.md
+++ b/.changeset/readme-hiring-cta.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+docs(readme): add a "Who builds ThumbGate — and hiring me" section that routes the repo's qualified readers to the maintainer's freelance/contract availability (payments, AI agents, Android). Repositions ThumbGate's credibility as a lead source per the Option-C monetization analysis; no code or runtime behavior change.

--- a/README.md
+++ b/README.md
@@ -643,6 +643,22 @@ Pro ($19/mo or $149/yr) removes the rule cap and adds history-aware lesson recal
 
 ---
 
+## Who builds ThumbGate — and hiring me
+
+I'm **Igor Ganapolsky** — I designed and maintain ThumbGate. If you're shipping **payments, AI agents, or Android features** and want them built by someone demonstrably careful with production and with money, I take a small number of **freelance / contract** engagements.
+
+ThumbGate is the receipt, not the pitch: it fails *closed* on dangerous agent actions and publishes a [threat model](THREAT_MODEL.md) stating exactly what it enforces and what it can't contain. Documenting where my own guardrails end is the standard I hold client work to.
+
+- **Payments** — Stripe / Stripe Connect: destination charges, split payouts, escrow & milestone release, 3DS/SCA, idempotent webhooks, reconciliation.
+- **Applied AI / agents** — tool-use guardrails, MCP servers, orchestration, and evaluation loops (the engineering behind this repo).
+- **Android + backend** — native Android and the APIs behind it, shipped end-to-end.
+
+**$120–150/hr, 1099 · remote, US timezones** → **[LinkedIn](https://www.linkedin.com/in/igor-ganapolsky-859317343/)** · **[thumbgate.ai](https://thumbgate.ai)**
+
+> ThumbGate is free and MIT-licensed, and stays that way. If it saved you a costly mistake, the best thank-you is an intro to someone who needs an engineer who ships carefully.
+
+---
+
 ## License
 
 MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## What
Adds a short **"Who builds ThumbGate — and hiring me"** section at the end of the README (before License), routing qualified readers to freelance/contract availability (payments / AI agents / Android). Docs-only + a patch changeset; no code or runtime change.

## Why
Per this session's verified analysis:
- **$0 external revenue ever** (reconciled across 5 Stripe objects); the production funnel dies at discovery→pricing (**48 pricing views in 18 days**, and every checkout session that reached Stripe was test/bot — `test@example.com`, non-product amounts).
- The paid-SaaS motion has **never been tested against real qualified buyers**, so the product's near-term value is **credibility, not checkouts**.
- This routes ThumbGate's existing (small but real) qualified GitHub/npm audience toward the money engine that actually works — freelance engineering.

## Notes
- **Draft on purpose** — this is a brand/positioning change on the public flagship. Merge at your discretion.
- LinkedIn URL is the verified one; no fabricated metrics; agents deliberately **not** re-enumerated in this block (avoids the README-vs-`THREAT_MODEL.md` 6/7 mismatch, which is worth reconciling separately).
- Part of a staged asset set in `drafts/thumbgate-option-c/` (consulting one-pager, UpWork tagline, Stripe-Connect lead magnet, qualified-demand test spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
