### PR TITLE
fix(mcp): fast-start MCP server + Codex hooks instead of reinstalling every launch

### DIFF
--- a/.changeset/mcp-serve-fast-start.md
+++ b/.changeset/mcp-serve-fast-start.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+fix(mcp): stop reinstalling thumbgate@latest on every MCP server launch. The serve entry now fast-starts from the installed runtime and resolves @latest via npx only when the runtime is absent — matching the hook commands. Removes a per-launch blocking `npm install` that could hang or fail server startup on slow/offline networks (agents saw the server / capture "time out").

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,4 +122,8 @@ Rules:
 
 ## 🛡️ Self-Harness Prevention Rules (Auto-Generated)
 
-- No active auto-generated prevention rules at this time.
+> [!IMPORTANT]
+> The following rules were automatically derived from execution failures and thumbs-down feedback.
+> You MUST follow these constraints strictly to prevent repeated errors.
+
+- **Rule [auto-promoted-mr3rwu9r-0]**: NEVER repeated problem context string

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,4 +16,8 @@ Key: Always dogfood the latest local changes before publishing.
 
 ## 🛡️ Self-Harness Prevention Rules (Auto-Generated)
 
-- No active auto-generated prevention rules at this time.
+> [!IMPORTANT]
+> The following rules were automatically derived from execution failures and thumbs-down feedback.
+> You MUST follow these constraints strictly to prevent repeated errors.
+
+- **Rule [auto-promoted-mr3rwu9r-0]**: NEVER repeated problem context string

--- a/adapters/codex/config.toml
+++ b/adapters/codex/config.toml
@@ -3,9 +3,9 @@
 # ~/.codex/config.json with the ThumbGate hooks and status line.
 [mcp_servers.thumbgate]
 command = "sh"
-args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""]
+args = ["-lc", "[ -x \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" ] && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\" || mkdir -p \"$HOME/.thumbgate/runtime\" && exec npm \"exec\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--yes\" \"--package\" \"thumbgate@latest\" \"--\" \"thumbgate\" \"serve\""]
 
 # Hard PreToolUse hook for Codex
 [hooks.pre_tool_use]
 command = "sh"
-args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"gate-check\""]
+args = ["-lc", "[ -x \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" ] && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"gate-check\" || mkdir -p \"$HOME/.thumbgate/runtime\" && exec npm \"exec\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--yes\" \"--package\" \"thumbgate@latest\" \"--\" \"thumbgate\" \"gate-check\""]

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -97,8 +97,8 @@ This lane is for Claude Code users who want Codex review, adversarial review, an
 - Repo-local Codex MCP config: `plugins/codex-profile/.mcp.json`
 - Repo-local Codex marketplace: `.agents/plugins/marketplace.json`
 - Current Codex evidence: `codex plugin marketplace list --json` shows the repo-local `thumbgate-plugin-catalog`; do not claim OpenAI curated plugin-directory approval until the public Codex plugin directory shows ThumbGate.
-- Transport: local stdio MCP server launched through `npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest` followed by `~/.thumbgate/runtime/node_modules/.bin/thumbgate serve`
-- Update policy: Codex MCP and hook launchers resolve `thumbgate@latest` at startup instead of preferring a stale installed runtime binary; unpublished local source checkouts fall back to the local server path
+- Transport: local stdio MCP server that fast-starts by exec'ing the installed `~/.thumbgate/runtime/node_modules/.bin/thumbgate serve`, and only resolves `thumbgate@latest` via `npm exec` (npx) when that runtime binary is absent
+- Update policy: Codex MCP and hook launchers fast-start from the installed runtime binary and resolve `thumbgate@latest` via npx only when it is missing, so startup never blocks on a per-launch reinstall; unpublished local source checkouts fall back to the local server path
 
 The standalone Codex bundle ships `.codex-plugin/plugin.json`, `.mcp.json`, `.agents/plugins/marketplace.json`, `config.toml`, and install docs in one zip. Stable releases publish `thumbgate-codex-plugin.zip`; prereleases publish `thumbgate-codex-plugin-next.zip`. The bundle metadata remains versioned for marketplace review, while the runtime follows the latest npm release for active Codex installs.
 

--- a/plugins/codex-profile/.mcp.json
+++ b/plugins/codex-profile/.mcp.json
@@ -4,7 +4,7 @@
       "command": "sh",
       "args": [
         "-lc",
-        "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""
+        "[ -x \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" ] && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\" || mkdir -p \"$HOME/.thumbgate/runtime\" && exec npm \"exec\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--yes\" \"--package\" \"thumbgate@latest\" \"--\" \"thumbgate\" \"serve\""
       ]
     }
   }

--- a/plugins/codex-profile/INSTALL.md
+++ b/plugins/codex-profile/INSTALL.md
@@ -132,7 +132,7 @@ The following block is appended to `~/.codex/config.toml` when the published pac
 ```toml
 [mcp_servers.thumbgate]
 command = "sh"
-args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""]
+args = ["-lc", "[ -x \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" ] && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\" || mkdir -p \"$HOME/.thumbgate/runtime\" && exec npm \"exec\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--yes\" \"--package\" \"thumbgate@latest\" \"--\" \"thumbgate\" \"serve\""]
 ```
 
 The launcher resolves `thumbgate@latest` each time Codex starts the MCP server instead of reusing a stale installed binary. If you are developing from an unpublished local checkout, `npx thumbgate init --agent codex` falls back to the local `adapters/mcp/server-stdio.js` path so work-in-progress code still runs.
@@ -144,19 +144,19 @@ The Codex status line and hook bundle live in `~/.codex/config.json`. `npx thumb
 ```json
 {
   "hooks": {
-    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate gate-check" }] }],
-    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate hook-auto-capture" }] }],
-    "PostToolUse": [{ "matcher": "mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard", "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate cache-update" }] }],
-    "SessionStart": [{ "hooks": [{ "type": "command", "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate session-start" }] }]
+    "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "[ -x ~/.thumbgate/runtime/node_modules/.bin/thumbgate ] && exec ~/.thumbgate/runtime/node_modules/.bin/thumbgate gate-check || mkdir -p ~/.thumbgate/runtime && exec npm exec --prefix ~/.thumbgate/runtime --yes --package thumbgate@latest -- thumbgate gate-check" }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "[ -x ~/.thumbgate/runtime/node_modules/.bin/thumbgate ] && exec ~/.thumbgate/runtime/node_modules/.bin/thumbgate hook-auto-capture || mkdir -p ~/.thumbgate/runtime && exec npm exec --prefix ~/.thumbgate/runtime --yes --package thumbgate@latest -- thumbgate hook-auto-capture" }] }],
+    "PostToolUse": [{ "matcher": "mcp__thumbgate__feedback_stats|mcp__thumbgate__dashboard", "hooks": [{ "type": "command", "command": "[ -x ~/.thumbgate/runtime/node_modules/.bin/thumbgate ] && exec ~/.thumbgate/runtime/node_modules/.bin/thumbgate cache-update || mkdir -p ~/.thumbgate/runtime && exec npm exec --prefix ~/.thumbgate/runtime --yes --package thumbgate@latest -- thumbgate cache-update" }] }],
+    "SessionStart": [{ "hooks": [{ "type": "command", "command": "[ -x ~/.thumbgate/runtime/node_modules/.bin/thumbgate ] && exec ~/.thumbgate/runtime/node_modules/.bin/thumbgate session-start || mkdir -p ~/.thumbgate/runtime && exec npm exec --prefix ~/.thumbgate/runtime --yes --package thumbgate@latest -- thumbgate session-start" }] }]
   },
   "statusLine": {
     "type": "command",
-    "command": "npm install --prefix ~/.thumbgate/runtime --no-save --omit=dev thumbgate@latest && ~/.thumbgate/runtime/node_modules/.bin/thumbgate statusline-render"
+    "command": "[ -x ~/.thumbgate/runtime/node_modules/.bin/thumbgate ] && exec ~/.thumbgate/runtime/node_modules/.bin/thumbgate statusline-render || mkdir -p ~/.thumbgate/runtime && exec npm exec --prefix ~/.thumbgate/runtime --yes --package thumbgate@latest -- thumbgate statusline-render"
   }
 }
 ```
 
-The real generated command includes a `mkdir -p ~/.thumbgate/runtime` guard before the `npm install` call and suppresses install noise.
+The real generated command fast-starts from the installed runtime binary and only resolves `thumbgate@latest` via `npm exec` (npx) when that binary is absent, so Codex never blocks MCP/hook startup on a per-launch reinstall.
 
 ## Verify
 

--- a/plugins/codex-profile/README.md
+++ b/plugins/codex-profile/README.md
@@ -76,7 +76,7 @@ That profile launches the latest npm release instead of pinning a stale local ru
 ```toml
 [mcp_servers.thumbgate]
 command = "sh"
-args = ["-lc", "mkdir -p \"$HOME/.thumbgate/runtime\" && npm \"install\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--no-save\" \"--omit=dev\" \"thumbgate@latest\" >/dev/null 2>&1 && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\""]
+args = ["-lc", "[ -x \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" ] && exec \"$HOME/.thumbgate/runtime/node_modules/.bin/thumbgate\" \"serve\" || mkdir -p \"$HOME/.thumbgate/runtime\" && exec npm \"exec\" \"--prefix\" \"$HOME/.thumbgate/runtime\" \"--yes\" \"--package\" \"thumbgate@latest\" \"--\" \"thumbgate\" \"serve\""]
 ```
 
 ### Build from source

--- a/scripts/hook-runtime.js
+++ b/scripts/hook-runtime.js
@@ -53,12 +53,12 @@ function resolveCliCommand(subcommand) {
 function resolveCodexCliCommand(subcommand) {
   const version = packageVersion();
   if (publishedHookCommandsAvailable(version)) {
-    return publishedCliShellCommand('latest', [subcommand], { preferInstalled: false });
+    return publishedCliShellCommand('latest', [subcommand]);
   }
   if (isSourceCheckout(PKG_ROOT)) {
     return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))} ${subcommand}`;
   }
-  return publishedCliShellCommand('latest', [subcommand], { preferInstalled: false });
+  return publishedCliShellCommand('latest', [subcommand]);
 }
 
 function buildPortableHookCommand(subcommand) {

--- a/scripts/mcp-config.js
+++ b/scripts/mcp-config.js
@@ -107,9 +107,15 @@ function portableMcpEntry(pkgVersion) {
 }
 
 function codexAutoUpdateCliEntry(commandArgs = []) {
+  // Fast-start from the installed runtime binary; only resolve @latest via npx
+  // when the runtime is absent (e.g. first launch). This matches the hook
+  // commands and must never block MCP server startup on a per-launch reinstall
+  // (a blocking `npm install thumbgate@latest` on every launch caused
+  // capture/serve timeouts on slow or offline networks — a failed install left
+  // the chained `exec` unreached, so the server never started).
   return {
     command: 'sh',
-    args: ['-lc', publishedCliShellCommand('latest', commandArgs, { preferInstalled: false })],
+    args: ['-lc', publishedCliShellCommand('latest', commandArgs)],
   };
 }
 

--- a/scripts/published-cli.js
+++ b/scripts/published-cli.js
@@ -37,14 +37,6 @@ function publishedCliShellCommand(pkgVersion, commandArgs = [], options = {}) {
   const escapedArgs = commandArgs.map(shellQuote).join(' ');
   const fastPath = `[ -x ${shellQuote(runtimeBin)} ] && exec ${shellQuote(runtimeBin)}${escapedArgs ? ` ${escapedArgs}` : ''}`;
   const installPath = `mkdir -p ${shellQuote(prefixDir)} && exec npm ${publishedCliArgs(pkgVersion, commandArgs, { prefixDir }).map(shellQuote).join(' ')}`;
-  if (options.preferInstalled === false) {
-    const packageSpec = `thumbgate@${pkgVersion}`;
-    return [
-      `mkdir -p ${shellQuote(prefixDir)}`,
-      `npm "install" "--prefix" ${shellQuote(prefixDir)} "--no-save" "--omit=dev" ${shellQuote(packageSpec)} >/dev/null 2>&1`,
-      `exec ${shellQuote(runtimeBin)}${escapedArgs ? ` ${escapedArgs}` : ''}`,
-    ].join(' && ');
-  }
   return `${fastPath} || ${installPath}`;
 }
 

--- a/tests/adapters.test.js
+++ b/tests/adapters.test.js
@@ -21,7 +21,10 @@ function assertCodexLatestShellEntry(entry) {
   assert.match(entry.args[1], /thumbgate/);
   assert.match(entry.args[1], /serve/);
   assert.match(entry.args[1], /\.thumbgate\/runtime/);
-  assert.doesNotMatch(entry.args[1], /\[ -x /);
+  // Fast-start form: exec the installed runtime binary; resolve @latest via npx
+  // only when it is absent. Must not block MCP startup on a per-launch reinstall.
+  assert.match(entry.args[1], /\[ -x /);
+  assert.doesNotMatch(entry.args[1], /npm "install"/);
 }
 
 test('adapter files exist', () => {
@@ -95,9 +98,11 @@ test('codex config.toml contains mcp_servers section', () => {
   
   if (content.includes('thumbgate@latest')) {
     assert.match(content, /command = "sh"/);
-    assert.match(content, /npm \\"install\\"/);
     assert.match(content, /node_modules\/\.bin\/thumbgate/);
-    assert.doesNotMatch(content, /\[ -x /);
+    // Fast-start form: exec the installed runtime binary, resolving @latest via
+    // npx only when it is absent. No blocking per-launch reinstall.
+    assert.match(content, /\[ -x /);
+    assert.doesNotMatch(content, /npm \\"install\\"/);
   } else if (content.includes('command = "npx"')) {
     assert.match(content, new RegExp(`thumbgate@${packageVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
   } else {
@@ -439,7 +444,8 @@ test('codex config.toml uses npx, node, or latest-resolving shell command', () =
   }
   if (usesShell) {
     assert.match(content, /thumbgate@latest/, 'shell command should resolve latest npm release');
-    assert.doesNotMatch(content, /\[ -x /, 'shell command should not prefer a stale installed runtime');
+    assert.match(content, /\[ -x /, 'shell command should fast-start from the installed runtime binary');
+    assert.doesNotMatch(content, /npm \\"install\\"/, 'shell command should not block startup on a per-launch reinstall');
   }
 });
 

--- a/tests/codex-plugin.test.js
+++ b/tests/codex-plugin.test.js
@@ -30,7 +30,10 @@ function assertCodexLatestShellEntry(entry) {
   assert.match(entry.args[1], /\.thumbgate\/runtime/);
   assert.match(entry.args[1], /thumbgate/);
   assert.match(entry.args[1], /serve/);
-  assert.doesNotMatch(entry.args[1], /\[ -x /);
+  // Fast-start form: exec the installed runtime binary; resolve @latest via npx
+  // only when it is absent. Must not block MCP startup on a per-launch reinstall.
+  assert.match(entry.args[1], /\[ -x /);
+  assert.doesNotMatch(entry.args[1], /npm \\?"install\\?"|npm "install"/);
 }
 
 test('codex plugin marketplace points at the shipped codex profile', () => {
@@ -171,7 +174,8 @@ test('codex plugin staging writes a standalone bundle with self-contained market
     assert.match(install, /Portable release bundle/i);
     assert.match(install, /not a double-click macOS installer/i);
     assert.match(configToml, /thumbgate@latest/);
-    assert.doesNotMatch(configToml, /\[ -x /);
+    assert.match(configToml, /\[ -x /, 'config.toml serve launcher must fast-start from the installed runtime');
+    assert.doesNotMatch(configToml, /npm \\"install\\"/, 'config.toml must not block startup on a per-launch reinstall');
   } finally {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }

--- a/tests/install-mcp.test.js
+++ b/tests/install-mcp.test.js
@@ -35,8 +35,10 @@ function assertLatestResolvingMcpConfig(entry) {
   assert.equal(entry.command, 'sh');
   assert.deepEqual(entry.args.slice(0, 1), ['-lc']);
   assert.match(entry.args[1], /thumbgate@latest/);
-  assert.match(entry.args[1], /npm "install"/);
-  assert.doesNotMatch(entry.args[1], /\[ -x /);
+  // Fast-start form: exec the installed runtime binary, resolving @latest via
+  // npx only when it is absent. Must not block startup on a per-launch reinstall.
+  assert.match(entry.args[1], /\[ -x /);
+  assert.doesNotMatch(entry.args[1], /npm "install"/);
   assert.match(entry.args[1], /\.thumbgate\/runtime/);
   assert.match(entry.args[1], /thumbgate/);
   assert.match(entry.args[1], /serve/);
@@ -122,8 +124,8 @@ describe('install-mcp', () => {
     assert.equal(projectConfig.command, 'sh');
     assert.deepEqual(projectConfig.args.slice(0, 1), ['-lc']);
     assert.match(projectConfig.args[1], /thumbgate@latest/);
-    assert.match(projectConfig.args[1], /npm "install"/);
-    assert.doesNotMatch(projectConfig.args[1], /\[ -x /);
+    assert.match(projectConfig.args[1], /\[ -x /);
+    assert.doesNotMatch(projectConfig.args[1], /npm "install"/);
     assert.match(projectConfig.args[1], /\.thumbgate\/runtime/);
     assert.match(projectConfig.args[1], /serve/);
 

--- a/tests/mcp-config.test.js
+++ b/tests/mcp-config.test.js
@@ -39,7 +39,7 @@ describe('mcp-config', () => {
     assert.match(entry.args[1], /\.thumbgate\/runtime/);
   });
 
-  it('codexAutoUpdateMcpEntry returns a latest-resolving shell wrapper without the stale binary fast path', () => {
+  it('codexAutoUpdateMcpEntry fast-starts from the installed runtime and resolves @latest via npx only when absent', () => {
     const entry = codexAutoUpdateMcpEntry();
     assert.strictEqual(entry.command, 'sh');
     assert.deepStrictEqual(entry.args.slice(0, 1), ['-lc']);
@@ -47,7 +47,10 @@ describe('mcp-config', () => {
     assert.match(entry.args[1], /thumbgate/);
     assert.match(entry.args[1], /serve/);
     assert.match(entry.args[1], /\.thumbgate\/runtime/);
-    assert.doesNotMatch(entry.args[1], /\[ -x /);
+    assert.match(entry.args[1], /\[ -x /, 'must include the [ -x fast-path guard');
+    const [fastPath] = entry.args[1].split(' || ');
+    assert.match(fastPath, /exec\s+"[^"]+"\s+"serve"/, 'fast-path must exec the runtime with serve');
+    assert.doesNotMatch(entry.args[1], /npm "install"/, 'must not block startup on a per-launch npm install');
   });
 
   it('resolveMcpEntry uses a latest-resolving launcher for published external installs', () => {
@@ -63,8 +66,8 @@ describe('mcp-config', () => {
 
       assert.strictEqual(entry.command, 'sh');
       assert.match(entry.args[1], /thumbgate@latest/);
-      assert.match(entry.args[1], /npm "install"/);
-      assert.doesNotMatch(entry.args[1], /\[ -x /);
+      assert.match(entry.args[1], /\[ -x /);
+      assert.doesNotMatch(entry.args[1], /npm "install"/);
       assert.doesNotMatch(entry.args[1], /thumbgate@1\.2\.3/);
     } finally {
       delete process.env.THUMBGATE_PUBLISH_STATE;
@@ -84,19 +87,22 @@ describe('mcp-config', () => {
 
       assert.strictEqual(entry.command, 'sh');
       assert.match(entry.args[1], /thumbgate@latest/);
-      assert.match(entry.args[1], /npm "install"/);
+      assert.match(entry.args[1], /\[ -x /);
+      assert.doesNotMatch(entry.args[1], /npm "install"/);
       assert.doesNotMatch(entry.args[1], /thumbgate@1\.2\.3/);
     } finally {
       fs.rmSync(pkgRoot, { recursive: true, force: true });
     }
   });
-  it('codexAutoUpdateCliEntry supports hook commands with the same latest-resolving policy', () => {
+  it('codexAutoUpdateCliEntry supports hook commands with the same fast-start policy', () => {
     const entry = codexAutoUpdateCliEntry(['gate-check']);
     assert.strictEqual(entry.command, 'sh');
     assert.match(entry.args[1], /thumbgate@latest/);
     assert.match(entry.args[1], /gate-check/);
-    assert.match(entry.args[1], /npm "install"/);
-    assert.doesNotMatch(entry.args[1], /\[ -x /);
+    assert.match(entry.args[1], /\[ -x /);
+    assert.doesNotMatch(entry.args[1], /npm "install"/);
+    const [fastPath] = entry.args[1].split(' || ');
+    assert.match(fastPath, /exec\s+"[^"]+"\s+"gate-check"/, 'fast-path must exec the runtime with the subcommand');
   });
 
   it('localMcpEntry returns node command pointing to server-stdio.js', () => {

--- a/tests/published-cli.test.js
+++ b/tests/published-cli.test.js
@@ -19,18 +19,18 @@ test('publishedCliShellCommand prefers the installed runtime binary before npm e
   assert.match(command, /npm "exec"/);
 });
 
-test('publishedCliShellCommand can bypass the installed runtime for latest-resolving launchers', () => {
+test('publishedCliShellCommand fast-starts the serve launcher instead of reinstalling on every launch', () => {
   const prefixDir = runtimePrefixDir('/tmp/thumbgate-runtime');
-  const command = publishedCliShellCommand('latest', ['serve'], {
-    prefixDir,
-    preferInstalled: false,
-  });
+  const command = publishedCliShellCommand('latest', ['serve'], { prefixDir });
 
-  assert.doesNotMatch(command, /\[ -x /);
-  assert.match(command, /thumbgate@latest/);
-  assert.match(command, /npm "install"/);
+  // Fast-path guard exists: exec the installed runtime binary when present.
+  assert.match(command, /\[ -x /, 'must include a [ -x fast-path guard');
+  assert.match(command, /thumbgate@latest/, 'must resolve @latest for the npx fallback');
   assert.match(command, /node_modules\/\.bin\/thumbgate/);
-  assert.match(command, /serve/);
+  const [fastPath] = command.split(' || ');
+  assert.match(fastPath, /exec\s+"[^"]+"\s+"serve"/, 'fast-path must exec the runtime with the serve subcommand');
+  // The blocking per-launch reinstall form must be gone.
+  assert.doesNotMatch(command, /npm "install"/, 'must not block startup on a per-launch npm install');
 });
 
 test('installedRuntimeBin resolves within the runtime prefix directory', () => {
@@ -71,10 +71,12 @@ test('publishedCliShellCommand emits the subcommand twice (once per branch) for 
   }
 });
 
-test('publishedCliShellCommand preferInstalled=false exec line includes the subcommand', () => {
+test('publishedCliShellCommand latest-resolving serve launcher includes the subcommand in both branches', () => {
   const command = publishedCliShellCommand('latest', ['serve'], {
     prefixDir: '/tmp/thumbgate-runtime',
-    preferInstalled: false,
   });
-  assert.match(command, /exec\s+"[^"]+"\s+"serve"/, 'install-then-exec must include the subcommand');
+  const [fastPath, fallback] = command.split(' || ');
+  assert.ok(fastPath && fallback, 'must have both branches');
+  assert.match(fastPath, /exec\s+"[^"]+"\s+"serve"/, 'fast-path exec must include the subcommand');
+  assert.match(fallback, /serve/, 'npx fallback must include the subcommand');
 });


### PR DESCRIPTION
## What
Stop the MCP server (and Codex hooks) from running a **blocking `npm install thumbgate@latest` on every launch**. They now fast-start from the installed runtime and only npx-resolve `@latest` when the runtime is absent — matching the Claude Code hook commands.

## Why (root-caused in #2750)
The launch command chained a blocking install with `&&` before `exec`:
```
BEFORE: mkdir -p PREFIX && npm install --prefix PREFIX --no-save --omit=dev thumbgate@latest >/dev/null 2>&1 && exec BIN serve
```
On a slow or offline network the install hung or failed, and because of the `&&` a failed install left `exec` **unreached — so the server never started.** Calling agents (e.g. Codex) saw `capture`/`serve` "time out" and concluded the tool was broken.
```
AFTER: [ -x BIN ] && exec BIN serve || mkdir -p PREFIX && exec npm exec --prefix PREFIX --yes --package thumbgate@latest -- thumbgate serve
```

## Changes
- `scripts/published-cli.js`: removed the redundant `preferInstalled:false` blocking-reinstall branch; `publishedCliShellCommand` now always returns the fast-start form.
- `scripts/mcp-config.js`: `codexAutoUpdateCliEntry` uses fast-start (+ explanatory comment).
- `scripts/hook-runtime.js`: Codex hook commands (gate-check, auto-capture, …) also fast-start (they used the blocking form too).
- Regenerated committed static artifacts to the fast-start form: `plugins/codex-profile/.mcp.json`, `adapters/codex/config.toml`, plus docs.
- Tests updated across `published-cli` / `mcp-config` / `install-mcp` / `adapters` / `codex-plugin` (flipped old-form assertions to fast-start; **coverage preserved**). Changeset added.

## Behavior note
Per-launch auto-update-to-`@latest` is intentionally dropped for the serve/Codex-hook entries in favor of reliability: they now fast-start the installed runtime and resolve `@latest` when absent or on re-wire — the same tradeoff the Claude Code hooks already make.

## Verification
- Affected suites re-run independently: **91 tests, 91 pass, 0 fail** (`published-cli`, `mcp-config`, `hook-runtime-subcommands`, `adapters`, `codex-plugin`, `install-mcp`, `cursor-plugin`).
- `node scripts/sync-version.js --check` → exit 0 (32 targets in sync).
- Local `npm test` fails only on `tests/billing.test.js` (`Cannot find module 'stripe'`) — a worktree provisioning gap (no `node_modules` in the ephemeral worktree); `stripe` is a declared prod dep that CI installs via `npm ci`. No billing/`package.json`/stripe code touched.

Closes #2750 (the startup-timeout root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
