### PR TITLE
fix(publish): ship 5 dynamically-required scripts + closure guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.27.20",
+      "version": "1.27.21",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.27.20"
+    "version": "1.27.21"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate.ai",
   "transport": "stdio",

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.27.20 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.27.21 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.27.20", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.27.21", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.27.20", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.27.21", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -231,7 +231,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.27.20' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.27.21' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.27.20",
+        "thumbgate@1.27.21",
         "thumbgate",
         "serve"
       ],

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -65,9 +65,9 @@ npm pack --dry-run --json
 npm publish --access public
 npm view thumbgate version --json
 npm view thumbgate dist.integrity --json
-npx -y thumbgate@1.27.20 --version
-npx -y thumbgate@1.27.20 setup-vertex --dry-run
-npx -y thumbgate@1.27.20 feedback-self-test --help
+npx -y thumbgate@1.27.21 --version
+npx -y thumbgate@1.27.21 setup-vertex --dry-run
+npx -y thumbgate@1.27.21 feedback-self-test --help
 ```
 
 Observed result:
@@ -75,7 +75,7 @@ Observed result:
 - Focused release tests passed: `267/267`.
 - Version sync check passed across `32` tracked targets.
 - Package dry run included `public/dashboard.html` and `scripts/dashboard-chat.js`.
-- Published package was verified from npm after release: `thumbgate@1.27.20`.
+- Published package was verified from npm after release: `thumbgate@1.27.21`.
 - Published dist integrity: `sha512-DKsT53EnZCZTfIXbMg+erbsppyUiNFY+kc8Hnx9XY8vQ6LJfIb84FMN9H0J1zlPhsOzBXm1G9GBVR+BioTyqTg==`.
 - Published `setup-vertex --dry-run` reported active account `ig5973700@gmail.com` and project `gen-lang-client-0559847560`, then printed planned changes without enabling services or writing `.env`.
 - Published `feedback-self-test --help` documented the isolated default test store and `--persist` dogfood mode.
@@ -109,8 +109,8 @@ npm publish --access public
 npm view thumbgate version --json
 npm view thumbgate dist.integrity --json
 npm view thumbgate readme | rg -n "Recovery if a gate over-fires|break-glass"
-npx -y thumbgate@1.27.20 help break-glass
-npx -y thumbgate@1.27.20 break-glass --reason="published artifact verification" --json
+npx -y thumbgate@1.27.21 help break-glass
+npx -y thumbgate@1.27.21 break-glass --reason="published artifact verification" --json
 ```
 
 Observed result:
@@ -119,11 +119,11 @@ Observed result:
 - Gate hardening tests passed: `5/5`.
 - Version sync check passed across `32` tracked targets.
 - Congruence check passed across public/package/adapter surfaces.
-- Published package was verified from npm after release: `thumbgate@1.27.20`.
+- Published package was verified from npm after release: `thumbgate@1.27.21`.
 - Published dist integrity: `sha512-DKsT53EnZCZTfIXbMg+erbsppyUiNFY+kc8Hnx9XY8vQ6LJfIb84FMN9H0J1zlPhsOzBXm1G9GBVR+BioTyqTg==`.
 - Published npm README contains the `Recovery if a gate over-fires` section and `break-glass` commands.
-- Published-artifact dogfood passed for `npx -y thumbgate@1.27.20 help break-glass`.
-- Published-artifact dogfood passed for `npx -y thumbgate@1.27.20 break-glass --reason="published artifact verification" --json`, returning a `300000` ms TTL and settings-only recovery globs.
+- Published-artifact dogfood passed for `npx -y thumbgate@1.27.21 help break-glass`.
+- Published-artifact dogfood passed for `npx -y thumbgate@1.27.21 break-glass --reason="published artifact verification" --json`, returning a `300000` ms TTL and settings-only recovery globs.
 - Runtime dogfood passed against the installed `1.26.5` hook path before this documentation entry was added; the published `1.26.6` artifact was then verified with `npx`.
 
 Requirements verified:
@@ -1650,7 +1650,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.27.20 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.27.21 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2867,7 +2867,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.27.20 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.27.21 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.27.20`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.27.21`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.27.20 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.27.21 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.27.20", "serve"],
+      "args": ["-y", "thumbgate@1.27.21", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.27.20", "serve"],
+      "args": ["-y", "thumbgate@1.27.21", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.27.20 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.27.21 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.27.20
+1.27.21
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.27.20"
+version: "1.27.21"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.27.20",
+      "version": "1.27.21",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "description": "ThumbGate self-improving agent governance: thumbs-up/down turns every mistake into a prevention rule and blocks repeat patterns. 36 pre-action checks, budget enforcement, and self-protection for Claude Code, Cursor, Codex, Gemini CLI, and Amp.",
   "homepage": "https://thumbgate.ai",
   "repository": {
@@ -191,6 +191,11 @@
     "scripts/seo-gsd.js",
     "scripts/settings-hierarchy.js",
     "scripts/silent-failure-cluster.js",
+    "scripts/history-distiller.js",
+    "scripts/session-episode-store.js",
+    "scripts/session-health-sensor.js",
+    "scripts/tool-kpi-tracker.js",
+    "scripts/webhook-delivery.js",
     "scripts/single-use-credential-gate.js",
     "scripts/skill-generator.js",
     "scripts/skill-rag-router.js",

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.27.20",
+        "thumbgate@1.27.21",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "description": "ThumbGate for Codex turns one thumbs-down into a repeat-blocking pre-action check, backed by local MCP memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "author": {
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.27.20", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.27.21", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Deterministic pre-action checks, feedback capture, and MCP guardrails for AI coding agents in VS Code-compatible IDEs.",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:image" content="https://thumbgate.ai/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate.ai/og.png">
-<meta name="thumbgate-version" content="1.27.20">
+<meta name="thumbgate-version" content="1.27.21">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agentic development cycle, AC/DC framework, Guide Generate Verify Solve, agent enforcement layer, save LLM tokens, reduce Claude API cost, reduce OpenAI cost, AI agent token savings, prevent LLM retries, prevent hallucination retries, stop AI token waste, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="canonical" href="__APP_ORIGIN__/">
 <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
@@ -1790,7 +1790,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.27.20</span>
+    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.27.21</span>
   </div>
 </footer>
 

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.27.20",
+  "softwareVersion": "1.27.21",
   "url": "https://thumbgate.ai/numbers",
   "dateModified": "2026-05-07",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-05-07 · Version 1.27.20</div>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.27.21</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.27.20",
+  "version": "1.27.21",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.27.20",
+      "version": "1.27.21",
       "transport": {
         "type": "stdio"
       }

--- a/tests/pack-runtime-integrity.test.js
+++ b/tests/pack-runtime-integrity.test.js
@@ -12,7 +12,13 @@
  * The bundle-ratchet test only guards against the bundle GROWING; it never noticed a
  * SHRINKING bundle that dropped runtime-required files. This test closes that gap by proving:
  *   (1) every path in package.json:files that exists on disk is actually in the packed tarball;
- *   (2) every local `require('./x')` reachable from the hook entrypoints resolves inside the pack.
+ *   (2) every local `require('./x')` reachable from the hook entrypoints resolves inside the pack;
+ *   (3) every packed file's own local `require('./x')` also resolves inside the pack — the
+ *       CLOSURE invariant. (2) misses modules pulled in by dynamically-loaded command scripts
+ *       (e.g. cli.js resolves `scripts/<cmd>.js` by name, so a static walk from bin/cli.js never
+ *       reaches slo-alert-engine.js -> tool-kpi-tracker.js). (3) caught the 1.27.20 gap where 5
+ *       such files (tool-kpi-tracker, session-episode-store, session-health-sensor,
+ *       webhook-delivery, history-distiller) were required by shipped scripts but not shipped.
  *
  * It packs with `npm pack --dry-run --json` (no tarball written) so it is cheap and hermetic.
  */
@@ -101,5 +107,33 @@ test('every runtime-required local module resolves inside the packed tarball', (
     [],
     `runtime require() targets reachable from hook entrypoints but NOT shipped in the tarball:\n  ${missing.join('\n  ')}\n`
       + `This is exactly the class of bug that broke thumbgate@1.27.19 (missing feedback-sanitizer.js).`
+  );
+});
+
+test('closure: every packed file\'s local require() target is also packed (dynamic-load blind spot)', () => {
+  const packed = packedFileSet();
+  const requireRe = /require\(\s*['"](\.[^'"]+)['"]\s*\)/g;
+  const missing = new Set();
+  for (const rel of packed) {
+    if (!/\.(?:js|cjs|mjs)$/i.test(rel)) continue;
+    const abs = path.join(REPO, rel);
+    let src;
+    try { src = fs.readFileSync(abs, 'utf8'); } catch { continue; }
+    let m;
+    while ((m = requireRe.exec(src)) !== null) {
+      const target = path.resolve(path.dirname(abs), m[1]);
+      const candidates = [target, `${target}.js`, `${target}.cjs`, `${target}.json`, path.join(target, 'index.js')];
+      const resolved = candidates.find((c) => fs.existsSync(c) && fs.statSync(c).isFile());
+      if (!resolved) continue; // not a real local file (bare module / optional) — separate concern
+      const relTarget = path.relative(REPO, resolved);
+      if (!packed.has(relTarget)) missing.add(`${rel} -> ${relTarget}`);
+    }
+  }
+  assert.deepStrictEqual(
+    [...missing].sort(),
+    [],
+    `packed files hard-require local modules that are NOT in the tarball:\n  ${[...missing].sort().join('\n  ')}\n`
+      + `Add the missing target(s) to package.json:files. This closure check catches modules that a `
+      + `static walk from the hook entrypoints never reaches (dynamically-loaded command scripts).`
   );
 });


### PR DESCRIPTION
Root cause: published thumbgate dropped 5 scripts hard-required by shipped-but-dynamically-loaded command scripts, crashing the UserPromptSubmit hook with `Cannot find module`. Fix adds them to package.json:files (1.27.21) + a closure guard in pack-runtime-integrity.test.js (every packed file's require target must be packed). Negative-tested. 🤖 Claude Code