### PR TITLE
feat(pro): email owner on Pro activation

### DIFF
--- a/.changeset/pro-activation-owner-alerts.md
+++ b/.changeset/pro-activation-owner-alerts.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Email the operator when a customer activates ThumbGate Pro locally. The CLI now pings the hosted activation endpoint with the Pro key only as Bearer auth, while the hosted server validates the billing key and sends a secret-safe owner alert containing only a key fingerprint and activation metadata.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1593,6 +1593,7 @@ function pro() {
   trackEvent('cli_pro_view', { command: 'pro' });
   const args = parseArgs(process.argv.slice(3));
   const {
+    notifyHostedProActivation,
     resolveProKey,
     saveLicense,
     startLocalProDashboard,
@@ -1661,7 +1662,22 @@ function pro() {
     console.log('\n✅ Pro license activated!');
     console.log(`   Key saved to: ${licensePath}`);
     console.log('   Launching your personal local dashboard...\n');
-    return launchDashboard(license.key, 'pro_activate');
+    return notifyHostedProActivation({
+      key: license.key,
+      source: 'cli_pro_activate',
+      version: license.version,
+    })
+      .then((notificationResult) => {
+        appendLocalTelemetry({
+          eventType: 'pro_activation_alert',
+          version: license.version,
+          timestamp: new Date().toISOString(),
+          notified: Boolean(notificationResult && notificationResult.notified),
+          sent: Boolean(notificationResult && notificationResult.alert && notificationResult.alert.sent),
+          reason: notificationResult && notificationResult.reason ? notificationResult.reason : null,
+        });
+        return launchDashboard(license.key, 'pro_activate');
+      });
   }
 
   if (args.upgrade) {

--- a/scripts/pro-local-dashboard.js
+++ b/scripts/pro-local-dashboard.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const fs = require('fs');
+const crypto = require('crypto');
 const os = require('os');
 const path = require('path');
 
 const DEFAULT_PRO_API = 'https://thumbgate-production.up.railway.app';
+const DEFAULT_PRO_ACTIVATION_ALERT_EMAIL = 'igor.ganapolsky@gmail.com';
 const CREATOR_BYPASS_VALUE = process.env.THUMBGATE_DEV_SECRET || '';
 const CREATOR_BYPASS_ENV = 'THUMBGATE_DEV_BYPASS';
 const CREATOR_SYNTHETIC_KEY = process.env.THUMBGATE_DEV_KEY || '';
@@ -53,6 +55,195 @@ function getLicenseDir(homeDir = process.env.HOME || process.env.USERPROFILE || 
 
 function getLicensePath(homeDir = process.env.HOME || process.env.USERPROFILE || os.homedir()) {
   return path.join(getLicenseDir(homeDir), 'license.json');
+}
+
+function isTruthyEnv(value) {
+  return /^(1|true|yes|on)$/i.test(String(value || '').trim());
+}
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function fingerprintProKey(key) {
+  const normalized = normalizeText(key);
+  if (!normalized) return '';
+  return `sha256:${crypto.createHash('sha256').update(normalized).digest('hex').slice(0, 12)}`;
+}
+
+function resolveProActivationAlertRecipient(env = process.env) {
+  return normalizeText(
+    env.THUMBGATE_PRO_ACTIVATION_ALERT_EMAIL ||
+    env.THUMBGATE_OPERATOR_ALERT_EMAIL ||
+    env.THUMBGATE_SUPPORT_EMAIL ||
+    DEFAULT_PRO_ACTIVATION_ALERT_EMAIL
+  );
+}
+
+function canSendProActivationAlert({ env = process.env, sendEmailImpl } = {}) {
+  if (isTruthyEnv(env.THUMBGATE_DISABLE_PRO_ACTIVATION_ALERTS)) return false;
+  if (!resolveProActivationAlertRecipient(env)) return false;
+  if (sendEmailImpl) return true;
+  return Boolean(normalizeText(env.RESEND_API_KEY || env.THUMBGATE_RESEND_API_KEY));
+}
+
+function renderProActivationAlertBodies({
+  keyFingerprint,
+  source,
+  version,
+  activatedAt,
+  hostname,
+  platform,
+  arch,
+  nodeVersion,
+  customerId,
+  installId,
+  usageCount,
+} = {}) {
+  const occurredAt = activatedAt || new Date().toISOString();
+  const runtimePlatform = platform || process.platform;
+  const runtimeArch = arch || process.arch;
+  const runtimeNode = nodeVersion || process.version;
+  const text = [
+    'ThumbGate Pro activation detected.',
+    '',
+    `Activated at: ${occurredAt}`,
+    `Key fingerprint: ${keyFingerprint || 'unknown'}`,
+    `Source: ${source || 'unknown'}`,
+    `Version: ${version || 'unknown'}`,
+    `Customer ID: ${customerId || 'unknown'}`,
+    `Install ID: ${installId || 'unknown'}`,
+    `Usage count: ${usageCount ?? 'unknown'}`,
+    `Host: ${hostname || 'unknown'}`,
+    `Runtime: ${runtimePlatform}/${runtimeArch} on ${runtimeNode}`,
+    '',
+    'Secret hygiene: this alert intentionally does not include the raw Pro key.',
+  ].join('\n');
+  const html = `<!doctype html>
+<html>
+  <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;color:#17212b;line-height:1.5;">
+    <h1 style="font-size:20px;margin:0 0 12px;">ThumbGate Pro activation detected</h1>
+    <table role="presentation" cellspacing="0" cellpadding="0" style="border-collapse:collapse;">
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Activated at</td><td style="padding:4px 0;">${escapeHtml(occurredAt)}</td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Key fingerprint</td><td style="padding:4px 0;"><code>${escapeHtml(keyFingerprint || 'unknown')}</code></td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Source</td><td style="padding:4px 0;">${escapeHtml(source || 'unknown')}</td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Version</td><td style="padding:4px 0;">${escapeHtml(version || 'unknown')}</td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Customer ID</td><td style="padding:4px 0;">${escapeHtml(customerId || 'unknown')}</td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Install ID</td><td style="padding:4px 0;">${escapeHtml(installId || 'unknown')}</td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Usage count</td><td style="padding:4px 0;">${escapeHtml(usageCount ?? 'unknown')}</td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Host</td><td style="padding:4px 0;">${escapeHtml(hostname || 'unknown')}</td></tr>
+      <tr><td style="padding:4px 14px 4px 0;color:#64748b;">Runtime</td><td style="padding:4px 0;">${escapeHtml(runtimePlatform)}/${escapeHtml(runtimeArch)} on ${escapeHtml(runtimeNode)}</td></tr>
+    </table>
+    <p style="margin-top:16px;color:#64748b;">Secret hygiene: this alert intentionally does not include the raw Pro key.</p>
+  </body>
+</html>`;
+  return { text, html };
+}
+
+async function sendProActivationAlert({
+  key,
+  source = 'unknown',
+  version,
+  customerId,
+  installId,
+  usageCount,
+  env = process.env,
+  sendEmailImpl,
+} = {}) {
+  const keyFingerprint = fingerprintProKey(key);
+  if (!keyFingerprint) return { sent: false, reason: 'missing_key' };
+  if (!canSendProActivationAlert({ env, sendEmailImpl })) {
+    return { sent: false, reason: 'activation_alert_disabled_or_unconfigured' };
+  }
+
+  const to = resolveProActivationAlertRecipient(env);
+  const { html, text } = renderProActivationAlertBodies({
+    keyFingerprint,
+    source,
+    version,
+    customerId,
+    installId,
+    usageCount,
+    activatedAt: new Date().toISOString(),
+    hostname: os.hostname(),
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+  });
+  const sender = sendEmailImpl || require('./mailer').sendEmail;
+
+  try {
+    return await sender({
+      to,
+      subject: 'ThumbGate Pro activated',
+      html,
+      text,
+    });
+  } catch (error) {
+    return {
+      sent: false,
+      reason: 'exception',
+      error: error && error.message ? error.message : String(error),
+    };
+  }
+}
+
+async function notifyHostedProActivation({
+  key,
+  source = 'cli_pro_activate',
+  version,
+  apiBaseUrl = process.env.THUMBGATE_API_BASE_URL || DEFAULT_PRO_API,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const normalizedKey = normalizeText(key);
+  if (!normalizedKey) return { notified: false, reason: 'missing_key' };
+  if (typeof fetchImpl !== 'function') return { notified: false, reason: 'no_fetch' };
+
+  const keyFingerprint = fingerprintProKey(normalizedKey);
+  const endpoint = new URL('/v1/billing/pro-activation', apiBaseUrl).toString();
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${normalizedKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        keyFingerprint,
+        source,
+        version: version || null,
+      }),
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        notified: false,
+        reason: body && body.detail ? body.detail : `http_${response.status}`,
+        status: response.status,
+      };
+    }
+    return {
+      notified: true,
+      status: response.status,
+      alert: body.alert || null,
+      keyFingerprint: body.keyFingerprint || keyFingerprint,
+    };
+  } catch (error) {
+    return {
+      notified: false,
+      reason: 'exception',
+      error: error && error.message ? error.message : String(error),
+    };
+  }
 }
 
 function readLicense({ homeDir } = {}) {
@@ -162,12 +353,19 @@ module.exports = {
   CREATOR_BYPASS_VALUE,
   CREATOR_SYNTHETIC_KEY,
   DEFAULT_PRO_API,
+  DEFAULT_PRO_ACTIVATION_ALERT_EMAIL,
+  canSendProActivationAlert,
+  fingerprintProKey,
   getLicenseDir,
   getLicensePath,
   hasDevOverride,
   isCreatorDev,
   readLicense,
+  renderProActivationAlertBodies,
+  notifyHostedProActivation,
+  resolveProActivationAlertRecipient,
   saveLicense,
+  sendProActivationAlert,
   resolveProKey,
   validateProKey,
   startLocalProDashboard,

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -220,6 +220,10 @@ const pendingOauthAuthorizeRequests = new Map();
 const OAUTH_AUTHORIZE_REQUEST_TTL_MS = 10 * 60 * 1000;
 const resendMailer = require('../../scripts/mailer/resend-mailer');
 const {
+  fingerprintProKey,
+  sendProActivationAlert,
+} = require('../../scripts/pro-local-dashboard');
+const {
   buildContextFootprintReport,
 } = require('../../scripts/context-footprint');
 const {
@@ -9223,6 +9227,48 @@ a{color:#8b9}</style></head><body><form class="card" method="post" action="/oaut
           key: token,
           customerId: validation.customerId,
           usageCount: validation.usageCount,
+        });
+        return;
+      }
+
+      // POST /v1/billing/pro-activation — customer key activation alert.
+      if (req.method === 'POST' && pathname === '/v1/billing/pro-activation') {
+        const token = extractBearerToken(req);
+        const validation = validateApiKey(token);
+        if (!validation.valid) {
+          sendProblem(res, {
+            type: PROBLEM_TYPES.UNAUTHORIZED,
+            title: 'Unauthorized',
+            status: 401,
+            detail: 'A valid API key is required to access this endpoint.',
+          });
+          return;
+        }
+
+        const body = await parseJsonBody(req);
+        const keyFingerprint = fingerprintProKey(token);
+        const alert = await sendProActivationAlert({
+          key: token,
+          source: body.source || 'hosted_pro_activation',
+          version: body.version || null,
+          customerId: validation.customerId,
+          installId: validation.installId,
+          usageCount: validation.usageCount,
+          env: process.env,
+        });
+
+        sendJson(res, 200, {
+          ok: true,
+          customerId: validation.customerId,
+          installId: validation.installId,
+          usageCount: validation.usageCount,
+          keyFingerprint,
+          keyFingerprintMatchesClient: body.keyFingerprint ? body.keyFingerprint === keyFingerprint : null,
+          alert: {
+            sent: Boolean(alert && alert.sent),
+            reason: alert && alert.reason ? alert.reason : null,
+            id: alert && alert.id ? alert.id : null,
+          },
         });
         return;
       }

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -3161,6 +3161,48 @@ test('billing provision requires static admin key and rejects billing keys', asy
   assert.equal(res.status, 403);
 });
 
+test('billing pro activation endpoint validates customer key and returns secret-safe alert status', async () => {
+  const savedResend = process.env.RESEND_API_KEY;
+  const savedThumbgateResend = process.env.THUMBGATE_RESEND_API_KEY;
+  delete process.env.RESEND_API_KEY;
+  delete process.env.THUMBGATE_RESEND_API_KEY;
+
+  const billingKey = billing.provisionApiKey('cus_activation_alert', {
+    installId: 'inst_activation_alert',
+    source: 'test_activation_alert',
+  }).key;
+
+  try {
+    const res = await fetch(apiUrl('/v1/billing/pro-activation'), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${billingKey}`,
+      },
+      body: JSON.stringify({
+        keyFingerprint: 'sha256:clienthint',
+        source: 'api_server_test',
+        version: '1.2.3-test',
+      }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.customerId, 'cus_activation_alert');
+    assert.equal(body.installId, 'inst_activation_alert');
+    assert.match(body.keyFingerprint, /^sha256:[a-f0-9]{12}$/);
+    assert.equal(body.keyFingerprintMatchesClient, false);
+    assert.equal(body.alert.sent, false);
+    assert.equal(body.alert.reason, 'activation_alert_disabled_or_unconfigured');
+    assert.doesNotMatch(JSON.stringify(body), new RegExp(billingKey));
+  } finally {
+    if (savedResend === undefined) delete process.env.RESEND_API_KEY;
+    else process.env.RESEND_API_KEY = savedResend;
+    if (savedThumbgateResend === undefined) delete process.env.THUMBGATE_RESEND_API_KEY;
+    else process.env.THUMBGATE_RESEND_API_KEY = savedThumbgateResend;
+  }
+});
+
 test('billing summary returns admin-only operational proxy', async () => {
   fs.writeFileSync(path.join(tmpFeedbackDir, 'workflow-sprint-leads.jsonl'), `${JSON.stringify({
     leadId: 'lead_admin_summary',

--- a/tests/pro-local-dashboard.test.js
+++ b/tests/pro-local-dashboard.test.js
@@ -14,11 +14,17 @@ const {
   CREATOR_BYPASS_ENV,
   CREATOR_BYPASS_VALUE,
   CREATOR_SYNTHETIC_KEY,
+  canSendProActivationAlert,
+  fingerprintProKey,
   getLicensePath,
   isCreatorDev,
+  notifyHostedProActivation,
   readLicense,
+  renderProActivationAlertBodies,
+  resolveProActivationAlertRecipient,
   resolveProKey,
   saveLicense,
+  sendProActivationAlert,
   startLocalProDashboard,
   validateProKey,
 } = require('../scripts/pro-local-dashboard');
@@ -104,6 +110,118 @@ test('pro local dashboard helper starts localhost dashboard and seeds pro env', 
   assert.equal(env.PORT, '0');
   assert.equal(result.port, 4123);
   assert.equal(result.url, 'http://localhost:4123/dashboard');
+});
+
+test('pro activation alert sends a secret-safe owner email', async () => {
+  const rawKey = 'tg_pro_unit_test_secret_key_1234567890';
+  const sent = [];
+
+  const result = await sendProActivationAlert({
+    key: rawKey,
+    source: 'unit_test_activate',
+    version: '9.9.9-test',
+    env: {
+      THUMBGATE_PRO_ACTIVATION_ALERT_EMAIL: 'owner@example.com',
+    },
+    sendEmailImpl: async (payload) => {
+      sent.push(payload);
+      return { sent: true, id: 'email_test_activation' };
+    },
+  });
+
+  assert.deepEqual(result, { sent: true, id: 'email_test_activation' });
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].to, 'owner@example.com');
+  assert.equal(sent[0].subject, 'ThumbGate Pro activated');
+  assert.match(sent[0].text, /ThumbGate Pro activation detected/);
+  assert.match(sent[0].text, /Key fingerprint: sha256:/);
+  assert.match(sent[0].html, /Key fingerprint/);
+  assert.doesNotMatch(sent[0].text, new RegExp(rawKey));
+  assert.doesNotMatch(sent[0].html, new RegExp(rawKey));
+});
+
+test('pro activation alert skips cleanly when email is unconfigured', async () => {
+  const result = await sendProActivationAlert({
+    key: 'tg_pro_unit_test_secret_key_0987654321',
+    env: {
+      RESEND_API_KEY: '',
+      THUMBGATE_RESEND_API_KEY: '',
+    },
+    sendEmailImpl: null,
+  });
+
+  assert.deepEqual(result, {
+    sent: false,
+    reason: 'activation_alert_disabled_or_unconfigured',
+  });
+});
+
+test('pro activation alert can be disabled explicitly', () => {
+  assert.equal(canSendProActivationAlert({
+    env: {
+      RESEND_API_KEY: 're_test_key',
+      THUMBGATE_DISABLE_PRO_ACTIVATION_ALERTS: '1',
+    },
+  }), false);
+});
+
+test('pro activation alert fingerprints keys without exposing the key', () => {
+  const key = 'tg_pro_unit_test_fingerprint_key_1234567890';
+  const fingerprint = fingerprintProKey(key);
+  const bodies = renderProActivationAlertBodies({
+    keyFingerprint: fingerprint,
+    source: 'unit_test',
+    version: '1.2.3',
+    activatedAt: '2026-07-09T12:00:00.000Z',
+    hostname: 'test-host',
+    platform: 'darwin',
+    arch: 'arm64',
+    nodeVersion: 'v99.0.0',
+  });
+
+  assert.match(fingerprint, /^sha256:[a-f0-9]{12}$/);
+  assert.equal(resolveProActivationAlertRecipient({
+    THUMBGATE_PRO_ACTIVATION_ALERT_EMAIL: 'alerts@example.com',
+  }), 'alerts@example.com');
+  assert.match(bodies.text, new RegExp(fingerprint));
+  assert.match(bodies.html, new RegExp(fingerprint));
+  assert.doesNotMatch(bodies.text, new RegExp(key));
+  assert.doesNotMatch(bodies.html, new RegExp(key));
+});
+
+test('hosted pro activation notifier sends key only as bearer auth', async () => {
+  const rawKey = 'tg_pro_unit_test_notify_key_1234567890';
+  let captured = null;
+  const result = await notifyHostedProActivation({
+    key: rawKey,
+    source: 'unit_test_cli',
+    version: '7.7.7-test',
+    apiBaseUrl: 'https://api.example.com/base',
+    fetchImpl: async (url, init) => {
+      captured = { url, init };
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            alert: { sent: true, id: 'email_activation_test' },
+            keyFingerprint: fingerprintProKey(rawKey),
+          };
+        },
+      };
+    },
+  });
+
+  assert.equal(result.notified, true);
+  assert.equal(result.alert.sent, true);
+  assert.equal(captured.url, 'https://api.example.com/v1/billing/pro-activation');
+  assert.equal(captured.init.method, 'POST');
+  assert.equal(captured.init.headers.authorization, `Bearer ${rawKey}`);
+  const body = JSON.parse(captured.init.body);
+  assert.equal(body.source, 'unit_test_cli');
+  assert.equal(body.version, '7.7.7-test');
+  assert.match(body.keyFingerprint, /^sha256:[a-f0-9]{12}$/);
+  assert.doesNotMatch(captured.init.body, new RegExp(rawKey));
 });
 
 // ── Creator dev bypass tests ────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a hosted Pro activation alert endpoint at `POST /v1/billing/pro-activation` that validates the customer billing key and sends an owner email from server-side Resend.
- Update `npx thumbgate pro --activate --key=...` to notify the hosted endpoint before launching the local dashboard.
- Keep activation alerts secret-safe: responses and emails use a SHA-256 key fingerprint prefix, never the raw Pro key.

## Verification
- `node --test tests/pro-local-dashboard.test.js` → 16/16 passing
- `node --test tests/api-server.test.js` → 147/147 passing
- `npm run test:cli` → 246/246 passing
- `npm run test:mailer` → 46/46 passing
- `npm run test:license` → 7/7 passing
- `npm run test:public-bundle-ratchet` → 2/2 passing
- `git diff --check` → clean
- touched-file secret scan for exposed-key fragments/live secret patterns → no matches

## Notes
- Customer machines do not need Resend credentials. The CLI sends the Pro key only as Bearer auth to the hosted API; the JSON body carries only fingerprint/source/version.
- If hosted Resend is missing, activation still succeeds and the endpoint returns a structured alert skip reason.