### PR TITLE
fix(marketing): align Pro copy with real packaging

### DIFF
--- a/.changeset/pro-packaging-copy-truth.md
+++ b/.changeset/pro-packaging-copy-truth.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Align Pro and Enterprise packaging copy across checkout, pricing, public comparison pages, LLM context, and CLI upgrade receipts. Pro is now described as personal recall, dashboard proof, exports, and managed adapter coverage; Enterprise owns shared hosted lessons, org visibility, and rollout support.

--- a/.changeset/pro-packaging-copy-truth.md
+++ b/.changeset/pro-packaging-copy-truth.md
@@ -2,4 +2,4 @@
 "thumbgate": patch
 ---
 
-Align Pro and Enterprise packaging copy across checkout, pricing, public comparison pages, LLM context, and CLI upgrade receipts. Pro is now described as personal recall, dashboard proof, exports, and managed adapter coverage; Enterprise owns shared hosted lessons, org visibility, and rollout support.
+Align Pro and Enterprise packaging copy across checkout, pricing, public pages, LLM context, and CLI receipts. Pro is personal recall, dashboard proof, exports, and managed adapters; Enterprise is shared hosted lessons, org visibility, and rollout support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,17 +122,4 @@ Rules:
 
 ## 🛡️ Self-Harness Prevention Rules (Auto-Generated)
 
-> [!IMPORTANT]
-> The following rules were automatically derived from execution failures and thumbs-down feedback.
-> You MUST follow these constraints strictly to prevent repeated errors.
-
-- **Rule [auto-entity-customer-entity-revenue]**: Auto-promoted repeated pattern: "{"session_id":"0758648e-518b-4c60-8ada-c1bee25ffa5a","transcript_path":"/Users/igorganapolsky/.claude/projects/-Users-ig" (1 occurrences in 30 days)
-- **Rule [auto-commercial-truth-email-thread-entity-customer-lead]**: Auto-promoted repeated pattern: "User showed Gmail thread after asking if outreach was on track; I answered as if Pro access still needed to be sent, des" (1 occurrences in 30 days)
-- **Rule [auto-codeql-prove-before-claim-security-verification-xs]**: Auto-promoted repeated pattern: "CodeQL #252 reflected-XSS: I dismissed the alert as false-positive and claimed the security dashboard was clean BEFORE v" (1 occurrences in 30 days)
-- **Rule [auto-never-force-push-to-main-again]**: Auto-promoted repeated pattern: "never force-push to main again" (1 occurrences in 30 days)
-- **Rule [auto-promoted-mrdpihth-0]**: NEVER The instructions omitted the hydraulic accumulator pressure bleed step.
-- **Rule [auto-promoted-mrdpihth-1]**: NEVER MISTAKE: This is a test failure
-- **Rule [auto-promoted-mrdpihth-2]**: NEVER CEO gave thumbs down because the mandatory session closure phrase 'Done merging 
-- **Rule [auto-promoted-mrdpihth-3]**: NEVER thumbs down This response skipped the required verification
-- **Rule [auto-promoted-mrdpindv-0]**: NEVER repeated problem context string
-- **Rule [auto-meta-mistake-failure]**: Repeated failure pattern: mistake this is a test failure
+- No active auto-generated prevention rules at this time.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,17 +16,4 @@ Key: Always dogfood the latest local changes before publishing.
 
 ## 🛡️ Self-Harness Prevention Rules (Auto-Generated)
 
-> [!IMPORTANT]
-> The following rules were automatically derived from execution failures and thumbs-down feedback.
-> You MUST follow these constraints strictly to prevent repeated errors.
-
-- **Rule [auto-entity-customer-entity-revenue]**: Auto-promoted repeated pattern: "{"session_id":"0758648e-518b-4c60-8ada-c1bee25ffa5a","transcript_path":"/Users/igorganapolsky/.claude/projects/-Users-ig" (1 occurrences in 30 days)
-- **Rule [auto-commercial-truth-email-thread-entity-customer-lead]**: Auto-promoted repeated pattern: "User showed Gmail thread after asking if outreach was on track; I answered as if Pro access still needed to be sent, des" (1 occurrences in 30 days)
-- **Rule [auto-codeql-prove-before-claim-security-verification-xs]**: Auto-promoted repeated pattern: "CodeQL #252 reflected-XSS: I dismissed the alert as false-positive and claimed the security dashboard was clean BEFORE v" (1 occurrences in 30 days)
-- **Rule [auto-never-force-push-to-main-again]**: Auto-promoted repeated pattern: "never force-push to main again" (1 occurrences in 30 days)
-- **Rule [auto-promoted-mrdpihth-0]**: NEVER The instructions omitted the hydraulic accumulator pressure bleed step.
-- **Rule [auto-promoted-mrdpihth-1]**: NEVER MISTAKE: This is a test failure
-- **Rule [auto-promoted-mrdpihth-2]**: NEVER CEO gave thumbs down because the mandatory session closure phrase 'Done merging 
-- **Rule [auto-promoted-mrdpihth-3]**: NEVER thumbs down This response skipped the required verification
-- **Rule [auto-promoted-mrdpindv-0]**: NEVER repeated problem context string
-- **Rule [auto-meta-mistake-failure]**: Repeated failure pattern: mistake this is a test failure
+- No active auto-generated prevention rules at this time.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -134,7 +134,7 @@ function upgradeNudge() {
     '\n  Team rollout: start with the $499 Workflow Hardening Diagnostic\n' +
     `  ${diagnosticUrl}\n` +
     `\n  Solo side lane: Pro — ${PRO_PRICE_LABEL}\n` +
-    '  Removes solo caps and adds personal lesson recall, dashboard proof, exports, and managed adapter coverage.\n' +
+    '  Removes solo caps; adds personal recall, dashboard proof, exports, and managed adapters.\n' +
     `  ${pricingUrl}\n\n`
   );
 }
@@ -234,9 +234,9 @@ function proNudge(context) {
   const checkoutUrl = checkoutUrlFor('cli_nudge', context || COMMAND || 'general');
   const pricingUrl = pricingUrlFor('cli_nudge', context || COMMAND || 'general');
   const messages = [
-    `\n  💡 Pro (${PRO_PRICE_LABEL}): remove solo caps and add personal recall, dashboard proof, exports, and managed adapter coverage.\n     See pricing: ${pricingUrl}\n`,
-    `\n  💡 You just taught ThumbGate something locally. Pro keeps your personal lessons searchable and exportable without the free-tier caps.\n     See pricing: ${pricingUrl}\n`,
-    `\n  💡 ThumbGate Pro keeps the adapter matrix maintained across Claude, Codex, Cursor, containers, and CI. ${PRO_PRICE_LABEL}.\n     Start Pro: ${checkoutUrl}\n`,
+    `\n  💡 Pro (${PRO_PRICE_LABEL}): personal recall, dashboard proof, exports, and managed adapters.\n     See pricing: ${pricingUrl}\n`,
+    `\n  💡 You just taught ThumbGate something locally. Pro keeps personal lessons searchable and exportable without free-tier caps.\n     See pricing: ${pricingUrl}\n`,
+    `\n  💡 ThumbGate Pro maintains adapter coverage across Claude, Codex, Cursor, containers, and CI. ${PRO_PRICE_LABEL}.\n     Start Pro: ${checkoutUrl}\n`,
   ];
   // Rotate message daily — no Math.random (security policy)
   const msg = messages[Math.floor(Date.now() / 86400000) % messages.length];
@@ -1607,10 +1607,10 @@ function pro() {
     console.log('Self-serve side lane today: Pro ($19/mo or $149/yr).');
     console.log('Every licensed Pro user gets a personal local dashboard on localhost.');
     console.log('\nWhat is available:');
-    console.log('  - Personal recall: search lessons, rules, and proof without free-tier caps');
+    console.log('  - Personal recall: search lessons, rules, and proof');
     console.log('  - Local Pro dashboard: your own browser dashboard for search, gates, and DPO export');
-    console.log('  - Managed adapter coverage: Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode drift is tracked for you');
-    console.log('  - Team rollout path: Enterprise adds shared hosted lessons, org visibility, and workflow proof');
+    console.log('  - Managed adapters: Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode');
+    console.log('  - Team rollout path: Enterprise adds shared hosted lessons, org visibility, workflow proof');
     console.log('  - Commercial truth doc: source of truth for traction, pricing, and proof claims');
     console.log('\nLinks:');
     console.log(`  Buy Pro         : ${PRO_CHECKOUT_URL}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -134,7 +134,7 @@ function upgradeNudge() {
     '\n  Team rollout: start with the $499 Workflow Hardening Diagnostic\n' +
     `  ${diagnosticUrl}\n` +
     `\n  Solo side lane: Pro — ${PRO_PRICE_LABEL}\n` +
-    '  Keeps lessons, rules, and the dashboard synced across machines and agent runtimes.\n' +
+    '  Removes solo caps and adds personal lesson recall, dashboard proof, exports, and managed adapter coverage.\n' +
     `  ${pricingUrl}\n\n`
   );
 }
@@ -234,9 +234,9 @@ function proNudge(context) {
   const checkoutUrl = checkoutUrlFor('cli_nudge', context || COMMAND || 'general');
   const pricingUrl = pricingUrlFor('cli_nudge', context || COMMAND || 'general');
   const messages = [
-    `\n  💡 Pro (${PRO_PRICE_LABEL}): keep lessons, rules, and dashboard state synced across machines and agent runtimes.\n     See pricing: ${pricingUrl}\n`,
-    `\n  💡 You just taught ThumbGate something locally. Pro keeps that lesson alive on every laptop, CI box, and agent runtime.\n     See pricing: ${pricingUrl}\n`,
-    `\n  💡 ThumbGate Pro syncs lessons/rules across Claude, Codex, Cursor, containers, and CI. ${PRO_PRICE_LABEL}.\n     Start Pro: ${checkoutUrl}\n`,
+    `\n  💡 Pro (${PRO_PRICE_LABEL}): remove solo caps and add personal recall, dashboard proof, exports, and managed adapter coverage.\n     See pricing: ${pricingUrl}\n`,
+    `\n  💡 You just taught ThumbGate something locally. Pro keeps your personal lessons searchable and exportable without the free-tier caps.\n     See pricing: ${pricingUrl}\n`,
+    `\n  💡 ThumbGate Pro keeps the adapter matrix maintained across Claude, Codex, Cursor, containers, and CI. ${PRO_PRICE_LABEL}.\n     Start Pro: ${checkoutUrl}\n`,
   ];
   // Rotate message daily — no Math.random (security policy)
   const msg = messages[Math.floor(Date.now() / 86400000) % messages.length];
@@ -1607,9 +1607,10 @@ function pro() {
     console.log('Self-serve side lane today: Pro ($19/mo or $149/yr).');
     console.log('Every licensed Pro user gets a personal local dashboard on localhost.');
     console.log('\nWhat is available:');
-    console.log('  - Hosted sync: keep lessons, rules, and dashboard state aligned across laptops, CI, containers, and agent runtimes');
+    console.log('  - Personal recall: search lessons, rules, and proof without free-tier caps');
     console.log('  - Local Pro dashboard: your own browser dashboard for search, gates, and DPO export');
-    console.log('  - Team rollout path: shared hosted lessons, org visibility, and workflow proof');
+    console.log('  - Managed adapter coverage: Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode drift is tracked for you');
+    console.log('  - Team rollout path: Enterprise adds shared hosted lessons, org visibility, and workflow proof');
     console.log('  - Commercial truth doc: source of truth for traction, pricing, and proof claims');
     console.log('\nLinks:');
     console.log(`  Buy Pro         : ${PRO_CHECKOUT_URL}`);

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -36,7 +36,7 @@ process.stderr.write(`
   ╰─────────────────────────────────────────────────────╯
 
   Trial unlocks: unlimited rules, lesson search, DPO export,
-  hosted dashboard. After 7 days, free tier limits apply.
+  and personal dashboard proof. After 7 days, free tier limits apply.
   Subscribe for the 5-min setup guide + weekly tips:
   npx thumbgate subscribe you@company.com
 

--- a/public/agent-manager.html
+++ b/public/agent-manager.html
@@ -46,7 +46,7 @@
       "name": "How does ThumbGate help the Agent Manager?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate is the pre-action enforcement layer underneath what the role owns. It runs PreToolUse hooks at the tool-call boundary, auto-distills prevention rules from real thumbs-down feedback and writes them into CLAUDE.md, provides an org-wide rule library and hosted dashboard, and keeps an adapter matrix current as Claude Code, Cursor, and Codex change — so the role does not have to be the operator themselves. Each block carries the rule that fired and the evidence that triggered it, so the agent can choose a safer plan."
+        "text": "ThumbGate is the pre-action enforcement layer underneath what the role owns. It runs PreToolUse hooks at the tool-call boundary, auto-distills prevention rules from repeated thumbs-down feedback and writes them into CLAUDE.md. Pro keeps personal recall, exports, dashboard proof, and adapters maintained; Enterprise adds the org-wide rule library and hosted dashboard so the role does not have to be the operator themselves. Each block carries the rule that fired and the evidence that triggered it, so the agent can choose a safer plan."
       }
     },
     {
@@ -54,7 +54,7 @@
       "name": "Is ThumbGate free for the Agent Manager to start?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. npx thumbgate init in one repo is free and MIT licensed, and the gates work locally without a hosted account. The paid tier adds the hosted dashboard, the org-wide rule library, DPO/HuggingFace export, and 24x7 ops on the adapter matrix — the operational work the role would otherwise have to do itself."
+        "text": "Yes. npx thumbgate init in one repo is free and MIT licensed, and the gates work locally without a hosted account. Pro adds personal recall, dashboard proof, DPO/HuggingFace export, and managed adapter coverage. Enterprise adds the hosted dashboard, org-wide rule library, and rollout support — the operational work the role would otherwise have to do itself."
       }
     },
     {
@@ -112,7 +112,7 @@
     <tbody>
       <tr>
         <td><strong>CLAUDE.md hierarchy</strong><br>Keeping the policy that the model reads on every session current and consistent across repos.</td>
-        <td>Prevention rules auto-distilled from real <code>👎</code> feedback and written into <code>CLAUDE.md</code> by <code>scripts/feedback-to-rules.js</code>. Org-wide rule library on the hosted dashboard.</td>
+        <td>Prevention rules auto-distilled from repeated real <code>👎</code> feedback and written into <code>CLAUDE.md</code> by <code>scripts/feedback-to-rules.js</code>. Enterprise adds the org-wide rule library on the hosted dashboard.</td>
       </tr>
       <tr>
         <td><strong>Plugin marketplace</strong><br>Deciding which Claude Code / Cursor / Codex plugins are blessed and which are not.</td>
@@ -128,7 +128,7 @@
       </tr>
       <tr>
         <td><strong>Keep them current</strong><br>When Claude Code ships a breaking change to hooks or to the plugin API, your rollout cannot wait a quarter.</td>
-        <td>24×7 ops on the adapter matrix. SonarCloud regressions fixed in &lt;24h. The hosted tier is the operator the role does not have to be themselves.</td>
+        <td>24×7 ops on the adapter matrix. SonarCloud regressions fixed in &lt;24h. Pro covers personal adapter maintenance; Enterprise is the hosted operator the role does not have to be themselves.</td>
       </tr>
     </tbody>
   </table>
@@ -145,7 +145,7 @@
     </div>
     <div class="card">
       <h3>Phase 2 — Rollout lands</h3>
-      <p>Infrastructure is ready; the first wave finds it productive. This is where the Agent Manager becomes a named role. ThumbGate's hosted dashboard, org-wide rule library, and DPO export are what that role uses to keep CLAUDE.md and the permissions policy consistent across repos.</p>
+      <p>Infrastructure is ready; the first wave finds it productive. This is where the Agent Manager becomes a named role. ThumbGate Enterprise's hosted dashboard, org-wide rule library, and DPO export are what that role uses to keep CLAUDE.md and the permissions policy consistent across repos.</p>
     </div>
     <div class="card">
       <h3>Phase 3 — Adoption spreads</h3>

--- a/public/agent-manager.html
+++ b/public/agent-manager.html
@@ -46,7 +46,7 @@
       "name": "How does ThumbGate help the Agent Manager?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate is the pre-action enforcement layer underneath what the role owns. It runs PreToolUse hooks at the tool-call boundary, auto-distills prevention rules from repeated thumbs-down feedback and writes them into CLAUDE.md. Pro keeps personal recall, exports, dashboard proof, and adapters maintained; Enterprise adds the org-wide rule library and hosted dashboard so the role does not have to be the operator themselves. Each block carries the rule that fired and the evidence that triggered it, so the agent can choose a safer plan."
+        "text": "ThumbGate is the pre-action enforcement layer under the role. It runs PreToolUse hooks, distills repeated thumbs-down feedback into CLAUDE.md rules, and shows the rule plus evidence on each block. Pro keeps personal recall, exports, dashboard proof, and adapters maintained; Enterprise adds the org-wide rule library and hosted dashboard."
       }
     },
     {
@@ -54,7 +54,7 @@
       "name": "Is ThumbGate free for the Agent Manager to start?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. npx thumbgate init in one repo is free and MIT licensed, and the gates work locally without a hosted account. Pro adds personal recall, dashboard proof, DPO/HuggingFace export, and managed adapter coverage. Enterprise adds the hosted dashboard, org-wide rule library, and rollout support — the operational work the role would otherwise have to do itself."
+        "text": "Yes. npx thumbgate init in one repo is free and MIT licensed, and gates work locally without a hosted account. Pro adds personal recall, dashboard proof, DPO/HuggingFace export, and managed adapters. Enterprise adds the hosted dashboard, org-wide rule library, and rollout support."
       }
     },
     {
@@ -112,7 +112,7 @@
     <tbody>
       <tr>
         <td><strong>CLAUDE.md hierarchy</strong><br>Keeping the policy that the model reads on every session current and consistent across repos.</td>
-        <td>Prevention rules auto-distilled from repeated real <code>👎</code> feedback and written into <code>CLAUDE.md</code> by <code>scripts/feedback-to-rules.js</code>. Enterprise adds the org-wide rule library on the hosted dashboard.</td>
+        <td>Prevention rules distilled from repeated real <code>👎</code> feedback and written into <code>CLAUDE.md</code> by <code>scripts/feedback-to-rules.js</code>. Enterprise adds the hosted org-wide rule library.</td>
       </tr>
       <tr>
         <td><strong>Plugin marketplace</strong><br>Deciding which Claude Code / Cursor / Codex plugins are blessed and which are not.</td>
@@ -128,7 +128,7 @@
       </tr>
       <tr>
         <td><strong>Keep them current</strong><br>When Claude Code ships a breaking change to hooks or to the plugin API, your rollout cannot wait a quarter.</td>
-        <td>24×7 ops on the adapter matrix. SonarCloud regressions fixed in &lt;24h. Pro covers personal adapter maintenance; Enterprise is the hosted operator the role does not have to be themselves.</td>
+        <td>24×7 ops on the adapter matrix. SonarCloud regressions fixed in &lt;24h. Pro covers personal adapter maintenance; Enterprise is the hosted operator.</td>
       </tr>
     </tbody>
   </table>
@@ -145,7 +145,7 @@
     </div>
     <div class="card">
       <h3>Phase 2 — Rollout lands</h3>
-      <p>Infrastructure is ready; the first wave finds it productive. This is where the Agent Manager becomes a named role. ThumbGate Enterprise's hosted dashboard, org-wide rule library, and DPO export are what that role uses to keep CLAUDE.md and the permissions policy consistent across repos.</p>
+      <p>Infrastructure is ready; the first wave finds it productive. This is where the Agent Manager becomes a named role. ThumbGate Enterprise's hosted dashboard, org-wide rule library, and DPO export keep CLAUDE.md and permissions consistent across repos.</p>
     </div>
     <div class="card">
       <h3>Phase 3 — Adoption spreads</h3>

--- a/public/agents-cost-savings.html
+++ b/public/agents-cost-savings.html
@@ -131,7 +131,7 @@ npx thumbgate cost        # see what the gates were worth</code></pre>
   <div class="quote">"The category isn't 'FinOps for AI' — it's 'gates that stop the spend so FinOps has less to report on.' One sits behind the other."</div>
 
   <div class="card">
-    <p><strong>The free CLI is real. The paid tier is the hosted dashboard, org-wide rule library, and the operator the Agent Manager doesn't have to be themselves.</strong></p>
+    <p><strong>The free CLI is real. Pro adds the personal dashboard, recall, exports, and managed adapters. Enterprise is the hosted dashboard, org-wide rule library, and the operator the Agent Manager doesn't have to be themselves.</strong></p>
     <p>
       <a href="/#workflow-sprint-intake?utm_source=website&amp;utm_medium=agents_cost_savings_page&amp;utm_campaign=finops_sprint&amp;cta_id=agents_cost_savings_sprint_intake&amp;cta_placement=agents_cost_savings_page" class="cta">Start the Workflow Hardening Sprint</a>
       <a href="/checkout/pro?utm_source=website&amp;utm_medium=agents_cost_savings_page&amp;utm_campaign=pro_upgrade&amp;cta_id=agents_cost_savings_pro_checkout&amp;cta_placement=agents_cost_savings_page&amp;plan_id=pro" class="secondary">Or start Pro at $19/mo →</a>

--- a/public/codex-enterprise.html
+++ b/public/codex-enterprise.html
@@ -101,7 +101,7 @@
   <p>This wires the Codex hook, sets up the local lesson DB, and gives you the capture/promote/block loop without a hosted account. If you want the standalone Codex plugin as a self-contained zip — for offline distribution to Dell-managed machines or for security review — grab it from <a href="https://github.com/IgorGanapolsky/ThumbGate/releases" target="_blank" rel="noopener" style="color:var(--cyan)">GitHub releases</a> (look for <code>codex-plugin-*.zip</code>).</p>
 
   <div class="card">
-    <p><strong>The free CLI is real. The paid tier is the hosted dashboard, the org-wide rule library, and the operator the Agent Manager doesn't have to be themselves.</strong></p>
+    <p><strong>The free CLI is real. Pro adds the personal dashboard, recall, exports, and managed adapters. Enterprise is the hosted dashboard, the org-wide rule library, and the operator the Agent Manager doesn't have to be themselves.</strong></p>
     <p>
       <a href="/#workflow-sprint-intake?utm_source=website&amp;utm_medium=codex_enterprise_page&amp;utm_campaign=codex_enterprise_sprint&amp;cta_id=codex_enterprise_sprint_intake&amp;cta_placement=codex_enterprise_page" class="cta">Start the Workflow Hardening Sprint</a>
       <a href="/checkout/pro?utm_source=website&amp;utm_medium=codex_enterprise_page&amp;utm_campaign=pro_upgrade&amp;cta_id=codex_enterprise_pro_checkout&amp;cta_placement=codex_enterprise_page&amp;plan_id=pro" class="secondary">Or start Pro at $19/mo →</a>

--- a/public/compare.html
+++ b/public/compare.html
@@ -62,7 +62,7 @@
       "name": "Is ThumbGate free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate has a free tier that includes local enforcement with 2 feedback captures/day, 10 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds personal recall, lesson search, a personal local dashboard, managed adapter coverage, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared hosted lesson database and org dashboard."
+        "text": "ThumbGate free includes local enforcement with 2 captures/day, 10 total captures, 3 active auto-promoted prevention rules, and pre-action blocking. Pro ($19/mo or $149/yr) adds personal recall, search, a local dashboard, managed adapters, unlimited captures/rules, and DPO export. Enterprise adds a shared hosted lesson DB and org dashboard."
       }
     },
     {
@@ -271,7 +271,7 @@
 <p style="color:var(--muted);">Every head-to-head in one place. ThumbGate is the local-first, learning enforcement layer at the tool-call boundary — most of these tools sit at a different layer and are complementary.</p>
 <ul class="compare-index">
   <li><a href="/compare/sigmashake">ThumbGate vs SigmaShake</a> — learns the rule from your thumbs-down vs a hand-picked ruleset hub</li>
-  <li><a href="/compare/claude-code-hooks">ThumbGate vs claude-code-hooks</a> — personal recall, exports, and managed adapter coverage on top of local shell-script hooks</li>
+  <li><a href="/compare/claude-code-hooks">ThumbGate vs claude-code-hooks</a> — personal recall, exports, and managed adapters on top of local shell-script hooks</li>
   <li><a href="/compare/arcjet">ThumbGate vs Arcjet</a> — agent-outbound gate pairs with an app-inbound firewall</li>
   <li><a href="/compare/bumblebee">ThumbGate vs Bumblebee</a> — runtime enforcement pairs with static inventory</li>
   <li><a href="/compare/anthropic-containment">ThumbGate vs Anthropic's Claude Containment</a> — an IDE-agent extension of Anthropic's published architecture</li>
@@ -334,7 +334,7 @@
 
 <div class="card">
   <h3>Is ThumbGate free?</h3>
-  <p>ThumbGate has a free tier that includes local enforcement with 2 feedback captures/day, 10 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds personal recall, lesson search, a personal local dashboard, managed adapter coverage, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared hosted lesson database and org dashboard.</p>
+  <p>ThumbGate free includes local enforcement with 2 captures/day, 10 total captures, 3 active auto-promoted prevention rules, and pre-action blocking. Pro ($19/mo or $149/yr) adds personal recall, search, a local dashboard, managed adapters, unlimited captures/rules, and DPO export. Enterprise adds a shared hosted lesson DB and org dashboard.</p>
 </div>
 
 <div class="card">

--- a/public/compare.html
+++ b/public/compare.html
@@ -62,7 +62,7 @@
       "name": "Is ThumbGate free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "ThumbGate has a free tier that includes local enforcement with 2 feedback captures/day, 10 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared lesson database and org dashboard."
+        "text": "ThumbGate has a free tier that includes local enforcement with 2 feedback captures/day, 10 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds personal recall, lesson search, a personal local dashboard, managed adapter coverage, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared hosted lesson database and org dashboard."
       }
     },
     {
@@ -271,7 +271,7 @@
 <p style="color:var(--muted);">Every head-to-head in one place. ThumbGate is the local-first, learning enforcement layer at the tool-call boundary — most of these tools sit at a different layer and are complementary.</p>
 <ul class="compare-index">
   <li><a href="/compare/sigmashake">ThumbGate vs SigmaShake</a> — learns the rule from your thumbs-down vs a hand-picked ruleset hub</li>
-  <li><a href="/compare/claude-code-hooks">ThumbGate vs claude-code-hooks</a> — hosted sync &amp; learning on top of local shell-script hooks</li>
+  <li><a href="/compare/claude-code-hooks">ThumbGate vs claude-code-hooks</a> — personal recall, exports, and managed adapter coverage on top of local shell-script hooks</li>
   <li><a href="/compare/arcjet">ThumbGate vs Arcjet</a> — agent-outbound gate pairs with an app-inbound firewall</li>
   <li><a href="/compare/bumblebee">ThumbGate vs Bumblebee</a> — runtime enforcement pairs with static inventory</li>
   <li><a href="/compare/anthropic-containment">ThumbGate vs Anthropic's Claude Containment</a> — an IDE-agent extension of Anthropic's published architecture</li>
@@ -334,7 +334,7 @@
 
 <div class="card">
   <h3>Is ThumbGate free?</h3>
-  <p>ThumbGate has a free tier that includes local enforcement with 2 feedback captures/day, 10 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds hosted sync, a personal local dashboard, recall, lesson search, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared lesson database and org dashboard.</p>
+  <p>ThumbGate has a free tier that includes local enforcement with 2 feedback captures/day, 10 total captures, up to 3 active auto-promoted prevention rules, and pre-action check blocking. Pro ($19/mo or $149/yr) adds personal recall, lesson search, a personal local dashboard, managed adapter coverage, unlimited captures/rules, and DPO export. Enterprise (custom pricing, scoped after intake) adds a shared hosted lesson database and org dashboard.</p>
 </div>
 
 <div class="card">

--- a/public/compare/anthropic-containment.html
+++ b/public/compare/anthropic-containment.html
@@ -250,7 +250,7 @@
       </a>
       <a class="related-card" href="/compare/claude-code-hooks">
         <strong>ThumbGate vs claude-code-hooks</strong><br>
-        <span style="color: var(--muted); font-size: 13px;">Hosted sync vs local shell scripts</span>
+        <span style="color: var(--muted); font-size: 13px;">Personal recall vs local shell scripts</span>
       </a>
       <a class="related-card" href="/compare/heidi">
         <strong>ThumbGate vs HEIDI</strong><br>

--- a/public/compare/bumblebee.html
+++ b/public/compare/bumblebee.html
@@ -273,7 +273,7 @@ bumblebee scan profile baseline</pre>
       </a>
       <a class="related-card" href="/compare/claude-code-hooks">
         <strong>ThumbGate vs claude-code-hooks</strong><br>
-        <span style="color: var(--muted); font-size: 13px;">Hosted sync vs local shell scripts</span>
+        <span style="color: var(--muted); font-size: 13px;">Personal recall vs local shell scripts</span>
       </a>
       <a class="related-card" href="/compare/heidi">
         <strong>ThumbGate vs HEIDI</strong><br>

--- a/public/compare/claude-code-hooks.html
+++ b/public/compare/claude-code-hooks.html
@@ -59,7 +59,7 @@
   "@context": "https://schema.org",
   "@type": "TechArticle",
   "headline": "ThumbGate vs claude-code-hooks",
-  "description": "karanb192/claude-code-hooks is a copy-paste bash hook collection for one laptop. ThumbGate is the same enforcement model plus personal recall, exports, managed adapter coverage across 8 agent runtimes, and an Enterprise rollout path. Side-by-side comparison.",
+  "description": "karanb192/claude-code-hooks is a copy-paste bash hook collection for one laptop. ThumbGate adds personal recall, exports, managed adapters across 8 agent runtimes, and an Enterprise rollout path.",
   "about": ["thumbgate vs claude-code-hooks", "AI coding agent safety hooks", "PreToolUse hook comparison", "Claude Code shell hooks"],
   "url": "https://thumbgate.ai/compare/claude-code-hooks",
   "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
@@ -76,7 +76,7 @@
       "name": "Is claude-code-hooks a direct ThumbGate competitor?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Same category, different scope. karanb192/claude-code-hooks is a curated GitHub repository of bash scripts you copy into ~/.claude/hooks and edit by hand. ThumbGate ships the same PreToolUse enforcement model as a runtime engine plus personal lesson recall, a maintained adapter matrix for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and Claude Desktop, dashboard proof, and an Enterprise rollout path. If you only run one agent on one laptop and you like bash, claude-code-hooks is great. If the same governance pattern has to work across multiple agents or teammates, that's where ThumbGate fits."
+        "text": "Same category, different scope. karanb192/claude-code-hooks is a curated GitHub repository of bash scripts you copy into ~/.claude/hooks and edit by hand. ThumbGate ships PreToolUse enforcement plus personal recall, a maintained adapter matrix, dashboard proof, and an Enterprise rollout path. If you only run one agent on one laptop and like bash, claude-code-hooks is great. If governance must work across agents or teammates, ThumbGate fits."
       }
     },
     {
@@ -92,7 +92,7 @@
       "name": "What does ThumbGate Pro add that the free tier and claude-code-hooks don't?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Personal recall and search, the managed adapter matrix (when Claude Code, Cursor, or Codex ship a breaking change to their hook API, that's our problem not yours), a dashboard with gate hit rates, DPO/HuggingFace export for fine-tuning, and 24x7 ops. Enterprise adds shared hosted lessons and org rollout. claude-code-hooks doesn't aim to do any of that on purpose — its scope is intentionally local-only."
+        "text": "Personal recall/search, managed adapters, a dashboard with gate hit rates, DPO/HuggingFace export, and 24x7 ops. Enterprise adds shared hosted lessons and org rollout. claude-code-hooks stays intentionally local-only."
       }
     },
     {
@@ -222,7 +222,7 @@
         <h2>FAQ</h2>
         <details class="faq-item" open>
           <summary>Is claude-code-hooks a direct ThumbGate competitor?</summary>
-          <p>Same category, different scope. claude-code-hooks is a copy-paste bash hook collection for one laptop running Claude Code. ThumbGate is the same PreToolUse enforcement model packaged as a runtime engine with personal recall, a multi-agent adapter matrix, dashboard proof, and an Enterprise rollout path. If you only need a few static rules on one machine, claude-code-hooks is fine. If you need the same governance pattern to work across agents or teammates, that's where ThumbGate fits.</p>
+          <p>Same category, different scope. claude-code-hooks is a copy-paste bash hook collection for one laptop running Claude Code. ThumbGate packages PreToolUse enforcement with personal recall, multi-agent adapters, dashboard proof, and an Enterprise rollout path. If you only need static rules on one machine, claude-code-hooks is fine. If governance must work across agents or teammates, ThumbGate fits.</p>
         </details>
         <details class="faq-item">
           <summary>Is ThumbGate's free CLI as capable as claude-code-hooks?</summary>

--- a/public/compare/claude-code-hooks.html
+++ b/public/compare/claude-code-hooks.html
@@ -59,7 +59,7 @@
   "@context": "https://schema.org",
   "@type": "TechArticle",
   "headline": "ThumbGate vs claude-code-hooks",
-  "description": "karanb192/claude-code-hooks is a copy-paste bash hook collection for one laptop. ThumbGate is the same enforcement model plus hosted lesson sync, an adapter matrix across 8 agent runtimes, and a dashboard. Side-by-side comparison.",
+  "description": "karanb192/claude-code-hooks is a copy-paste bash hook collection for one laptop. ThumbGate is the same enforcement model plus personal recall, exports, managed adapter coverage across 8 agent runtimes, and an Enterprise rollout path. Side-by-side comparison.",
   "about": ["thumbgate vs claude-code-hooks", "AI coding agent safety hooks", "PreToolUse hook comparison", "Claude Code shell hooks"],
   "url": "https://thumbgate.ai/compare/claude-code-hooks",
   "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
@@ -76,7 +76,7 @@
       "name": "Is claude-code-hooks a direct ThumbGate competitor?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Same category, different scope. karanb192/claude-code-hooks is a curated GitHub repository of bash scripts you copy into ~/.claude/hooks and edit by hand. ThumbGate ships the same PreToolUse enforcement model as a runtime engine plus hosted lesson sync across machines, a maintained adapter matrix for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and Claude Desktop, and a dashboard you don't self-host. If you only run one agent on one laptop and you like bash, claude-code-hooks is great. If the same rule has to fire across multiple machines, multiple agents, or multiple teammates, that's where ThumbGate fits."
+        "text": "Same category, different scope. karanb192/claude-code-hooks is a curated GitHub repository of bash scripts you copy into ~/.claude/hooks and edit by hand. ThumbGate ships the same PreToolUse enforcement model as a runtime engine plus personal lesson recall, a maintained adapter matrix for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, and Claude Desktop, dashboard proof, and an Enterprise rollout path. If you only run one agent on one laptop and you like bash, claude-code-hooks is great. If the same governance pattern has to work across multiple agents or teammates, that's where ThumbGate fits."
       }
     },
     {
@@ -92,7 +92,7 @@
       "name": "What does ThumbGate Pro add that the free tier and claude-code-hooks don't?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Hosted lesson sync (the same rule fires on your laptop and your CI runner without you re-copying scripts), the managed adapter matrix (when Claude Code, Cursor, or Codex ship a breaking change to their hook API, that's our problem not yours), a dashboard with gate hit rates and agent inventory, DPO/HuggingFace export for fine-tuning, and 24x7 ops. claude-code-hooks doesn't aim to do any of that on purpose — its scope is intentionally local-only."
+        "text": "Personal recall and search, the managed adapter matrix (when Claude Code, Cursor, or Codex ship a breaking change to their hook API, that's our problem not yours), a dashboard with gate hit rates, DPO/HuggingFace export for fine-tuning, and 24x7 ops. Enterprise adds shared hosted lessons and org rollout. claude-code-hooks doesn't aim to do any of that on purpose — its scope is intentionally local-only."
       }
     },
     {
@@ -222,7 +222,7 @@
         <h2>FAQ</h2>
         <details class="faq-item" open>
           <summary>Is claude-code-hooks a direct ThumbGate competitor?</summary>
-          <p>Same category, different scope. claude-code-hooks is a copy-paste bash hook collection for one laptop running Claude Code. ThumbGate is the same PreToolUse enforcement model packaged as a runtime engine with hosted sync, a multi-agent adapter matrix, and a dashboard. If you only need a few static rules on one machine, claude-code-hooks is fine. If you need the same rule to fire across machines, agents, or teammates, that's where ThumbGate fits.</p>
+          <p>Same category, different scope. claude-code-hooks is a copy-paste bash hook collection for one laptop running Claude Code. ThumbGate is the same PreToolUse enforcement model packaged as a runtime engine with personal recall, a multi-agent adapter matrix, dashboard proof, and an Enterprise rollout path. If you only need a few static rules on one machine, claude-code-hooks is fine. If you need the same governance pattern to work across agents or teammates, that's where ThumbGate fits.</p>
         </details>
         <details class="faq-item">
           <summary>Is ThumbGate's free CLI as capable as claude-code-hooks?</summary>
@@ -230,7 +230,7 @@
         </details>
         <details class="faq-item">
           <summary>What does ThumbGate Pro add over both the free tier and claude-code-hooks?</summary>
-          <p>Hosted lesson sync, the maintained adapter matrix, the dashboard, DPO and HuggingFace export, and 24x7 ops on the rule engine. Pro is $19/mo. Enterprise adds shared lesson DB and the Workflow Hardening Sprint engagement.</p>
+          <p>Personal recall, the maintained adapter matrix, the dashboard, DPO and HuggingFace export, and 24x7 ops on the rule engine. Pro is $19/mo. Enterprise adds a shared hosted lesson DB and the Workflow Hardening Sprint engagement.</p>
         </details>
         <details class="faq-item">
           <summary>Where do I start?</summary>

--- a/public/compare/oak-and-sparrow-gatekeeper.html
+++ b/public/compare/oak-and-sparrow-gatekeeper.html
@@ -189,7 +189,7 @@
           <tr>
             <td>License / availability</td>
             <td>Enterprise (no public pricing published as of 2026-05-27)</td>
-            <td>MIT-licensed npm package (free local CLI); $19/mo Pro for hosted sync + dashboard + DPO export; $49/seat Team for shared lesson DB + workflow hardening</td>
+            <td>MIT-licensed npm package (free local CLI); $19/mo Pro for personal recall + dashboard + DPO export; Enterprise for shared hosted lessons + workflow hardening</td>
           </tr>
         </tbody>
       </table>
@@ -267,7 +267,7 @@
       </a>
       <a class="related-card" href="/compare/claude-code-hooks">
         <strong>ThumbGate vs claude-code-hooks</strong><br>
-        <span style="color: var(--muted); font-size: 13px;">Hosted sync vs local shell scripts</span>
+        <span style="color: var(--muted); font-size: 13px;">Personal recall vs local shell scripts</span>
       </a>
       <a class="related-card" href="/compare/arcjet">
         <strong>ThumbGate vs Arcjet</strong><br>

--- a/public/compare/sigmashake.html
+++ b/public/compare/sigmashake.html
@@ -37,7 +37,7 @@
       "name": "What's the difference between ThumbGate and SigmaShake?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Both gate an AI coding agent's tool calls before they run, across Claude Code, Cursor, Codex and others. The core difference is where the rules come from. SigmaShake gives you a hub of ready-made signed community rulesets and a three-tier enforcement model (DENY / ASK / FORCE-substitute-a-safe-command). ThumbGate generates the rule from your own correction: one thumbs-down on a mistake auto-writes the rule that blocks that exact mistake from then on, synced across your machines and team. SigmaShake is the broader, more mature catalog; ThumbGate is the learning loop for the mistakes no catalog has a rule for yet."
+        "text": "Both gate an AI coding agent's tool calls before they run, across Claude Code, Cursor, Codex and others. The core difference is where the rules come from. SigmaShake gives you a hub of ready-made signed community rulesets and a three-tier enforcement model (DENY / ASK / FORCE-substitute-a-safe-command). ThumbGate captures your correction, accumulates repeat evidence for the same mistake, and turns that pattern into an auditable pre-action rule. SigmaShake is the broader, more mature catalog; ThumbGate is the learning loop for the mistakes no catalog has a rule for yet."
       }
     },
     {
@@ -88,7 +88,7 @@
   <h1>ThumbGate vs SigmaShake (and APort, and agent-guardrails)</h1>
   <p style="color:var(--muted);">For developers and teams choosing a pre-action gate for their AI coding agents</p>
 
-  <div class="tldr"><strong>TL;DR:</strong> Four tools gate an AI coding agent before it acts. <strong>SigmaShake</strong> is the most polished: a hub of ready-made signed rulesets, three-tier DENY/ASK/FORCE enforcement (including auto-substituting a safe command), a desktop app, and a tamper-evident audit log. <strong>ThumbGate</strong>'s one differentiator is the learning loop — a single thumbs-down auto-writes the rule that blocks that exact mistake forever, synced across machines and team, instead of asking you to find or author one. <strong>APort</strong> is the org-identity layer (agent "passports," central policy). <strong>agent-guardrails</strong> is a free MIT starting point. We're honest below about where SigmaShake is ahead.</div>
+  <div class="tldr"><strong>TL;DR:</strong> Four tools gate an AI coding agent before it acts. <strong>SigmaShake</strong> is the most polished: a hub of ready-made signed rulesets, three-tier DENY/ASK/FORCE enforcement (including auto-substituting a safe command), a desktop app, and a tamper-evident audit log. <strong>ThumbGate</strong>'s one differentiator is the learning loop — thumbs-down corrections accumulate into auditable rules for repeated mistakes, instead of asking you to find or author one. <strong>APort</strong> is the org-identity layer (agent "passports," central policy). <strong>agent-guardrails</strong> is a free MIT starting point. We're honest below about where SigmaShake is ahead.</div>
 
   <h2>The shared category</h2>
   <p>All four start from the same fact: prompt-level rules in <code>CLAUDE.md</code> or <code>.cursorrules</code> are suggestions the model can ignore under context pressure. To actually stop a force-push to main or a <code>DROP TABLE</code>, you need a gate that fires <em>before</em> the tool call executes — not a reviewer after the PR, not a git revert after the damage. ThumbGate, SigmaShake, and agent-guardrails all hook the PreToolUse boundary. APort sits one layer up, as an identity/authorization layer for organizations.</p>
@@ -116,7 +116,7 @@
       </tr>
       <tr>
         <td>Learns rules from your corrections</td>
-        <td class="yes">Yes — one thumbs-down auto-writes the rule</td>
+        <td class="yes">Yes — repeated corrections become auditable rules</td>
         <td class="no">No — rules installed or authored</td>
         <td class="no">No — policy authored</td>
         <td class="no">No — hand-written deny rules</td>
@@ -143,8 +143,8 @@
         <td class="partial">Claude Code (settings.json hooks)</td>
       </tr>
       <tr>
-        <td>Team / cross-machine sync of learned rules</td>
-        <td class="yes">Yes — hosted sync (Pro)</td>
+        <td>Team / cross-machine rollout of learned rules</td>
+        <td class="partial">Enterprise — shared hosted lessons and org rollout</td>
         <td class="partial">Local-first; optional cloud</td>
         <td class="yes">Yes — central org policy</td>
         <td class="no">No</td>
@@ -192,8 +192,8 @@
   <ul>
     <li><strong>The mistakes no catalog has a rule for.</strong> Every team has codebase-specific footguns ("never edit the generated client," "this repo deploys from <code>release</code> not <code>main</code>"). No community hub ships those. ThumbGate writes the rule the first time you thumbs-down the mistake.</li>
     <li><strong>Zero rule-authoring overhead.</strong> SigmaShake and agent-guardrails both ask you to install or write rules. ThumbGate's primary input is a thumbs-down — the correction <em>is</em> the rule authoring.</li>
-    <li><strong>MIT core.</strong> The CLI and hook layer are MIT; the hosted sync is the paid part. SigmaShake and APort are closed-source.</li>
-    <li><strong>Learned rules sync across the team.</strong> One engineer's thumbs-down becomes everyone's prevention rule.</li>
+    <li><strong>MIT core.</strong> The CLI and hook layer are MIT; Pro adds personal recall, dashboard proof, exports, and managed adapter coverage. SigmaShake and APort are closed-source.</li>
+    <li><strong>Enterprise rollout for learned rules.</strong> A team correction can become shared enforcement through the hosted Enterprise lesson database.</li>
   </ul>
 
   <h2>And APort and agent-guardrails?</h2>
@@ -216,7 +216,7 @@
       <ul>
         <li>Your pain is repeat, team-specific mistakes no generic ruleset covers</li>
         <li>You'd rather thumbs-down a mistake than hunt for or author a rule</li>
-        <li>You want learned rules to sync across machines and teammates</li>
+        <li>You want an Enterprise path for learned rules to roll out across machines and teammates</li>
         <li>You want an MIT-licensed core you can read and embed</li>
       </ul>
     </div>

--- a/public/guide.html
+++ b/public/guide.html
@@ -375,7 +375,7 @@ npx thumbgate init --agent gemini</code></pre>
 <a href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" class="cta cta-secondary">Pay $499 diagnostic</a>
 <a href="__WORKFLOW_SPRINT_CHECKOUT_URL__" class="cta cta-secondary">Pay $1500 sprint</a>
 <a href="https://thumbgate.ai/#workflow-sprint-intake" class="cta cta-secondary">Send workflow first</a>
-<p style="color:var(--muted); font-size:0.85rem;">Free: 2 captures/day, 10 total captures, 3 active prevention rules, hook blocking. Pro: hosted sync, dashboard, recall, lesson search, unlimited captures/rules, DPO export. Enterprise: intake first, then custom pricing scoped to your rollout.</p>
+<p style="color:var(--muted); font-size:0.85rem;">Free: 2 captures/day, 10 total captures, 3 active prevention rules, hook blocking. Pro: personal dashboard, recall, lesson search, unlimited captures/rules, managed adapter coverage, DPO export. Enterprise: shared hosted lessons, org visibility, and custom rollout support scoped after intake.</p>
 
 </div>
 <script src="/js/buyer-intent.js"></script>

--- a/public/guide.html
+++ b/public/guide.html
@@ -375,7 +375,7 @@ npx thumbgate init --agent gemini</code></pre>
 <a href="__SPRINT_DIAGNOSTIC_CHECKOUT_URL__" class="cta cta-secondary">Pay $499 diagnostic</a>
 <a href="__WORKFLOW_SPRINT_CHECKOUT_URL__" class="cta cta-secondary">Pay $1500 sprint</a>
 <a href="https://thumbgate.ai/#workflow-sprint-intake" class="cta cta-secondary">Send workflow first</a>
-<p style="color:var(--muted); font-size:0.85rem;">Free: 2 captures/day, 10 total captures, 3 active prevention rules, hook blocking. Pro: personal dashboard, recall, lesson search, unlimited captures/rules, managed adapter coverage, DPO export. Enterprise: shared hosted lessons, org visibility, and custom rollout support scoped after intake.</p>
+<p style="color:var(--muted); font-size:0.85rem;">Free: 2 captures/day, 10 total captures, 3 active prevention rules, hook blocking. Pro: personal dashboard, recall, search, unlimited captures/rules, managed adapters, DPO export. Enterprise: shared hosted lessons, org visibility, custom rollout support.</p>
 
 </div>
 <script src="/js/buyer-intent.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -1571,7 +1571,7 @@ __GA_BOOTSTRAP__
           <tr>
             <td><strong>Best for</strong></td>
             <td>Solo proof that a repeat mistake can be blocked</td>
-            <td>One operator who wants hosted sync, dashboard proof, and exports</td>
+            <td>One operator who wants personal recall, dashboard proof, managed adapters, and exports</td>
             <td>Teams &amp; regulated orgs — one person's correction protects every seat; banking, insurance, healthcare, public sector, audited workflows</td>
           </tr>
           <tr>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -329,15 +329,15 @@ In May 2026, Anthropic publicly named the role that owns enterprise Claude Code 
 
 ThumbGate is the pre-action enforcement runtime that the Agent Manager needs at the tool-call boundary. The job description maps directly onto what ThumbGate already ships:
 
-- **CLAUDE.md hierarchy**: `scripts/feedback-to-rules.js` distills repeated thumbs-down feedback into prevention rules and writes them into CLAUDE.md. The hosted dashboard surfaces an org-wide rule library so the Agent Manager keeps policy consistent across repos without manually editing each CLAUDE.md.
-- **Plugin marketplace**: ThumbGate ships as a Claude Code plugin, a Cursor extension (Cursor Marketplace listing submitted 2026-05-19, currently pending Cursor's manual review; runtime install works today via `npx thumbgate init --agent cursor`), a Codex plugin, and a Gemini CLI hook. One install path covers every blessed runtime; the adapter compatibility matrix is maintained by the hosted Pro/Team tier so version drift is not the Agent Manager's problem.
+- **CLAUDE.md hierarchy**: `scripts/feedback-to-rules.js` distills repeated thumbs-down feedback into prevention rules and writes them into CLAUDE.md. Enterprise surfaces an org-wide rule library in the hosted dashboard so the Agent Manager keeps policy consistent across repos without manually editing each CLAUDE.md.
+- **Plugin marketplace**: ThumbGate ships as a Claude Code plugin, a Cursor extension (Cursor Marketplace listing submitted 2026-05-19, currently pending Cursor's manual review; runtime install works today via `npx thumbgate init --agent cursor`), a Codex plugin, and a Gemini CLI hook. One install path covers every blessed runtime; Pro adds managed adapter coverage for individuals, and Enterprise extends that into rollout support so version drift is not the Agent Manager's problem.
 - **Permissions policy**: PreToolUse hooks at the tool-call boundary are the canonical permissions enforcement layer. Every block carries the rule that fired, the evidence that triggered it, and a reason the agent can use to choose a safer plan. No "tell the model to be more careful."
 - **Which skills ship**: The `adapters/*` directory is the skill ship matrix. Each adapter is version-pinned and CI-checked against the upstream runtime; when Claude Code, Cursor, or Codex ship breaking changes to hooks or plugin APIs, ThumbGate's hosted ops keeps the matrix current in under 24 hours instead of a quarter.
 
 Three-phase rollout the Agent Manager navigates, with ThumbGate's role in each:
 
 1. **Quiet investment**: Individual engineers install agents; CLAUDE.md is whatever they wrote. ThumbGate enters as `npx thumbgate init` — one repo, one repeated failure, one Pre-Action Check.
-2. **Rollout lands**: A named Agent Manager takes ownership. ThumbGate's hosted dashboard, org-wide rule library, and DPO export are what the role uses to keep CLAUDE.md, plugin policy, and permissions consistent across repos.
+2. **Rollout lands**: A named Agent Manager takes ownership. ThumbGate Enterprise's hosted dashboard, org-wide rule library, and DPO export are what the role uses to keep CLAUDE.md, plugin policy, and permissions consistent across repos.
 3. **Adoption spreads**: The team becomes the harness. The Agent Manager stops being a bottleneck because policy enforces itself at the tool-call boundary. The Workflow Hardening Sprint locks down phase-two patterns so the next 10x of engineers cannot regress them.
 
 Dedicated landing page at `/agent-manager` documents the mapping in full, including JSON-LD `TechArticle` markup with `about[]: Agent Manager / Claude Code rollout / Pre-Action Checks`.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,7 +13,7 @@
 ## Core
 
 - [Pricing](https://thumbgate.ai/pricing): Free local CLI with 2 captures/day, 10 total captures, and 3 active rules; Pro $19/mo or $149/yr; Workflow Hardening Sprint is intake-led and custom-scoped.
-- [Pro checkout](https://thumbgate.ai/checkout/pro): Personal enforcement proof, recall, hosted sync, local dashboard, DPO export.
+- [Pro checkout](https://thumbgate.ai/checkout/pro): Personal enforcement proof, recall, managed adapter coverage, dashboard evidence, DPO export.
 - [Workflow Hardening Sprint](https://thumbgate.ai/#workflow-sprint-intake): Intake-led offer for one repeated AI-agent failure, one workflow owner, and one proof plan.
 - [Setup guide](https://thumbgate.ai/guide): `npx thumbgate init` for Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode.
 - [Comparison](https://thumbgate.ai/compare): vs CLAUDE.md, ESLint, manual code review, Mem0, SpecLock.

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -101,8 +101,8 @@ __GA_BOOTSTRAP__
   "@context": "https://schema.org",
   "@type": "FAQPage",
   "mainEntity": [
-    { "@type": "Question", "name": "What does Pro add over the free CLI?", "acceptedAnswer": { "@type": "Answer", "text": "Free gives you 2 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for the hosted layer, higher limits, managed adapter coverage, and support — the gate logic itself is open source." } },
-    { "@type": "Question", "name": "Does ThumbGate send my code to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. The CLI is local-first — no data leaves your machine. Pro and Enterprise add hosted sync for dashboards and shared lessons, but your source code stays local." } },
+    { "@type": "Question", "name": "What does Pro add over the free CLI?", "acceptedAnswer": { "@type": "Answer", "text": "Free gives you 2 captures/day and 3 active rules, running entirely on your machine. Pro removes solo caps and adds personal lesson recall, a personal dashboard, managed adapter updates, and DPO export. Enterprise adds shared hosted lesson databases and org visibility." } },
+    { "@type": "Question", "name": "Does ThumbGate send my code to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. The CLI is local-first — no source code leaves your machine. Pro adds personal proof and export surfaces; Enterprise adds shared hosted lessons and org dashboards for teams." } },
     { "@type": "Question", "name": "When should I pick Enterprise over Pro?", "acceptedAnswer": { "@type": "Answer", "text": "When one engineer's correction should protect the whole team. Enterprise shares the lesson database across the org so a fix in one repo prevents the same mistake in every repo." } },
     { "@type": "Question", "name": "Can I cancel anytime?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Pro and Enterprise are month-to-month with a 7-day refund window on the first charge. Cancel from the billing portal and your subscription ends at the period close." } }
   ]
@@ -339,7 +339,7 @@ __GA_BOOTSTRAP__
     <div class="faq-list">
       <div class="faq-item">
         <div class="faq-q">What does Pro add over the free CLI?</div>
-        <div class="faq-a">Free gives you 2 captures/day and 3 active rules, running entirely on your machine. Pro is the hosted layer: unlimited captures, unlimited rules, lesson sync across machines, a dashboard without self-hosting, managed adapter updates, and DPO export. You're paying for the hosted layer, higher limits, managed adapter coverage, and support — the gate logic itself is open source.</div>
+        <div class="faq-a">Free gives you 2 captures/day and 3 active rules, running entirely on your machine. Pro removes solo caps and adds personal lesson recall, a personal dashboard, managed adapter updates, and DPO export. Enterprise adds shared hosted lesson databases and org visibility.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q">Why not just use an enterprise AI control plane?</div>
@@ -347,7 +347,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q">Does ThumbGate send my code to the cloud?</div>
-        <div class="faq-a">No. The CLI is local-first and no source code leaves your machine. Pro and Enterprise add hosted sync for dashboards and shared lessons, but your code stays local.</div>
+        <div class="faq-a">No. The CLI is local-first and no source code leaves your machine. Pro adds personal proof and export surfaces; Enterprise adds shared hosted lessons and org dashboards for teams.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q">When should I pick Enterprise over Pro?</div>
@@ -359,7 +359,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q">What happens if I stop paying?</div>
-        <div class="faq-a">You keep the free CLI, capped at 3 active rules and 2 captures/day. Your existing rules and captures stay on your machine. You lose the hosted dashboard, cross-machine sync, managed adapter updates, and higher limits.</div>
+        <div class="faq-a">You keep the free CLI, capped at 3 active rules and 2 captures/day. Your existing rules and captures stay on your machine. You lose the personal dashboard, managed adapter updates, exports, and higher limits. Shared hosted lessons and org dashboards are Enterprise.</div>
       </div>
     </div>
   </div>

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -101,8 +101,8 @@ __GA_BOOTSTRAP__
   "@context": "https://schema.org",
   "@type": "FAQPage",
   "mainEntity": [
-    { "@type": "Question", "name": "What does Pro add over the free CLI?", "acceptedAnswer": { "@type": "Answer", "text": "Free gives you 2 captures/day and 3 active rules, running entirely on your machine. Pro removes solo caps and adds personal lesson recall, a personal dashboard, managed adapter updates, and DPO export. Enterprise adds shared hosted lesson databases and org visibility." } },
-    { "@type": "Question", "name": "Does ThumbGate send my code to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. The CLI is local-first — no source code leaves your machine. Pro adds personal proof and export surfaces; Enterprise adds shared hosted lessons and org dashboards for teams." } },
+    { "@type": "Question", "name": "What does Pro add over the free CLI?", "acceptedAnswer": { "@type": "Answer", "text": "Free gives you 2 captures/day and 3 active rules, running on your machine. Pro removes solo caps and adds personal recall, dashboard proof, managed adapters, and DPO export. Enterprise adds shared hosted lessons and org visibility." } },
+    { "@type": "Question", "name": "Does ThumbGate send my code to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. The CLI is local-first — no source code leaves your machine. Pro adds personal proof and exports; Enterprise adds shared hosted lessons and org dashboards." } },
     { "@type": "Question", "name": "When should I pick Enterprise over Pro?", "acceptedAnswer": { "@type": "Answer", "text": "When one engineer's correction should protect the whole team. Enterprise shares the lesson database across the org so a fix in one repo prevents the same mistake in every repo." } },
     { "@type": "Question", "name": "Can I cancel anytime?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Pro and Enterprise are month-to-month with a 7-day refund window on the first charge. Cancel from the billing portal and your subscription ends at the period close." } }
   ]
@@ -339,7 +339,7 @@ __GA_BOOTSTRAP__
     <div class="faq-list">
       <div class="faq-item">
         <div class="faq-q">What does Pro add over the free CLI?</div>
-        <div class="faq-a">Free gives you 2 captures/day and 3 active rules, running entirely on your machine. Pro removes solo caps and adds personal lesson recall, a personal dashboard, managed adapter updates, and DPO export. Enterprise adds shared hosted lesson databases and org visibility.</div>
+        <div class="faq-a">Free gives you 2 captures/day and 3 active rules, running on your machine. Pro removes solo caps and adds personal recall, dashboard proof, managed adapters, and DPO export. Enterprise adds shared hosted lessons and org visibility.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q">Why not just use an enterprise AI control plane?</div>
@@ -347,7 +347,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q">Does ThumbGate send my code to the cloud?</div>
-        <div class="faq-a">No. The CLI is local-first and no source code leaves your machine. Pro adds personal proof and export surfaces; Enterprise adds shared hosted lessons and org dashboards for teams.</div>
+        <div class="faq-a">No. The CLI is local-first and no source code leaves your machine. Pro adds personal proof and exports; Enterprise adds shared hosted lessons and org dashboards.</div>
       </div>
       <div class="faq-item">
         <div class="faq-q">When should I pick Enterprise over Pro?</div>
@@ -359,7 +359,7 @@ __GA_BOOTSTRAP__
       </div>
       <div class="faq-item">
         <div class="faq-q">What happens if I stop paying?</div>
-        <div class="faq-a">You keep the free CLI, capped at 3 active rules and 2 captures/day. Your existing rules and captures stay on your machine. You lose the personal dashboard, managed adapter updates, exports, and higher limits. Shared hosted lessons and org dashboards are Enterprise.</div>
+        <div class="faq-a">You keep the free CLI, capped at 3 active rules and 2 captures/day. Existing rules and captures stay on your machine. You lose the personal dashboard, managed adapters, exports, and higher limits. Shared hosted lessons and org dashboards are Enterprise.</div>
       </div>
     </div>
   </div>

--- a/scripts/commercial-offer.js
+++ b/scripts/commercial-offer.js
@@ -67,11 +67,11 @@ function buildCaptureReceipt({ signal, feedbackId, memoryId, actionType } = {}) 
     memoryId ? `  Local memory   : ${memoryId}` : '  Local memory   : saved locally',
     actionType ? `  Rule pressure  : ${actionType}` : '  Rule pressure  : available for promotion',
     '  Free today     : this proof protects this local machine',
-    '  Pro sync       : keep this lesson, rule, and dashboard synced across machines and agent runtimes',
+    '  Pro recall     : keep this lesson searchable, exportable, and visible in your personal dashboard',
     '  Next proof     : npx thumbgate stats',
     '  Cost proof     : npx thumbgate cost',
     '',
-    `  Solo Pro       : ${PRO_PRICE_LABEL} for hosted sync, search, dashboard, and exports`,
+    `  Solo Pro       : ${PRO_PRICE_LABEL} for recall, search, dashboard, managed adapters, and exports`,
     `  Upgrade        : ${trackedProUrl('cli_capture_receipt', actionType || normalizedSignal.toLowerCase())}`,
     `  Enterprise     : ${ENTERPRISE_PRICE_LABEL}; start with one repeated workflow failure`,
     '                   https://thumbgate.ai/#workflow-sprint-intake',
@@ -105,7 +105,7 @@ function buildStatsReceipt(stats = {}) {
     lines.push(`  Failure pressure   : ${negatives} negative ${pluralize(negatives, 'signal')}`);
   }
   lines.push('  Show the buyer     : npx thumbgate cost');
-  lines.push('  Pro sync value     : keep these lessons/rules visible across laptops, CI, containers, and agent runtimes');
+  lines.push('  Pro recall value   : keep these lessons/rules searchable, exportable, and visible in your personal dashboard');
   lines.push(`  Solo Pro           : ${trackedProUrl('cli_stats_receipt', 'proof_seen')}`);
   lines.push('  Enterprise         : https://thumbgate.ai/#workflow-sprint-intake');
   lines.push('');

--- a/scripts/commercial-offer.js
+++ b/scripts/commercial-offer.js
@@ -67,11 +67,11 @@ function buildCaptureReceipt({ signal, feedbackId, memoryId, actionType } = {}) 
     memoryId ? `  Local memory   : ${memoryId}` : '  Local memory   : saved locally',
     actionType ? `  Rule pressure  : ${actionType}` : '  Rule pressure  : available for promotion',
     '  Free today     : this proof protects this local machine',
-    '  Pro recall     : keep this lesson searchable, exportable, and visible in your personal dashboard',
+    '  Pro recall     : keep this lesson searchable, exportable, and visible',
     '  Next proof     : npx thumbgate stats',
     '  Cost proof     : npx thumbgate cost',
     '',
-    `  Solo Pro       : ${PRO_PRICE_LABEL} for recall, search, dashboard, managed adapters, and exports`,
+    `  Solo Pro       : ${PRO_PRICE_LABEL} for recall, dashboard, adapters, and exports`,
     `  Upgrade        : ${trackedProUrl('cli_capture_receipt', actionType || normalizedSignal.toLowerCase())}`,
     `  Enterprise     : ${ENTERPRISE_PRICE_LABEL}; start with one repeated workflow failure`,
     '                   https://thumbgate.ai/#workflow-sprint-intake',
@@ -105,7 +105,7 @@ function buildStatsReceipt(stats = {}) {
     lines.push(`  Failure pressure   : ${negatives} negative ${pluralize(negatives, 'signal')}`);
   }
   lines.push('  Show the buyer     : npx thumbgate cost');
-  lines.push('  Pro recall value   : keep these lessons/rules searchable, exportable, and visible in your personal dashboard');
+  lines.push('  Pro recall value   : keep lessons/rules searchable, exportable, and visible');
   lines.push(`  Solo Pro           : ${trackedProUrl('cli_stats_receipt', 'proof_seen')}`);
   lines.push('  Enterprise         : https://thumbgate.ai/#workflow-sprint-intake');
   lines.push('');

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -2672,10 +2672,10 @@ function buildBlockActionProCta() {
     if (totalBlocks < 5) return null; // Too early — let them experience the product
 
     if (totalBlocks < 25) {
-      return '\n\n💡 Pro: keep this rule searchable, exportable, and visible in your personal dashboard → thumbgate.ai/go/pro';
+      return '\n\n💡 Pro: keep this rule searchable, exportable, and visible → thumbgate.ai/go/pro';
     }
     if (totalBlocks < 100) {
-      return `\n\n💡 ${totalBlocks} actions blocked. Pro removes solo caps and adds personal recall, dashboard proof, and exports → thumbgate.ai/go/pro ($19/mo)`;
+      return `\n\n💡 ${totalBlocks} actions blocked. Pro adds recall, dashboard proof, and exports → thumbgate.ai/go/pro ($19/mo)`;
     }
     return `\n\n💡 ${totalBlocks} mistakes caught. Your team could use Enterprise shared hosted enforcement → thumbgate.ai/go/pro`;
   } catch (_) {

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -2672,12 +2672,12 @@ function buildBlockActionProCta() {
     if (totalBlocks < 5) return null; // Too early — let them experience the product
 
     if (totalBlocks < 25) {
-      return '\n\n💡 Pro: keep this rule synced across laptops, CI, containers, and agent runtimes → thumbgate.ai/go/pro';
+      return '\n\n💡 Pro: keep this rule searchable, exportable, and visible in your personal dashboard → thumbgate.ai/go/pro';
     }
     if (totalBlocks < 100) {
-      return `\n\n💡 ${totalBlocks} actions blocked. Pro keeps these lessons/rules synced everywhere → thumbgate.ai/go/pro ($19/mo)`;
+      return `\n\n💡 ${totalBlocks} actions blocked. Pro removes solo caps and adds personal recall, dashboard proof, and exports → thumbgate.ai/go/pro ($19/mo)`;
     }
-    return `\n\n💡 ${totalBlocks} mistakes caught. Your team could use shared hosted enforcement → thumbgate.ai/go/pro`;
+    return `\n\n💡 ${totalBlocks} mistakes caught. Your team could use Enterprise shared hosted enforcement → thumbgate.ai/go/pro`;
   } catch (_) {
     return null;
   }

--- a/scripts/seo-gsd.js
+++ b/scripts/seo-gsd.js
@@ -562,7 +562,7 @@ const PRETOOLUSE_HOOK_GUIDE_SPEC = Object.freeze({
     ],
     [
       'Does this run locally or call a cloud service?',
-      'Local-first. The PreToolUse decision happens in the hook process on your machine in milliseconds — no network round-trip, no cloud dependency, no data leaving the laptop. Optional hosted sync exists for teams that want to share rules across seats.',
+      'Local-first. The PreToolUse decision happens in the hook process on your machine in milliseconds — no network round-trip, no cloud dependency, no data leaving the laptop. Pro adds personal recall, exports, dashboard proof, and managed adapter coverage. Enterprise adds hosted sharing for teams that want to share rules across seats.',
     ],
   ],
   relatedPaths: ['/guides/mcp-tool-governance', '/guides/ai-agent-pre-action-approval-gates', '/guides/ai-coding-agent-zero-trust'],
@@ -1972,7 +1972,7 @@ const PAGE_BLUEPRINTS = [
     faq: [
       {
         question: 'Why pay $19/mo for ThumbGate Pro when disler hooks are free?',
-        answer: 'Free disler hooks are static patterns you maintain per machine — re-copying them when they change, debugging false positives alone, and re-applying them in every new project. ThumbGate Pro adds the learning loop (thumbs-down → cross-session prevention rule), the dashboard, hosted sync across machines, and adapter maintenance across the weekly breaking-change cycle of Claude Code, Cursor, and Cline. Free disler is the right answer if you only ever work in one project on one machine and never want to learn from past mistakes. Pro is the right answer when those assumptions stop holding.',
+        answer: 'Free disler hooks are static patterns you maintain per machine — re-copying them when they change, debugging false positives alone, and re-applying them in every new project. ThumbGate Pro adds the learning loop (repeated thumbs-downs → cross-session prevention rule), the personal dashboard, lesson recall/search, DPO export, and adapter maintenance across the weekly breaking-change cycle of Claude Code, Cursor, and Cline. Free disler is the right answer if you only ever work in one project on one machine and never want to learn from past mistakes. Pro is the right answer when those assumptions stop holding; Enterprise adds shared hosted lessons across seats.',
       },
       {
         question: 'Is ThumbGate just a packaged version of disler/claude-code-hooks-mastery?',

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2251,7 +2251,7 @@ a{display:block;text-decoration:none}a.secondary{border:1px solid #374151;color:
 <div class="brand"><span class="brand-mark"></span><span>ThumbGate</span></div>
 <h1>Start ThumbGate Pro</h1>
 <div class="price">$19<small>/mo</small></div>
-<p>The npm package runs your gates locally. <strong>Pro</strong> removes solo caps and adds personal proof, recall, exports, and adapter maintenance. Shared hosted lesson databases and org dashboards are Enterprise.</p>
+<p>The npm package runs your gates locally. <strong>Pro</strong> removes solo caps and adds personal recall, proof, exports, and adapter maintenance. Shared hosted lessons and org dashboards are Enterprise.</p>
 <form action="${PRO_CHECKOUT_URL}" method="GET" data-i="pro_checkout_confirmed">
 ${hiddenInputs}
 <input type="email" name="prefilled_email" value="${escapeHtmlAttribute(prefilledEmail)}" placeholder="you@company.com" autocomplete="email">
@@ -2271,7 +2271,7 @@ ${hiddenInputs}
 </div>
 <div class="feedback-saved" id="feedback-saved">Feedback saved.</div>
 </div>
-<div class="trust"><div class="trust-item">Personal lesson recall and proof exports without lifting the free-tier caps yourself</div><div class="trust-item">Adapter matrix kept current for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — version drift is our problem, not yours</div><div class="trust-item">Personal dashboard: gate stats, rule evidence, and DPO export</div><div class="trust-item">Enterprise adds shared hosted lessons, org visibility, and workflow rollout support</div></div>
+<div class="trust"><div class="trust-item">Personal recall and proof exports without free-tier caps</div><div class="trust-item">Adapter matrix kept current for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode</div><div class="trust-item">Personal dashboard: gate stats, rule evidence, DPO export</div><div class="trust-item">Enterprise adds shared hosted lessons, org visibility, rollout support</div></div>
 <p class="back"><a href="/">← Back to thumbgate.ai</a></p>
 </main>
 <script>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2251,7 +2251,7 @@ a{display:block;text-decoration:none}a.secondary{border:1px solid #374151;color:
 <div class="brand"><span class="brand-mark"></span><span>ThumbGate</span></div>
 <h1>Start ThumbGate Pro</h1>
 <div class="price">$19<small>/mo</small></div>
-<p>The npm package runs your gates locally. <strong>Pro</strong> is what keeps them working across every machine, every agent runtime, and every breaking-change week.</p>
+<p>The npm package runs your gates locally. <strong>Pro</strong> removes solo caps and adds personal proof, recall, exports, and adapter maintenance. Shared hosted lesson databases and org dashboards are Enterprise.</p>
 <form action="${PRO_CHECKOUT_URL}" method="GET" data-i="pro_checkout_confirmed">
 ${hiddenInputs}
 <input type="email" name="prefilled_email" value="${escapeHtmlAttribute(prefilledEmail)}" placeholder="you@company.com" autocomplete="email">
@@ -2271,7 +2271,7 @@ ${hiddenInputs}
 </div>
 <div class="feedback-saved" id="feedback-saved">Feedback saved.</div>
 </div>
-<div class="trust"><div class="trust-item">Lessons synced across all your machines — no local SQLite to babysit</div><div class="trust-item">Adapter matrix kept current for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — version drift is our problem, not yours</div><div class="trust-item">Hosted dashboard: gate stats, DPO export, org-wide rule library</div><div class="trust-item">24×7 ops on the rule engine — SonarCloud regressions fixed in &lt;24h</div></div>
+<div class="trust"><div class="trust-item">Personal lesson recall and proof exports without lifting the free-tier caps yourself</div><div class="trust-item">Adapter matrix kept current for Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode — version drift is our problem, not yours</div><div class="trust-item">Personal dashboard: gate stats, rule evidence, and DPO export</div><div class="trust-item">Enterprise adds shared hosted lessons, org visibility, and workflow rollout support</div></div>
 <p class="back"><a href="/">← Back to thumbgate.ai</a></p>
 </main>
 <script>

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1000,7 +1000,9 @@ describe('bin/cli.js', () => {
     });
     assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\n${result.stderr}`);
     assert.match(result.stdout, /Pro \(\$19\/mo or \$149\/yr\)/);
-    assert.match(result.stdout, /Hosted sync: keep lessons, rules, and dashboard state aligned across laptops, CI, containers, and agent runtimes/);
+    assert.match(result.stdout, /Personal recall: search lessons, rules, and proof without free-tier caps/);
+    assert.match(result.stdout, /Managed adapter coverage: Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode drift is tracked for you/);
+    assert.match(result.stdout, /Enterprise adds shared hosted lessons, org visibility, and workflow proof/);
     assert.match(result.stdout, /personal local dashboard/i);
     assert.match(result.stdout, /Launch dashboard\s*:\s*npx thumbgate pro/);
     assert.match(result.stdout, /Activate \+ run\s*:\s*npx thumbgate pro --activate --key=YOUR_KEY/);
@@ -1277,7 +1279,8 @@ describe('bin/cli.js', () => {
     });
     assert.equal(checkoutUrl, PRO_MONTHLY_PAYMENT_LINK, 'Pro command should include the attributed Pro checkout URL');
     assert.ok(result.stdout.includes('$19/mo or $149/yr'), 'Pro command should include current pricing');
-    assert.ok(result.stdout.includes('Hosted sync: keep lessons, rules, and dashboard state aligned'), 'Pro command should lead with hosted sync');
+    assert.ok(result.stdout.includes('Personal recall: search lessons, rules, and proof without free-tier caps'), 'Pro command should lead with personal recall');
+    assert.ok(result.stdout.includes('Enterprise adds shared hosted lessons, org visibility, and workflow proof'), 'Pro command should separate Enterprise hosted rollout features');
     assert.ok(result.stdout.includes('Launch dashboard: npx thumbgate pro'), 'Pro command should include the local dashboard launcher');
     assert.ok(result.stdout.includes('Private core    : ThumbGate-Core (private repo)'), 'Pro command should describe the current private-core split');
   });

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1000,9 +1000,9 @@ describe('bin/cli.js', () => {
     });
     assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}\n${result.stderr}`);
     assert.match(result.stdout, /Pro \(\$19\/mo or \$149\/yr\)/);
-    assert.match(result.stdout, /Personal recall: search lessons, rules, and proof without free-tier caps/);
-    assert.match(result.stdout, /Managed adapter coverage: Claude Code, Cursor, Codex, Gemini, Amp, Cline, and OpenCode drift is tracked for you/);
-    assert.match(result.stdout, /Enterprise adds shared hosted lessons, org visibility, and workflow proof/);
+    assert.match(result.stdout, /Personal recall: search lessons, rules, and proof/);
+    assert.match(result.stdout, /Managed adapters: Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode/);
+    assert.match(result.stdout, /Enterprise adds shared hosted lessons, org visibility, workflow proof/);
     assert.match(result.stdout, /personal local dashboard/i);
     assert.match(result.stdout, /Launch dashboard\s*:\s*npx thumbgate pro/);
     assert.match(result.stdout, /Activate \+ run\s*:\s*npx thumbgate pro --activate --key=YOUR_KEY/);
@@ -1279,8 +1279,8 @@ describe('bin/cli.js', () => {
     });
     assert.equal(checkoutUrl, PRO_MONTHLY_PAYMENT_LINK, 'Pro command should include the attributed Pro checkout URL');
     assert.ok(result.stdout.includes('$19/mo or $149/yr'), 'Pro command should include current pricing');
-    assert.ok(result.stdout.includes('Personal recall: search lessons, rules, and proof without free-tier caps'), 'Pro command should lead with personal recall');
-    assert.ok(result.stdout.includes('Enterprise adds shared hosted lessons, org visibility, and workflow proof'), 'Pro command should separate Enterprise hosted rollout features');
+    assert.ok(result.stdout.includes('Personal recall: search lessons, rules, and proof'), 'Pro command should lead with personal recall');
+    assert.ok(result.stdout.includes('Enterprise adds shared hosted lessons, org visibility, workflow proof'), 'Pro command should separate Enterprise hosted rollout features');
     assert.ok(result.stdout.includes('Launch dashboard: npx thumbgate pro'), 'Pro command should include the local dashboard launcher');
     assert.ok(result.stdout.includes('Private core    : ThumbGate-Core (private repo)'), 'Pro command should describe the current private-core split');
   });

--- a/tests/free-to-paid-conversion-units.test.js
+++ b/tests/free-to-paid-conversion-units.test.js
@@ -282,14 +282,14 @@ test('gates-engine.buildBlockActionProCta tiered messages at 5, 25, and 100 bloc
     fs.writeFileSync(ge.STATS_PATH, JSON.stringify({ blocked: 10, warned: 0, passed: 0, byGate: {} }));
     const lowMsg = ge.buildBlockActionProCta();
     assert.ok(lowMsg && lowMsg.includes('thumbgate.ai/go/pro'));
-    assert.match(lowMsg, /rule searchable, exportable, and visible in your personal dashboard/);
+    assert.match(lowMsg, /rule searchable, exportable, and visible/);
 
     fs.writeFileSync(ge.STATS_PATH, JSON.stringify({ blocked: 50, warned: 0, passed: 0, byGate: {} }));
     const midMsg = ge.buildBlockActionProCta();
     assert.ok(midMsg && midMsg.includes('thumbgate.ai/go/pro'));
     assert.match(midMsg, /\$19\/mo/);
     assert.match(midMsg, /50 actions blocked/);
-    assert.match(midMsg, /personal recall, dashboard proof, and exports/);
+    assert.match(midMsg, /recall, dashboard proof, and exports/);
 
     fs.writeFileSync(ge.STATS_PATH, JSON.stringify({ blocked: 250, warned: 0, passed: 0, byGate: {} }));
     const teamMsg = ge.buildBlockActionProCta();
@@ -314,7 +314,7 @@ test('commercial-offer capture receipt sells personal recall at the moment of pr
   });
 
   assert.match(receipt, /Free today\s*: this proof protects this local machine/);
-  assert.match(receipt, /Pro recall\s*: keep this lesson searchable, exportable, and visible in your personal dashboard/);
+  assert.match(receipt, /Pro recall\s*: keep this lesson searchable, exportable, and visible/);
   assert.match(receipt, /utm_source=cli_capture_receipt/);
 });
 

--- a/tests/free-to-paid-conversion-units.test.js
+++ b/tests/free-to-paid-conversion-units.test.js
@@ -282,14 +282,14 @@ test('gates-engine.buildBlockActionProCta tiered messages at 5, 25, and 100 bloc
     fs.writeFileSync(ge.STATS_PATH, JSON.stringify({ blocked: 10, warned: 0, passed: 0, byGate: {} }));
     const lowMsg = ge.buildBlockActionProCta();
     assert.ok(lowMsg && lowMsg.includes('thumbgate.ai/go/pro'));
-    assert.match(lowMsg, /rule synced across laptops, CI, containers, and agent runtimes/);
+    assert.match(lowMsg, /rule searchable, exportable, and visible in your personal dashboard/);
 
     fs.writeFileSync(ge.STATS_PATH, JSON.stringify({ blocked: 50, warned: 0, passed: 0, byGate: {} }));
     const midMsg = ge.buildBlockActionProCta();
     assert.ok(midMsg && midMsg.includes('thumbgate.ai/go/pro'));
     assert.match(midMsg, /\$19\/mo/);
     assert.match(midMsg, /50 actions blocked/);
-    assert.match(midMsg, /lessons\/rules synced everywhere/);
+    assert.match(midMsg, /personal recall, dashboard proof, and exports/);
 
     fs.writeFileSync(ge.STATS_PATH, JSON.stringify({ blocked: 250, warned: 0, passed: 0, byGate: {} }));
     const teamMsg = ge.buildBlockActionProCta();
@@ -304,7 +304,7 @@ test('gates-engine.buildBlockActionProCta tiered messages at 5, 25, and 100 bloc
   }
 });
 
-test('commercial-offer capture receipt sells hosted sync at the moment of proof', () => {
+test('commercial-offer capture receipt sells personal recall at the moment of proof', () => {
   const { buildCaptureReceipt } = require('../scripts/commercial-offer');
   const receipt = buildCaptureReceipt({
     signal: 'down',
@@ -314,7 +314,7 @@ test('commercial-offer capture receipt sells hosted sync at the moment of proof'
   });
 
   assert.match(receipt, /Free today\s*: this proof protects this local machine/);
-  assert.match(receipt, /Pro sync\s*: keep this lesson, rule, and dashboard synced across machines and agent runtimes/);
+  assert.match(receipt, /Pro recall\s*: keep this lesson searchable, exportable, and visible in your personal dashboard/);
   assert.match(receipt, /utm_source=cli_capture_receipt/);
 });
 

--- a/tests/xss-checkout-escape.test.js
+++ b/tests/xss-checkout-escape.test.js
@@ -43,3 +43,12 @@ test('checkout page does not reflect a malicious email as executable markup', ()
   const html2 = renderCheckoutIntentPage(`x' onmouseover='alert(1)`);
   assert.ok(!html2.includes(`' onmouseover='`), 'single-quote breakout must not survive');
 });
+
+test('checkout page Pro copy stays truthful about personal vs Enterprise features', () => {
+  const html = renderCheckoutIntentPage('buyer@example.com');
+  assert.match(html, /Pro<\/strong> removes solo caps and adds personal proof, recall, exports, and adapter maintenance/);
+  assert.match(html, /Personal dashboard: gate stats, rule evidence, and DPO export/);
+  assert.match(html, /Enterprise adds shared hosted lessons, org visibility, and workflow rollout support/);
+  assert.doesNotMatch(html, /Lessons synced across all your machines/i);
+  assert.doesNotMatch(html, /Hosted dashboard: gate stats, DPO export, org-wide rule library/i);
+});

--- a/tests/xss-checkout-escape.test.js
+++ b/tests/xss-checkout-escape.test.js
@@ -46,9 +46,9 @@ test('checkout page does not reflect a malicious email as executable markup', ()
 
 test('checkout page Pro copy stays truthful about personal vs Enterprise features', () => {
   const html = renderCheckoutIntentPage('buyer@example.com');
-  assert.match(html, /Pro<\/strong> removes solo caps and adds personal proof, recall, exports, and adapter maintenance/);
-  assert.match(html, /Personal dashboard: gate stats, rule evidence, and DPO export/);
-  assert.match(html, /Enterprise adds shared hosted lessons, org visibility, and workflow rollout support/);
+  assert.match(html, /Pro<\/strong> removes solo caps and adds personal recall, proof, exports, and adapter maintenance/);
+  assert.match(html, /Personal dashboard: gate stats, rule evidence, DPO export/);
+  assert.match(html, /Enterprise adds shared hosted lessons, org visibility, rollout support/);
   assert.doesNotMatch(html, /Lessons synced across all your machines/i);
   assert.doesNotMatch(html, /Hosted dashboard: gate stats, DPO export, org-wide rule library/i);
 });


### PR DESCRIPTION
## Summary
- align checkout, pricing, guide, comparison, LLM context, and CLI upgrade copy around the real packaging boundary
- position Pro as personal recall, dashboard proof, exports, and managed adapter coverage
- position Enterprise as shared hosted lessons, org visibility, and rollout support
- remove public overclaims that one thumbs-down immediately writes a forever rule

## Verification
- node --test tests/xss-checkout-escape.test.js tests/public-landing.test.js tests/pro-landing.test.js tests/public-static-assets.test.js tests/cli.test.js tests/free-to-paid-conversion-units.test.js
- npm run test:check-congruence
- git diff --check
- pre-commit guards passed
- pre-push guards passed

## Revenue note
This follows PR #2803, which fixed /checkout/pro to point at the real $19/mo Pro Payment Link. This PR removes stale claims from the pages and CLI nudges that send buyers into that checkout.