### PR TITLE
fix(feedback): require leading explicit signals

### DIFF
--- a/.changeset/explicit-feedback-signal-detection.md
+++ b/.changeset/explicit-feedback-signal-detection.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Require automatic feedback signals to be standalone or lead the operator message, preventing quoted, descriptive, negated, and mid-sentence mentions from being captured while preserving explicit and typo-tolerant thumbs feedback.

--- a/scripts/feedback-quality.js
+++ b/scripts/feedback-quality.js
@@ -100,49 +100,49 @@ function isNearDownToken(token) {
 
 function detectFeedbackSignal(value) {
   const raw = String(value || '');
-  if (/[👎👎🏻👎🏼👎🏽👎🏾👎🏿]/u.test(raw)) return { signal: 'down', confidence: 'emoji', match: '👎' };
-  if (/[👍👍🏻👍🏼👍🏽👍🏾👍🏿]/u.test(raw)) return { signal: 'up', confidence: 'emoji', match: '👍' };
+  const leading = raw.trimStart();
+  if (/^["'`]/.test(leading)) return null;
+  if (/^👎(?:🏻|🏼|🏽|🏾|🏿)?/u.test(leading)) return { signal: 'down', confidence: 'emoji', match: '👎' };
+  if (/^👍(?:🏻|🏼|🏽|🏾|🏿)?/u.test(leading)) return { signal: 'up', confidence: 'emoji', match: '👍' };
 
   const normalized = normalizeFeedbackText(raw);
   if (!normalized) return null;
 
   const exactDown = [
-    /\bthumbs?\s*down\b/,
-    /\bthumbs?down\b/,
-    /\bthat failed\b/,
-    /\bit failed\b/,
-    /\bthat was wrong\b/,
-    /\bfix this\b/,
+    /^thumbs?\s*down\b/,
+    /^thumbs?down\b/,
+    /^that failed\b/,
+    /^it failed\b/,
+    /^that was wrong\b/,
+    /^fix this\b/,
   ];
   if (exactDown.some((pattern) => pattern.test(normalized))) {
     return { signal: 'down', confidence: 'exact', match: normalized };
   }
 
   const exactUp = [
-    /\bthumbs?\s*up\b/,
-    /\bthumbs?up\b/,
-    /\bthat worked\b/,
-    /\bit worked\b/,
-    /\blooks good\b/,
-    /\bgood job\b/,
-    /\bgood work\b/,
-    /\bnice work\b/,
-    /\bperfect\b/,
-    /\blgtm\b/,
+    /^thumbs?\s*up\b/,
+    /^thumbs?up\b/,
+    /^that worked\b/,
+    /^it worked\b/,
+    /^looks good\b/,
+    /^good job\b/,
+    /^good work\b/,
+    /^nice work\b/,
+    /^perfect\b/,
+    /^lgtm\b/,
   ];
   if (exactUp.some((pattern) => pattern.test(normalized))) {
     return { signal: 'up', confidence: 'exact', match: normalized };
   }
 
   const words = normalized.split(/\s+/).filter(Boolean);
-  for (let i = 0; i < words.length - 1; i++) {
-    if (!isNearThumbToken(words[i])) continue;
-    if (isNearDownToken(words[i + 1])) {
-      return { signal: 'down', confidence: 'fuzzy', match: `${words[i]} ${words[i + 1]}` };
-    }
-    if (isNearUpToken(words[i + 1])) {
-      return { signal: 'up', confidence: 'fuzzy', match: `${words[i]} ${words[i + 1]}` };
-    }
+  if (!isNearThumbToken(words[0])) return null;
+  if (isNearDownToken(words[1])) {
+    return { signal: 'down', confidence: 'fuzzy', match: `${words[0]} ${words[1]}` };
+  }
+  if (isNearUpToken(words[1])) {
+    return { signal: 'up', confidence: 'fuzzy', match: `${words[0]} ${words[1]}` };
   }
 
   return null;

--- a/scripts/feedback-quality.js
+++ b/scripts/feedback-quality.js
@@ -114,7 +114,6 @@ function detectFeedbackSignal(value) {
     /^that failed\b/,
     /^it failed\b/,
     /^that was wrong\b/,
-    /^fix this\b/,
   ];
   if (exactDown.some((pattern) => pattern.test(normalized))) {
     return { signal: 'down', confidence: 'exact', match: normalized };

--- a/tests/feedback-quality.test.js
+++ b/tests/feedback-quality.test.js
@@ -44,7 +44,6 @@ test('detectFeedbackSignal accepts explicit standalone and leading signals', () 
     ['👍 verified before claiming done', 'up'],
     ['👎 claimed published without npm proof', 'down'],
     ['perfect, the verification was clear', 'up'],
-    ['fix this bug before closing the task', 'down'],
   ];
 
   for (const [value, expectedSignal] of cases) {
@@ -58,6 +57,7 @@ test('detectFeedbackSignal rejects quoted, descriptive, negated, and mid-sentenc
     'I just gave you a thumbs up; did it work?',
     'the text says "thumbs up"',
     'I will fix this bug',
+    'fix this bug before closing the task',
     'the operator typed thumbss up in the transcript',
     'the example contains 👎 but is not feedback',
     '"thumbs down: reason"',

--- a/tests/feedback-quality.test.js
+++ b/tests/feedback-quality.test.js
@@ -34,13 +34,39 @@ test('isGenericFeedbackText rejects detailed feedback', () => {
   assert.equal(isGenericFeedbackText('Great fix for the race condition in the auth flow', 'positive'), false);
 });
 
-test('detectFeedbackSignal handles typo variants of thumbs feedback', () => {
-  assert.equal(detectFeedbackSignal('thumbss up, evidence was clear').signal, 'up');
-  assert.equal(detectFeedbackSignal('thubs don this skipped verification').signal, 'down');
-  assert.equal(detectFeedbackSignal('thums down: wrong claim').signal, 'down');
-  assert.equal(detectFeedbackSignal('👍 verified before claiming done').signal, 'up');
-  assert.equal(detectFeedbackSignal('👎 claimed published without npm proof').signal, 'down');
-  assert.equal(detectFeedbackSignal('please update the docs'), null);
+test('detectFeedbackSignal accepts explicit standalone and leading signals', () => {
+  const cases = [
+    ['thumbs up', 'up'],
+    ['thumbs down: reason', 'down'],
+    ['thumbss up, evidence was clear', 'up'],
+    ['thubs don this skipped verification', 'down'],
+    ['thums down: wrong claim', 'down'],
+    ['👍 verified before claiming done', 'up'],
+    ['👎 claimed published without npm proof', 'down'],
+    ['perfect, the verification was clear', 'up'],
+    ['fix this bug before closing the task', 'down'],
+  ];
+
+  for (const [value, expectedSignal] of cases) {
+    assert.equal(detectFeedbackSignal(value)?.signal, expectedSignal, value);
+  }
+});
+
+test('detectFeedbackSignal rejects quoted, descriptive, negated, and mid-sentence mentions', () => {
+  const cases = [
+    'This is not perfect',
+    'I just gave you a thumbs up; did it work?',
+    'the text says "thumbs up"',
+    'I will fix this bug',
+    'the operator typed thumbss up in the transcript',
+    'the example contains 👎 but is not feedback',
+    '"thumbs down: reason"',
+    'please update the docs',
+  ];
+
+  for (const value of cases) {
+    assert.equal(detectFeedbackSignal(value), null, value);
+  }
 });
 
 test('assessFeedbackActionability returns promotable for detailed negative', () => {


### PR DESCRIPTION
## Summary
- require automatic feedback signals to be standalone or lead the operator message
- stop quoted, descriptive, negated, emoji, and fuzzy typo mentions from auto-capturing mid-sentence
- preserve explicit thumbs up/down, leading reasons, accepted typo variants, and leading emoji
- add one `thumbgate` patch changeset

## Test evidence
- `npm ci`
- `node --test tests/feedback-quality.test.js` (10 passed)
- `node --test --test-name-pattern='hook-auto-capture|capture typo thumbs positional arguments' tests/cli.test.js` (5 passed)
- `npx changeset status --since=origin/main` (`thumbgate` patch)
- pre-commit and pre-push ThumbGate guards passed

Verification context: [`VERIFICATION_EVIDENCE.md`](https://github.com/IgorGanapolsky/ThumbGate/blob/main/VERIFICATION_EVIDENCE.md).