### PR TITLE
fix(tests): retry deployment fixture cleanup

### DIFF
--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -75,7 +75,13 @@ function runDeployScopeFixture(changePath, eventName = 'push', beforeShaOverride
 
     return JSON.parse(fs.readFileSync(jsonOutput, 'utf8'));
   } finally {
-    fs.rmSync(repoDir, { recursive: true, force: true });
+    // Retry transient APFS ENOTEMPTY teardown failures observed under Node 26.
+    fs.rmSync(repoDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- retry recursive deployment-fixture cleanup after transient macOS APFS `ENOTEMPTY` failures under Node 26
- keep the change test-only; no production deployment behavior changes

## Reproduction
- clean `origin/main` at `b54e5e9343a9f6244eff2f88cb946231d393101f`
- Node `v26.3.1`
- `node --test tests/deployment.test.js` failed `54/56` with `ENOTEMPTY` from `runDeployScopeFixture` teardown at both deployment-scope tests

## Verification
- post-fix focused run: `56/56`
- 20 fresh-process focused repetitions: `20/20` passed (`1,120/1,120` assertions)
- `env -u THUMBGATE_API_KEY npm run test:deployment`: `123/123` passed
- pre-push package, internal-link, and regression guards passed

## Scope
- changed only `tests/deployment.test.js`
- no changeset: the repository changeset policy explicitly excludes test-only diffs

This PR is intentionally not queued or merged.