### PR TITLE
fix(deploy): align homepage sentinel with shipped copy

### DIFF
--- a/.changeset/align-homepage-sentinel.md
+++ b/.changeset/align-homepage-sentinel.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Keep the production homepage verifier aligned with the shipped enforcement copy.

--- a/config/post-deploy-marketing-pages.json
+++ b/config/post-deploy-marketing-pages.json
@@ -4,7 +4,7 @@
   "pages": [
     {
       "route": "/",
-      "sentinel": "Stop paying for the same AI mistake twice",
+      "sentinel": "Catch AI agents before they spend money",
       "description": "Home page hero (lifeblood — never regress)"
     },
     {

--- a/tests/verify-marketing-pages-deployed.test.js
+++ b/tests/verify-marketing-pages-deployed.test.js
@@ -285,6 +285,11 @@ test('manifest contract: shipped config/post-deploy-marketing-pages.json is vali
   const home = m.pages.find((p) => p.route === '/');
   assert.ok(home, 'manifest must include /');
   assert.ok(home.sentinel.length > 0);
+  const homeHtml = fs.readFileSync(path.resolve(__dirname, '..', 'public', 'index.html'), 'utf8');
+  assert.ok(
+    homeHtml.includes(home.sentinel),
+    'home-page sentinel must match shipped public/index.html before deployment',
+  );
   const checkout = m.pages.find((p) => p.route === '/checkout/pro');
   assert.ok(checkout, 'manifest must include the revenue-critical Pro checkout route');
   assert.match(checkout.sentinel, /Stripe can collect your email/);


### PR DESCRIPTION
## Summary
- update the production homepage sentinel after the enforcement-copy correction in #2883
- pin the manifest sentinel to `public/index.html` in unit tests so copy and deploy verification cannot drift silently again

## Evidence
- `npm run test:verify-marketing-pages-deployed` (20/20 pass)
- `node scripts/verify-marketing-pages-deployed.js --prod-url=https://thumbgate-production.up.railway.app` (14/14 live routes pass)
- `git diff --check`

## Failure addressed
The exact merge SHA for #2883 deployed successfully, but `Verify Production Deploy` failed because `/` still expected the removed headline `Stop paying for the same AI mistake twice`. The live homepage correctly ships `Catch AI agents before they spend money, leak secrets, or break production.`
