### PR TITLE
fix(marketing): satisfy release campaign quality gate

### DIFF
--- a/.changeset/release-campaign-quality-gate.md
+++ b/.changeset/release-campaign-quality-gate.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Fix direct-run detection and simplify release-campaign publishing so the article, receipt verifier, and direct fallback commands execute reliably and pass the new-code quality gate.

--- a/scripts/social-analytics/cli-entrypoint.js
+++ b/scripts/social-analytics/cli-entrypoint.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const path = require('node:path');
+
+function isDirectRun(argv = process.argv, filename = __filename) {
+  return Boolean(argv[1]) && Object.is(path.resolve(argv[1]), path.resolve(filename));
+}
+
+function runAsyncCli(main, filename, argv = process.argv) {
+  if (!isDirectRun(argv, filename)) return false;
+
+  return Promise.resolve()
+    .then(main)
+    .catch((error) => {
+      console.error(error?.message || error);
+      process.exitCode = 1;
+    });
+}
+
+module.exports = { isDirectRun, runAsyncCli };

--- a/scripts/social-analytics/cli-entrypoint.js
+++ b/scripts/social-analytics/cli-entrypoint.js
@@ -6,15 +6,17 @@ function isDirectRun(argv = process.argv, filename = __filename) {
   return Boolean(argv[1]) && Object.is(path.resolve(argv[1]), path.resolve(filename));
 }
 
-function runAsyncCli(main, filename, argv = process.argv) {
+async function runAsyncCli(main, filename, argv = process.argv) {
   if (!isDirectRun(argv, filename)) return false;
 
-  return Promise.resolve()
-    .then(main)
-    .catch((error) => {
-      console.error(error?.message || error);
-      process.exitCode = 1;
-    });
+  try {
+    await main();
+    return true;
+  } catch (error) {
+    console.error(error?.message || error);
+    process.exitCode = 1;
+    return false;
+  }
 }
 
 module.exports = { isDirectRun, runAsyncCli };

--- a/scripts/social-analytics/publish-latest-release-article.js
+++ b/scripts/social-analytics/publish-latest-release-article.js
@@ -3,6 +3,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { isDirectRun, runAsyncCli } = require('./cli-entrypoint');
 const { loadLocalEnv } = require('./load-env');
 const { listMyArticles, publishArticle } = require('./publishers/devto');
 
@@ -54,17 +55,7 @@ async function main() {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
-function isDirectRun(argv = process.argv, filename = __filename) {
-  if (!argv[1]) return false;
-  return path.resolve(argv[1]) === path.resolve(filename);
-}
-
-if (isDirectRun()) {
-  main().catch((error) => {
-    console.error(error?.message || error);
-    process.exit(1);
-  });
-}
+runAsyncCli(main, __filename);
 
 module.exports = {
   ARTICLE_PATH,

--- a/scripts/social-analytics/publish-latest-release-article.js
+++ b/scripts/social-analytics/publish-latest-release-article.js
@@ -54,9 +54,14 @@ async function main() {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
-if (require.main === module) {
+function isDirectRun(argv = process.argv, filename = __filename) {
+  if (!argv[1]) return false;
+  return path.resolve(argv[1]) === path.resolve(filename);
+}
+
+if (isDirectRun()) {
   main().catch((error) => {
-    console.error(error && error.message ? error.message : error);
+    console.error(error?.message || error);
     process.exit(1);
   });
 }
@@ -64,5 +69,6 @@ if (require.main === module) {
 module.exports = {
   ARTICLE_PATH,
   ARTICLE_TITLE,
+  isDirectRun,
   publishLatestReleaseArticle,
 };

--- a/scripts/social-analytics/publish-latest-release-fallbacks.js
+++ b/scripts/social-analytics/publish-latest-release-fallbacks.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const path = require('node:path');
+const { isDirectRun, runAsyncCli } = require('./cli-entrypoint');
 const {
   buildLatestReleasePost,
   buildLatestReleaseUrl,
@@ -178,17 +178,7 @@ async function main() {
   if (results.errors.length > 0) process.exitCode = 1;
 }
 
-function isDirectRun(argv = process.argv, filename = __filename) {
-  if (!argv[1]) return false;
-  return path.resolve(argv[1]) === path.resolve(filename);
-}
-
-if (isDirectRun()) {
-  main().catch((error) => {
-    console.error(error?.message || error);
-    process.exit(1);
-  });
-}
+runAsyncCli(main, __filename);
 
 module.exports = {
   DEFAULT_REDDIT_PARENT_ID,

--- a/scripts/social-analytics/publish-latest-release-fallbacks.js
+++ b/scripts/social-analytics/publish-latest-release-fallbacks.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const path = require('node:path');
 const {
   buildLatestReleasePost,
   buildLatestReleaseUrl,
@@ -21,8 +22,7 @@ function parseArgs(argv = []) {
     redditThreadUrl: DEFAULT_REDDIT_THREAD_URL,
   };
 
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index];
+  for (const token of argv) {
     if (token === '--dry-run') {
       options.dryRun = true;
       continue;
@@ -79,12 +79,68 @@ function buildRedditCommentUrl(comment, threadUrl = DEFAULT_REDDIT_THREAD_URL) {
   return `${String(threadUrl).replace(/\/?$/, '/')}${id}/`;
 }
 
-async function publishLatestReleaseFallbacks(options = {}, publishers = {}, env = process.env) {
-  const platforms = (options.platforms && options.platforms.length > 0
-    ? options.platforms
-    : ['linkedin', 'reddit'])
+function resolvePlatforms(platforms = []) {
+  const requested = platforms.length > 0 ? platforms : ['linkedin', 'reddit'];
+  return requested
     .map((platform) => String(platform).trim().toLowerCase())
     .filter((platform) => SUPPORTED_PLATFORMS.has(platform));
+}
+
+function buildPreview(platform) {
+  const isReddit = platform === 'reddit';
+  return {
+    content: isReddit ? buildRedditProjectThreadComment() : buildLatestReleasePost(platform),
+    platform,
+    title: isReddit ? 'r/AI_Agents weekly project-display comment' : null,
+  };
+}
+
+async function publishLinkedInFallback(content, api, env) {
+  const postUrn = await api.publishLinkedIn(
+    env.LINKEDIN_ACCESS_TOKEN,
+    env.LINKEDIN_PERSON_URN,
+    content,
+  );
+  const url = buildLinkedInPostUrl(postUrn);
+  if (!url) throw new Error('LinkedIn publish returned no post URN');
+  return { platform: 'linkedin', postId: postUrn, url };
+}
+
+async function publishRedditFallback(content, options, api, env) {
+  const gateResult = qualityGate.gatePost(content);
+  if (!gateResult.allowed) throw new Error('Reddit quality gate blocked the release comment');
+
+  const redditToken = await api.getRedditToken(
+    env.REDDIT_CLIENT_ID,
+    env.REDDIT_CLIENT_SECRET,
+    env.REDDIT_USERNAME,
+    env.REDDIT_PASSWORD,
+  );
+  const redditResult = await api.submitRedditComment(
+    redditToken,
+    env.REDDIT_USER_AGENT || `thumbgate/1.0 by ${env.REDDIT_USERNAME}`,
+    {
+      parentId: options.redditParentId || DEFAULT_REDDIT_PARENT_ID,
+      text: content,
+    },
+  );
+  const url = buildRedditCommentUrl(redditResult, options.redditThreadUrl);
+  if (!url) throw new Error('Reddit publish returned no public comment URL');
+  return {
+    platform: 'reddit',
+    postId: redditResult.name || redditResult.id || null,
+    subreddit: 'AI_Agents',
+    url,
+  };
+}
+
+function publishPlatformFallback(platform, content, options, api, env) {
+  if (platform === 'linkedin') return publishLinkedInFallback(content, api, env);
+  return publishRedditFallback(content, options, api, env);
+}
+
+async function publishLatestReleaseFallbacks(options = {}, publishers = {}, env = process.env) {
+  const platforms = resolvePlatforms(options.platforms);
   const api = {
     publishLinkedIn: publishers.publishLinkedIn || publishTextPost,
     getRedditToken: publishers.getRedditToken || getRedditToken,
@@ -98,53 +154,16 @@ async function publishLatestReleaseFallbacks(options = {}, publishers = {}, env 
   };
 
   for (const platform of platforms) {
-    const content = platform === 'reddit'
-      ? buildRedditProjectThreadComment()
-      : buildLatestReleasePost(platform);
-    const title = platform === 'reddit' ? 'r/AI_Agents weekly project-display comment' : null;
-    results.previews.push({ content, platform, title });
+    const preview = buildPreview(platform);
+    results.previews.push(preview);
     if (results.dryRun) continue;
 
     try {
-      if (platform === 'linkedin') {
-        const postUrn = await api.publishLinkedIn(
-          env.LINKEDIN_ACCESS_TOKEN,
-          env.LINKEDIN_PERSON_URN,
-          content,
-        );
-        const url = buildLinkedInPostUrl(postUrn);
-        if (!url) throw new Error('LinkedIn publish returned no post URN');
-        results.published.push({ platform, postId: postUrn, url });
-        continue;
-      }
-
-      const gateResult = qualityGate.gatePost(content);
-      if (!gateResult.allowed) throw new Error('Reddit quality gate blocked the release comment');
-      const redditToken = await api.getRedditToken(
-        env.REDDIT_CLIENT_ID,
-        env.REDDIT_CLIENT_SECRET,
-        env.REDDIT_USERNAME,
-        env.REDDIT_PASSWORD,
-      );
-      const redditResult = await api.submitRedditComment(
-        redditToken,
-        env.REDDIT_USER_AGENT || `thumbgate/1.0 by ${env.REDDIT_USERNAME}`,
-        {
-          parentId: options.redditParentId || DEFAULT_REDDIT_PARENT_ID,
-          text: content,
-        },
-      );
-      const url = buildRedditCommentUrl(redditResult, options.redditThreadUrl);
-      if (!url) throw new Error('Reddit publish returned no public comment URL');
-      results.published.push({
-        platform,
-        postId: redditResult.name || redditResult.id || null,
-        subreddit: 'AI_Agents',
-        url,
-      });
+      const receipt = await publishPlatformFallback(platform, preview.content, options, api, env);
+      results.published.push(receipt);
     } catch (error) {
       results.errors.push({
-        error: error && error.message ? error.message : String(error),
+        error: error?.message || String(error),
         platform,
       });
     }
@@ -159,9 +178,14 @@ async function main() {
   if (results.errors.length > 0) process.exitCode = 1;
 }
 
-if (require.main === module) {
+function isDirectRun(argv = process.argv, filename = __filename) {
+  if (!argv[1]) return false;
+  return path.resolve(argv[1]) === path.resolve(filename);
+}
+
+if (isDirectRun()) {
   main().catch((error) => {
-    console.error(error && error.message ? error.message : error);
+    console.error(error?.message || error);
     process.exit(1);
   });
 }
@@ -172,6 +196,7 @@ module.exports = {
   buildLinkedInPostUrl,
   buildRedditCommentUrl,
   buildRedditProjectThreadComment,
+  isDirectRun,
   normalizeRedditPostUrl,
   parseArgs,
   publishLatestReleaseFallbacks,

--- a/scripts/social-analytics/publish-thumbgate-launch.js
+++ b/scripts/social-analytics/publish-thumbgate-launch.js
@@ -53,6 +53,16 @@ function resolveLatestReleaseMediaPlan(platform) {
   return ['instagram', 'youtube'].includes(normalized) ? [LATEST_RELEASE_MEDIA.square] : [];
 }
 
+function resolveOfferMediaPlan(offer, platform) {
+  if (offer === 'operator-lab') {
+    return resolveOperatorLabMediaPlan(platform);
+  }
+  if (offer === 'release-1.28.0') {
+    return resolveLatestReleaseMediaPlan(platform);
+  }
+  return [];
+}
+
 function describeMediaPlan(paths = []) {
   return paths.map((p) => ({
     path: p,
@@ -750,9 +760,7 @@ async function publishLaunchCampaign(options = {}, publisher = {}) {
     }
 
     const content = buildPlatformPost(normalizedPlatform, offer);
-    const mediaPlanPaths = offer === 'operator-lab'
-      ? resolveOperatorLabMediaPlan(normalizedPlatform)
-      : (offer === 'release-1.28.0' ? resolveLatestReleaseMediaPlan(normalizedPlatform) : []);
+    const mediaPlanPaths = resolveOfferMediaPlan(offer, normalizedPlatform);
     results.previews.push({
       platform: normalizedPlatform,
       content,

--- a/scripts/social-analytics/verify-latest-release-posts.js
+++ b/scripts/social-analytics/verify-latest-release-posts.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-const path = require('node:path');
+const { isDirectRun, runAsyncCli } = require('./cli-entrypoint');
 const { listPosts } = require('./publishers/zernio');
 
 const LATEST_RELEASE_MARKERS = [
@@ -62,17 +62,7 @@ async function main() {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
-function isDirectRun(argv = process.argv, filename = __filename) {
-  if (!argv[1]) return false;
-  return path.resolve(argv[1]) === path.resolve(filename);
-}
-
-if (isDirectRun()) {
-  main().catch((error) => {
-    console.error(error?.message || error);
-    process.exit(1);
-  });
-}
+runAsyncCli(main, __filename);
 
 module.exports = {
   flattenPostReceipts,

--- a/scripts/social-analytics/verify-latest-release-posts.js
+++ b/scripts/social-analytics/verify-latest-release-posts.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const path = require('node:path');
 const { listPosts } = require('./publishers/zernio');
 
 const LATEST_RELEASE_MARKERS = [
@@ -61,9 +62,14 @@ async function main() {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
-if (require.main === module) {
+function isDirectRun(argv = process.argv, filename = __filename) {
+  if (!argv[1]) return false;
+  return path.resolve(argv[1]) === path.resolve(filename);
+}
+
+if (isDirectRun()) {
   main().catch((error) => {
-    console.error(error && error.message ? error.message : error);
+    console.error(error?.message || error);
     process.exit(1);
   });
 }
@@ -71,6 +77,7 @@ if (require.main === module) {
 module.exports = {
   flattenPostReceipts,
   isLatestReleasePost,
+  isDirectRun,
   parseArgs,
   selectLatestByPlatform,
   verifyLatestReleasePosts,

--- a/tests/latest-release-campaign-ops.test.js
+++ b/tests/latest-release-campaign-ops.test.js
@@ -2,10 +2,12 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const path = require('node:path');
 
 const {
   buildLinkedInPostUrl,
   buildRedditProjectThreadComment,
+  isDirectRun,
   normalizeRedditPostUrl,
   parseArgs: parseFallbackArgs,
   publishLatestReleaseFallbacks,
@@ -36,6 +38,14 @@ test('fallback argument parsing and receipt URL normalization are deterministic'
   );
   assert.match(buildRedditProjectThreadComment(), /Disclosure: I maintain ThumbGate/);
   assert.doesNotMatch(buildRedditProjectThreadComment(), /\$|buy\.stripe\.com/);
+});
+
+test('direct-run detection compares resolved entrypoint paths', () => {
+  const sourcePath = require.resolve('../scripts/social-analytics/publish-latest-release-fallbacks');
+
+  assert.equal(isDirectRun([process.execPath, sourcePath], sourcePath), true);
+  assert.equal(isDirectRun([process.execPath, path.join(__dirname, 'other.js')], sourcePath), false);
+  assert.equal(isDirectRun([process.execPath], sourcePath), false);
 });
 
 test('fallback publisher returns public receipts for LinkedIn and Reddit', async () => {

--- a/tests/publish-latest-release-article.test.js
+++ b/tests/publish-latest-release-article.test.js
@@ -46,10 +46,10 @@ test('shared CLI runner invokes only a matching entrypoint', async () => {
   };
 
   assert.equal(
-    runAsyncCli(main, sourcePath, [process.execPath, path.join(__dirname, 'other.js')]),
+    await runAsyncCli(main, sourcePath, [process.execPath, path.join(__dirname, 'other.js')]),
     false,
   );
-  await runAsyncCli(main, sourcePath, [process.execPath, sourcePath]);
+  assert.equal(await runAsyncCli(main, sourcePath, [process.execPath, sourcePath]), true);
   assert.equal(calls, 1);
   assert.equal(isDirectRun([process.execPath], sourcePath), false);
 });
@@ -61,11 +61,12 @@ test('shared CLI runner reports a rejected command', async (context) => {
   context.mock.method(console, 'error', (message) => errors.push(message));
 
   try {
-    await runAsyncCli(
+    const result = await runAsyncCli(
       async () => { throw new Error('expected CLI failure'); },
       sourcePath,
       [process.execPath, sourcePath],
     );
+    assert.equal(result, false);
     assert.deepEqual(errors, ['expected CLI failure']);
     assert.equal(process.exitCode, 1);
   } finally {

--- a/tests/publish-latest-release-article.test.js
+++ b/tests/publish-latest-release-article.test.js
@@ -2,10 +2,37 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const path = require('node:path');
 const {
   ARTICLE_TITLE,
+  isDirectRun: isArticleDirectRun,
   publishLatestReleaseArticle,
 } = require('../scripts/social-analytics/publish-latest-release-article');
+const {
+  isDirectRun: isVerifierDirectRun,
+} = require('../scripts/social-analytics/verify-latest-release-posts');
+
+test('CLI entrypoint detection compares resolved paths', () => {
+  const cases = [
+    [
+      isArticleDirectRun,
+      require.resolve('../scripts/social-analytics/publish-latest-release-article'),
+    ],
+    [
+      isVerifierDirectRun,
+      require.resolve('../scripts/social-analytics/verify-latest-release-posts'),
+    ],
+  ];
+
+  for (const [isDirectRun, sourcePath] of cases) {
+    assert.equal(isDirectRun([process.execPath, sourcePath], sourcePath), true);
+    assert.equal(
+      isDirectRun([process.execPath, path.join(__dirname, 'other.js')], sourcePath),
+      false,
+    );
+    assert.equal(isDirectRun([process.execPath], sourcePath), false);
+  }
+});
 
 test('publishes the latest release article with technical tags', async () => {
   let received;

--- a/tests/publish-latest-release-article.test.js
+++ b/tests/publish-latest-release-article.test.js
@@ -4,6 +4,10 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 const {
+  isDirectRun,
+  runAsyncCli,
+} = require('../scripts/social-analytics/cli-entrypoint');
+const {
   ARTICLE_TITLE,
   isDirectRun: isArticleDirectRun,
   publishLatestReleaseArticle,
@@ -31,6 +35,41 @@ test('CLI entrypoint detection compares resolved paths', () => {
       false,
     );
     assert.equal(isDirectRun([process.execPath], sourcePath), false);
+  }
+});
+
+test('shared CLI runner invokes only a matching entrypoint', async () => {
+  const sourcePath = require.resolve('../scripts/social-analytics/publish-latest-release-article');
+  let calls = 0;
+  const main = async () => {
+    calls += 1;
+  };
+
+  assert.equal(
+    runAsyncCli(main, sourcePath, [process.execPath, path.join(__dirname, 'other.js')]),
+    false,
+  );
+  await runAsyncCli(main, sourcePath, [process.execPath, sourcePath]);
+  assert.equal(calls, 1);
+  assert.equal(isDirectRun([process.execPath], sourcePath), false);
+});
+
+test('shared CLI runner reports a rejected command', async (context) => {
+  const sourcePath = require.resolve('../scripts/social-analytics/publish-latest-release-article');
+  const originalExitCode = process.exitCode;
+  const errors = [];
+  context.mock.method(console, 'error', (message) => errors.push(message));
+
+  try {
+    await runAsyncCli(
+      async () => { throw new Error('expected CLI failure'); },
+      sourcePath,
+      [process.execPath, sourcePath],
+    );
+    assert.deepEqual(errors, ['expected CLI failure']);
+    assert.equal(process.exitCode, 1);
+  } finally {
+    process.exitCode = originalExitCode;
   }
 });
 


### PR DESCRIPTION
## Summary
- fix the real Sonar findings reported after #2911 entered Trunk
- replace always-false direct-run comparisons with tested resolved-path detection
- reduce fallback publisher cognitive complexity and remove nested ternary/optional-chain findings

## Failure evidence
SonarCloud reported `C Reliability Rating on New Code` (required A), including always-false comparisons in the article publisher, verifier, and fallback publisher plus a cognitive-complexity violation. The original PR merged through Trunk before this repair commit was pushed, so this is the clean follow-up from the exact post-merge `main`.

## Verification
- `npm run test:publish-thumbgate-launch`: 27/27 passed
- `npm run test:social-quality-gate`: 25/25 passed
- `npm run test:publisher-credential-guards`: 5/5 passed
- `npm run test:reddit-publisher`: passed
- `node --check` on all modified scripts: passed
- `git diff --check`: passed
- pre-commit and pre-push repository guards: passed