### PR TITLE
feat(marketing): add checkout-free partner intake

### DIFF
--- a/.changeset/partner-intake-conversion.md
+++ b/.changeset/partner-intake-conversion.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add a form-only partner intake route that preserves referral attribution and contains no price or checkout path before scope review.

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "public/learn.html",
     "public/lessons.html",
     "public/numbers.html",
+    "public/partner-intake.html",
     "public/pricing.html",
     "public/pro.html",
     "public/assets/brand/",

--- a/public/partner-intake.html
+++ b/public/partner-intake.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ThumbGate Partner Workflow Intake</title>
+<meta name="description" content="Submit one failing AI-agent workflow for fit review before implementation.">
+<meta name="robots" content="noindex,nofollow">
+<link rel="canonical" href="__APP_ORIGIN__/partner-intake">
+<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
+<meta property="og:title" content="ThumbGate Partner Workflow Intake">
+<meta property="og:description" content="Describe one repeated AI-agent workflow failure and the proof gap around it.">
+<meta property="og:url" content="__APP_ORIGIN__/partner-intake">
+<meta property="og:type" content="website">
+__GOOGLE_SITE_VERIFICATION_META__
+__GA_BOOTSTRAP__
+<style>
+:root {
+  color-scheme: dark;
+  --bg: #070a0c;
+  --panel: #10161a;
+  --line: #2a3941;
+  --text: #edf7f8;
+  --muted: #a7b5ba;
+  --cyan: #2fd2e6;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+header, main, footer { width: min(1040px, calc(100% - 32px)); margin: 0 auto; }
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 24px 0;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text);
+  font-weight: 800;
+  text-decoration: none;
+}
+.brand img { display: block; width: 28px; height: 28px; }
+.partner-label { color: var(--muted); font-size: 14px; }
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+  gap: 48px;
+  align-items: start;
+  padding: 56px 0 64px;
+}
+.eyebrow {
+  color: var(--cyan);
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+}
+h1 {
+  margin: 14px 0 18px;
+  max-width: 620px;
+  font-size: 52px;
+  line-height: 1;
+  letter-spacing: 0;
+}
+.lede { max-width: 600px; color: var(--muted); font-size: 19px; }
+.signals {
+  display: grid;
+  gap: 12px;
+  margin-top: 30px;
+  padding: 0;
+  list-style: none;
+}
+.signals li { padding-left: 18px; border-left: 3px solid var(--cyan); color: var(--muted); }
+.signals strong { color: var(--text); }
+.intake-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 24px;
+}
+.intake-card h2 { margin: 0 0 8px; font-size: 24px; }
+.intake-card > p { margin: 0 0 18px; color: var(--muted); }
+label { display: block; margin: 14px 0 7px; font-size: 14px; font-weight: 750; }
+input, textarea, select {
+  width: 100%;
+  border: 1px solid #35464e;
+  border-radius: 7px;
+  background: #080c0f;
+  color: var(--text);
+  padding: 12px;
+  font: inherit;
+}
+textarea { min-height: 124px; resize: vertical; }
+button {
+  width: 100%;
+  min-height: 50px;
+  margin-top: 18px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--cyan);
+  color: #041014;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+.hint { margin: 12px 0 0; color: var(--muted); font-size: 13px; }
+footer { padding: 28px 0 40px; border-top: 1px solid var(--line); color: var(--muted); }
+@media (max-width: 800px) {
+  header { align-items: flex-start; flex-direction: column; }
+  .layout { grid-template-columns: 1fr; padding-top: 36px; }
+  h1 { font-size: 40px; }
+}
+</style>
+</head>
+<body>
+<header>
+  <a class="brand" href="/">
+    <img src="/assets/brand/thumbgate-mark-inline-v3.svg" alt="ThumbGate" width="28" height="28">
+    <span>ThumbGate</span>
+  </a>
+  <span class="partner-label">Partner workflow intake</span>
+</header>
+<main>
+  <div class="layout">
+    <section aria-labelledby="partner-intake-title">
+      <div class="eyebrow">Workflow fit review</div>
+      <h1 id="partner-intake-title">Send one failing AI-agent workflow.</h1>
+      <p class="lede">Describe the repeated action, the agent involved, and the proof gap. We will review whether the workflow is a fit and return the next concrete step through the referring partner.</p>
+      <ul class="signals">
+        <li><strong>One workflow:</strong> keep the review narrow enough to verify.</li>
+        <li><strong>One owner:</strong> identify who can approve the resulting boundary.</li>
+        <li><strong>One proof target:</strong> state what must be true before the action runs again.</li>
+      </ul>
+    </section>
+    <form class="intake-card" action="/v1/intake/workflow-sprint" method="POST" data-partner-intake-form>
+      <h2>Submit workflow</h2>
+      <p>Use a work email so we can return the fit review to the right owner.</p>
+      <input type="hidden" name="ctaId" value="partner_intake_submit">
+      <input type="hidden" name="ctaPlacement" value="partner_intake">
+      <input type="hidden" name="planId" value="diagnostic">
+      <input type="hidden" name="page" value="/partner-intake">
+      <input type="hidden" name="source" value="__SERVER_ATTRIBUTION_SOURCE__">
+      <input type="hidden" name="utmSource" value="__SERVER_UTM_SOURCE__">
+      <input type="hidden" name="utmMedium" value="__SERVER_UTM_MEDIUM__">
+      <input type="hidden" name="utmCampaign" value="__SERVER_UTM_CAMPAIGN__">
+      <input type="hidden" name="utmContent" value="__SERVER_UTM_CONTENT__">
+      <label for="partner-name">Name</label>
+      <input id="partner-name" name="name" autocomplete="name" required>
+      <label for="partner-email">Work email</label>
+      <input id="partner-email" name="email" type="email" autocomplete="email" required>
+      <label for="partner-company">Company or project</label>
+      <input id="partner-company" name="company" autocomplete="organization">
+      <label for="partner-workflow">What workflow keeps failing?</label>
+      <textarea id="partner-workflow" name="workflow" required placeholder="Example: the agent sends a customer update before the evidence and approver are confirmed."></textarea>
+      <label for="partner-urgency">Urgency</label>
+      <select id="partner-urgency" name="urgency">
+        <option>Repeated failure already cost us time</option>
+        <option>We are about to roll this workflow out</option>
+        <option>We need an independent proof checklist first</option>
+      </select>
+      <button type="submit">Send workflow for review</button>
+      <p class="hint">The next page confirms receipt and provides the review references.</p>
+    </form>
+  </div>
+</main>
+<footer>ThumbGate reviews one concrete agent workflow at a time so the resulting boundary can be tested.</footer>
+<script>
+(function () {
+  const form = document.querySelector('[data-partner-intake-form]');
+  if (!form) return;
+
+  const search = new URLSearchParams(window.location.search);
+  const fields = {
+    source: search.get('utm_source') || search.get('source') || 'partner',
+    utmSource: search.get('utm_source') || search.get('source') || 'partner',
+    utmMedium: search.get('utm_medium') || 'partner',
+    utmCampaign: search.get('utm_campaign') || 'hosted_listing',
+    utmContent: search.get('utm_content') || 'partner_intake'
+  };
+
+  for (const [name, value] of Object.entries(fields)) {
+    const input = form.querySelector(`input[name="${name}"]`);
+    if (input && value.trim()) input.value = value.trim();
+  }
+}());
+</script>
+</body>
+</html>

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -249,6 +249,7 @@ const FEDERAL_PAGE_PATH = path.resolve(__dirname, '../../public/federal.html');
 const PRICING_PAGE_PATH = path.resolve(__dirname, '../../public/pricing.html');
 const ABOUT_PAGE_PATH = path.resolve(__dirname, '../../public/about.html');
 const DIAGNOSTIC_PAGE_PATH = path.resolve(__dirname, '../../public/diagnostic.html');
+const PARTNER_INTAKE_PAGE_PATH = path.resolve(__dirname, '../../public/partner-intake.html');
 const INSTALL_PAGE_PATH = path.resolve(__dirname, '../../public/install.html');
 const LEARN_DIR = path.resolve(__dirname, '../../public/learn');
 const GUIDES_DIR = path.resolve(__dirname, '../../public/guides');
@@ -2890,6 +2891,11 @@ function loadPublicMarketingTemplateHtml(templatePath, runtimeConfig, pageContex
     '__SERVER_SESSION_ID__': pageContext.serverSessionId || '',
     '__SERVER_ACQUISITION_ID__': pageContext.serverAcquisitionId || '',
     '__SERVER_TELEMETRY_CAPTURED__': pageContext.serverTelemetryCaptured ? 'true' : 'false',
+    '__SERVER_ATTRIBUTION_SOURCE__': escapeHtmlAttribute(pageContext.serverAttributionSource || 'partner'),
+    '__SERVER_UTM_SOURCE__': escapeHtmlAttribute(pageContext.serverUtmSource || 'partner'),
+    '__SERVER_UTM_MEDIUM__': escapeHtmlAttribute(pageContext.serverUtmMedium || 'partner'),
+    '__SERVER_UTM_CAMPAIGN__': escapeHtmlAttribute(pageContext.serverUtmCampaign || 'hosted_listing'),
+    '__SERVER_UTM_CONTENT__': escapeHtmlAttribute(pageContext.serverUtmContent || 'partner_intake'),
     '__VERIFICATION_URL__': 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md',
     '__COMPATIBILITY_REPORT_URL__': 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md',
     '__AUTOMATION_REPORT_URL__': 'https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md',
@@ -2909,6 +2915,10 @@ function loadProPageHtml(runtimeConfig, pageContext = {}) {
 
 function loadDiagnosticPageHtml(runtimeConfig, pageContext = {}) {
   return loadPublicMarketingTemplateHtml(DIAGNOSTIC_PAGE_PATH, runtimeConfig, pageContext);
+}
+
+function loadPartnerIntakePageHtml(runtimeConfig, pageContext = {}) {
+  return loadPublicMarketingTemplateHtml(PARTNER_INTAKE_PAGE_PATH, runtimeConfig, pageContext);
 }
 
 function loadInstallPageHtml(runtimeConfig, pageContext = {}) {
@@ -3730,6 +3740,11 @@ function servePublicMarketingPage({
     serverSessionId: journeyState.sessionId,
     serverAcquisitionId: journeyState.acquisitionId,
     serverTelemetryCaptured: landingTelemetryCaptured,
+    serverAttributionSource: landingAttribution.source,
+    serverUtmSource: landingAttribution.utmSource,
+    serverUtmMedium: landingAttribution.utmMedium,
+    serverUtmCampaign: landingAttribution.utmCampaign,
+    serverUtmContent: landingAttribution.utmContent,
     requestHost,
   });
 
@@ -5787,6 +5802,25 @@ async function addContext(){
         'Cache-Control': 'no-store',
       });
       res.end();
+      return;
+    }
+
+    if (isGetLikeRequest && (pathname === '/partner-intake' || pathname === '/partner-intake.html')) {
+      try {
+        servePublicMarketingPage({
+          req,
+          res,
+          parsed,
+          hostedConfig,
+          isHeadRequest,
+          renderHtml: loadPartnerIntakePageHtml,
+          extraTelemetry: {
+            pageType: 'partner_intake',
+          },
+        });
+      } catch (err) {
+        sendText(res, 500, err.message || 'Partner intake page unavailable');
+      }
       return;
     }
 

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -553,6 +553,32 @@ test('/pro serves the Pro landing page instead of redirecting to the homepage', 
   assert.match(html, /\/checkout\/pro\?plan_id=pro&billing_cycle=monthly/);
 });
 
+test('/partner-intake serves an attributed form without a price or payment path', async () => {
+  const res = await fetch(apiUrl('/partner-intake?utm_source=aiventyx&utm_medium=partner&utm_campaign=hosted_listing'));
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') || '', /text\/html/);
+  const html = await res.text();
+  assert.match(html, /Send one failing AI-agent workflow/);
+  assert.match(html, /action="\/v1\/intake\/workflow-sprint"/);
+  assert.match(html, /name="page" value="\/partner-intake"/);
+  assert.match(html, /name="source" value="aiventyx"/);
+  assert.match(html, /name="utmSource" value="aiventyx"/);
+  assert.match(html, /name="utmMedium" value="partner"/);
+  assert.match(html, /name="utmCampaign" value="hosted_listing"/);
+  assert.match(html, /search\.get\('utm_source'\)/);
+  assert.doesNotMatch(html, /\$\s*\d|Stripe|checkout|payment|data-revenue-cta/i);
+});
+
+test('/partner-intake escapes server-rendered attribution values', async () => {
+  const maliciousSource = 'aiventyx\"><script>window.partnerPwned=true</script>';
+  const query = new URLSearchParams({ utm_source: maliciousSource });
+  const res = await fetch(apiUrl(`/partner-intake?${query.toString()}`));
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.doesNotMatch(html, /value="aiventyx"><script>window\.partnerPwned/);
+  assert.match(html, /value="aiventyx&quot;&gt;&lt;script&gt;window\.partnerPwned=true&lt;\/script&gt;"/);
+});
+
 test('/diagnostic serves the focused Workflow Hardening Diagnostic intake page', async () => {
   const res = await fetch(apiUrl('/diagnostic?utm_source=reddit&utm_campaign=workflow_diagnostic'), { redirect: 'manual' });
   assert.equal(res.status, 200);
@@ -2800,6 +2826,7 @@ test('workflow sprint intake accepts form posts, seeds journey cookies, and retu
   assert.match(html, /Workflow sprint intake received/);
   assert.match(html, /Review Proof Pack/);
   assert.match(html, /Review Sprint Brief/);
+  assert.doesNotMatch(html, /\$\s*\d|Stripe|checkout|payment/i);
 
   const leads = readJsonl(path.join(tmpFeedbackDir, 'workflow-sprint-leads.jsonl'));
   const lead = leads.find((entry) => entry.contact.email === 'formbuyer@example.com');

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -340,8 +340,8 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // (never/always directive -> force-gate offer) in lockstep with the
   // public-core-boundary ceiling.
   assert.ok(
-    manifest.fileCount <= 332,
-    `npm package should stay <= 332 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 333,
+    `npm package should stay <= 333 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -103,7 +103,9 @@ const path = require('node:path');
 // UserPromptSubmit / SessionStart enforcement lifecycle (without it an install
 // got skills+commands+mcpServers but ZERO enforcement). It replaced headroom
 // under the ceiling, so the count stays at 332 — no baseline bump required.
-const BASELINE_FILE_COUNT = 332;
+// 332 -> 333: public/partner-intake.html adds the form-only partner handoff
+// used by attributed marketplace listings before a scoped offer is accepted.
+const BASELINE_FILE_COUNT = 333;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -171,7 +171,7 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // (never/always directive -> force-gate offer) and scripts/rule-clustering.js
   // (landing concurrently). Keep in lockstep with public-bundle-ratchet.
   const files = npmPackFiles();
-  const CEILING = 332;
+  const CEILING = 333;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -156,6 +156,7 @@ test('homepage and pricing surfaces expose canonical and LLM context links', asy
     ['/pricing', `${origin}/pricing`, `${origin}/llm-context.md`],
     ['/pro', `${origin}/pro`, `${origin}/llm-context.md`],
     ['/diagnostic', `${origin}/diagnostic`, `${origin}/llm-context.md`],
+    ['/partner-intake', `${origin}/partner-intake`, `${origin}/llm-context.md`],
   ];
 
   for (const [pathname, canonicalUrl, contextUrl] of pages) {
@@ -165,6 +166,22 @@ test('homepage and pricing surfaces expose canonical and LLM context links', asy
     assert.match(html, new RegExp(`<link rel="canonical" href="${canonicalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
     assert.match(html, new RegExp(`<link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="${contextUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
   }
+});
+
+test('GET /partner-intake serves a clean form-only partner handoff', async () => {
+  const res = await fetch(`${origin}/partner-intake?utm_source=aiventyx&utm_medium=partner&utm_campaign=hosted_listing`);
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') || '', /text\/html/);
+  const html = await res.text();
+  assert.match(html, /Partner Workflow Intake/);
+  assert.match(html, /action="\/v1\/intake\/workflow-sprint"/);
+  assert.match(html, /data-partner-intake-form/);
+  assert.match(html, /name="ctaId" value="partner_intake_submit"/);
+  assert.match(html, /name="source" value="aiventyx"/);
+  assert.match(html, /name="utmSource" value="aiventyx"/);
+  assert.match(html, /name="utmMedium" value="partner"/);
+  assert.match(html, /name="utmCampaign" value="hosted_listing"/);
+  assert.doesNotMatch(html, /\$\s*\d|Stripe|checkout|payment|data-revenue-cta/i);
 });
 
 test('GET /diagnostic serves the Workflow Hardening Diagnostic intake page', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated `/partner-intake` route for marketplace and referral handoffs
- preserve partner UTM attribution in server-rendered hidden fields, with client-side query synchronization as progressive enhancement
- keep the full intake and confirmation path free of price, Stripe, checkout, and payment CTAs

## Revenue reason
Qaiser correctly rejected the existing Aiventyx link because it reused the $499 diagnostic page. This route gives the marketplace listing a clean qualification handoff before commercial scope acceptance.

## Verification
- `node --test tests/public-static-assets.test.js`: 79 passed
- `node --test tests/api-server.test.js`: 153 passed
- package-boundary matrix: 11 passed
- `npm run prove:adapters`: passed
- `npm run prove:automation`: 55 passed
- pre-commit and pre-push guards: passed
- `npm test`: all sections reached the known local maintainer-bypass exception; only 3 existing `rate-limiter.test.js` free-tier assertions failed because this machine exports the maintainer Pro bypass. CI is the clean-environment authority.

## Security
- server-rendered attribution is HTML-attribute escaped
- regression test covers hostile markup in `utm_source`
- no credentials or buyer data are included
