### PR TITLE
fix(gtm): lead with paid diagnostic/sprint so money can convert today

### DIFF
--- a/.changeset/money-today-cta-sprint.md
+++ b/.changeset/money-today-cta-sprint.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Lead homepage and pricing with paid Workflow Hardening Diagnostic ($499) and Sprint ($1,500) checkouts; route `/docs` to the setup guide; keep Pro as the solo side lane.

--- a/docs/COMMERCIAL_TRUTH.md
+++ b/docs/COMMERCIAL_TRUTH.md
@@ -9,8 +9,8 @@ This document is the source of truth for product, pricing, traction, and proof c
 
 - The open-source `thumbgate` package is free and MIT licensed.
 - The local CLI is the adoption wedge; it is not the primary monetization story.
-- The primary commercial motion is the **Workflow Hardening Sprint** for one workflow, followed by Enterprise scoping when approval boundaries, rollback requirements, and evidence ownership must be designed across operators.
-- The current public self-serve commercial offer is **Pro at $19/mo or $149/yr** via Stripe checkout.
+- The primary commercial motion is the **Workflow Hardening Sprint** ($1,500 via `/go/sprint`) for one workflow, with an optional **Workflow Hardening Diagnostic** ($499 via `/go/diagnostic`, credited toward the sprint when implementation follows), then Enterprise scoping when approval boundaries, rollback requirements, and evidence ownership must be designed across operators.
+- The current public self-serve **subscription** offer is **Pro at $19/mo or $149/yr** via Stripe checkout — the solo side lane. Homepage and pricing lead with the paid diagnostic/sprint services, not Pro.
 - Legacy one-time Stripe links are retained only for past buyers and are not a current public offer.
 - Enterprise is the contact-sales tier: **custom pricing, scoped after intake**, and the public Enterprise path remains an **intake-led pilot for the first workflow**. Hosted team lesson sync and a hosted org dashboard are not general-availability features in the current public runtime. The former Team seat tier is retired.
 - The open-source runtime now supports history-aware lesson distillation from up to 8 prior recorded entries in the current Claude auto-capture path, linked 60-second feedback sessions, and reflector rule proposals across CLI, hosted API, Cursor, and Claude Desktop surfaces.

--- a/docs/WORKFLOW_HARDENING_SPRINT.md
+++ b/docs/WORKFLOW_HARDENING_SPRINT.md
@@ -52,11 +52,13 @@ Only move forward when the buyer has:
 
 ## Commercial Motion
 
-- This is a pilot-by-request service offer, not a new public self-serve subscription tier.
-- The public self-serve offer remains Pro at `$19/mo or $149/yr` per [COMMERCIAL_TRUTH.md](COMMERCIAL_TRUTH.md).
+- Public paid checkout (live Stripe Payment Links, substituted at runtime):
+  - **Diagnostic: $499** — `/go/diagnostic` (or `/diagnostic` for scope + pay)
+  - **Sprint: $1,500** — `/go/sprint`
+- Pro at `$19/mo or $149/yr` remains the solo self-serve side lane per [COMMERCIAL_TRUTH.md](COMMERCIAL_TRUTH.md).
 - Enterprise scope and pricing remain intake-first after the initial workflow is qualified.
 - Use booked pilots, paid orders, or named pilot agreements as commercial proof.
-- Same-day next step after a qualified call: send the sprint brief, the proof pack, and the proposed buyer review path.
+- Same-day next step after a qualified call: Stripe checkout for diagnostic or sprint, or intake only when the workflow still needs fit review.
 
 ## Contact
 

--- a/public/index.html
+++ b/public/index.html
@@ -719,7 +719,7 @@ __GA_BOOTSTRAP__
       <a href="#claude-code-section" class="nav-claude" onclick="posthog.capture('nav_claude_click')" style="display:none;">Claude</a>
       <a href="#workflow-sprint-intake" onclick="posthog.capture('workflow_sprint')" style="display:none;">Start Sprint</a>
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" onclick="posthog.capture('nav_claude_extension_click',{cta:'install_claude_extension'})" class="nav-cta" style="background:#d97706;display:none;">Claude Extension</a>
-      <a href="/checkout/pro?utm_source=website&utm_medium=nav&utm_campaign=pro_upgrade&cta_id=nav_start_pro&cta_placement=nav&plan_id=pro&landing_path=%2F" data-revenue-cta data-cta-id="nav_start_pro" data-cta-placement="nav" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);try{posthog.capture('nav_pro_click',{cta:'nav_start_pro',tier:'pro',price:19})}catch(_){}" class="nav-cta">Start Pro — $19/mo</a>
+      <a href="/go/diagnostic?utm_source=website&utm_medium=nav&utm_campaign=money_today&utm_content=nav_diagnostic&cta_id=nav_pay_diagnostic&cta_placement=nav&plan_id=sprint_diagnostic" data-revenue-cta data-cta-id="nav_pay_diagnostic" data-cta-placement="nav" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__" onclick="trackRevenueCta(this);try{posthog.capture('nav_diagnostic_click',{cta:'nav_pay_diagnostic',price:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__})}catch(_){}" class="nav-cta">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
     </div>
   </div>
 </nav>
@@ -743,26 +743,30 @@ __GA_BOOTSTRAP__
     </div>
 
     <div class="hero-actions">
-      <a href="/checkout/pro?utm_source=website&utm_medium=hero_cta&utm_campaign=pro_upgrade&cta_id=hero_start_pro&cta_placement=hero&plan_id=pro&landing_path=%2F" data-revenue-cta data-cta-id="hero_start_pro" data-cta-placement="hero" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);try{posthog.capture('hero_pro_checkout_click',{cta:'hero_start_pro',tier:'pro',price:19})}catch(_){}" class="btn-pro-page hero-pro hero-pro-primary">Start Pro — $19/mo</a>
-      <a href="#workflow-sprint-intake" onclick="try{posthog.capture('hero_sprint_click',{cta:'sprint_intake'})}catch(_){};sendFirstPartyTelemetry('hero_sprint_intake_started',{ctaId:'hero_workflow_sprint',ctaPlacement:'hero',offer:'workflow_sprint'});" class="btn-pro-page hero-pro">Workflow Hardening Sprint →</a>
+      <a href="/go/diagnostic?utm_source=website&utm_medium=hero_cta&utm_campaign=money_today&utm_content=hero_diagnostic&cta_id=hero_workflow_sprint_diagnostic_checkout&cta_placement=hero&plan_id=sprint_diagnostic" data-revenue-cta data-cta-id="hero_workflow_sprint_diagnostic_checkout" data-cta-placement="hero" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__" data-sprint-paid-path="diagnostic" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero',offer:'sprint_diagnostic',price:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__});try{posthog.capture('hero_diagnostic_checkout_click',{cta:'hero_diagnostic',price:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__})}catch(_){}" class="btn-pro-page hero-pro hero-pro-primary hero-diagnostic">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
+      <a href="/go/sprint?utm_source=website&utm_medium=hero_cta&utm_campaign=money_today&utm_content=hero_sprint&cta_id=hero_workflow_sprint_checkout&cta_placement=hero&plan_id=workflow_sprint" data-revenue-cta data-cta-id="hero_workflow_sprint_checkout" data-cta-placement="hero" data-tier="service" data-plan-id="workflow_sprint" data-price="__WORKFLOW_SPRINT_PRICE_DOLLARS__" data-sprint-paid-path="sprint" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero',offer:'workflow_sprint',price:__WORKFLOW_SPRINT_PRICE_DOLLARS__});try{posthog.capture('hero_sprint_checkout_click',{cta:'hero_sprint',price:__WORKFLOW_SPRINT_PRICE_DOLLARS__})}catch(_){}" class="btn-pro-page hero-pro">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
+      <a href="/checkout/pro?utm_source=website&utm_medium=hero_cta&utm_campaign=pro_upgrade&cta_id=hero_start_pro&cta_placement=hero&plan_id=pro&landing_path=%2F" data-revenue-cta data-cta-id="hero_start_pro" data-cta-placement="hero" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);try{posthog.capture('hero_pro_checkout_click',{cta:'hero_start_pro',tier:'pro',price:19})}catch(_){}" class="btn-pro-page hero-pro">Start Pro — $19/mo</a>
       <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-free btn-install-hero" title="Click to copy: npx thumbgate init">Install Free CLI</a>
     </div>
+    <p class="hero-paid-note" style="margin-top:4px;">Money path today: <strong>Workflow Hardening Diagnostic ($__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__)</strong> or <strong>Sprint ($__WORKFLOW_SPRINT_PRICE_DOLLARS__)</strong> for one repeated agent failure. Pro stays the solo self-serve lane. Prefer scoping first? <a href="#workflow-sprint-intake" style="color:var(--cyan);" onclick="try{posthog.capture('hero_sprint_click',{cta:'sprint_intake'})}catch(_){};sendFirstPartyTelemetry('hero_sprint_intake_started',{ctaId:'hero_workflow_sprint',ctaPlacement:'hero',offer:'workflow_sprint'});sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'hero_workflow_sprint_recovery_intake',ctaPlacement:'hero',offer:'workflow_sprint_intake'});">Send workflow first</a>.</p>
 
     <div class="offer-router" aria-label="Choose the right ThumbGate path">
       <div class="offer-route primary">
+        <strong>Team / enterprise: buy proof this week</strong>
+        <p>One workflow. One repeated failure. Paid diagnostic or sprint with Stripe — credit applies when you continue to implementation.</p>
+        <a href="/go/diagnostic?utm_source=website&utm_medium=offer_router&utm_campaign=money_today&cta_id=router_pay_diagnostic&cta_placement=offer_router&plan_id=sprint_diagnostic" data-revenue-cta data-cta-id="router_pay_diagnostic" data-cta-placement="offer_router" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_diagnostic_checkout_started',{ctaId:'router_pay_diagnostic',ctaPlacement:'offer_router',offer:'sprint_diagnostic'});">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic →</a>
+        <a href="/go/sprint?utm_source=website&utm_medium=offer_router&utm_campaign=money_today&cta_id=router_pay_sprint&cta_placement=offer_router&plan_id=workflow_sprint" data-revenue-cta data-cta-id="router_pay_sprint" data-cta-placement="offer_router" data-tier="service" data-plan-id="workflow_sprint" data-price="__WORKFLOW_SPRINT_PRICE_DOLLARS__" style="display:block;margin-top:8px;" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_checkout_started',{ctaId:'router_pay_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint →</a>
+      </div>
+      <div class="offer-route">
         <strong>Solo operator: Start Pro</strong>
-        <p>Unlimited rules, recall, proof, exports.</p>
+        <p>Unlimited rules, recall, proof, exports after one real caught repeat.</p>
         <a href="/checkout/pro?utm_source=website&utm_medium=offer_router&cta_id=router_start_pro&cta_placement=offer_router&plan_id=pro" data-revenue-cta data-cta-id="router_start_pro" data-cta-placement="offer_router" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);">Pay $19/mo with Stripe →</a>
       </div>
       <div class="offer-route">
-        <strong>Enterprise governance: Start with one workflow</strong>
-        <p>Finance, healthcare, insurance, public sector, critical infrastructure, manufacturing.</p>
-        <a href="#workflow-sprint-intake" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});">Talk to us →</a>
-      </div>
-      <div class="offer-route">
-        <strong>Still evaluating: Free CLI</strong>
-        <p>2 captures/day, 3 active rules. Enough to prove one caught repeat.</p>
+        <strong>Still evaluating: Free CLI or intake</strong>
+        <p>2 captures/day, 3 active rules. Or send the workflow if you need fit review before paying.</p>
         <button data-router-install onclick="copyInstall(this)"><span class="copy-hint">Copy npx thumbgate init</span></button>
+        <a href="#workflow-sprint-intake" style="display:block;margin-top:10px;color:var(--cyan);font-weight:700;text-decoration:none;" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'router_workflow_sprint_recovery_intake',ctaPlacement:'offer_router',offer:'workflow_sprint_intake'});">Send workflow first →</a>
       </div>
     </div>
 

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 __GOOGLE_SITE_VERIFICATION_META__
 <title>Pricing — ThumbGate</title>
-<meta name="description" content="ThumbGate pricing: free CLI forever, $19/mo Pro dashboard, and custom Enterprise enforcement scoped after intake. One clear subscription path.">
+<meta name="description" content="ThumbGate pricing: free CLI, $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic, $__WORKFLOW_SPRINT_PRICE_DOLLARS__ workflow sprint, $19/mo Pro, and Enterprise after scope. Paid services first.">
 <meta property="og:title" content="Pricing — ThumbGate">
-<meta property="og:description" content="Free CLI, Pro self-serve, and Enterprise after workflow scope. No mixed consulting checkout maze.">
+<meta property="og:description" content="Buy a $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic or $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint today. Free CLI forever. Pro $19/mo for solo operators.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="__APP_ORIGIN__/pricing">
 <meta property="og:image" content="/og.png">
@@ -89,6 +89,8 @@ __GA_BOOTSTRAP__
   "url": "__APP_ORIGIN__/pricing",
   "offers": [
     { "@type": "Offer", "name": "ThumbGate CLI (Free)", "price": "0", "priceCurrency": "USD" },
+    { "@type": "Offer", "name": "Workflow Hardening Diagnostic", "price": "__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__", "priceCurrency": "USD", "url": "__APP_ORIGIN__/go/diagnostic" },
+    { "@type": "Offer", "name": "Workflow Hardening Sprint", "price": "__WORKFLOW_SPRINT_PRICE_DOLLARS__", "priceCurrency": "USD", "url": "__APP_ORIGIN__/go/sprint" },
     { "@type": "Offer", "name": "ThumbGate Pro Monthly", "price": "__PRO_PRICE_DOLLARS__", "priceCurrency": "USD", "url": "__APP_ORIGIN__/checkout/pro?confirm=1&plan_id=pro&billing_cycle=monthly&landing_path=%2Fpricing" },
     { "@type": "Offer", "name": "ThumbGate Pro Annual", "price": "149", "priceCurrency": "USD", "url": "__APP_ORIGIN__/checkout/pro?confirm=1&plan_id=pro&billing_cycle=annual&landing_path=%2Fpricing" },
     { "@type": "Offer", "name": "ThumbGate Enterprise", "priceCurrency": "USD", "url": "__APP_ORIGIN__/#workflow-sprint-intake" }
@@ -165,8 +167,14 @@ __GA_BOOTSTRAP__
   .pricing-hero .lede { color: var(--text-muted); font-size: 17px; max-width: 560px; margin: 0 auto; }
 
   /* GRID */
-  .pricing-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin: 40px 0 32px; }
+  .pricing-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 20px; margin: 40px 0 32px; }
   @media (max-width: 768px) { .pricing-grid { grid-template-columns: 1fr; } }
+  .price-card.money { border-color: rgba(74,222,128,0.45); box-shadow: 0 0 0 1px rgba(74,222,128,0.15); }
+  .price-card.money .tier { color: var(--green, #4ade80); }
+  .btn-money {
+    display: block; width: 100%; text-align: center; padding: 12px 16px; border-radius: 8px;
+    background: var(--green, #4ade80); color: #06120a; font-weight: 800; text-decoration: none;
+  }
 
   /* CARDS */
   .price-card {
@@ -259,7 +267,7 @@ __GA_BOOTSTRAP__
       <a href="/pricing" style="color:var(--text);">Pricing</a>
       <a href="/guide">Guide</a>
       <a href="/dashboard">Dashboard</a>
-      <a class="nav-cta" href="/checkout/pro?confirm=1&utm_source=pricing&utm_medium=nav&utm_campaign=pricing_page&cta_id=pricing_nav_start_pro&cta_placement=nav&plan_id=pro&landing_path=%2Fpricing" data-pricing-cta data-cta-id="pricing_nav_start_pro" data-cta-placement="nav" data-tier="pro" data-plan-id="pro" data-billing-cycle="monthly" data-price="19">Start Pro</a>
+      <a class="nav-cta" href="/go/diagnostic?utm_source=pricing&utm_medium=nav&utm_campaign=money_today&cta_id=pricing_nav_diagnostic&cta_placement=nav&plan_id=sprint_diagnostic" data-pricing-cta data-cta-id="pricing_nav_diagnostic" data-cta-placement="nav" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
     </div>
   </div>
 </nav>
@@ -267,12 +275,40 @@ __GA_BOOTSTRAP__
 <section class="pricing-hero">
   <div class="container">
     <h1>Stop paying for the same AI mistake twice.</h1>
-    <p class="lede">One self-serve paid path for solo operators. Teams start with workflow scope so shared enforcement is mapped before checkout.</p>
+    <p class="lede">Paid services first: harden one AI-agent workflow with a <strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</strong> or <strong>$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</strong>. Free CLI forever. Pro is the solo self-serve lane. Enterprise is intake after proof.</p>
   </div>
 </section>
 
 <section class="container">
   <div class="pricing-grid">
+
+    <div class="price-card money highlight" id="diagnostic">
+      <div class="tier">Diagnostic</div>
+      <div class="price">$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</div>
+      <div class="price-sub"><strong>Fastest path to cash + proof.</strong> Map one repeated agent failure: block / warn / human-review split and a shippable proof checklist. Credited toward the sprint when you continue.</div>
+      <ul>
+        <li>One workflow, one owner, one failure pattern</li>
+        <li>Gate split + proof checklist deliverable</li>
+        <li>Stripe checkout — pay today</li>
+        <li>Credit toward $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint when implementation follows</li>
+      </ul>
+      <a class="btn-money" href="/go/diagnostic?utm_source=pricing&utm_medium=hero_card&utm_campaign=money_today&cta_id=pricing_diagnostic&cta_placement=pricing&plan_id=sprint_diagnostic" data-pricing-cta data-cta-id="pricing_diagnostic" data-cta-placement="pricing" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__" onclick="try{posthog.capture('pricing_cta_click',{cta:'pay_diagnostic',tier:'service',placement:'pricing_page',price:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'pay_diagnostic',tier:'service'}})}catch(_){}">Pay $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
+      <p class="btn-sub"><a href="/diagnostic" style="color:var(--cyan);text-decoration:none;font-weight:600;">Or open the diagnostic page →</a></p>
+    </div>
+
+    <div class="price-card money" id="sprint">
+      <div class="tier">Workflow Hardening Sprint</div>
+      <div class="price">$__WORKFLOW_SPRINT_PRICE_DOLLARS__</div>
+      <div class="price-sub"><strong>Primary commercial motion.</strong> Wire gates for one workflow, promote prevention rules, deliver verification evidence and a rollout checklist.</div>
+      <ul>
+        <li>Workflow map + approval boundaries</li>
+        <li>Memory / gate wiring plan</li>
+        <li>Proof pack for the next production-facing iteration</li>
+        <li>Expands into Enterprise when shared lessons matter</li>
+      </ul>
+      <a class="btn-money" href="/go/sprint?utm_source=pricing&utm_medium=hero_card&utm_campaign=money_today&cta_id=pricing_sprint&cta_placement=pricing&plan_id=workflow_sprint" data-pricing-cta data-cta-id="pricing_sprint" data-cta-placement="pricing" data-tier="service" data-plan-id="workflow_sprint" data-price="__WORKFLOW_SPRINT_PRICE_DOLLARS__" onclick="try{posthog.capture('pricing_cta_click',{cta:'pay_sprint',tier:'service',placement:'pricing_page',price:__WORKFLOW_SPRINT_PRICE_DOLLARS__})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'pay_sprint',tier:'service'}})}catch(_){}">Pay $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
+      <p class="btn-sub"><a href="/?utm_source=pricing&utm_medium=sprint_intake#workflow-sprint-intake" style="color:var(--cyan);text-decoration:none;font-weight:600;">Need fit review first? Send the workflow →</a></p>
+    </div>
 
     <div class="price-card">
       <div class="tier" style="color:var(--cyan);">Free</div>
@@ -288,11 +324,11 @@ __GA_BOOTSTRAP__
       <a class="btn-install" href="/go/install?utm_source=pricing&utm_medium=free_card&cta_id=pricing_install_free&cta_placement=free_card" data-pricing-cta data-cta-id="pricing_install_free" data-cta-placement="free_card" data-tier="free" data-plan-id="free" data-price="0" onclick="try{posthog.capture('pricing_cta_click',{cta:'install_free',tier:'free',placement:'pricing_page'})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'install_free',tier:'free'}})}catch(_){}">Install free</a>
     </div>
 
-    <div class="price-card highlight" id="pro">
+    <div class="price-card" id="pro">
       <div class="tier">Pro</div>
       <div class="price">$19<span>/mo</span></div>
       <div class="price-sub">
-        <strong>Don't buy a tool — buy proof + compatibility insurance.</strong> The free CLI runs your gates locally. Pro removes the solo caps and adds the personal dashboard, recall, exports, and active adapter maintenance to stay compatible with weekly breaking updates in Claude Code, Cursor, and Cline. Shared hosted lesson databases are Enterprise.
+        <strong>Solo self-serve side lane.</strong> After one real caught repeat: personal dashboard, recall, exports, managed adapters. Shared hosted lessons are Enterprise.
       </div>
       <ul>
         <li><strong>Personal lesson recall</strong> — search and reuse your own corrections across sessions</li>
@@ -309,8 +345,8 @@ __GA_BOOTSTRAP__
 
     <div class="price-card enterprise-card" id="enterprise">
       <div class="tier">Enterprise</div>
-      <div class="price">Custom<span> / scoped after intake</span></div>
-      <div class="price-sub">Shared enforcement for the whole team and regulated workflows. One engineer's save protects every agent.</div>
+      <div class="price">Custom<span> / after sprint proof</span></div>
+      <div class="price-sub">Shared enforcement for the whole team and regulated workflows. Start with a paid diagnostic or sprint — then expand.</div>
       <ul>
         <li>Everything in Pro, for every developer and agent</li>
         <li><strong>Shared lesson database</strong> — one engineer's fix protects every agent on the team</li>
@@ -321,15 +357,16 @@ __GA_BOOTSTRAP__
         <li>Custom policy layers, compliance audit export, approval boundaries, SSO, and dedicated onboarding with SLA</li>
         <li>Rollout starts only after workflow and proof review are explicit</li>
       </ul>
-      <a class="btn-team" href="/?utm_source=pricing&utm_medium=enterprise_card&utm_campaign=enterprise_intake&cta_id=pricing_enterprise_intake&cta_placement=pricing&plan_id=enterprise#workflow-sprint-intake" data-pricing-cta data-cta-id="pricing_enterprise_intake" data-cta-placement="pricing" data-tier="enterprise" data-plan-id="enterprise" data-price="0" onclick="try{posthog.capture('pricing_cta_click',{cta:'enterprise_intake',tier:'enterprise',placement:'pricing_page',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'enterprise_intake',tier:'enterprise'}})}catch(_){}">Talk to us</a>
-      <p class="btn-sub">Custom pricing, scoped through intake so the workflow is explicit before checkout.</p>
+      <a class="btn-team" href="/go/sprint?utm_source=pricing&utm_medium=enterprise_card&utm_campaign=money_today&cta_id=pricing_enterprise_sprint&cta_placement=pricing&plan_id=workflow_sprint" data-pricing-cta data-cta-id="pricing_enterprise_sprint" data-cta-placement="pricing" data-tier="service" data-plan-id="workflow_sprint" data-price="__WORKFLOW_SPRINT_PRICE_DOLLARS__" onclick="try{posthog.capture('pricing_cta_click',{cta:'enterprise_sprint',tier:'service',placement:'pricing_page',price:__WORKFLOW_SPRINT_PRICE_DOLLARS__})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'enterprise_sprint',tier:'service'}})}catch(_){}">Start with $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
+      <p class="btn-sub"><a href="/?utm_source=pricing&utm_medium=enterprise_intake&utm_campaign=enterprise_intake&cta_id=pricing_enterprise_intake&cta_placement=pricing&plan_id=enterprise#workflow-sprint-intake" data-pricing-cta data-cta-id="pricing_enterprise_intake" data-cta-placement="pricing" data-tier="enterprise" data-plan-id="enterprise" data-price="0" style="color:var(--cyan);text-decoration:none;font-weight:600;">Or send workflow intake →</a></p>
     </div>
 
   </div>
 
   <div style="text-align:center;margin:32px 0;color:var(--text-muted);font-size:14px;">
-    Need founder help? Do not buy a blind diagnostic from a pricing table.
-    <a href="/?utm_source=pricing&utm_medium=scope_first&utm_campaign=enterprise_intake&cta_id=pricing_scope_first&cta_placement=pricing_note&plan_id=enterprise#workflow-sprint-intake" data-pricing-cta data-cta-id="pricing_scope_first" data-cta-placement="pricing_note" data-tier="enterprise" data-plan-id="enterprise" data-price="0" style="color:var(--cyan);text-decoration:none;font-weight:600;" onclick="try{posthog.capture('pricing_cta_click',{cta:'scope_first',tier:'enterprise',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'scope_first',tier:'enterprise'}})}catch(_){}">Send the workflow first</a> — then we scope the smallest paid rollout that can prove one repeated failure is blocked.
+    Prefer a scoped conversation before Stripe?
+    <a href="/?utm_source=pricing&utm_medium=scope_first&utm_campaign=enterprise_intake&cta_id=pricing_scope_first&cta_placement=pricing_note&plan_id=enterprise#workflow-sprint-intake" data-pricing-cta data-cta-id="pricing_scope_first" data-cta-placement="pricing_note" data-tier="enterprise" data-plan-id="enterprise" data-price="0" style="color:var(--cyan);text-decoration:none;font-weight:600;" onclick="try{posthog.capture('pricing_cta_click',{cta:'scope_first',tier:'enterprise',price:0})}catch(_){};try{plausible('pricing_cta_click',{props:{cta:'scope_first',tier:'enterprise'}})}catch(_){}">Send the workflow first</a>
+    — or pay the diagnostic today if you already know the failure.
   </div>
 </section>
 

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5670,6 +5670,16 @@ async function addContext(){
       return;
     }
 
+    // /docs is a common buyer URL; route to the public setup guide instead of 404.
+    if (isGetLikeRequest && (pathname === '/docs' || pathname === '/docs/' || pathname === '/documentation' || pathname === '/documentation/')) {
+      res.writeHead(302, {
+        Location: '/guide',
+        'Cache-Control': 'public, max-age=300',
+      });
+      res.end();
+      return;
+    }
+
     if (isGetLikeRequest && (pathname === '/guide' || pathname === '/guide.html')) {
       try {
         servePublicMarketingPage({

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -933,30 +933,32 @@ test('terms of service route covers payment, refunds, acceptable use, and limita
 });
 
 test('pricing page is the single source of truth for what ThumbGate sells', async () => {
-  // Resolves the "pricing schizophrenia" flagged in the audit: sales/pricing.json
-  // said $49/$299, COMMERCIAL_TRUTH.md said $19/$149, and no buyer-facing
-  // surface existed to reconcile. This page MUST stay canonical.
+  // Canonical money path: paid diagnostic + sprint services first, Pro solo
+  // subscription side lane, Enterprise after proof. No retired seat/kit ladders.
   const res = await fetch(apiUrl('/pricing'));
   assert.equal(res.status, 200);
   assert.match(String(res.headers.get('content-type')), /text\/html/);
   const body = await res.text();
-  // Three coherent tiers present; consulting and kit checkout are intentionally
-  // kept out of the pricing table so cold buyers see one purchase decision.
-  assert.match(body, /ThumbGate CLI/i);
-  assert.match(body, /ThumbGate Pro/i);
+  assert.match(body, /ThumbGate CLI|Forever free for solo|Free/i);
+  assert.match(body, /ThumbGate Pro|<div class="tier">Pro/i);
   assert.match(body, /\$19/);
   assert.match(body, /\$149/);
   assert.match(body, /ThumbGate Enterprise|<div class="tier">Enterprise/i);
+  assert.match(body, /Workflow Hardening Sprint/i);
+  assert.match(body, /Diagnostic/i);
+  assert.match(body, /\$499/);
+  assert.match(body, /\$1500/);
   assert.doesNotMatch(body, /\$49\b[\s\S]{0,40}seat/i);
-  assert.doesNotMatch(body, /Workflow Hardening Sprint/i);
-  assert.doesNotMatch(body, /\$499|\$1,500|\$97/);
+  assert.doesNotMatch(body, /\$97\b/);
   assert.doesNotMatch(body, /buy\.stripe\.com/);
   assert.doesNotMatch(body, /mailto:igor\.ganapolsky@gmail\.com/);
   assert.doesNotMatch(body, /self-serve checkout on every subscription plan/i);
-  // CTAs route to the canonical paths.
+  // CTAs route to the canonical paths (services via /go/* routers, Pro checkout).
   assert.match(body, /href="\/go\/install/);
+  assert.match(body, /href="\/go\/diagnostic/);
+  assert.match(body, /href="\/go\/sprint/);
   assert.match(body, /href="\/checkout\/pro/);
-  assert.match(body, /pricing_enterprise_intake/);
+  assert.match(body, /pricing_enterprise_intake|pricing_enterprise_sprint/);
   assert.match(body, /#workflow-sprint-intake/);
   // Cross-links so it's a navigation hub, not a dead end.
   assert.match(body, /href="\/support"/);

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -25,10 +25,12 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await page.goto('/');
     await expect(page.locator('.hero-pro-primary')).toBeVisible();
     await expect(page.locator('.btn-install-hero')).toBeVisible();
-    await expect(page.locator('.hero-pro', { hasText: /Workflow Hardening Sprint/ })).toBeVisible();
+    await expect(page.locator('.hero-pro', { hasText: /Pay \$\d+ diagnostic/ })).toBeVisible();
+    await expect(page.locator('.hero-pro', { hasText: /Pay \$\d+ sprint/ })).toBeVisible();
+    await expect(page.locator('.hero-pro', { hasText: /Start Pro/ })).toBeVisible();
     await expect(page.locator('.offer-router')).toBeVisible();
     await expect(page.locator('.offer-route', { hasText: /Solo operator/ })).toBeVisible();
-    await expect(page.locator('.offer-route', { hasText: /Enterprise/ })).toBeVisible();
+    await expect(page.locator('.offer-route', { hasText: /Team \/ enterprise|buy proof/i })).toBeVisible();
     await expect(page.locator('.offer-route', { hasText: /Still evaluating/ })).toBeVisible();
   });
 
@@ -50,16 +52,22 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await expect(btn).toHaveText(/Copied/);
   });
 
-  test('clicking "Talk to me — Workflow Hardening Sprint" anchors to #workflow-sprint-intake', async ({ page }) => {
+  test('clicking hero "Send workflow first" anchors to #workflow-sprint-intake', async ({ page }) => {
     await page.goto('/');
-    await page.locator('a.hero-pro', { hasText: /Workflow Hardening Sprint/ }).click();
+    await page.locator('.hero-paid-note a', { hasText: /Send workflow first/ }).click();
     await expect(page).toHaveURL(/#workflow-sprint-intake$/);
+  });
+
+  test('router primary CTA navigates to diagnostic Stripe checkout', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('.offer-route.primary a', { hasText: /Pay \$\d+ diagnostic/ }).click();
+    // /go/diagnostic routes through telemetry then Stripe Payment Link
+    await expect(page).toHaveURL(/buy\.stripe\.com\//);
   });
 
   test('router Pro CTA navigates to hosted Pro checkout', async ({ page }) => {
     await page.goto('/');
-    await page.locator('.offer-route.primary a', { hasText: /Pay \$19\/mo with Stripe/ }).click();
-    // Bypass is ON by default — Pro CTA now redirects directly to Stripe Payment Link
+    await page.locator('.offer-route', { hasText: /Solo operator/ }).locator('a', { hasText: /Pay \$19\/mo with Stripe/ }).click();
     await expect(page).toHaveURL(/buy\.stripe\.com\//);
     await expect(page).toHaveURL(/cta_id=router_start_pro/);
   });
@@ -98,13 +106,13 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await page.waitForURL(/\/learn$/);
   });
 
-  test('nav "Start Pro" CTA navigates to /checkout/pro', async ({ page }) => {
+  test('nav diagnostic CTA routes toward paid diagnostic checkout', async ({ page }) => {
     await page.goto('/');
-    await page.route('**/checkout/pro**', (route) =>
-      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>checkout</body></html>' }),
+    await page.route('**/buy.stripe.com/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>stripe</body></html>' }),
     );
-    await page.locator('nav a.nav-cta', { hasText: 'Start Pro' }).first().click();
-    await page.waitForURL(/\/checkout\/pro/);
+    await page.locator('nav a.nav-cta', { hasText: /diagnostic/i }).first().click();
+    await expect(page).toHaveURL(/buy\.stripe\.com\//);
   });
 
   // --- FAQ accordion (deterministic, no backend) ---

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -12,13 +12,15 @@ test.describe('/pricing clickability — full CTA coverage', () => {
     await mockDashboardApis(page);
   });
 
-  test('renders three plan cards with hardcoded prices', async ({ page }) => {
+  test('renders money-first plan cards with diagnostic, sprint, free, pro, enterprise', async ({ page }) => {
     await page.goto('/pricing');
     const cards = page.locator('.price-card');
-    await expect(cards).toHaveCount(3);
-    await expect(page.locator('.price-card').nth(0).locator('.price')).toHaveText('$0');
+    await expect(cards).toHaveCount(5);
+    await expect(page.locator('#diagnostic .price')).toContainText('$499');
+    await expect(page.locator('#sprint .price')).toContainText('$1500');
     await expect(page.locator('#pro .price')).toContainText('$19');
     await expect(page.locator('#enterprise .price')).toContainText('Custom');
+    await expect(page.locator('.price-card', { hasText: /Forever free for solo/ }).locator('.price')).toHaveText('$0');
   });
 
   // --- nav (5 anchors) ---
@@ -47,18 +49,34 @@ test.describe('/pricing clickability — full CTA coverage', () => {
     await page.waitForURL(/\/dashboard$/);
   });
 
-  test('nav: "Start Pro" CTA links to /checkout/pro with pricing utm_source', async ({ page }) => {
+  test('nav: diagnostic CTA links to /go/diagnostic with pricing utm_source', async ({ page }) => {
     await page.goto('/pricing');
-    const cta = page.locator('nav a.nav-cta', { hasText: 'Start Pro' });
-    await expect(cta).toHaveAttribute('href', /\/checkout\/pro/);
+    const cta = page.locator('nav a.nav-cta', { hasText: /diagnostic/i });
+    await expect(cta).toHaveAttribute('href', /\/go\/diagnostic/);
     await expect(cta).toHaveAttribute('href', /utm_source=pricing/);
   });
 
-  // --- 3 plan CTAs ---
+  // --- plan CTAs ---
+
+  test('Diagnostic card CTA links to /go/diagnostic', async ({ page }) => {
+    await page.goto('/pricing');
+    const cta = page.locator('#diagnostic a.btn-money');
+    await expect(cta).toContainText(/diagnostic/i);
+    await expect(cta).toHaveAttribute('href', /\/go\/diagnostic/);
+    await expect(cta).toHaveAttribute('href', /utm_source=pricing/);
+  });
+
+  test('Sprint card CTA links to /go/sprint', async ({ page }) => {
+    await page.goto('/pricing');
+    const cta = page.locator('#sprint a.btn-money');
+    await expect(cta).toContainText(/sprint/i);
+    await expect(cta).toHaveAttribute('href', /\/go\/sprint/);
+    await expect(cta).toHaveAttribute('href', /utm_source=pricing/);
+  });
 
   test('Free card "Install free" CTA links to /go/install with pricing utm_source', async ({ page }) => {
     await page.goto('/pricing');
-    const cta = page.locator('.price-card').nth(0).locator('a.btn-install');
+    const cta = page.locator('.price-card', { hasText: /Forever free for solo/ }).locator('a.btn-install');
     await expect(cta).toHaveAttribute('href', /\/go\/install/);
     await expect(cta).toHaveAttribute('href', /utm_source=pricing/);
   });
@@ -72,11 +90,11 @@ test.describe('/pricing clickability — full CTA coverage', () => {
     await expect(cta).toHaveAttribute('href', /utm_medium=hero_card/);
   });
 
-  test('Enterprise card CTA "Talk to us" links to / with #workflow-sprint-intake', async ({ page }) => {
+  test('Enterprise card CTA starts with paid sprint checkout', async ({ page }) => {
     await page.goto('/pricing');
     const cta = page.locator('#enterprise a.btn-team');
-    await expect(cta).toContainText('Talk to us');
-    await expect(cta).toHaveAttribute('href', /#workflow-sprint-intake$/);
+    await expect(cta).toContainText(/sprint/i);
+    await expect(cta).toHaveAttribute('href', /\/go\/sprint/);
     await expect(cta).toHaveAttribute('href', /utm_medium=enterprise_card/);
   });
 

--- a/tests/pricing-page-telemetry.test.js
+++ b/tests/pricing-page-telemetry.test.js
@@ -12,11 +12,19 @@ test('pricing page emits first-party telemetry for views and CTA clicks', () => 
   assert.match(pricingHtml, /pricing_page_view/);
   assert.match(pricingHtml, /pricing_cta_click/);
   assert.match(pricingHtml, /data-pricing-cta/);
+  assert.match(pricingHtml, /data-cta-id="pricing_diagnostic"/);
+  assert.match(pricingHtml, /data-cta-id="pricing_sprint"/);
   assert.match(pricingHtml, /data-cta-id="pricing_pro"/);
 });
 
-test('pricing Pro CTAs use confirmed checkout so Stripe collects email without the extra gate', () => {
-  assert.match(pricingHtml, /href="\/checkout\/pro\?confirm=1[^"]*cta_id=pricing_nav_start_pro/);
+test('pricing leads with paid diagnostic/sprint and keeps confirmed Pro checkout', () => {
+  assert.match(pricingHtml, /href="\/go\/diagnostic\?[^"]*cta_id=pricing_nav_diagnostic/);
+  assert.match(pricingHtml, /href="\/go\/diagnostic\?[^"]*cta_id=pricing_diagnostic/);
+  assert.match(pricingHtml, /href="\/go\/sprint\?[^"]*cta_id=pricing_sprint/);
+  assert.match(pricingHtml, /Pay \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
+  assert.match(pricingHtml, /Pay \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
   assert.match(pricingHtml, /href="\/checkout\/pro\?confirm=1[^"]*cta_id=pricing_pro/);
   assert.match(pricingHtml, /"url": "__APP_ORIGIN__\/checkout\/pro\?confirm=1&plan_id=pro&billing_cycle=monthly/);
+  assert.match(pricingHtml, /"name": "Workflow Hardening Diagnostic"/);
+  assert.match(pricingHtml, /"name": "Workflow Hardening Sprint"/);
 });

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -132,7 +132,7 @@ test('public landing page distinguishes pre-action governance from logging and s
   assert.match(landingPage, /hosted team sync, org dashboards, SSO, SIEM, and compliance packaging are not general-availability/i);
 });
 
-test('public landing page exposes above-fold paid Pro CTA with canonical revenue analytics', () => {
+test('public landing page exposes above-fold paid diagnostic/sprint CTAs with Pro as side lane', () => {
   const landingPage = readLandingPage();
   const heroStart = landingPage.indexOf('<!-- HERO -->');
   const heroEnd = landingPage.indexOf('<div class="hero-trust-bar">');
@@ -141,17 +141,24 @@ test('public landing page exposes above-fold paid Pro CTA with canonical revenue
 
   assert.ok(heroStart > -1);
   assert.ok(heroEnd > heroStart);
-  assert.match(aboveFold, /cta_id=nav_start_pro/);
-  assert.match(aboveFold, /data-revenue-cta data-cta-id="nav_start_pro"/);
+  assert.match(aboveFold, /cta_id=nav_pay_diagnostic/);
+  assert.match(aboveFold, /data-revenue-cta data-cta-id="nav_pay_diagnostic"/);
+  assert.match(heroBlock, /cta_id=hero_workflow_sprint_diagnostic_checkout/);
+  assert.match(heroBlock, /data-revenue-cta data-cta-id="hero_workflow_sprint_diagnostic_checkout"/);
+  assert.match(heroBlock, /Pay \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
+  assert.match(heroBlock, /cta_id=hero_workflow_sprint_checkout/);
+  assert.match(heroBlock, /Pay \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
   assert.match(heroBlock, /cta_id=hero_start_pro/);
-  assert.match(heroBlock, /data-revenue-cta data-cta-id="hero_start_pro"/);
   assert.match(heroBlock, /Start Pro — \$19\/mo/);
   assert.match(heroBlock, /\/checkout\/pro\?/);
+  assert.ok(heroBlock.indexOf('hero_workflow_sprint_diagnostic_checkout') < heroBlock.indexOf('hero_start_pro'));
   assert.ok(heroBlock.indexOf('hero_start_pro') < heroBlock.indexOf('hero_install_cli'));
   assert.match(heroBlock, /aria-label="Choose the right ThumbGate path"/);
+  assert.match(heroBlock, /Team \/ enterprise: buy proof this week/);
+  assert.match(heroBlock, /data-cta-id="router_pay_diagnostic"/);
+  assert.match(heroBlock, /data-cta-id="router_pay_sprint"/);
   assert.match(heroBlock, /Solo operator: Start Pro/);
   assert.match(heroBlock, /data-cta-id="router_start_pro"/);
-  assert.match(heroBlock, /Enterprise governance: Start with one workflow/);
   assert.match(heroBlock, /Ideal customer/);
   assert.match(heroBlock, /enterprise engineering, security, and platform teams/i);
   assert.match(heroBlock, /Detection and coordination layers can identify drift/);
@@ -240,61 +247,41 @@ test('public landing page shows an at-a-glance plan comparison matrix with consi
   assert.match(landingPage, /SSO, SIEM \+ compliance packaging[\s\S]{0,500}Not GA/i);
 });
 
-test('public landing page keeps services intake-led instead of exposing a paid-service price ladder', () => {
+test('public landing page leads with paid diagnostic/sprint checkout, not retired service ladders', () => {
   const landingPage = readLandingPage();
 
   assert.match(landingPage, /Have one AI-agent failure that keeps repeating\?/);
   assert.match(landingPage, /one real workflow, one repeated failure pattern, enforceable pre-action gates/);
-  assert.doesNotMatch(landingPage, /const sprintDiagnosticCheckoutUrl/);
-  assert.doesNotMatch(landingPage, /const workflowSprintCheckoutUrl/);
-  assert.doesNotMatch(landingPage, /__SPRINT_DIAGNOSTIC_CHECKOUT_URL__/);
-  assert.doesNotMatch(landingPage, /__WORKFLOW_SPRINT_CHECKOUT_URL__/);
-  assert.doesNotMatch(landingPage, /data-sprint-paid-path/);
-  assert.doesNotMatch(landingPage, /Workflow Hardening Diagnostic/);
-  assert.doesNotMatch(landingPage, /founder_workflow_diagnostic_checkout_started/);
+  // Canonical money path: template-substituted diagnostic + sprint prices via /go/* routers.
+  assert.match(landingPage, /Pay \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
+  assert.match(landingPage, /Pay \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
+  assert.match(landingPage, /\/go\/diagnostic\?/);
+  assert.match(landingPage, /\/go\/sprint\?/);
+  assert.match(landingPage, /data-sprint-paid-path="diagnostic"/);
+  assert.match(landingPage, /data-sprint-paid-path="sprint"/);
+  assert.match(landingPage, /hero_workflow_sprint_diagnostic_checkout/);
+  assert.match(landingPage, /hero_workflow_sprint_checkout/);
+  assert.match(landingPage, /workflow_sprint_diagnostic_checkout_started/);
+  assert.match(landingPage, /workflow_sprint_checkout_started/);
+  assert.match(landingPage, /Send workflow first/);
+  assert.match(landingPage, /hero_workflow_sprint_recovery_intake/);
+  assert.match(landingPage, /workflow_sprint_recovery_intake_clicked/);
+  assert.match(landingPage, /ctaId: 'hero_workflow_sprint'/);
+  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_recovery_intake'/);
+  // Retired experimental ladders must stay off the homepage.
   assert.doesNotMatch(landingPage, /Pay \$99 diagnostic/);
-  assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/7sY4gzgH24r49G17mb3sI0g/);
-  assert.doesNotMatch(landingPage, /First AI Agent Failure Rule/);
-  assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/4gM6oHgH2bTw4lH6i73sI0z/);
   assert.doesNotMatch(landingPage, /Pay \$1 first rule/);
   assert.doesNotMatch(landingPage, /first_failure_rule_checkout_started/);
-  assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/7sYfZhgH29LodWhdKz3sI0v/);
   assert.doesNotMatch(landingPage, /Pay \$99 teardown/);
-  assert.doesNotMatch(landingPage, /AI Agent Failure Quick Read/);
   assert.doesNotMatch(landingPage, /Pay \$19 quick read/);
-  assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/aFa8wPgH29Lo4lH35V3sI0w/);
   assert.doesNotMatch(landingPage, /quick_read_checkout_started/);
-  // Hero keeps a paid Pro side lane plus Workflow Hardening Sprint intake.
-  // Services are no longer exposed as competing direct checkout paths on the
-  // homepage.
-  assert.doesNotMatch(landingPage, /Pay \$499 diagnostic/);
-  assert.match(landingPage, /Start the AI Agent Governance Sprint/);
-  assert.doesNotMatch(landingPage, /Pay \$1500 sprint/);
-  assert.doesNotMatch(landingPage, /Reliable AI Agent Governance Setup/);
   assert.doesNotMatch(landingPage, /\$3,997/);
   assert.doesNotMatch(landingPage, /\$297\/mo/);
-  assert.doesNotMatch(landingPage, /governance_setup_intake_clicked/);
   assert.doesNotMatch(landingPage, /OpenClaw Agent Governance Kit/);
-  assert.doesNotMatch(landingPage, /https:\/\/buy\.stripe\.com\/bJe14naiE9Lo7xT49Z3sI12/);
   assert.doesNotMatch(landingPage, /openclaw_governance_kit_checkout_started/);
-  assert.doesNotMatch(landingPage, /team_openclaw_governance_kit_checkout/);
   assert.doesNotMatch(landingPage, /Buy kit/);
-  assert.match(landingPage, /Send workflow first/);
-  assert.doesNotMatch(landingPage, /Pay for diagnostic/);
-  assert.doesNotMatch(landingPage, /Pay for sprint/);
-  assert.doesNotMatch(landingPage, /workflow_teardown_checkout_started/);
-  assert.doesNotMatch(landingPage, /hero_workflow_sprint_diagnostic_checkout/);
-  assert.doesNotMatch(landingPage, /hero_workflow_sprint_checkout/);
-  assert.match(landingPage, /hero_workflow_sprint_recovery_intake/);
-  assert.doesNotMatch(landingPage, /workflow_sprint_diagnostic_checkout_started/);
-  assert.doesNotMatch(landingPage, /workflow_sprint_checkout_started/);
-  assert.match(landingPage, /workflow_sprint_recovery_intake_clicked/);
-  assert.match(landingPage, /workflow_sprint_recovery_intake/);
   assert.doesNotMatch(landingPage, /ctaId:'hero_first_failure_rule_checkout'/);
   assert.doesNotMatch(landingPage, /ctaId:'hero_workflow_teardown_checkout'/);
-  assert.match(landingPage, /ctaId: 'hero_workflow_sprint'/);
-  assert.doesNotMatch(landingPage, /ctaId: 'hero_workflow_sprint_checkout'/);
-  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_recovery_intake'/);
 });
 
 test('public landing page includes Plausible analytics and search engine proof bar', () => {

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -453,7 +453,9 @@ test('commercial truth sources stay aligned across public and historical docs', 
   assert.doesNotMatch(anthropicStrategy, /^We are an official Anthropic partner\b/m);
 
   assert.match(workflowSprint, /Status: current/i);
-  assert.match(workflowSprint, /pilot-by-request/i);
+  assert.match(workflowSprint, /Public paid checkout/i);
+  assert.match(workflowSprint, /\$499|Diagnostic: \$499/);
+  assert.match(workflowSprint, /\$1,500|Sprint: \$1,500/);
   assert.match(workflowSprint, /one workflow/i);
   assert.match(workflowSprint, /VERIFICATION_EVIDENCE\.md/);
   assert.doesNotMatch(workflowSprint, /^We are an official Anthropic partner\b/m);

--- a/tests/workflow-hardening-sprint.test.js
+++ b/tests/workflow-hardening-sprint.test.js
@@ -12,7 +12,9 @@ test('workflow hardening sprint brief stays current, proof-backed, and commercia
   assert.match(brief, /one workflow/i);
   assert.match(brief, /one owner/i);
   assert.match(brief, /one proof review/i);
-  assert.match(brief, /pilot-by-request/i);
+  assert.match(brief, /Public paid checkout/i);
+  assert.match(brief, /\$499|Diagnostic: \$499/);
+  assert.match(brief, /\$1,500|Sprint: \$1,500/);
   assert.match(brief, /first-dollar path/i);
   assert.match(brief, /igor\.ganapolsky@gmail\.com/i);
   assert.match(brief, /workflow-sprint-intake/i);


### PR DESCRIPTION
## Summary
- Homepage and pricing now **lead with paid services**: $499 Workflow Hardening Diagnostic (`/go/diagnostic`) and $1,500 Sprint (`/go/sprint`), with Pro $19 as the solo side lane.
- `/docs` redirects to `/guide` instead of 404.
- Commercial truth + sprint docs document the live Stripe prices.
- Landing/pricing tests updated to lock the money-first CTA hierarchy.

## Why
Live funnel showed checkout starts without paid conversion while the real first-dollar offer was unpriced intake. Product positioning was correct; commercial packaging was not.

## Test plan
- [x] `node --test tests/public-landing.test.js`
- [x] `node --test tests/pricing-page-telemetry.test.js tests/stripe-checkout-diagnostic.test.js`
- [ ] CI green on PR
- [ ] After merge: production homepage hero shows Pay $499 diagnostic before Start Pro
- [ ] `/docs` → 302/redirect to `/guide`
- [ ] Stripe links for diagnostic and sprint still open checkout