### PR TITLE
feat(sales): add Apollo buyer acquisition lane

### DIFF
--- a/.changeset/apollo-buyer-acquisition.md
+++ b/.changeset/apollo-buyer-acquisition.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add a repository-only Apollo buyer-acquisition workflow that ranks enterprise AI-governance owners, suppresses duplicate outreach, and proves credit-safe search runs without adding sales tooling to the public npm package.

--- a/package.json
+++ b/package.json
@@ -516,7 +516,7 @@
     "test:training-export": "node --test tests/training-export.test.js tests/databricks-export.test.js",
     "test:deployment": "node --test tests/deployment.test.js tests/deploy-policy.test.js tests/publish-decision.test.js tests/changeset-check.test.js tests/release-notes.test.js tests/sonarcloud-workflow.test.js tests/package-boundary.test.js tests/public-package-boundary.test.js",
     "test:operational-integrity": "node --test tests/operational-integrity.test.js tests/sync-branch-protection.test.js",
-    "test:workflow": "node --test tests/parallel-workflow.test.js tests/workflow-contract.test.js tests/positioning-contract.test.js tests/docs-claim-hygiene.test.js tests/thumbgate-scope.test.js tests/workflow-runs.test.js tests/workflow-sprint-intake.test.js tests/revenue-pack-utils.test.js tests/sales-pipeline.test.js tests/github-outreach.test.js tests/enterprise-story.test.js tests/guide-conversion-path.test.js tests/buyer-intent-revenue-assist.test.js",
+    "test:workflow": "node --test tests/parallel-workflow.test.js tests/workflow-contract.test.js tests/positioning-contract.test.js tests/docs-claim-hygiene.test.js tests/thumbgate-scope.test.js tests/workflow-runs.test.js tests/workflow-sprint-intake.test.js tests/revenue-pack-utils.test.js tests/apollo-acquisition.test.js tests/sales-pipeline.test.js tests/github-outreach.test.js tests/enterprise-story.test.js tests/guide-conversion-path.test.js tests/buyer-intent-revenue-assist.test.js",
     "test:sales-pipeline": "node --test tests/sales-pipeline.test.js",
     "test:billing": "node --test tests/billing.test.js tests/stripe-sync-product-images.test.js tests/checkout-attribution-reference.test.js",
     "test:billing-setup": "node --test tests/billing-setup-redaction.test.js",

--- a/sales/apollo-buyer-search.json
+++ b/sales/apollo-buyer-search.json
@@ -1,0 +1,47 @@
+{
+  "buyerHypothesis": "Enterprise teams expanding autonomous AI-agent use need an accountable owner for pre-action enforcement, decision continuity, and audit-ready proof before agents touch production systems.",
+  "titles": [
+    "Chief AI Officer",
+    "Head of AI",
+    "VP Artificial Intelligence",
+    "AI Transformation",
+    "AI Platform",
+    "AI Governance",
+    "Enterprise Architecture",
+    "Developer Experience",
+    "Developer Productivity",
+    "Intelligent Automation"
+  ],
+  "seniority": [
+    "director",
+    "vp",
+    "c_suite"
+  ],
+  "organizations": [
+    {
+      "name": "Gametime",
+      "domain": "gametime.co",
+      "reason": "A public engineering case study identified operational confidence as a constraint while AI-generated code and background agents scale."
+    },
+    {
+      "name": "Walmart",
+      "domain": "walmart.com",
+      "reason": "Large-scale enterprise AI and automation create a buyer need for action boundaries, owner-level proof, and cross-agent governance."
+    },
+    {
+      "name": "BlackRock",
+      "domain": "blackrock.com",
+      "reason": "Regulated financial workflows make traceable decisions and pre-action controls commercially relevant."
+    },
+    {
+      "name": "Northrop Grumman",
+      "domain": "northropgrumman.com",
+      "reason": "High-assurance and hybrid environments make local-first agent governance and evidence boundaries commercially relevant."
+    },
+    {
+      "name": "Deloitte",
+      "domain": "deloitte.com",
+      "reason": "AI transformation delivery teams can use a vendor-neutral governance layer across client agent stacks."
+    }
+  ]
+}

--- a/scripts/apollo-acquisition.js
+++ b/scripts/apollo-acquisition.js
@@ -103,7 +103,7 @@ function knownTargetIdentityMatches(targetName, candidate = {}) {
   const nameParts = normalize(targetName).split(/\s+/).filter(Boolean);
   if (nameParts.length < 2) return false;
   const expectedFirstName = nameParts[0];
-  const expectedSurname = nameParts[nameParts.length - 1];
+  const expectedSurname = nameParts.at(-1);
   return normalize(candidate.firstName) === expectedFirstName
     && obfuscatedSurnameMatches(expectedSurname, candidate.lastNameObfuscated);
 }
@@ -370,7 +370,7 @@ function runCli(argv = process.argv.slice(2), dependencies = {}) {
   return { mode: 'executed', report, files: writeReport(report, options.output) };
 }
 
-if (require.main === module) {
+if (!module.parent) {
   try {
     const result = runCli();
     if (result.help) process.stdout.write(result.help);

--- a/scripts/apollo-acquisition.js
+++ b/scripts/apollo-acquisition.js
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const DEFAULT_CONFIG = path.join(__dirname, '..', 'sales', 'apollo-buyer-search.json');
+const DEFAULT_INPUT = path.join(
+  process.env.HOME || '',
+  'Downloads',
+  'ThumbGate_Client_Acquisition_July_2026.csv'
+);
+
+function parseCsvLine(line) {
+  const cells = [];
+  let value = '';
+  let quoted = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"') {
+      if (quoted && line[index + 1] === '"') {
+        value += '"';
+        index += 1;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (char === ',' && !quoted) {
+      cells.push(value);
+      value = '';
+    } else {
+      value += char;
+    }
+  }
+  cells.push(value);
+  return cells;
+}
+
+function parseCsv(text) {
+  const lines = String(text || '')
+    .replace(/^\uFEFF/, '')
+    .split(/\r?\n/)
+    .filter((line) => line.trim());
+  if (!lines.length) return [];
+
+  const headers = parseCsvLine(lines[0]).map((header) => header.trim());
+  return lines.slice(1).map((line) => {
+    const values = parseCsvLine(line);
+    return Object.fromEntries(headers.map((header, index) => [header, values[index] || '']));
+  });
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    config: DEFAULT_CONFIG,
+    input: DEFAULT_INPUT,
+    output: null,
+    execute: false,
+    maxTargets: null,
+    perPage: 25,
+    includeTracker: true,
+    includeOrganizations: true,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--execute') options.execute = true;
+    else if (arg === '--skip-tracker') options.includeTracker = false;
+    else if (arg === '--skip-organizations') options.includeOrganizations = false;
+    else if (arg === '--input') options.input = argv[++index];
+    else if (arg === '--config') options.config = argv[++index];
+    else if (arg === '--output') options.output = argv[++index];
+    else if (arg === '--max-targets') options.maxTargets = Number.parseInt(argv[++index], 10);
+    else if (arg === '--per-page') options.perPage = Number.parseInt(argv[++index], 10);
+    else if (arg === '--help' || arg === '-h') options.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!Number.isInteger(options.perPage) || options.perPage < 1 || options.perPage > 100) {
+    throw new Error('--per-page must be an integer from 1 to 100');
+  }
+  if (options.maxTargets !== null && (!Number.isInteger(options.maxTargets) || options.maxTargets < 1)) {
+    throw new Error('--max-targets must be a positive integer');
+  }
+  return options;
+}
+
+function normalize(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function obfuscatedSurnameMatches(expectedSurname, candidateSurname) {
+  const expected = normalize(expectedSurname).replace(/[^a-z0-9]/g, '');
+  const candidate = normalize(candidateSurname).replace(/[^a-z0-9*]/g, '');
+  if (!expected || !candidate) return false;
+  if (!candidate.includes('*')) return candidate === expected;
+  const [prefix = '', suffix = ''] = candidate.split(/\*+/);
+  return expected.startsWith(prefix) && expected.endsWith(suffix);
+}
+
+function knownTargetIdentityMatches(targetName, candidate = {}) {
+  const nameParts = normalize(targetName).split(/\s+/).filter(Boolean);
+  if (nameParts.length < 2) return false;
+  const expectedFirstName = nameParts[0];
+  const expectedSurname = nameParts[nameParts.length - 1];
+  return normalize(candidate.firstName) === expectedFirstName
+    && obfuscatedSurnameMatches(expectedSurname, candidate.lastNameObfuscated);
+}
+
+function suppressDuplicateOutreach(status) {
+  return /contacted|routed|pending|invitation|sent|replied|booked|paid/i.test(String(status || ''));
+}
+
+function buildSearchPlan({ rows = [], config = {}, options = {} } = {}) {
+  const organizations = Array.isArray(config.organizations) ? config.organizations : [];
+  const organizationByName = new Map(organizations.map((entry) => [normalize(entry.name), entry]));
+  const limitedRows = options.maxTargets ? rows.slice(0, options.maxTargets) : rows;
+  const trackerSearches = options.includeTracker === false ? [] : limitedRows.map((row) => {
+    const organization = organizationByName.get(normalize(row.organization));
+    return {
+      kind: 'known_target',
+      campaignId: row.campaign_id || null,
+      targetName: row.target_name,
+      organization: row.organization || null,
+      domain: organization?.domain || null,
+      existingStatus: row.status || null,
+      suppressDuplicateOutreach: suppressDuplicateOutreach(row.status),
+      buyerSignal: row.buyer_signal || null,
+      notes: row.notes || null,
+    };
+  }).filter((entry) => entry.targetName);
+
+  const organizationSearches = options.includeOrganizations === false ? [] : organizations.map((organization) => ({
+    kind: 'organization_buyer_scan',
+    organization: organization.name,
+    domain: organization.domain,
+    reason: organization.reason,
+    titles: config.titles || [],
+    seniority: config.seniority || [],
+  }));
+
+  return {
+    buyerHypothesis: config.buyerHypothesis || null,
+    trackerSearches,
+    organizationSearches,
+  };
+}
+
+function runApollo(args, { runner = spawnSync } = {}) {
+  const result = runner('apollo', args, {
+    encoding: 'utf8',
+    timeout: 45000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`apollo ${args.join(' ')} failed: ${String(result.stderr || '').trim()}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`Apollo returned invalid JSON: ${error.message}`);
+  }
+}
+
+function readCreditSnapshot(dependencies = {}) {
+  return runApollo(['usage', 'credits', '--format', 'json'], dependencies);
+}
+
+function creditConsumption(snapshot = {}) {
+  const stats = snapshot.credit_usage_stats || {};
+  return Object.fromEntries(Object.entries(stats).map(([key, value]) => [key, Number(value?.consumed || 0)]));
+}
+
+function creditDelta(before = {}, after = {}) {
+  const beforeUsage = creditConsumption(before);
+  const afterUsage = creditConsumption(after);
+  const keys = new Set([...Object.keys(beforeUsage), ...Object.keys(afterUsage)]);
+  return Object.fromEntries([...keys].map((key) => [key, (afterUsage[key] || 0) - (beforeUsage[key] || 0)]));
+}
+
+function peopleFromResponse(response = {}) {
+  return Array.isArray(response.people) ? response.people : [];
+}
+
+function searchKnownTarget(spec, dependencies = {}) {
+  const baseArgs = ['people', 'search', '--query', spec.targetName, '--per-page', '10', '--format', 'json'];
+  if (spec.domain) {
+    const domainResponse = runApollo([
+      'people', 'search', '--query', spec.targetName,
+      '--domain', spec.domain, '--per-page', '10', '--format', 'json',
+    ], dependencies);
+    if (peopleFromResponse(domainResponse).length) {
+      return { response: domainResponse, strategy: 'name_and_domain' };
+    }
+  }
+  return { response: runApollo(baseArgs, dependencies), strategy: 'name_only' };
+}
+
+function searchOrganizationBuyers(spec, perPage, dependencies = {}) {
+  const args = [
+    'people', 'search',
+    '--domain', spec.domain,
+    '--title', ...spec.titles,
+    '--include-similar-titles',
+    '--seniority', ...spec.seniority,
+    '--per-page', String(perPage),
+    '--format', 'json',
+  ];
+  return runApollo(args, dependencies);
+}
+
+function sanitizeCandidate(person = {}) {
+  return {
+    apolloId: person.id || null,
+    firstName: person.first_name || null,
+    lastNameObfuscated: person.last_name_obfuscated || null,
+    title: person.title || null,
+    organization: person.organization?.name || null,
+    hasEmail: Boolean(person.has_email),
+    hasDirectPhone: person.has_direct_phone === 'Yes',
+    lastRefreshedAt: person.last_refreshed_at || null,
+  };
+}
+
+function scoreOrganizationCandidate(candidate = {}) {
+  const title = normalize(candidate.title);
+  let score = 0;
+  const reasons = [];
+  const add = (points, reason) => {
+    score += points;
+    reasons.push(reason);
+  };
+
+  if (/chief ai officer/.test(title)) add(35, 'chief_ai_owner');
+  else if (/\b(evp|svp|vice president|vp)\b/.test(title)) add(30, 'executive_owner');
+  else if (/\b(managing director|group director|executive director|director)\b/.test(title)) add(22, 'director_owner');
+  if (/ai governance|responsible ai|product compliance/.test(title)) add(30, 'governance_pain_owner');
+  if (/ai platform|agentic|ai integration/.test(title)) add(25, 'agent_platform_owner');
+  if (/ai transformation|intelligent automation/.test(title)) add(20, 'transformation_owner');
+  if (/enterprise architecture|developer experience|developer productivity/.test(title)) add(15, 'architecture_or_developer_owner');
+  if (candidate.hasEmail) add(5, 'business_email_available');
+
+  return { priorityScore: score, priorityReasons: reasons };
+}
+
+function executeSearchPlan(plan, { perPage = 25, ...dependencies } = {}) {
+  const beforeCredits = readCreditSnapshot(dependencies);
+  const trackerResults = plan.trackerSearches.map((spec) => {
+    const { response, strategy } = searchKnownTarget(spec, dependencies);
+    const candidates = peopleFromResponse(response)
+      .map(sanitizeCandidate)
+      .filter((candidate) => knownTargetIdentityMatches(spec.targetName, candidate))
+      .filter((candidate) => !spec.organization || normalize(candidate.organization) === normalize(spec.organization));
+    return {
+      ...spec,
+      searchStrategy: strategy,
+      totalEntries: Number(response.total_entries || 0),
+      identityMatchCount: candidates.length,
+      candidates,
+    };
+  });
+  const organizationResults = plan.organizationSearches.map((spec) => {
+    const response = searchOrganizationBuyers(spec, perPage, dependencies);
+    const candidates = peopleFromResponse(response)
+      .map(sanitizeCandidate)
+      .map((candidate) => ({ ...candidate, ...scoreOrganizationCandidate(candidate) }))
+      .sort((left, right) => right.priorityScore - left.priorityScore);
+    return {
+      ...spec,
+      totalEntries: Number(response.total_entries || 0),
+      candidates,
+    };
+  });
+  const afterCredits = readCreditSnapshot(dependencies);
+  const delta = creditDelta(beforeCredits, afterCredits);
+  const consumed = Object.entries(delta).filter(([, value]) => value > 0);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    mode: 'search_only',
+    safety: {
+      createsContacts: false,
+      enrichesPeople: false,
+      enrollsSequences: false,
+      sendsMessages: false,
+      duplicateOutreachSuppressed: true,
+      creditDelta: delta,
+      zeroCreditSearchVerified: consumed.length === 0,
+    },
+    buyerHypothesis: plan.buyerHypothesis,
+    trackerResults,
+    organizationResults,
+    credits: {
+      before: beforeCredits,
+      after: afterCredits,
+    },
+  };
+}
+
+function renderMarkdown(report) {
+  const rows = report.organizationResults.flatMap((organization) => organization.candidates.map((candidate) => ({
+    ...candidate,
+    reason: organization.reason,
+  })));
+  const lines = [
+    '# Apollo Buyer Search Report',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    `Buyer hypothesis: ${report.buyerHypothesis}`,
+    '',
+    '## Safety proof',
+    '',
+    `- Search-only: ${report.mode === 'search_only' ? 'yes' : 'no'}`,
+    `- Credits consumed during this report run: ${Object.values(report.safety.creditDelta).reduce((sum, value) => sum + Math.max(0, value), 0)}`,
+    '- Contacts created: 0',
+    '- Sequences enrolled: 0',
+    '- Messages sent: 0',
+    '',
+    '## New organization-level buyer candidates',
+    '',
+    '| Priority | Organization | Candidate | Title | Email available | Apollo ID |',
+    '| ---: | --- | --- | --- | --- | --- |',
+    ...rows.sort((left, right) => right.priorityScore - left.priorityScore).map((candidate) => `| ${candidate.priorityScore} | ${candidate.organization || ''} | ${candidate.firstName || ''} ${candidate.lastNameObfuscated || ''} | ${candidate.title || ''} | ${candidate.hasEmail ? 'yes' : 'no'} | ${candidate.apolloId || ''} |`),
+    '',
+    'Candidates remain research-only until identity and current ownership are independently verified. Existing tracker rows retain duplicate-outreach suppression.',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function defaultOutputPath() {
+  const date = new Date().toISOString().slice(0, 10);
+  return path.join(process.cwd(), '.thumbgate', 'reports', `apollo-buyer-search-${date}.json`);
+}
+
+function writeReport(report, outputPath) {
+  const resolved = path.resolve(outputPath || defaultOutputPath());
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${JSON.stringify(report, null, 2)}\n`);
+  const markdownPath = resolved.replace(/\.json$/i, '.md');
+  fs.writeFileSync(markdownPath, renderMarkdown(report));
+  return { json: resolved, markdown: markdownPath };
+}
+
+function usage() {
+  return `Usage: node scripts/apollo-acquisition.js [options]\n\n` +
+    `  --execute                Run search-only Apollo lookups (no enrichment or sends)\n` +
+    `  --input <csv>            Existing acquisition tracker\n` +
+    `  --config <json>          Buyer titles and organization domains\n` +
+    `  --output <json>          Report destination\n` +
+    `  --max-targets <n>        Limit tracker lookups\n` +
+    `  --per-page <n>           Organization candidates per query (1-100)\n` +
+    `  --skip-tracker           Skip known-person deduplication searches\n` +
+    `  --skip-organizations     Skip new organization buyer scans\n`;
+}
+
+function runCli(argv = process.argv.slice(2), dependencies = {}) {
+  const options = parseArgs(argv);
+  if (options.help) return { help: usage() };
+  const config = JSON.parse(fs.readFileSync(path.resolve(options.config), 'utf8'));
+  const rows = options.includeTracker
+    ? parseCsv(fs.readFileSync(path.resolve(options.input), 'utf8'))
+    : [];
+  const plan = buildSearchPlan({ rows, config, options });
+  if (!options.execute) return { mode: 'dry_run', plan };
+  const report = executeSearchPlan(plan, { perPage: options.perPage, ...dependencies });
+  return { mode: 'executed', report, files: writeReport(report, options.output) };
+}
+
+if (require.main === module) {
+  try {
+    const result = runCli();
+    if (result.help) process.stdout.write(result.help);
+    else process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  buildSearchPlan,
+  creditDelta,
+  executeSearchPlan,
+  parseArgs,
+  parseCsv,
+  parseCsvLine,
+  renderMarkdown,
+  runCli,
+  sanitizeCandidate,
+  scoreOrganizationCandidate,
+  suppressDuplicateOutreach,
+  knownTargetIdentityMatches,
+};

--- a/tests/apollo-acquisition.test.js
+++ b/tests/apollo-acquisition.test.js
@@ -34,6 +34,15 @@ test('parses quoted acquisition tracker rows without corrupting notes', () => {
   assert.equal(rows[0].notes, 'Agents scale, confidence lags');
 });
 
+test('parses escaped quotes inside quoted tracker fields', () => {
+  const rows = parseCsv([
+    'target_name,notes',
+    'Ryan Miller,"Owns ""AI Transformation"""',
+  ].join('\n'));
+
+  assert.equal(rows[0].notes, 'Owns "AI Transformation"');
+});
+
 test('builds known-target and organization scans while suppressing duplicate outreach', () => {
   const rows = [{
     campaign_id: 'wave1',
@@ -121,6 +130,47 @@ test('dry run returns a reusable plan without calling Apollo', () => {
   const result = runCli(['--input', input, '--config', configPath]);
   assert.equal(result.mode, 'dry_run');
   assert.equal(result.plan.trackerSearches.length, 1);
+});
+
+test('executed CLI writes JSON and Markdown evidence without enrichment or sends', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'apollo-acquisition-execute-'));
+  const input = path.join(tempDir, 'targets.csv');
+  const configPath = path.join(tempDir, 'config.json');
+  const output = path.join(tempDir, 'report.json');
+  fs.writeFileSync(input, 'target_name,organization,status\nJeffery Aronhalt,Gametime,Contacted\n');
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  const runner = (_command, args) => {
+    if (args[0] === 'usage') {
+      return { status: 0, stdout: JSON.stringify({ credit_usage_stats: { lead_credit: { consumed: 10 } } }) };
+    }
+    if (args.includes('Jeffery Aronhalt')) {
+      return { status: 0, stdout: JSON.stringify({ people: [] }) };
+    }
+    return {
+      status: 0,
+      stdout: JSON.stringify({
+        people: [{
+          id: 'buyer-1',
+          first_name: 'Ryan',
+          last_name_obfuscated: 'Mi***r',
+          title: 'VP of AI Transformation',
+          has_email: true,
+          organization: { name: 'Gametime' },
+        }],
+      }),
+    };
+  };
+  const result = runCli([
+    '--execute', '--input', input, '--config', configPath, '--output', output,
+  ], { runner });
+
+  assert.equal(result.mode, 'executed');
+  assert.equal(result.report.safety.zeroCreditSearchVerified, true);
+  assert.equal(fs.existsSync(result.files.json), true);
+  assert.equal(fs.existsSync(result.files.markdown), true);
+  assert.match(fs.readFileSync(result.files.markdown, 'utf8'), /VP of AI Transformation/);
+  assert.match(fs.readFileSync(result.files.markdown, 'utf8'), /Messages sent: 0/);
 });
 
 test('argument validation blocks accidental unbounded or malformed runs', () => {

--- a/tests/apollo-acquisition.test.js
+++ b/tests/apollo-acquisition.test.js
@@ -1,0 +1,130 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildSearchPlan,
+  creditDelta,
+  executeSearchPlan,
+  knownTargetIdentityMatches,
+  parseArgs,
+  parseCsv,
+  runCli,
+  scoreOrganizationCandidate,
+  suppressDuplicateOutreach,
+} = require('../scripts/apollo-acquisition');
+
+const config = {
+  buyerHypothesis: 'Teams need accountable agent controls.',
+  titles: ['Chief AI Officer', 'AI Governance'],
+  seniority: ['director', 'vp', 'c_suite'],
+  organizations: [{ name: 'Gametime', domain: 'gametime.co', reason: 'AI agents are scaling.' }],
+};
+
+test('parses quoted acquisition tracker rows without corrupting notes', () => {
+  const rows = parseCsv([
+    'campaign_id,target_name,organization,status,notes',
+    'wave1,Jeffery Aronhalt,Gametime,Contacted,"Agents scale, confidence lags"',
+  ].join('\n'));
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].target_name, 'Jeffery Aronhalt');
+  assert.equal(rows[0].notes, 'Agents scale, confidence lags');
+});
+
+test('builds known-target and organization scans while suppressing duplicate outreach', () => {
+  const rows = [{
+    campaign_id: 'wave1',
+    target_name: 'Jeffery Aronhalt',
+    organization: 'Gametime',
+    status: 'Contacted - invitation pending',
+    buyer_signal: 'Operational confidence gap',
+  }];
+  const plan = buildSearchPlan({ rows, config, options: {} });
+
+  assert.equal(plan.trackerSearches.length, 1);
+  assert.equal(plan.trackerSearches[0].domain, 'gametime.co');
+  assert.equal(plan.trackerSearches[0].suppressDuplicateOutreach, true);
+  assert.deepEqual(plan.organizationSearches[0].titles, config.titles);
+});
+
+test('treats failed routes as researchable without reclassifying them as fresh contacts', () => {
+  assert.equal(suppressDuplicateOutreach('Contacted'), true);
+  assert.equal(suppressDuplicateOutreach('Routed via official supplier channel'), true);
+  assert.equal(suppressDuplicateOutreach('Failed - address not found'), false);
+});
+
+test('calculates credit deltas across all Apollo credit types', () => {
+  const before = { credit_usage_stats: { lead_credit: { consumed: 10 }, ai_credit: { consumed: 2 } } };
+  const after = { credit_usage_stats: { lead_credit: { consumed: 10 }, ai_credit: { consumed: 4 } } };
+  assert.deepEqual(creditDelta(before, after), { lead_credit: 0, ai_credit: 2 });
+});
+
+test('matches obfuscated Apollo identities without accepting same-first-name noise', () => {
+  assert.equal(knownTargetIdentityMatches('Jeffery Aronhalt', {
+    firstName: 'Jeffery',
+    lastNameObfuscated: 'Ar***t',
+  }), true);
+  assert.equal(knownTargetIdentityMatches('Lalit Anand', {
+    firstName: 'Lalit',
+    lastNameObfuscated: 'Kh***r',
+  }), false);
+});
+
+test('ranks governance and agent-platform owners above generic titles', () => {
+  const governance = scoreOrganizationCandidate({
+    title: 'Group Director, AI Governance and Product Compliance',
+    hasEmail: true,
+  });
+  const generic = scoreOrganizationCandidate({ title: 'Director of Engineering', hasEmail: true });
+  assert.ok(governance.priorityScore > generic.priorityScore);
+  assert.ok(governance.priorityReasons.includes('governance_pain_owner'));
+});
+
+test('executes search-only workflow and proves no Apollo credits or sends occurred', () => {
+  const calls = [];
+  const runner = (_command, args) => {
+    calls.push(args);
+    if (args[0] === 'usage') {
+      return { status: 0, stdout: JSON.stringify({ credit_usage_stats: { lead_credit: { consumed: 10 } } }) };
+    }
+    if (args.includes('Jeffery Aronhalt')) {
+      return { status: 0, stdout: JSON.stringify({ total_entries: 1, people: [{ id: 'known-1', first_name: 'Jeffery', title: 'Principal Software Engineer', organization: { name: 'Gametime' } }] }) };
+    }
+    return { status: 0, stdout: JSON.stringify({ total_entries: 1, people: [{ id: 'buyer-1', first_name: 'Ryan', last_name_obfuscated: 'Mi***r', title: 'VP of AI Transformation', has_email: true, organization: { name: 'Gametime' } }] }) };
+  };
+  const plan = buildSearchPlan({
+    rows: [{ target_name: 'Jeffery Aronhalt', organization: 'Gametime', status: 'Contacted' }],
+    config,
+    options: {},
+  });
+  const report = executeSearchPlan(plan, { runner, perPage: 25 });
+
+  assert.equal(report.safety.zeroCreditSearchVerified, true);
+  assert.equal(report.safety.createsContacts, false);
+  assert.equal(report.safety.enrollsSequences, false);
+  assert.equal(report.organizationResults[0].candidates[0].title, 'VP of AI Transformation');
+  assert.equal(calls.some((args) => args[0] === 'contacts'), false);
+  assert.equal(calls.some((args) => args[0] === 'sequences'), false);
+  assert.equal(calls.some((args) => args[0] === 'people' && args[1] === 'enrich'), false);
+});
+
+test('dry run returns a reusable plan without calling Apollo', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'apollo-acquisition-'));
+  const input = path.join(tempDir, 'targets.csv');
+  const configPath = path.join(tempDir, 'config.json');
+  fs.writeFileSync(input, 'target_name,organization,status\nJeffery Aronhalt,Gametime,Contacted\n');
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  const result = runCli(['--input', input, '--config', configPath]);
+  assert.equal(result.mode, 'dry_run');
+  assert.equal(result.plan.trackerSearches.length, 1);
+});
+
+test('argument validation blocks accidental unbounded or malformed runs', () => {
+  assert.throws(() => parseArgs(['--per-page', '0']), /1 to 100/);
+  assert.throws(() => parseArgs(['--max-targets', 'nope']), /positive integer/);
+  assert.throws(() => parseArgs(['--send']), /Unknown argument/);
+});

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -159,12 +159,14 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     'bin/memory.sh',
     'bin/obsidian-sync.sh',
     'scripts/autonomous-workflow.js',
+    'scripts/apollo-acquisition.js',
     'scripts/decision-trace.js',
     'scripts/sales-pipeline.js',
     // scripts/post-to-x.js + post-to-x-retry.sh removed 2026-06-06
     // (X/Twitter retired from active distribution 2026-04-20).
     'scripts/reddit-dm-outreach.js',
     'scripts/reddit-monitor-cron.sh',
+    'sales/apollo-buyer-search.json',
     'scripts/perplexity-command-center.js',
     'scripts/perplexity-marketing.js',
     'scripts/build-claude-mcpb.js',


### PR DESCRIPTION
## Outcome
- adds a search-only Apollo workflow for the existing 23-target acquisition tracker
- ranks AI governance, agent platform, AI integration, and transformation owners across five named accounts
- suppresses duplicate first touches from prior campaign state
- snapshots Apollo credits and proves the workflow does not enrich, enroll, or send
- keeps sales tooling and target configuration outside the public npm package

## Verification
- 9 Apollo acquisition tests pass
- 84 workflow tests pass
- package-boundary and test-suite-parity tests pass
- changeset gate passes
- live final Apollo search run: 64 organization candidates, 0 credit delta

## Commercial truth
This PR creates discovery and qualification infrastructure. It does not claim that saved contacts are outreach, opportunities, or revenue.