### PR TITLE
fix(mcp): preserve long-running stdio sessions

### DIFF
--- a/.changeset/quiet-dragons-coexist.md
+++ b/.changeset/quiet-dragons-coexist.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Preserve long-running MCP transports when additional ThumbGate sessions start. Live lock owners now coexist through per-session locks regardless of age instead of being terminated after two hours.

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -1431,21 +1431,13 @@ function writeNdjsonResponse(id, payload, error = null) {
 }
 
 /**
- * Default staleness threshold: if a lock is older than this (ms), the holder
- * is considered orphaned even if its PID is still alive — it likely belongs
- * to a defunct Claude Code session whose process was never reaped.
- */
-const LOCK_STALE_MS = Number(process.env.THUMBGATE_LOCK_STALE_MS) || 2 * 60 * 60 * 1000; // 2 hours
-
-/**
  * Acquire a file-system lock to prevent duplicate MCP server instances.
- * Returns { lockFile, cleanupLock } on success, or calls process.exit(1)
- * if another live server holds the lock.
+ * Returns { lockFile, cleanupLock } on success.
  *
- * Staleness reaping: if the lock-holding process is alive but the lock is
- * older than LOCK_STALE_MS, the holder is killed (SIGTERM) and the lock is
- * reclaimed. This prevents orphaned `thumbgate serve` processes from permanently
- * blocking new sessions.
+ * Every live stdio client needs its own MCP process, and those sessions can
+ * legitimately run for many hours. A lock's age is therefore not evidence that
+ * its owner is orphaned. Live owners coexist through per-session locks; only a
+ * lock whose PID is no longer running is reclaimed.
  */
 function acquireLock() {
   const feedbackDir = getFeedbackPaths().FEEDBACK_DIR;
@@ -1458,26 +1450,19 @@ function acquireLock() {
       try { process.kill(lockData.pid, 0); isRunning = true; } catch { /* process is dead */ }
 
       if (isRunning) {
-        const lockAge = Date.now() - new Date(lockData.startedAt).getTime();
-        if (lockAge > LOCK_STALE_MS) {
-          // Orphaned process — kill it and take over
-          process.stderr.write(`[thumbgate] Lock held by PID ${lockData.pid} is ${Math.round(lockAge / 60000)}m old (threshold: ${Math.round(LOCK_STALE_MS / 60000)}m). Reaping orphaned process.\n`);
-          try { process.kill(lockData.pid, 'SIGTERM'); } catch { /* already gone */ }
-        } else {
-          // Another session's MCP server is running — coexist via per-session lock.
-          // Each Claude session communicates via its own stdio pipe and needs its own server.
-          // SQLite WAL mode handles concurrent access safely.
-          process.stderr.write(`[thumbgate] Another MCP server (PID ${lockData.pid}) is running for ${feedbackDir}. Starting concurrent session.\n`);
-          const sessionLockFile = path.join(feedbackDir, `.mcp-server-${process.pid}.lock`);
-          fs.writeFileSync(sessionLockFile, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));
-          const cleanupSessionLock = () => { try { fs.unlinkSync(sessionLockFile); } catch { /* already removed */ } };
-          process.on('exit', cleanupSessionLock);
-          process.on('SIGTERM', () => { cleanupSessionLock(); process.exit(0); });
-          process.on('SIGINT', () => { cleanupSessionLock(); process.exit(0); });
-          return { lockFile: sessionLockFile, cleanupLock: cleanupSessionLock };
-        }
+        // Another session's MCP server is running — coexist via per-session lock.
+        // Each client communicates via its own stdio pipe and needs its own server.
+        // SQLite WAL mode handles concurrent access safely.
+        process.stderr.write(`[thumbgate] Another MCP server (PID ${lockData.pid}) is running for ${feedbackDir}. Starting concurrent session.\n`);
+        const sessionLockFile = path.join(feedbackDir, `.mcp-server-${process.pid}.lock`);
+        fs.writeFileSync(sessionLockFile, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));
+        const cleanupSessionLock = () => { try { fs.unlinkSync(sessionLockFile); } catch { /* already removed */ } };
+        process.on('exit', cleanupSessionLock);
+        process.on('SIGTERM', () => { cleanupSessionLock(); process.exit(0); });
+        process.on('SIGINT', () => { cleanupSessionLock(); process.exit(0); });
+        return { lockFile: sessionLockFile, cleanupLock: cleanupSessionLock };
       }
-      // Stale lock from a dead or reaped process — remove it
+      // Stale lock from a dead process — remove it.
       try { fs.unlinkSync(lockFile); } catch { /* already gone */ }
       process.stderr.write(`[thumbgate] Removed stale lock (PID ${lockData.pid} is no longer running).\n`);
     }

--- a/tests/server-stdio-lock.test.js
+++ b/tests/server-stdio-lock.test.js
@@ -87,15 +87,12 @@ test('acquireLock: lock held by active PID (fresh) — creates per-session lock 
   result.cleanupLock();
 });
 
-// ── Orphaned lock (live PID, stale): reap and take over ─────────────
+// ── Old lock with live PID: coexist without terminating owner ──────
 
-test('acquireLock: lock held by live PID but older than threshold — reaps and acquires', () => {
+test('acquireLock: old lock held by live PID — preserves owner and coexists', () => {
   const lockPath = path.join(tmpDir, '.mcp-server.lock');
-  // Set threshold very low so the lock is considered stale
-  process.env.THUMBGATE_LOCK_STALE_MS = '1'; // 1ms — any lock is stale
 
-  // Spawn a real child process so we have a live PID to reap
-  const { execSync } = require('child_process');
+  // Spawn a real child process so we can prove an old live owner survives.
   const child = require('child_process').spawn('sleep', ['60'], { detached: true, stdio: 'ignore' });
   child.unref();
   const childPid = child.pid;
@@ -105,24 +102,17 @@ test('acquireLock: lock held by live PID but older than threshold — reaps and 
 
   try {
     const { acquireLock } = freshRequire();
-    // Should NOT exit — should reap the orphaned process and take over
     const { lockFile, cleanupLock } = acquireLock();
 
-    assert.ok(fs.existsSync(lockPath), 'new lock file should be written');
+    assert.ok(lockFile.includes(`mcp-server-${process.pid}.lock`), 'should use a per-session lock');
+    assert.ok(fs.existsSync(lockPath), 'original lock should remain');
     const data = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-    assert.strictEqual(data.pid, process.pid, 'lock should now belong to current process');
+    assert.strictEqual(data.pid, childPid, 'original lock should still belong to the live owner');
 
-    // Verify the child was killed
-    let childStillRunning = false;
-    try { process.kill(childPid, 0); childStillRunning = true; } catch { /* dead */ }
-    // Give SIGTERM a moment to propagate
-    if (childStillRunning) {
-      try { process.kill(childPid, 'SIGKILL'); } catch { /* already gone */ }
-    }
+    assert.doesNotThrow(() => process.kill(childPid, 0), 'live owner must not be terminated because its lock is old');
 
     cleanupLock();
   } finally {
-    delete process.env.THUMBGATE_LOCK_STALE_MS;
     try { process.kill(childPid, 'SIGKILL'); } catch { /* cleanup */ }
   }
 });


### PR DESCRIPTION
## Summary
- stop treating lock age as proof that a live MCP stdio owner is orphaned
- keep live owners intact and start concurrent clients with per-session locks
- add a regression test proving an old live owner survives

## Root cause and scope
ThumbGate 1.28.0 could send SIGTERM to a live lock owner solely because its lock was older than two hours. The exact historical PID behind the reported `Transport closed` call is unavailable, so this PR fixes the deterministic termination path without overclaiming historical causality.

## Verification
- `npm test` (sanitized environment and global Git hooks disabled): pass
- `npm run test:coverage`: pass; 86.30% lines, 73.83% branches, 87.89% functions
- `npm run prove:adapters`: 48/48 pass
- `npm run prove:automation`: 55/55 pass
- `npm run self-heal:check`: pass
- `npm run test:server-lock`: 7/7 pass on final clean branch
- real two-server stdio proof: both servers initialized, each listed 87 tools, second used a per-session lock, and the first remained alive/responsive after its lock timestamp was aged to 2020

## Release
Includes a patch Changeset for the next `thumbgate` npm release.