### PR TITLE
chore(release): publish thumbgate 1.28.1

### DIFF
--- a/.changeset/aiventyx-diagnostic-attribution.md
+++ b/.changeset/aiventyx-diagnostic-attribution.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-fix(billing): preserve marketplace attribution (e.g. utm_source=aiventyx) across external Stripe Payment Links via client_reference_id, so paid diagnostics are credited/reported instead of landing as source=unknown.

--- a/.changeset/align-homepage-sentinel.md
+++ b/.changeset/align-homepage-sentinel.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Keep the production homepage verifier aligned with the shipped enforcement copy.

--- a/.changeset/apollo-buyer-acquisition.md
+++ b/.changeset/apollo-buyer-acquisition.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add a repository-only Apollo buyer-acquisition workflow that ranks enterprise AI-governance owners, suppresses duplicate outreach, and proves credit-safe search runs without adding sales tooling to the public npm package.

--- a/.changeset/bypass-immune-enforcement-floors.md
+++ b/.changeset/bypass-immune-enforcement-floors.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Keep secret exfiltration, critical security-scan findings, and all four self-protection gate classes as hard floors in both the CLI and plugin hook even when environment bypasses are active. Ordinary block gates remain advisory by default, while audited scoped approvals and the short-lived break-glass command preserve a repair path for protected configuration.

--- a/.changeset/changeset-gate-dependabot-actor.md
+++ b/.changeset/changeset-gate-dependabot-actor.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Fix the Dependabot bypass in the changeset gate keying on `github.actor` (who triggered the run) instead of `github.event.pull_request.user.login` (who authored the PR). Any human or agent that touched a Dependabot PR — a rebase, `gh pr update-branch`, a re-run — became the actor, so the bypass silently stopped applying and the gate demanded a changeset Dependabot will never write. Reproduced on #2766: the re-run reported `actor=IgorGanapolsky`, and `Verify changeset` went SUCCESS → FAILURE without the diff changing. This is the same class of failure the bypass was written for on 2026-05-12 ("6 stale PRs, oldest 16 days, traced to this single gate"), reintroduced by keying on a variable a rebase can change.

--- a/.changeset/explicit-feedback-signal-detection.md
+++ b/.changeset/explicit-feedback-signal-detection.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Require automatic feedback signals to be standalone or lead the operator message, preventing quoted, descriptive, negated, and mid-sentence mentions from being captured while preserving explicit and typo-tolerant thumbs feedback.

--- a/.changeset/feedback-event-idempotency.md
+++ b/.changeset/feedback-event-idempotency.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Deduplicate concurrent UserPromptSubmit and Claude-history feedback captures at the storage boundary so one user signal creates one feedback event, lesson, counter update, and SQLite record. Keep the npm runtime slim by excluding the repository-only GitHub social preview asset.

--- a/.changeset/feedback-lesson-sanitization.md
+++ b/.changeset/feedback-lesson-sanitization.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-fix(feedback): stop promoting raw session-metadata JSON blobs as lessons — capture only the human .prompt and reject transport blobs (session_id/transcript_path/JSON) in the sanitizer so recall stays clean.

--- a/.changeset/fix-diagnostic-fulfillment.md
+++ b/.changeset/fix-diagnostic-fulfillment.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Accept the public diagnostic intake fields, keep Aiventyx traffic on its billing rail, notify the operator about new leads, and fulfill paid diagnostic orders without provisioning Pro licenses.

--- a/.changeset/fix-sprint-checkout-price-fallback.md
+++ b/.changeset/fix-sprint-checkout-price-fallback.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Pin Workflow Hardening Sprint checkout fallback to the verified $1,500 PayPal rail so a missing env cannot charge the $499 diagnostic under a $1,500 label.

--- a/.changeset/honest-enforcement-claims.md
+++ b/.changeset/honest-enforcement-claims.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-fix(docs): correct the enforcement claim on README + landing — only secret exfiltration and guardrail-tampering hard-block by default; rm -rf, force-push, and supply-chain are flagged by default and hard-block under strict mode. Verified against the actual gate-check engine.

--- a/.changeset/latest-release-campaign.md
+++ b/.changeset/latest-release-campaign.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add an evidence-backed ThumbGate 1.28.0 release campaign with channel-specific copy, a verified social card, a deduplicated Dev.to article publisher, and GitHub-hosted publishing through the configured social accounts.

--- a/.changeset/money-today-cta-sprint.md
+++ b/.changeset/money-today-cta-sprint.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Lead homepage and pricing with paid Workflow Hardening Diagnostic ($499) and Sprint ($1,500) checkouts; route `/docs` to the setup guide; keep Pro as the solo side lane.

--- a/.changeset/never-bypass-branch-protection.md
+++ b/.changeset/never-bypass-branch-protection.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Add an absolute directive to `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`: never approve a pull request, mutate review or protection state, or use `--admin`/`--force`/owner credentials to make a blocked merge possible. The policy preserves non-mutating diagnosis and separate policy-change PRs while pinning the verified 2026-07-10 incident in which an agent used owner credentials to approve #2768. `tests/never-bypass-branch-protection.test.js` prevents the directive from being quietly deleted.

--- a/.changeset/partner-intake-conversion.md
+++ b/.changeset/partner-intake-conversion.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Add a form-only partner intake route that preserves referral attribution and contains no price or checkout path before scope review.

--- a/.changeset/plugin-hook-exec-form.md
+++ b/.changeset/plugin-hook-exec-form.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Run bundled Claude plugin hooks with exec-form command arguments so installation paths containing spaces cannot split the script path or disable enforcement.

--- a/.changeset/plugin-hooks-enforcement.md
+++ b/.changeset/plugin-hooks-enforcement.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-fix(plugin): ship a hooks lifecycle in the plugin manifest so fresh plugin/desktop-extension installs actually run PreToolUse enforcement, recall, and the session primer (previously only skills/commands/mcpServers were wired).

--- a/.changeset/public-truth-congruence.md
+++ b/.changeset/public-truth-congruence.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Align the README, landing page, JSON-LD FAQ, package description, and canonical GitHub About metadata with the shipped enforcement and commercial boundaries: default warnings for force-push, destructive-delete, fetch-and-run, and guardrail-file matches; narrow default denies for detected secret leaks and gate kill/bypass commands; strict-mode denies for matching warning checks; individual Pro packaging; and no generally available hosted team sync or org dashboard.

--- a/.changeset/quiet-dragons-coexist.md
+++ b/.changeset/quiet-dragons-coexist.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Preserve long-running MCP transports when additional ThumbGate sessions start. Live lock owners now coexist through per-session locks regardless of age instead of being terminated after two hours.

--- a/.changeset/release-campaign-quality-gate.md
+++ b/.changeset/release-campaign-quality-gate.md
@@ -1,5 +1,0 @@
----
-'thumbgate': patch
----
-
-Fix direct-run detection and simplify release-campaign publishing so the article, receipt verifier, and direct fallback commands execute reliably and pass the new-code quality gate.

--- a/.changeset/secret-file-exfiltration.md
+++ b/.changeset/secret-file-exfiltration.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Hard-deny outbound commands that attach local secret-bearing files through curl data, form, and upload options or wget post/body-file options, while keeping benign file references under the existing advisory network-egress policy.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.28.0",
+      "version": "1.28.1",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.28.0"
+    "version": "1.28.1"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate.ai",
   "transport": "stdio",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,9 +140,4 @@ Rules:
 
 ## 🛡️ Self-Harness Prevention Rules (Auto-Generated)
 
-> [!IMPORTANT]
-> The following rules were automatically derived from execution failures and thumbs-down feedback.
-> You MUST follow these constraints strictly to prevent repeated errors.
-
-- **Rule [auto-promoted-mriiwpw8-0]**: NEVER repeated problem context string
-- **Rule [auto-manual-ingest-markdown-migration]**: Auto-promoted repeated pattern: "MISTAKE: This is a test failure" (1 occurrences in 30 days)
+- No active auto-generated prevention rules at this time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.28.1
+
+### Patch Changes
+
+- 71be09d: fix(billing): preserve marketplace attribution (e.g. utm_source=aiventyx) across external Stripe Payment Links via client_reference_id, so paid diagnostics are credited/reported instead of landing as source=unknown.
+- e3fa2bd: Keep the production homepage verifier aligned with the shipped enforcement copy.
+- 36e859c: Add a repository-only Apollo buyer-acquisition workflow that ranks enterprise AI-governance owners, suppresses duplicate outreach, and proves credit-safe search runs without adding sales tooling to the public npm package.
+- 8b1d2b9: Keep secret exfiltration, critical security-scan findings, and all four self-protection gate classes as hard floors in both the CLI and plugin hook even when environment bypasses are active. Ordinary block gates remain advisory by default, while audited scoped approvals and the short-lived break-glass command preserve a repair path for protected configuration.
+- 5d031ab: Fix the Dependabot bypass in the changeset gate keying on `github.actor` (who triggered the run) instead of `github.event.pull_request.user.login` (who authored the PR). Any human or agent that touched a Dependabot PR — a rebase, `gh pr update-branch`, a re-run — became the actor, so the bypass silently stopped applying and the gate demanded a changeset Dependabot will never write. Reproduced on #2766: the re-run reported `actor=IgorGanapolsky`, and `Verify changeset` went SUCCESS → FAILURE without the diff changing. This is the same class of failure the bypass was written for on 2026-05-12 ("6 stale PRs, oldest 16 days, traced to this single gate"), reintroduced by keying on a variable a rebase can change.
+- 0dcdf35: Require automatic feedback signals to be standalone or lead the operator message, preventing quoted, descriptive, negated, and mid-sentence mentions from being captured while preserving explicit and typo-tolerant thumbs feedback.
+- 290e16b: Deduplicate concurrent UserPromptSubmit and Claude-history feedback captures at the storage boundary so one user signal creates one feedback event, lesson, counter update, and SQLite record. Keep the npm runtime slim by excluding the repository-only GitHub social preview asset.
+- df714ac: fix(feedback): stop promoting raw session-metadata JSON blobs as lessons — capture only the human .prompt and reject transport blobs (session_id/transcript_path/JSON) in the sanitizer so recall stays clean.
+- 271fbb0: Accept the public diagnostic intake fields, keep Aiventyx traffic on its billing rail, notify the operator about new leads, and fulfill paid diagnostic orders without provisioning Pro licenses.
+- 485595a: Pin Workflow Hardening Sprint checkout fallback to the verified $1,500 PayPal rail so a missing env cannot charge the $499 diagnostic under a $1,500 label.
+- 357d9c0: fix(docs): correct the enforcement claim on README + landing — only secret exfiltration and guardrail-tampering hard-block by default; rm -rf, force-push, and supply-chain are flagged by default and hard-block under strict mode. Verified against the actual gate-check engine.
+- 95232e2: Add an evidence-backed ThumbGate 1.28.0 release campaign with channel-specific copy, a verified social card, a deduplicated Dev.to article publisher, and GitHub-hosted publishing through the configured social accounts.
+- db64f2f: Lead homepage and pricing with paid Workflow Hardening Diagnostic ($499) and Sprint ($1,500) checkouts; route `/docs` to the setup guide; keep Pro as the solo side lane.
+- f17d5b2: Add an absolute directive to `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`: never approve a pull request, mutate review or protection state, or use `--admin`/`--force`/owner credentials to make a blocked merge possible. The policy preserves non-mutating diagnosis and separate policy-change PRs while pinning the verified 2026-07-10 incident in which an agent used owner credentials to approve #2768. `tests/never-bypass-branch-protection.test.js` prevents the directive from being quietly deleted.
+- 8819ab2: Add a form-only partner intake route that preserves referral attribution and contains no price or checkout path before scope review.
+- b54e5e9: Run bundled Claude plugin hooks with exec-form command arguments so installation paths containing spaces cannot split the script path or disable enforcement.
+- 419f109: fix(plugin): ship a hooks lifecycle in the plugin manifest so fresh plugin/desktop-extension installs actually run PreToolUse enforcement, recall, and the session primer (previously only skills/commands/mcpServers were wired).
+- 9cc0158: Align the README, landing page, JSON-LD FAQ, package description, and canonical GitHub About metadata with the shipped enforcement and commercial boundaries: default warnings for force-push, destructive-delete, fetch-and-run, and guardrail-file matches; narrow default denies for detected secret leaks and gate kill/bypass commands; strict-mode denies for matching warning checks; individual Pro packaging; and no generally available hosted team sync or org dashboard.
+- e9197b4: Preserve long-running MCP transports when additional ThumbGate sessions start. Live lock owners now coexist through per-session locks regardless of age instead of being terminated after two hours.
+- 9196892: Fix direct-run detection and simplify release-campaign publishing so the article, receipt verifier, and direct fallback commands execute reliably and pass the new-code quality gate.
+- 2fb11ff: Hard-deny outbound commands that attach local secret-bearing files through curl data, form, and upload options or wget post/body-file options, while keeping benign file references under the existing advisory network-egress policy.
+
 ## 1.28.0
 
 ### Minor Changes

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -32,9 +32,4 @@ An agent holding an owner's credential can do anything the owner can. That is pr
 
 ## 🛡️ Self-Harness Prevention Rules (Auto-Generated)
 
-> [!IMPORTANT]
-> The following rules were automatically derived from execution failures and thumbs-down feedback.
-> You MUST follow these constraints strictly to prevent repeated errors.
-
-- **Rule [auto-promoted-mriiwpw8-0]**: NEVER repeated problem context string
-- **Rule [auto-manual-ingest-markdown-migration]**: Auto-promoted repeated pattern: "MISTAKE: This is a test failure" (1 occurrences in 30 days)
+- No active auto-generated prevention rules at this time.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.28.0 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.28.1 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.28.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.28.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.28.0", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.28.1", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -231,7 +231,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.28.0' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.28.1' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.28.0",
+        "thumbgate@1.28.1",
         "thumbgate",
         "serve"
       ],

--- a/docs/VERIFICATION_EVIDENCE.md
+++ b/docs/VERIFICATION_EVIDENCE.md
@@ -65,9 +65,9 @@ npm pack --dry-run --json
 npm publish --access public
 npm view thumbgate version --json
 npm view thumbgate dist.integrity --json
-npx -y thumbgate@1.28.0 --version
-npx -y thumbgate@1.28.0 setup-vertex --dry-run
-npx -y thumbgate@1.28.0 feedback-self-test --help
+npx -y thumbgate@1.28.1 --version
+npx -y thumbgate@1.28.1 setup-vertex --dry-run
+npx -y thumbgate@1.28.1 feedback-self-test --help
 ```
 
 Observed result:
@@ -75,7 +75,7 @@ Observed result:
 - Focused release tests passed: `267/267`.
 - Version sync check passed across `32` tracked targets.
 - Package dry run included `public/dashboard.html` and `scripts/dashboard-chat.js`.
-- Published package was verified from npm after release: `thumbgate@1.28.0`.
+- Published package was verified from npm after release: `thumbgate@1.28.1`.
 - Published dist integrity: `sha512-DKsT53EnZCZTfIXbMg+erbsppyUiNFY+kc8Hnx9XY8vQ6LJfIb84FMN9H0J1zlPhsOzBXm1G9GBVR+BioTyqTg==`.
 - Published `setup-vertex --dry-run` reported active account `ig5973700@gmail.com` and project `gen-lang-client-0559847560`, then printed planned changes without enabling services or writing `.env`.
 - Published `feedback-self-test --help` documented the isolated default test store and `--persist` dogfood mode.
@@ -109,8 +109,8 @@ npm publish --access public
 npm view thumbgate version --json
 npm view thumbgate dist.integrity --json
 npm view thumbgate readme | rg -n "Recovery if a gate over-fires|break-glass"
-npx -y thumbgate@1.28.0 help break-glass
-npx -y thumbgate@1.28.0 break-glass --reason="published artifact verification" --json
+npx -y thumbgate@1.28.1 help break-glass
+npx -y thumbgate@1.28.1 break-glass --reason="published artifact verification" --json
 ```
 
 Observed result:
@@ -119,11 +119,11 @@ Observed result:
 - Gate hardening tests passed: `5/5`.
 - Version sync check passed across `32` tracked targets.
 - Congruence check passed across public/package/adapter surfaces.
-- Published package was verified from npm after release: `thumbgate@1.28.0`.
+- Published package was verified from npm after release: `thumbgate@1.28.1`.
 - Published dist integrity: `sha512-DKsT53EnZCZTfIXbMg+erbsppyUiNFY+kc8Hnx9XY8vQ6LJfIb84FMN9H0J1zlPhsOzBXm1G9GBVR+BioTyqTg==`.
 - Published npm README contains the `Recovery if a gate over-fires` section and `break-glass` commands.
-- Published-artifact dogfood passed for `npx -y thumbgate@1.28.0 help break-glass`.
-- Published-artifact dogfood passed for `npx -y thumbgate@1.28.0 break-glass --reason="published artifact verification" --json`, returning a `300000` ms TTL and settings-only recovery globs.
+- Published-artifact dogfood passed for `npx -y thumbgate@1.28.1 help break-glass`.
+- Published-artifact dogfood passed for `npx -y thumbgate@1.28.1 break-glass --reason="published artifact verification" --json`, returning a `300000` ms TTL and settings-only recovery globs.
 - Runtime dogfood passed against the installed `1.26.5` hook path before this documentation entry was added; the published `1.26.6` artifact was then verified with `npx`.
 
 Requirements verified:
@@ -1650,7 +1650,7 @@ Evidence artifacts:
 Requirements verified:
 
 - Source checkouts now install canonical MCP entries that launch the local stdio server directly via `node adapters/mcp/server-stdio.js`.
-- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.28.0 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
+- Portable docs and adapter examples now use the version-pinned launcher `npx -y thumbgate@1.28.1 serve` instead of an unpinned `npx` call that can be shadowed by stale local installs.
 - Re-running the MCP installer upgrades stale config entries instead of treating them as already configured.
 - Adapter and LanceDB proof cleanup now uses retry-capable recursive removal so ephemeral filesystem contention no longer flakes CI.
 - Transient `.thumbgate` reminder/A2UI/test-run files are now ignored as local runtime state and do not pollute git hygiene during verification.
@@ -2867,7 +2867,7 @@ Scope:
 
 - Added a repo-root Cursor marketplace manifest at `.cursor-plugin/marketplace.json`.
 - Added a dedicated Cursor plugin bundle in `plugins/cursor-marketplace/` with `.cursor-plugin/plugin.json`, `.mcp.json`, README, and committed logo asset.
-- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.28.0 serve` instead of any checkout-local absolute path.
+- Switched the Cursor launcher to the portable published package entrypoint `npx -y thumbgate@1.28.1 serve` instead of any checkout-local absolute path.
 - Removed the stale `.mcp.json.plugin` legacy config file so the repo has one canonical Cursor packaging path.
 - Extended `scripts/sync-version.js` so Cursor manifests and all pinned launcher docs stay version-synced on future releases.
 - Added regression coverage for the repo-level marketplace contract, manifest/version consistency, and MCP launcher safety.

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.28.0`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.28.1`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.28.0 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.28.1 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.28.0", "serve"],
+      "args": ["-y", "thumbgate@1.28.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.28.0", "serve"],
+      "args": ["-y", "thumbgate@1.28.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.28.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.28.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.28.0
+1.28.1
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.28.0"
+version: "1.28.1"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "ThumbGate Pre-Action Checks derive rules from repeated failures, flag risky tool calls, hard-block detected secret leaks, and block matches in strict mode.",
   "homepage": "https://thumbgate.ai",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.28.0",
+        "thumbgate@1.28.1",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "ThumbGate for Codex turns one thumbs-down into a repeat-blocking pre-action check, backed by local MCP memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "author": {
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.28.0", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.28.1", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Deterministic pre-action checks, feedback capture, and MCP guardrails for AI coding agents in VS Code-compatible IDEs.",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:image" content="https://thumbgate.ai/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate.ai/og.png">
-<meta name="thumbgate-version" content="1.28.0">
+<meta name="thumbgate-version" content="1.28.1">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agentic development cycle, AC/DC framework, Guide Generate Verify Solve, agent enforcement layer, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="canonical" href="__APP_ORIGIN__/">
 <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
@@ -1776,7 +1776,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.28.0</span>
+    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.28.1</span>
   </div>
 </footer>
 

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.28.0",
+  "softwareVersion": "1.28.1",
   "url": "https://thumbgate.ai/numbers",
   "dateModified": "2026-05-07",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-05-07 · Version 1.28.0</div>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.28.1</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.28.0",
+  "version": "1.28.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Release

Publishes ThumbGate 1.28.1 and consumes 21 pending patch changesets, including the MCP transport coexistence fix from #2929.

## Verification

- `npm run test:deployment` — 123/123 passed
- `npm run test:postinstall` — 4/4 passed
- `npm run prove:runtime` — 7/7 passed
- `npm run test:sync-version` — 14/14 passed
- `npm run test:release-window` — 15/15 passed
- `node scripts/sync-version.js --check` — 32/32 targets synced
- `npm pack --dry-run --json` — thumbgate@1.28.1, 333 entries
- `git diff --check` — clean

## MCP hotfix evidence

Long-running live MCP lock holders are no longer terminated based only on lock age. Regression coverage and a real two-server NDJSON proof verified coexistence and continued responsiveness.

See `VERIFICATION_EVIDENCE.md` for the machine-readable quality evidence surfaces.