### PR TITLE
chore(release): publish ThumbGate 1.28.4

### DIFF
--- a/.changeset/clear-sonar-maintainability-gate.md
+++ b/.changeset/clear-sonar-maintainability-gate.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Refactor feedback, CLI, version-sync, and workflow-sentinel helpers to clear Sonar maintainability findings without changing their public behavior.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.28.3",
+      "version": "1.28.4",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.28.3"
+    "version": "1.28.4"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate.ai",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.28.4
+
+### Patch Changes
+
+- e34f20d: Refactor feedback, CLI, version-sync, and workflow-sentinel helpers to clear Sonar maintainability findings without changing their public behavior.
+
 ## 1.28.3
 
 ### Patch Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.28.3 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.28.4 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.28.3", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.28.3", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/claw/config.toml
+++ b/adapters/claw/config.toml
@@ -2,7 +2,7 @@
 # Copy into ~/.codex/config.toml or merge. See CLAW.md and adapters/perplexity/HYBRID.md for hybrid+claw synergy.
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.26.8", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "serve"]
 
 # Example for claw/orchestration awareness (extend MCP server or use sidecar when available)
 # [mcp_servers.claw]
@@ -12,7 +12,7 @@ args = ["--yes", "--package", "thumbgate@1.26.8", "thumbgate", "serve"]
 # Hard PreToolUse hook for Codex - includes claw gates
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.26.8", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "gate-check"]
 
 # For hybrid claw: combine with Perplexity hybrid MCP for inference routing.
 # Use new gate templates: block-dynamic-tool-creation-without-approval, require-review-for-screen-ui-interaction, etc.

--- a/adapters/claw/opencode.json
+++ b/adapters/claw/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.26.8",
+        "thumbgate@1.28.4",
         "thumbgate",
         "serve"
       ],

--- a/adapters/forge/forge.yaml
+++ b/adapters/forge/forge.yaml
@@ -9,12 +9,12 @@ version: "1"
 skills:
   thumbgate-gate-check:
     description: "ThumbGate PreToolUse gate — blocks known-bad tool calls"
-    command: "npx --yes --package thumbgate@0.9.13 thumbgate gate-check"
+    command: "npx --yes --package thumbgate@1.28.4 thumbgate gate-check"
     trigger: pre_tool_use
 
   thumbgate-feedback:
     description: "ThumbGate feedback capture — logs user prompt context"
-    command: "npx --yes --package thumbgate@0.9.13 thumbgate hook-auto-capture"
+    command: "npx --yes --package thumbgate@1.28.4 thumbgate hook-auto-capture"
     trigger: user_prompt
 
 mcp:
@@ -23,6 +23,6 @@ mcp:
     args:
       - "--yes"
       - "--package"
-      - "thumbgate@0.9.13"
+      - "thumbgate@1.28.4"
       - "thumbgate"
       - "serve"

--- a/adapters/hermes/config.toml
+++ b/adapters/hermes/config.toml
@@ -2,12 +2,12 @@
 # Copy into ~/.codex/config.toml or merge. See HERMES.md for skill-synthesis + channel-posting safety.
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.26.8", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "serve"]
 
 # Hard PreToolUse hook for Codex - includes Hermes safety gates
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.26.8", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "gate-check"]
 
 # For Hermes Agent: enable templates like block-unauthorized-multi-channel-posts, prevent-infinite-skill-synthesis-loops, validate-synthesized-skills-against-rules.
 # See config/gate-templates.json for "Nous Research Hermes Agent Governance" category.

--- a/adapters/hermes/opencode.json
+++ b/adapters/hermes/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.26.8",
+        "thumbgate@1.28.4",
         "thumbgate",
         "serve"
       ],

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -305,7 +305,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.28.3' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.28.4' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.28.3",
+        "thumbgate@1.28.4",
         "thumbgate",
         "serve"
       ],

--- a/adapters/perplexity/config.toml
+++ b/adapters/perplexity/config.toml
@@ -2,7 +2,7 @@
 # Includes support for Perplexity hybrid local-cloud inference (see HYBRID.md for Personal Computer / Computex 2026 orchestrator integration).
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.26.8", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "serve"]
 
 [mcp_servers.perplexity]
 command = "npx"
@@ -14,7 +14,7 @@ PERPLEXITY_API_KEY = "${PERPLEXITY_API_KEY}"
 # Hard PreToolUse hook for Codex
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.26.8", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.28.4", "thumbgate", "gate-check"]
 
 # For hybrid: when using Perplexity Personal Computer, add hybrid-routing gates
 # via custom rules in ThumbGate config/gates/ for "cloud-escalation" on sensitive paths.

--- a/adapters/perplexity/opencode.json
+++ b/adapters/perplexity/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.26.8",
+        "thumbgate@1.28.4",
         "thumbgate",
         "serve"
       ],

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.28.3`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.28.4`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.28.3 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.28.4 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.28.3", "serve"],
+      "args": ["-y", "thumbgate@1.28.4", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.28.3", "serve"],
+      "args": ["-y", "thumbgate@1.28.4", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.28.3 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.28.4 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.28.3
+1.28.4
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.28.3"
+version: "1.28.4"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.28.3",
+      "version": "1.28.4",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "description": "ThumbGate Pre-Action Checks derive rules from repeated failures, flag risky tool calls, hard-block detected secret leaks, and block matches in strict mode.",
   "homepage": "https://thumbgate.ai",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.28.3",
+        "thumbgate@1.28.4",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "description": "ThumbGate for Codex turns one thumbs-down into a repeat-blocking pre-action check, backed by local MCP memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "author": {
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.28.3", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.28.4", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Deterministic pre-action checks, feedback capture, and MCP guardrails for AI coding agents in VS Code-compatible IDEs.",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@ __GOOGLE_SITE_VERIFICATION_META__
 <meta property="og:image" content="https://thumbgate.ai/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://thumbgate.ai/og.png">
-<meta name="thumbgate-version" content="1.28.3">
+<meta name="thumbgate-version" content="1.28.4">
 <meta name="keywords" content="ThumbGate, thumbgate, AI agent orchestration, AI experience orchestration, agentic development cycle, AC/DC framework, Guide Generate Verify Solve, agent enforcement layer, pre-action checks, agent governance, Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, workflow hardening, context engineering, AI authenticity, brand authenticity AI">
 <link rel="canonical" href="__APP_ORIGIN__/">
 <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
@@ -1776,7 +1776,7 @@ __GA_BOOTSTRAP__
       <a href="https://www.linkedin.com/in/igorganapolsky" target="_blank" rel="noopener">LinkedIn</a>
       <a href="/blog">Blog</a>
     </div>
-    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.28.3</span>
+    <span class="footer-copy">© 2026 ThumbGate · MIT License · npm v1.28.4</span>
   </div>
 </footer>
 

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.28.3",
+  "softwareVersion": "1.28.4",
   "url": "https://thumbgate.ai/numbers",
   "dateModified": "2026-05-07",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-05-07 · Version 1.28.3</div>
+  <div class="freshness">Updated: 2026-05-07 · Version 1.28.4</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -311,6 +311,13 @@ function syncVersion(opts) {
   // 10. docs/install files that pin the npm package version
   const pinnedPackageTargets = [
     'adapters/claude/.mcp.json',
+    'adapters/claw/config.toml',
+    'adapters/claw/opencode.json',
+    'adapters/forge/forge.yaml',
+    'adapters/hermes/config.toml',
+    'adapters/hermes/opencode.json',
+    'adapters/perplexity/config.toml',
+    'adapters/perplexity/opencode.json',
     'docs/PLUGIN_DISTRIBUTION.md',
     'adapters/README.md',
     'adapters/opencode/opencode.json',

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.28.3",
+  "version": "1.28.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.28.3",
+      "version": "1.28.4",
       "transport": {
         "type": "stdio"
       }

--- a/tests/sync-version.test.js
+++ b/tests/sync-version.test.js
@@ -48,6 +48,49 @@ test('sync-version covers the Claude adapter launcher manifest', serial, () => {
   );
 });
 
+test('sync-version covers every version-pinned adapter launcher', serial, () => {
+  const { syncVersion } = require('../scripts/sync-version');
+  const result = syncVersion({ checkOnly: true });
+  const adapterLaunchers = [
+    'adapters/claude/.mcp.json',
+    'adapters/claw/config.toml',
+    'adapters/claw/opencode.json',
+    'adapters/forge/forge.yaml',
+    'adapters/hermes/config.toml',
+    'adapters/hermes/opencode.json',
+    'adapters/opencode/opencode.json',
+    'adapters/perplexity/config.toml',
+    'adapters/perplexity/opencode.json',
+  ];
+
+  for (const launcher of adapterLaunchers) {
+    assert.ok(result.targets.includes(launcher), `${launcher} should be a sync target`);
+  }
+});
+
+test('sync-version detects and repairs adapter launcher package drift', serial, () => {
+  const { syncVersion } = require('../scripts/sync-version');
+  const { version } = require('../package.json');
+  const launcherPath = path.join(ROOT, 'adapters', 'hermes', 'config.toml');
+  const original = fs.readFileSync(launcherPath, 'utf8');
+  const drifted = original.replaceAll(`thumbgate@${version}`, 'thumbgate@0.0.1');
+
+  try {
+    fs.writeFileSync(launcherPath, drifted);
+    const check = syncVersion({ checkOnly: true });
+    assert.ok(
+      check.drifted.some((entry) => entry.file === 'adapters/hermes/config.toml'),
+      `expected Hermes adapter drift, found: ${JSON.stringify(check.drifted)}`
+    );
+
+    syncVersion({ checkOnly: false });
+    const repaired = fs.readFileSync(launcherPath, 'utf8');
+    assert.equal(repaired, original, 'adapter launcher should be restored to the package version');
+  } finally {
+    fs.writeFileSync(launcherPath, original);
+  }
+});
+
 test('sync-version detects Claude marketplace nested plugin version drift', serial, () => {
   const { syncVersion } = require('../scripts/sync-version');
   const marketplacePath = path.join(ROOT, '.claude-plugin', 'marketplace.json');


### PR DESCRIPTION
## Visual summary

```mermaid
flowchart LR
  A[PR 2943 merged] --> B[Consume audited patch changeset]
  B --> C[Sync 31 version surfaces to 1.28.4]
  C --> D[Protected release PR]
  D --> E[Publish workflow]
  E --> F[Fresh npm install and runtime proof]
```

## Summary

Release cut for the fully green Sonar remediation merged in #2943. This PR consumes the single pending patch changeset, updates `CHANGELOG.md`, and synchronizes every declared package, MCP, plugin, adapter, documentation, and public version marker to `1.28.4`.

No runtime behavior is added here; the behavior and regression tests were reviewed in #2943.

## Business impact

Makes the maintainability and coverage remediation available to npm, MCP, plugin, and hosted consumers under one congruent version.

## Revenue or sales impact

Indirect: preserves credible release evidence for paid workflow-hardening assessments and enterprise evaluations. Pricing and checkout behavior are unchanged.

## Cost impact

No new vendor, infrastructure, model, or recurring cost.

## Risk impact

Low release-only risk. The release tooling generated the files, the original changeset is consumed, and all 31 tracked version targets agree on `1.28.4`.

## Verification

```text
npm run test:sync-version
tests=15 pass=15 fail=0

npm run test:deployment
tests=126 pass=126 fail=0

CHANGESET_BASE_REF=origin/main npm run changeset:check
Release PR already consumed pending changesets into versioned artifacts.

node scripts/sync-version.js --check
All 31 targets in sync at v1.28.4

Pre-commit:
package parity passed
versions synced
congruence passed
landing-page claims passed

Pre-push:
npm pack dry-run passed
public HTML links passed
regression guards passed
```

The npm publish workflow and fresh-registry artifact proof must succeed after merge before `1.28.4` is represented as shipped.
