### PR TITLE
fix(landing): simplify first-screen conversion path

### DIFF
--- a/.changeset/simplify-landing-conversion.md
+++ b/.changeset/simplify-landing-conversion.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Simplify the landing page around one free-install path, concise local-first enforcement proof, and delayed buyer-intent prompts that no longer interrupt first-time visitors.

--- a/config/post-deploy-marketing-pages.json
+++ b/config/post-deploy-marketing-pages.json
@@ -4,7 +4,7 @@
   "pages": [
     {
       "route": "/",
-      "sentinel": "Catch AI agents before they spend money",
+      "sentinel": "Stop dangerous AI-agent actions before they run",
       "description": "Home page hero (lifeblood — never regress)"
     },
     {

--- a/public/index.html
+++ b/public/index.html
@@ -11,10 +11,10 @@ __GOOGLE_SITE_VERIFICATION_META__
 <link rel="alternate icon" type="image/svg+xml" href="/assets/brand/thumbgate-mark.svg">
 <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg">
 <meta property="og:image" content="/og.png">
-<title>ThumbGate — Pre-action checks for AI coding agents</title>
+<title>ThumbGate — Stop risky AI-agent actions before they run</title>
 <meta name="description" content="ThumbGate is the local pre-action governance runtime for AI coding agents (Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode): accepted 👍 thumbs-up and 👎 thumbs-down feedback becomes history-aware local lessons; repeated failures can become prevention rules. PreToolUse checks flag and log risky tool calls, hard-block detected secret leaks, and block matching actions in strict mode. Pro is for individual operators; Enterprise rollout is scoped after intake.">
-<meta property="og:title" content="ThumbGate — Inspect risky AI-agent actions before execution">
-<meta property="og:description" content="ThumbGate evaluates proposed tool calls before execution, records allow/warn/deny decisions, hard-blocks detected secret leaks, and supports strict enforcement for matched rules.">
+<meta property="og:title" content="ThumbGate — Stop risky AI-agent actions before they run">
+<meta property="og:description" content="Check AI-agent tool calls locally before execution. Deny detected secret exfiltration and gate-bypass commands by default, record every decision, and enforce matching rules in strict mode.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="__APP_ORIGIN__/">
 <meta property="og:image" content="https://thumbgate.ai/og.png">
@@ -396,13 +396,21 @@ __GA_BOOTSTRAP__
   .nav-cta:hover { opacity: 0.85; }
 
   /* HERO */
-  .hero { padding: 92px 0 56px; text-align: center; }
+  .hero { padding: 72px 0 56px; text-align: center; }
+  .hero > .container { max-width: 1120px; }
   .hero-thumbs { font-size: 72px; margin-bottom: 20px; line-height: 1; filter: drop-shadow(0 0 24px rgba(34,211,238,0.3)); }
   .hero-badge { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--cyan); background: var(--cyan-dim); border: 1px solid rgba(34,211,238,0.2); padding: 4px 12px; border-radius: 100px; margin-bottom: 24px; font-weight: 500; letter-spacing: 0.02em; text-transform: uppercase; }
-  .hero h1 { font-size: clamp(38px, 5.4vw, 68px); font-weight: 800; letter-spacing: -0.02em; line-height: 1.02; max-width: 900px; margin: 0 auto 18px; }
+  .hero h1 { font-size: clamp(40px, 5.2vw, 68px); font-weight: 800; letter-spacing: -0.035em; line-height: 1.02; max-width: 900px; margin: 0 auto 18px; }
   .hero p { font-size: 17px; color: var(--text-muted); max-width: 620px; margin: 0 auto 28px; line-height: 1.6; }
   .hero-lede { font-size: clamp(18px, 2vw, 21px) !important; max-width: 760px !important; color: var(--text-muted); }
-  .hero-proof-card { max-width: 720px; margin: 0 auto 28px; padding: 20px 22px; border: 1px solid rgba(34,211,238,0.24); border-radius: 8px; background: #090d12; box-shadow: 0 20px 80px rgba(0,0,0,0.35); font-family: var(--mono); text-align: left; }
+  .hero-above-fold { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(390px, 0.8fr); gap: clamp(32px, 4vw, 48px); align-items: center; text-align: left; }
+  .hero-copy .hero-badge { margin-bottom: 18px; }
+  .hero-copy h1 { max-width: 680px; margin: 0 0 20px; }
+  .hero-copy .hero-lede { max-width: 620px !important; margin: 0 0 26px; line-height: 1.55; }
+  .hero-proof-card { max-width: 720px; margin: 0; padding: 12px; border: 1px solid rgba(34,211,238,0.3); border-radius: 14px; background: #090d12; box-shadow: 0 24px 90px rgba(0,0,0,0.42); font-family: var(--mono); text-align: left; }
+  .hero-proof-card figcaption { display: block; padding: 12px 6px 2px; font-family: var(--font); }
+  .hero-proof-card figcaption strong { color: var(--text); font-size: 13px; }
+  .hero-proof-card figcaption span { display: block; margin-top: 5px; color: var(--text-muted); font-size: 12px; text-align: left; }
   .terminal-row { padding: 8px 0; font-size: 14px; line-height: 1.45; border-bottom: 1px solid rgba(255,255,255,0.06); }
   .terminal-row:last-child { border-bottom: 0; }
   .terminal-row.muted { color: var(--text-muted); }
@@ -417,10 +425,15 @@ __GA_BOOTSTRAP__
   .signal-pill.signal-up:hover { border-color: rgba(74, 222, 128, 0.6); background: rgba(74, 222, 128, 0.14); }
   .signal-pill.signal-down { border-color: rgba(248, 113, 113, 0.28); color: #ffc0c0; background: rgba(248, 113, 113, 0.08); }
   .signal-pill.signal-down:hover { border-color: rgba(248, 113, 113, 0.6); background: rgba(248, 113, 113, 0.14); }
-  .hero-actions { display: flex; justify-content: center; align-items: center; flex-wrap: wrap; gap: 12px; margin: 0 auto 16px; max-width: 900px; }
+  .hero-actions { display: flex; justify-content: flex-start; align-items: center; flex-wrap: wrap; gap: 12px; margin: 0 0 16px; max-width: 900px; }
   .hero-actions a, .hero-actions .hero-install { min-height: 48px; border-radius: 8px; }
   .hero-actions .hero-install { margin-bottom: 0; font-size: 18px; padding: 14px 22px; border: 1px solid rgba(34,211,238,0.55); background: rgba(34,211,238,0.07); box-shadow: none; }
-  .hero-actions .btn-install-hero { font-size: 16px; padding: 14px 22px; }
+  .hero-actions .btn-install-hero { font-size: 16px; padding: 14px 24px; background: var(--cyan); color: var(--bg); border: 1px solid var(--cyan); font-weight: 800; box-shadow: 0 12px 36px rgba(34,211,238,0.2); }
+  .hero-actions .hero-proof-link { display: inline-flex; align-items: center; justify-content: center; padding: 14px 18px; color: var(--text); border: 1px solid var(--border); background: var(--bg-raised); text-decoration: none; font-size: 15px; font-weight: 700; }
+  .hero-actions .hero-proof-link:hover { border-color: rgba(34,211,238,0.55); color: var(--cyan); }
+  .hero-team-link { margin: 0 !important; max-width: none !important; font-size: 13px !important; color: var(--text-muted); }
+  .hero-team-link a { color: var(--cyan); text-decoration: none; font-weight: 700; }
+  .hero-team-link a:hover { text-decoration: underline; }
   .hero-actions .hero-diagnostic { font-size: 16px; padding: 14px 22px; background: var(--green); color: #06120a; font-weight: 800; box-shadow: none; }
   .offer-router{max-width:940px;margin:18px auto 22px;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;text-align:left}
   .offer-route{border:1px solid rgba(34,211,238,.18);background:rgba(17,17,19,.72);border-radius:8px;padding:14px}
@@ -675,9 +688,14 @@ __GA_BOOTSTRAP__
     .team-intake-recovery { align-items: stretch; flex-direction: column; text-align: center; }
     .team-intake-recovery a { width: 100%; }
     .team-form { grid-template-columns: 1fr; }
-    .hero { padding: 72px 0 56px; }
+    .hero { padding: 52px 0 48px; }
+    .hero-above-fold { grid-template-columns: 1fr; gap: 30px; }
+    .hero-copy { text-align: center; }
+    .hero-copy h1, .hero-copy .hero-lede { margin-left: auto; margin-right: auto; }
     .hero-actions { flex-direction: column; }
     .hero-actions a { width: 100%; }
+    .hero-proof-card figcaption { display: block; }
+    .hero-proof-card figcaption span { display: block; margin-top: 5px; text-align: left; }
     .offer-router { grid-template-columns: 1fr; }
     .hero-paid-actions { justify-content: center; }
     .hero-paid-actions a { width: 100%; }
@@ -698,7 +716,7 @@ __GA_BOOTSTRAP__
   posthog.capture('$pageview');
   </script>
 </head>
-<body>
+<body data-revenue-assist="off">
 
 <!-- NAV -->
 <nav>
@@ -708,19 +726,8 @@ __GA_BOOTSTRAP__
       <a href="#how-it-works">How It Works</a>
       <a href="/pricing">Pricing</a>
       <a href="/case-studies">Case Studies</a>
-      <a href="/guides/autoresearch-agent-safety">Autoresearch</a>
-      <a href="#faq">FAQ</a>
       <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub</a>
-      <a href="#compatibility" style="display:none;">Compatibility</a>
-      <a href="#compare-guides" style="display:none;">Comparisons</a>
-      <a href="/guide" style="display:none;">Setup Guide</a>
-      <a href="/learn">Learn</a>
-      <a href="/compare" style="display:none;">Compare</a>
-      <a href="/dashboard" style="display:none;">Dashboard Demo</a>
-      <a href="#claude-code-section" class="nav-claude" onclick="posthog.capture('nav_claude_click')" style="display:none;">Claude</a>
-      <a href="#workflow-sprint-intake" onclick="posthog.capture('workflow_sprint')" style="display:none;">Start Sprint</a>
-      <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener" onclick="posthog.capture('nav_claude_extension_click',{cta:'install_claude_extension'})" class="nav-cta" style="background:#d97706;display:none;">Claude Extension</a>
-      <a href="/diagnostic?utm_source=website&utm_medium=nav&utm_campaign=money_today&utm_content=nav_diagnostic&cta_id=nav_pay_diagnostic&cta_placement=nav&plan_id=sprint_diagnostic" data-revenue-cta data-cta-id="nav_pay_diagnostic" data-cta-placement="nav" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__" onclick="trackRevenueCta(this);try{posthog.capture('nav_diagnostic_click',{cta:'nav_pay_diagnostic',price:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__})}catch(_){}" class="nav-cta">Start $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
+      <a href="/go/install?utm_source=website&utm_medium=nav&utm_campaign=install_free&cta_id=nav_install_cli&cta_placement=nav" data-nav-install onclick="event.preventDefault();navigator.clipboard.writeText('npx thumbgate init');this.textContent='Copied ✓';setTimeout(()=>{this.textContent='Install Free'},2000);try{posthog.capture('nav_install_click',{cta:'nav_install_cli'})}catch(_){}" class="nav-cta nav-install" title="Click to copy: npx thumbgate init">Install Free</a>
     </div>
   </div>
 </nav>
@@ -728,70 +735,32 @@ __GA_BOOTSTRAP__
 <!-- HERO -->
 <section class="hero">
   <div class="container">
-    <div class="hero-badge">👍 👎 Local-first · open-source · enterprise governance when agents touch real systems</div>
-    <h1>Catch AI agents before they spend money, leak secrets, or break production.</h1>
-    <p class="hero-lede">Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, and MCP tools can touch terminals, repos, databases, SaaS APIs, and cloud systems. After a configured agent proposes a tool call, ThumbGate evaluates it before execution and records the decision. The default policy denies detected secret exfiltration plus commands that kill the ThumbGate gate process or enable its bypass environment variable; other matched high-risk classes such as destructive deletes, force-pushes, and fetch-and-run commands warn by default. Strict mode turns matching warning-mode checks into denies. The beachhead buyer is an enterprise engineering, security, or platform team that needs governed AI-agent execution before agents touch regulated or high-blast-radius workflows.</p>
+    <div class="hero-above-fold">
+      <div class="hero-copy">
+        <div class="hero-badge">AI-agent firewall for Claude Code, Cursor, and Codex</div>
+        <h1>Stop dangerous AI-agent actions before they run.</h1>
+        <p class="hero-lede">ThumbGate checks tool calls locally, denies detected secret exfiltration and gate-bypass commands by default, and helps turn repeated failures into explicit rules.</p>
+        <div class="hero-actions">
+          <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault();navigator.clipboard.writeText('npx thumbgate init');this.textContent='Copied ✓ — paste in your repo';setTimeout(()=>{this.textContent='Install Free'},2000);try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-free btn-install-hero" title="Click to copy: npx thumbgate init">Install Free</a>
+          <a href="#live-proof" class="hero-proof-link">See it catch a risky command →</a>
+        </div>
+        <p class="hero-team-link">Securing a team workflow? <a href="/diagnostic?utm_source=website&utm_medium=hero_text&utm_campaign=team_workflow&cta_id=hero_team_diagnostic&cta_placement=hero">See the scoped diagnostic →</a></p>
+      </div>
 
-    <div class="hero-signals" aria-label="June 2026 buyer signals">
-      <a class="signal-pill signal-down" href="#june-2026-proof">MCP tool risk</a>
-      <a class="signal-pill" href="#june-2026-proof">Managed-agent rollout</a>
-      <a class="signal-pill" href="#june-2026-proof">Token spend pressure</a>
-      <a class="signal-pill signal-up" href="#workflow-sprint-intake">Regulated agent governance</a>
-    </div>
-
-    <div class="hero-proof-card" aria-label="ThumbGate flagging dangerous AI agent commands in real time">
-      <img src="/media/thumbgate-demo.gif" alt="ThumbGate flagging an AI agent's rm -rf, git push --force, and chmod 777 in real time — flagging them by default and hard-blocking under strict mode — while letting safe commands through" style="width:100%;display:block;border-radius:8px;" loading="lazy" />
-    </div>
-
-    <div class="hero-actions">
-      <a href="/diagnostic?utm_source=website&utm_medium=hero_cta&utm_campaign=money_today&utm_content=hero_diagnostic&cta_id=hero_workflow_sprint_diagnostic_checkout&cta_placement=hero&plan_id=sprint_diagnostic" data-revenue-cta data-cta-id="hero_workflow_sprint_diagnostic_checkout" data-cta-placement="hero" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__" data-sprint-paid-path="diagnostic" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_diagnostic_page_opened',{ctaId:'hero_workflow_sprint_diagnostic_checkout',ctaPlacement:'hero',offer:'sprint_diagnostic',price:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__});try{posthog.capture('hero_diagnostic_page_click',{cta:'hero_diagnostic',price:__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__})}catch(_){}" class="btn-pro-page hero-pro hero-pro-primary hero-diagnostic">Start $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic</a>
-      <a href="/go/sprint?utm_source=website&utm_medium=hero_cta&utm_campaign=money_today&utm_content=hero_sprint&cta_id=hero_workflow_sprint_checkout&cta_placement=hero&plan_id=workflow_sprint" data-revenue-cta data-cta-id="hero_workflow_sprint_checkout" data-cta-placement="hero" data-tier="service" data-plan-id="workflow_sprint" data-price="__WORKFLOW_SPRINT_PRICE_DOLLARS__" data-sprint-paid-path="sprint" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_scope_opened',{ctaId:'hero_workflow_sprint_checkout',ctaPlacement:'hero',offer:'workflow_sprint',price:__WORKFLOW_SPRINT_PRICE_DOLLARS__});try{posthog.capture('hero_sprint_scope_click',{cta:'hero_sprint',price:__WORKFLOW_SPRINT_PRICE_DOLLARS__})}catch(_){}" class="btn-pro-page hero-pro">Scope $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint</a>
-      <a href="/checkout/pro?utm_source=website&utm_medium=hero_cta&utm_campaign=pro_upgrade&cta_id=hero_start_pro&cta_placement=hero&plan_id=pro&landing_path=%2F" data-revenue-cta data-cta-id="hero_start_pro" data-cta-placement="hero" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);try{posthog.capture('hero_pro_checkout_click',{cta:'hero_start_pro',tier:'pro',price:19})}catch(_){}" class="btn-pro-page hero-pro">Start Pro — $19/mo</a>
-      <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault(); navigator.clipboard.writeText('npx thumbgate init'); this.textContent='Copied ✓ — paste in your repo'; setTimeout(()=>{this.textContent='Install Free CLI'},2000); try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-free btn-install-hero" title="Click to copy: npx thumbgate init">Install Free CLI</a>
-    </div>
-    <p class="hero-paid-note" style="margin-top:4px;">Money path today: confirm the <strong>Workflow Hardening Diagnostic ($__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__)</strong> with a work email, or scope the <strong>Sprint ($__WORKFLOW_SPRINT_PRICE_DOLLARS__)</strong> before checkout. Pro stays the solo self-serve lane. Prefer scoping first? <a href="#workflow-sprint-intake" style="color:var(--cyan);" onclick="try{posthog.capture('hero_sprint_click',{cta:'sprint_intake'})}catch(_){};sendFirstPartyTelemetry('hero_sprint_intake_started',{ctaId:'hero_workflow_sprint',ctaPlacement:'hero',offer:'workflow_sprint'});sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'hero_workflow_sprint_recovery_intake',ctaPlacement:'hero',offer:'workflow_sprint_intake'});">Send workflow first</a>.</p>
-
-    <div class="offer-router" aria-label="Choose the right ThumbGate path">
-      <div class="offer-route primary">
-        <strong>Team / enterprise: buy proof this week</strong>
-        <p>One workflow. One repeated failure. Confirm the diagnostic with email, or scope the sprint before checkout — credit applies when you continue to implementation.</p>
-        <a href="/diagnostic?utm_source=website&utm_medium=offer_router&utm_campaign=money_today&cta_id=router_pay_diagnostic&cta_placement=offer_router&plan_id=sprint_diagnostic" data-revenue-cta data-cta-id="router_pay_diagnostic" data-cta-placement="offer_router" data-tier="service" data-plan-id="sprint_diagnostic" data-price="__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_diagnostic_page_opened',{ctaId:'router_pay_diagnostic',ctaPlacement:'offer_router',offer:'sprint_diagnostic'});">Start $__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic →</a>
-        <a href="/go/sprint?utm_source=website&utm_medium=offer_router&utm_campaign=money_today&cta_id=router_pay_sprint&cta_placement=offer_router&plan_id=workflow_sprint" data-revenue-cta data-cta-id="router_pay_sprint" data-cta-placement="offer_router" data-tier="service" data-plan-id="workflow_sprint" data-price="__WORKFLOW_SPRINT_PRICE_DOLLARS__" style="display:block;margin-top:8px;" onclick="trackRevenueCta(this);sendFirstPartyTelemetry('workflow_sprint_scope_opened',{ctaId:'router_pay_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});">Scope $__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint →</a>
-      </div>
-      <div class="offer-route">
-        <strong>Solo operator: Start Pro</strong>
-        <p>Unlimited rules, recall, proof, exports after one real caught repeat.</p>
-        <a href="/checkout/pro?utm_source=website&utm_medium=offer_router&cta_id=router_start_pro&cta_placement=offer_router&plan_id=pro" data-revenue-cta data-cta-id="router_start_pro" data-cta-placement="offer_router" data-tier="pro" data-plan-id="pro" data-price="19" onclick="trackRevenueCta(this);">Confirm $19/mo Pro with email →</a>
-      </div>
-      <div class="offer-route">
-        <strong>Still evaluating: Free CLI or intake</strong>
-        <p>2 captures/day, 3 active rules. Or send the workflow if you need fit review before paying.</p>
-        <button data-router-install onclick="copyInstall(this)"><span class="copy-hint">Copy npx thumbgate init</span></button>
-        <a href="#workflow-sprint-intake" style="display:block;margin-top:10px;color:var(--cyan);font-weight:700;text-decoration:none;" onclick="sendFirstPartyTelemetry('workflow_sprint_intake_started',{ctaId:'router_workflow_sprint',ctaPlacement:'offer_router',offer:'workflow_sprint'});sendFirstPartyTelemetry('workflow_sprint_recovery_intake_clicked',{ctaId:'router_workflow_sprint_recovery_intake',ctaPlacement:'offer_router',offer:'workflow_sprint_intake'});">Send workflow first →</a>
-      </div>
-    </div>
-
-    <div style="max-width:920px;margin:22px auto 0;display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px;text-align:left;">
-      <div style="border:1px solid rgba(34,211,238,0.25);border-radius:10px;background:rgba(34,211,238,0.055);padding:16px;">
-        <strong style="display:block;color:var(--cyan);margin-bottom:6px;">Ideal customer</strong>
-        <span style="color:var(--text-dim);font-size:13px;line-height:1.55;">Enterprise engineering, security, and platform teams already using AI coding agents in repos, CI/CD, SaaS APIs, cloud operations, or audited workflows.</span>
-      </div>
-      <div style="border:1px solid rgba(74,222,128,0.24);border-radius:10px;background:rgba(74,222,128,0.055);padding:16px;">
-        <strong style="display:block;color:var(--green);margin-bottom:6px;">Pain</strong>
-        <span style="color:var(--text-dim);font-size:13px;line-height:1.55;">Security is the pain: agents can repeat dangerous actions. Enterprise governance is the budget: policy, auditability, approvals, and shared prevention before execution.</span>
-      </div>
-      <div style="border:1px solid rgba(168,85,247,0.24);border-radius:10px;background:rgba(168,85,247,0.055);padding:16px;">
-        <strong style="display:block;color:#c084fc;margin-bottom:6px;">Partnership fit</strong>
-        <span style="color:var(--text-dim);font-size:13px;line-height:1.55;">Detection and coordination layers can identify drift. ThumbGate turns approved findings into enforceable PreToolUse rules with decision evidence.</span>
-      </div>
+      <figure class="hero-proof-card" id="live-proof" aria-label="ThumbGate evaluating dangerous AI-agent commands in real time">
+        <img src="/media/thumbgate-demo.gif" alt="ThumbGate evaluating an AI agent's rm -rf, git push --force, and chmod 777 commands in real time while allowing safe commands through" style="width:100%;display:block;border-radius:8px;" loading="eager" fetchpriority="high" />
+        <figcaption>
+          <strong>Real pre-action decision</strong>
+          <span>Default denies for detected secret exfiltration and gate bypasses. Strict mode denies matching rules.</span>
+        </figcaption>
+      </figure>
     </div>
 
     <div class="hero-trust-bar">
-      <span><a href="https://www.npmjs.com/package/thumbgate" target="_blank" rel="noopener" style="color:inherit;text-decoration:none;"><img src="https://img.shields.io/npm/dw/thumbgate?label=npm&amp;color=22d3ee" alt="weekly npm installs of thumbgate" loading="lazy" style="vertical-align:middle;"></a></span>
       <span>MIT open source</span>
       <span>Local-first</span>
-      <span>Works with MCP-compatible agents</span>
-      <span>Verification evidence in GitHub</span>
+      <span>Free CLI</span>
+      <span>Runs before tool execution</span>
     </div>
     <figure style="max-width:760px;margin:32px auto 0;padding:20px 24px;border-left:3px solid var(--cyan);background:rgba(34,211,238,0.04);border-radius:0 8px 8px 0;">
       <blockquote style="margin:0;font-size:18px;line-height:1.5;color:var(--text);font-style:italic;">&ldquo;A better dashboard doesn&rsquo;t make the agents more reliable. The hard part isn&rsquo;t visibility. It&rsquo;s trust.&rdquo;</blockquote>
@@ -843,13 +812,12 @@ __GA_BOOTSTRAP__
       <p>Workflow governance for isolated execution: ThumbGate pairs policy checks with Docker Sandboxes, signed hosted sandbox dispatch, Changeset evidence, and exact main-branch merge commit verification before release claims ship.</p>
       <!--
         Hidden test/asserter strings — required by tests/public-landing.test.js regex assertions
-        (workflow_sprint_*, hero_workflow_sprint_*, ctaId references, dashboard-preview tokens,
-        ChatGPT/GPT messaging, team-pilot-intake-form attribute names). These strings are
+        (dashboard-preview tokens, ChatGPT/GPT messaging, and team-pilot-intake-form
+        attribute names). These strings are
         intentionally not user-visible body text. Do not render. If you remove this block,
         update the test assertions in the same PR.
       -->
       <div hidden aria-hidden="true" data-thumbgate-test-anchors style="display:none">
-        <span data-cta="hero_workflow_sprint_intake">ctaId: 'hero_workflow_sprint' ctaId: 'hero_workflow_sprint_recovery_intake' workflow_sprint_intake_started workflow_sprint_recovery_intake_clicked hero_workflow_sprint_recovery_intake</span>
         <span data-anchor="dashboard-preview">dashboard-preview What your Pro dashboard looks like check:no-force-push</span>
         <span data-anchor="team-intake-form">Start Enterprise Pilot Intake id="team-pilot-intake-form" data-team-intake-form name="ctaPlacement" value="team_visible_intake" name="utmMedium" value="visible_team_intake" name="planId" value="team" name="ctaId" value="workflow_sprint_intake" Enterprise checkout happens after scope. team_workflow_sprint_recovery_intake scope_first workflow_sprint_intake_started workflow_sprint_intake_submit_attempted pricing_team_intake team_intake_started</span>
         <span data-anchor="chatgpt-context">No, you do not have to chat inside the GPT forever. ChatGPT is a discovery and checkpointing surface. Do not rely on ChatGPT's native rating buttons for ThumbGate memory. Explore GPTs choose the GPT by Igor Ganapolsky Programming Do I have to chat inside the ThumbGate GPT for enforcement? capture typed thumbs-up/down feedback Local allow/warn/deny enforcement for coding agents requires a configured integration adapters/chatgpt/INSTALL.md Native ChatGPT rating buttons are not the ThumbGate capture path. thumbs up: this review named exact files, commands, and tests. thumbs down: the answer ignored my request.</span>

--- a/public/index.html
+++ b/public/index.html
@@ -1911,6 +1911,7 @@ function initializeTeamIntakeTelemetry() {
 function resolvePricingClickTier(el) {
   if (el.classList.contains('btn-install-hero')) return 'install';
   if (el.classList.contains('btn-install-link')) return 'install';
+  if (el.hasAttribute('data-nav-install')) return 'install';
   if (el.classList.contains('btn-gpt-page')) return 'chatgpt_gpt';
   if (el.classList.contains('btn-pro')) return 'pro';
   if (el.classList.contains('btn-pro-page')) return 'pro_page';
@@ -1983,7 +1984,14 @@ function copyInstall(el) {
   trackClick('.btn-team', 'workflow_sprint_intake_click', { tier: 'team', offer: 'workflow_hardening_sprint' });
   trackClick('.btn-free', 'install_click', { tier: 'free' });
   trackClick('.btn-demo-link', 'demo_click', { source: 'homepage' });
-  trackClick('.nav-cta:not([data-revenue-cta])', 'chatgpt_gpt_click', { tier: 'free', source: 'nav' });
+  trackClick('.nav-cta[data-nav-install]', 'install_guide_click', {
+    tier: 'free',
+    source: 'nav_install',
+    ctaId: 'nav_install_cli',
+    ctaPlacement: 'nav',
+    planId: 'free',
+  });
+  trackClick('.nav-cta:not([data-revenue-cta]):not([data-nav-install])', 'chatgpt_gpt_click', { tier: 'free', source: 'nav' });
 
   /* Pricing CTA conversion tracking — fires on every Get Started / Pro / Enterprise button click
      with section context so we can distinguish pricing section vs final CTA section clicks */

--- a/public/index.html
+++ b/public/index.html
@@ -762,15 +762,6 @@ __GA_BOOTSTRAP__
       <span>Free CLI</span>
       <span>Runs before tool execution</span>
     </div>
-    <figure style="max-width:760px;margin:32px auto 0;padding:20px 24px;border-left:3px solid var(--cyan);background:rgba(34,211,238,0.04);border-radius:0 8px 8px 0;">
-      <blockquote style="margin:0;font-size:18px;line-height:1.5;color:var(--text);font-style:italic;">&ldquo;A better dashboard doesn&rsquo;t make the agents more reliable. The hard part isn&rsquo;t visibility. It&rsquo;s trust.&rdquo;</blockquote>
-      <figcaption style="margin-top:12px;font-size:13px;color:var(--text-muted);">— Rob May, CEO &amp; co-founder, Neurometric AI, in <a href="https://thenewstack.io/claude-code-agent-view/" target="_blank" rel="noopener" style="color:var(--cyan);">The New Stack</a> on Anthropic&rsquo;s Claude Code Agent View (May 2026). This is Rob May describing the industry, not an endorsement of ThumbGate. ThumbGate addresses that trust problem with configured PreToolUse gates, accepted feedback, explicit prevention rules, and local decision records.</figcaption>
-    </figure>
-    <figure style="max-width:760px;margin:24px auto 0;padding:20px 24px;border-left:3px solid var(--cyan);background:rgba(34,211,238,0.04);border-radius:0 8px 8px 0;">
-      <p style="margin:0 0 8px;font-size:14px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.08em;">Local-first is the new default</p>
-      <blockquote style="margin:0;font-size:16px;line-height:1.55;color:var(--text);">Perplexity demoed a Personal Computer agent at Computex 2026 that <strong>asks the user before sending sensitive content to the cloud</strong>. Automation Anywhere shipped EnterpriseClaw with Cisco, NVIDIA, Okta, and OpenAI — <strong>central policy, locally enforced, audit reported back</strong>. The architectural debate is settled. ThumbGate runs the same pattern for the coding agent already on your laptop.</blockquote>
-      <figcaption style="margin-top:12px;font-size:13px;color:var(--text-muted);">Sources: Perplexity at Intel Computex keynote (2026-06-02), Automation Anywhere EnterpriseClaw launch (Imagine 2026), <a href="https://thenewstack.io/automation-anywhere-enterpriseclaw-ai-agents/" target="_blank" rel="noopener" style="color:var(--cyan);">The New Stack coverage</a>.</figcaption>
-    </figure>
     <div class="first-check-card" id="first-check">
       <div class="section-label" style="text-align:left;margin-bottom:8px;">First-Dollar Activation Path</div>
       <h2>Run your first pre-action check locally.</h2>
@@ -790,6 +781,10 @@ __GA_BOOTSTRAP__
         </div>
       </div>
     </div>
+
+    <aside style="max-width:760px;margin:24px auto 0;padding:16px 20px;border-left:3px solid var(--cyan);background:rgba(34,211,238,0.04);border-radius:0 8px 8px 0;">
+      <p style="margin:0;font-size:15px;line-height:1.55;color:var(--text);"><strong>Why local-first?</strong> Data ownership requires usable control, governance, portability, and structural independence—not merely a downloadable copy. ThumbGate keeps configured action checks, feedback, and prevention rules in the operator&rsquo;s workflow. <a href="https://www.infoq.com/news/2026/07/data-ownership-localfirst/" target="_blank" rel="noopener" style="color:var(--cyan);">Read the Local First Conf 2026 synthesis →</a></p>
+    </aside>
 
     <nav class="proof-bar" aria-label="ThumbGate install and proof links">
       <a href="https://github.com/IgorGanapolsky/ThumbGate/releases/latest/download/thumbgate-claude-desktop.mcpb" target="_blank" rel="noopener">Claude Extension →</a>

--- a/public/js/buyer-intent.js
+++ b/public/js/buyer-intent.js
@@ -361,10 +361,22 @@
       });
     }
 
-    if (checkoutWasSeen() && global.setTimeout) {
-      global.setTimeout(function() {
+    var checkoutReturnTimer = null;
+
+    function scheduleCheckoutReturnSurvey() {
+      if (!checkoutWasSeen() || !global.setTimeout) return;
+      if (checkoutReturnTimer && global.clearTimeout) {
+        global.clearTimeout(checkoutReturnTimer);
+      }
+      checkoutReturnTimer = global.setTimeout(function() {
+        checkoutReturnTimer = null;
         showAbandonSurvey('checkout_return');
       }, settings.checkoutReturnSurveyDelayMs || 1200);
+    }
+
+    scheduleCheckoutReturnSurvey();
+    if (global.addEventListener) {
+      global.addEventListener('pageshow', scheduleCheckoutReturnSurvey);
     }
 
     return {

--- a/public/js/buyer-intent.js
+++ b/public/js/buyer-intent.js
@@ -1,5 +1,6 @@
 (function(global) {
   var BUYER_EMAIL_STORAGE_KEY = 'thumbgateBuyerEmail';
+  var REVENUE_ASSIST_CHECKOUT_KEY = 'thumbgateRevenueAssistCheckoutSeen';
   var CHECKOUT_LINK_SELECTOR = 'a[href*="/checkout/pro"], a[href*="/go/pro"]';
   var BUYER_EMAIL_SELECTOR = '[data-buyer-email]';
 
@@ -263,9 +264,9 @@
 
     panel.querySelectorAll('[data-assist-cta]').forEach(function(link) {
       link.addEventListener('click', function() {
-        try {
-          global.sessionStorage.setItem('thumbgateRevenueAssistCheckoutSeen', '1');
-        } catch (_error) {}
+        if (link.getAttribute('data-assist-cta') === 'assist_pro_checkout') {
+          markCheckoutSeen();
+        }
         trackEvent('assist_cta_click', {
           ctaId: link.getAttribute('data-assist-cta'),
           ctaPlacement: placement,
@@ -282,7 +283,6 @@
           page: pathname,
         });
         panel.remove();
-        showAbandonSurvey('cta_dismiss');
       });
     }
 
@@ -308,22 +308,33 @@
 
     function checkoutWasSeen() {
       try {
-        return global.sessionStorage.getItem('thumbgateRevenueAssistCheckoutSeen') === '1';
+        return global.sessionStorage.getItem(REVENUE_ASSIST_CHECKOUT_KEY) === '1';
       } catch (_error) {
         return false;
       }
     }
 
+    function markCheckoutSeen() {
+      try {
+        global.sessionStorage.setItem(REVENUE_ASSIST_CHECKOUT_KEY, '1');
+      } catch (_error) {}
+    }
+
+    getCheckoutLinks().forEach(function(link) {
+      link.addEventListener('click', markCheckoutSeen);
+    });
+
     function showAbandonSurvey(trigger) {
-      if (wasSurveyShown() || checkoutWasSeen() || global.document.querySelector('[data-thumbgate-abandon-survey]')) {
+      if (wasSurveyShown() || !checkoutWasSeen() || global.document.querySelector('[data-thumbgate-abandon-survey]')) {
         return;
       }
       markSurveyShown();
+      panel.remove();
       var survey = global.document.createElement('aside');
       survey.setAttribute('data-thumbgate-abandon-survey', trigger || 'unknown');
       survey.setAttribute('aria-label', 'ThumbGate checkout feedback');
       survey.innerHTML = [
-        '<strong>What stopped you from buying today?</strong>',
+        '<strong>What stopped you from completing checkout?</strong>',
         '<div>',
         '<button type="button" data-abandon-reason="fit_unclear">Not sure it fits my agent stack</button>',
         '<button type="button" data-abandon-reason="need_proof">Need proof before paying</button>',
@@ -350,17 +361,10 @@
       });
     }
 
-    if (global.setTimeout) {
+    if (checkoutWasSeen() && global.setTimeout) {
       global.setTimeout(function() {
-        showAbandonSurvey('dwell_45s');
-      }, settings.surveyDelayMs || 45000);
-    }
-    if (global.document && global.document.addEventListener) {
-      global.document.addEventListener('mouseleave', function(event) {
-        if (event && event.clientY <= 0) {
-          showAbandonSurvey('exit_intent');
-        }
-      });
+        showAbandonSurvey('checkout_return');
+      }, settings.checkoutReturnSurveyDelayMs || 1200);
     }
 
     return {

--- a/tests/buyer-intent-revenue-assist.test.js
+++ b/tests/buyer-intent-revenue-assist.test.js
@@ -31,6 +31,15 @@ test('buyer intent script exposes paid CTA and abandon reason observability', ()
   assert.match(BUYER_INTENT, /researching/);
 });
 
+test('abandon survey requires a prior checkout visit and never fires on generic dwell or exit intent', () => {
+  assert.match(BUYER_INTENT, /wasSurveyShown\(\) \|\| !checkoutWasSeen\(\)/);
+  assert.match(BUYER_INTENT, /showAbandonSurvey\('checkout_return'\)/);
+  assert.match(BUYER_INTENT, /What stopped you from completing checkout\?/);
+  assert.doesNotMatch(BUYER_INTENT, /showAbandonSurvey\('dwell_45s'\)/);
+  assert.doesNotMatch(BUYER_INTENT, /showAbandonSurvey\('exit_intent'\)/);
+  assert.doesNotMatch(BUYER_INTENT, /showAbandonSurvey\('cta_dismiss'\)/);
+});
+
 test('revenue assist routes workflow help through intake, not blind diagnostic checkout', () => {
   const intakeLinkTemplate = BUYER_INTENT.match(/<a data-assist-cta="assist_workflow_intake"[^;]+Send workflow first<\/a>/);
 

--- a/tests/buyer-intent-revenue-assist.test.js
+++ b/tests/buyer-intent-revenue-assist.test.js
@@ -34,6 +34,9 @@ test('buyer intent script exposes paid CTA and abandon reason observability', ()
 test('abandon survey requires a prior checkout visit and never fires on generic dwell or exit intent', () => {
   assert.match(BUYER_INTENT, /wasSurveyShown\(\) \|\| !checkoutWasSeen\(\)/);
   assert.match(BUYER_INTENT, /showAbandonSurvey\('checkout_return'\)/);
+  assert.match(BUYER_INTENT, /function scheduleCheckoutReturnSurvey\(\)/);
+  assert.match(BUYER_INTENT, /global\.addEventListener\('pageshow', scheduleCheckoutReturnSurvey\)/);
+  assert.match(BUYER_INTENT, /global\.clearTimeout\(checkoutReturnTimer\)/);
   assert.match(BUYER_INTENT, /What stopped you from completing checkout\?/);
   assert.doesNotMatch(BUYER_INTENT, /showAbandonSurvey\('dwell_45s'\)/);
   assert.doesNotMatch(BUYER_INTENT, /showAbandonSurvey\('exit_intent'\)/);

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -56,10 +56,26 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
 
   test('clicking nav Install Free copies the command without leaving the page', async ({ page }) => {
     await page.goto('/');
+    await page.evaluate(() => {
+      window.__thumbgatePlausibleEvents = [];
+      window.plausible = (eventName, options) => {
+        window.__thumbgatePlausibleEvents.push({ eventName, options });
+      };
+    });
     const install = page.locator('[data-nav-install]');
     await install.click();
     await expect(install).toHaveText(/Copied/);
     await expect(page).toHaveURL(/\/$/);
+
+    const events = await page.evaluate(() => window.__thumbgatePlausibleEvents);
+    expect(events.some(({ eventName }) => eventName === 'install_guide_click')).toBe(true);
+    expect(events.some(({ eventName }) => eventName === 'chatgpt_gpt_click')).toBe(false);
+    expect(events).toContainEqual(expect.objectContaining({
+      eventName: 'pricing_cta_click',
+      options: expect.objectContaining({
+        props: expect.objectContaining({ tier: 'install' }),
+      }),
+    }));
   });
 
   test('hero explanation stays concise', async ({ page }) => {
@@ -68,6 +84,23 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
       element.textContent.trim().split(/\s+/).length
     ));
     expect(words).toBeLessThanOrEqual(25);
+  });
+
+  test('checkout-return survey is re-armed when browser history restores an eligible page', async ({ page }) => {
+    await page.goto('/guide');
+    const checkout = page.locator('[data-assist-cta="assist_pro_checkout"]');
+    await expect(checkout).toBeVisible();
+
+    await checkout.evaluate((element) => {
+      element.addEventListener('click', (event) => event.preventDefault(), { capture: true, once: true });
+    });
+    await checkout.click();
+    await expect(page.locator('[data-thumbgate-abandon-survey]')).toHaveCount(0);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('pageshow')));
+    const survey = page.locator('[data-thumbgate-abandon-survey="checkout_return"]');
+    await expect(survey).toBeVisible({ timeout: 5000 });
+    await expect(survey).toContainText('What stopped you from completing checkout?');
   });
 
   // --- nav region (in-page anchors that are actually visible) ---

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -23,54 +23,51 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
 
   test('renders the hero install command + visible CTAs', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.hero-pro-primary')).toBeVisible();
+    await expect(page.locator('.hero h1')).toHaveText('Stop dangerous AI-agent actions before they run.');
     await expect(page.locator('.btn-install-hero')).toBeVisible();
-    await expect(page.locator('.hero-pro', { hasText: /Start \$\d+ diagnostic/ })).toBeVisible();
-    await expect(page.locator('.hero-pro', { hasText: /Scope \$\d+ sprint/ })).toBeVisible();
-    await expect(page.locator('.hero-pro', { hasText: /Start Pro/ })).toBeVisible();
-    await expect(page.locator('.offer-router')).toBeVisible();
-    await expect(page.locator('.offer-route', { hasText: /Solo operator/ })).toBeVisible();
-    await expect(page.locator('.offer-route', { hasText: /Team \/ enterprise|buy proof/i })).toBeVisible();
-    await expect(page.locator('.offer-route', { hasText: /Still evaluating/ })).toBeVisible();
+    await expect(page.locator('.hero-proof-link')).toBeVisible();
+    await expect(page.locator('#live-proof')).toBeVisible();
+    await expect(page.locator('.hero-pro')).toHaveCount(0);
+    await expect(page.locator('.offer-router')).toHaveCount(0);
   });
 
-  test('clicking router install button copies the command and confirms the copy', async ({ page }) => {
+  test('clicking the proof CTA jumps to the live product demo', async ({ page }) => {
     await page.goto('/');
-    const btn = page.locator('[data-router-install]');
-    await expect(btn.locator('.copy-hint')).toHaveText('Copy npx thumbgate init');
-    await btn.click();
-    await expect(btn.locator('.copy-hint')).toHaveText('copied!');
-    await expect(btn.locator('.copy-hint')).toHaveClass(/copied/);
+    await page.locator('.hero-proof-link').click();
+    await expect(page).toHaveURL(/#live-proof$/);
+    await expect(page.locator('#live-proof')).toBeVisible();
   });
 
-  test('clicking "Install Free CLI" button swaps its label to the Copied confirmation', async ({ page }) => {
+  test('clicking "Install Free" button swaps its label to the Copied confirmation', async ({ page }) => {
     await page.goto('/');
     const btn = page.locator('.btn-install-hero');
     const originalText = (await btn.textContent()).trim();
-    expect(originalText).toBe('Install Free CLI');
+    expect(originalText).toBe('Install Free');
     await btn.click();
     await expect(btn).toHaveText(/Copied/);
   });
 
-  test('clicking hero "Send workflow first" anchors to #workflow-sprint-intake', async ({ page }) => {
+  test('the quiet team path opens the scoped diagnostic page', async ({ page }) => {
     await page.goto('/');
-    await page.locator('.hero-paid-note a', { hasText: /Send workflow first/ }).click();
-    await expect(page).toHaveURL(/#workflow-sprint-intake$/);
-  });
-
-  test('router primary CTA opens the diagnostic confirmation page', async ({ page }) => {
-    await page.goto('/');
-    await page.locator('.offer-route.primary a', { hasText: /Start \$\d+ diagnostic/ }).click();
+    await page.locator('.hero-team-link a', { hasText: /scoped diagnostic/i }).click();
     await expect(page).toHaveURL(/\/diagnostic\?/);
     await expect(page.locator('[data-diagnostic-pay-form] input[name="customer_email"]')).toBeVisible();
   });
 
-  test('router Pro CTA opens the email-backed Pro intent form', async ({ page }) => {
+  test('clicking nav Install Free copies the command without leaving the page', async ({ page }) => {
     await page.goto('/');
-    await page.locator('.offer-route', { hasText: /Solo operator/ }).locator('a', { hasText: /Confirm \$19\/mo Pro with email/ }).click();
-    await expect(page).toHaveURL(/\/checkout\/pro\?/);
-    await expect(page).toHaveURL(/cta_id=router_start_pro/);
-    await expect(page.locator('form[action="/checkout/pro"] input[name="customer_email"]')).toBeVisible();
+    const install = page.locator('[data-nav-install]');
+    await install.click();
+    await expect(install).toHaveText(/Copied/);
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('hero explanation stays concise', async ({ page }) => {
+    await page.goto('/');
+    const words = await page.locator('.hero-copy .hero-lede').evaluate((element) => (
+      element.textContent.trim().split(/\s+/).length
+    ));
+    expect(words).toBeLessThanOrEqual(25);
   });
 
   // --- nav region (in-page anchors that are actually visible) ---
@@ -88,10 +85,10 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await expect(page.locator('#how-it-works')).toBeVisible();
   });
 
-  test('nav "FAQ" link jumps to #faq', async ({ page }) => {
-    await page.goto('/');
-    await page.locator('nav a[href="#faq"]').first().click();
-    await expect(page).toHaveURL(/#faq$/);
+  test('secondary FAQ and Learn links stay out of the header while their pages remain available', async ({ page }) => {
+    await page.goto('/#faq');
+    await expect(page.locator('nav a[href="#faq"]')).toHaveCount(0);
+    await expect(page.locator('nav a[href="/learn"]')).toHaveCount(0);
     await expect(page.locator('#faq')).toBeVisible();
   });
 
@@ -101,17 +98,18 @@ test.describe('/ landing page clickability — comprehensive E2E coverage', () =
     await page.waitForURL(/\/pricing$/);
   });
 
-  test('nav "Learn" link navigates to /learn', async ({ page }) => {
+  test('nav "Case Studies" link navigates to /case-studies', async ({ page }) => {
     await page.goto('/');
-    await page.locator('nav a[href="/learn"]').first().click();
-    await page.waitForURL(/\/learn$/);
+    await page.locator('nav a[href="/case-studies"]').first().click();
+    await page.waitForURL(/\/case-studies$/);
   });
 
-  test('nav diagnostic CTA routes to the diagnostic confirmation page', async ({ page }) => {
+  test('nav CTA is the free install path, not a high-ticket checkout', async ({ page }) => {
     await page.goto('/');
-    await page.locator('nav a.nav-cta', { hasText: /diagnostic/i }).first().click();
-    await expect(page).toHaveURL(/\/diagnostic\?/);
-    await expect(page.locator('[data-diagnostic-pay-form] input[name="customer_email"]')).toBeVisible();
+    const cta = page.locator('nav a.nav-cta').first();
+    await expect(cta).toHaveText('Install Free');
+    await expect(cta).toHaveAttribute('href', /\/go\/install/);
+    await expect(cta).not.toHaveAttribute('href', /diagnostic/);
   });
 
   // --- FAQ accordion (deterministic, no backend) ---

--- a/tests/learn-hub.test.js
+++ b/tests/learn-hub.test.js
@@ -379,12 +379,12 @@ test('persistent-memory article has related links to other articles', () => {
 });
 
 // ============================================================
-// Integration: Landing page nav includes Learn link
+// Integration: Landing page includes Learn link without crowding the primary nav
 // ============================================================
 
-test('landing page nav includes Learn link', () => {
+test('landing page links to the Learn hub from the guide section', () => {
   const html = readFile(landingPath);
-  assert.match(html, /href="\/learn">Learn<\/a>/);
+  assert.match(html, /href="\/learn">Browse the guide library<\/a>/);
 });
 
 // ============================================================

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -648,7 +648,10 @@ test('public landing page includes Plausible custom event tracking for all CTAs'
   assert.match(landingPage, /selector: '#team-pilot-intake-form'/);
   assert.match(landingPage, /trackClick\('.btn-free', 'install_click'/);
   assert.match(landingPage, /trackClick\('.btn-demo-link', 'demo_click'/);
-  assert.match(landingPage, /trackClick\('.nav-cta:not\(\[data-revenue-cta\]\)', 'chatgpt_gpt_click'/);
+  assert.match(landingPage, /trackClick\('.nav-cta\[data-nav-install\]', 'install_guide_click'/);
+  assert.match(landingPage, /ctaId: 'nav_install_cli'/);
+  assert.match(landingPage, /trackClick\('.nav-cta:not\(\[data-revenue-cta\]\):not\(\[data-nav-install\]\)', 'chatgpt_gpt_click'/);
+  assert.match(landingPage, /if \(el\.hasAttribute\('data-nav-install'\)\) return 'install'/);
   assert.match(landingPage, /plausible\('faq_open'/);
   assert.match(landingPage, /plausible\('scroll_depth'/);
   assert.match(landingPage, /trackClick\('.proof-bar a', 'proof_bar_click'\)/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -132,38 +132,33 @@ test('public landing page distinguishes pre-action governance from logging and s
   assert.match(landingPage, /hosted team sync, org dashboards, SSO, SIEM, and compliance packaging are not general-availability/i);
 });
 
-test('public landing page exposes above-fold paid diagnostic/sprint CTAs with Pro as side lane', () => {
+test('public landing page exposes one primary free-install path with immediate proof', () => {
   const landingPage = readLandingPage();
   const heroStart = landingPage.indexOf('<!-- HERO -->');
   const heroEnd = landingPage.indexOf('<div class="hero-trust-bar">');
   const aboveFold = landingPage.slice(0, heroEnd);
   const heroBlock = landingPage.slice(heroStart, heroEnd);
+  const heroLede = heroBlock.match(/<p class="hero-lede">([\s\S]*?)<\/p>/);
 
   assert.ok(heroStart > -1);
   assert.ok(heroEnd > heroStart);
-  assert.match(aboveFold, /cta_id=nav_pay_diagnostic/);
-  assert.match(aboveFold, /data-revenue-cta data-cta-id="nav_pay_diagnostic"/);
-  assert.match(heroBlock, /cta_id=hero_workflow_sprint_diagnostic_checkout/);
-  assert.match(heroBlock, /data-revenue-cta data-cta-id="hero_workflow_sprint_diagnostic_checkout"/);
-  assert.match(heroBlock, /Start \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
-  assert.match(heroBlock, /href="\/diagnostic\?/);
-  assert.match(heroBlock, /cta_id=hero_workflow_sprint_checkout/);
-  assert.match(heroBlock, /Scope \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
-  assert.match(heroBlock, /cta_id=hero_start_pro/);
-  assert.match(heroBlock, /Start Pro — \$19\/mo/);
-  assert.match(heroBlock, /\/checkout\/pro\?/);
-  assert.ok(heroBlock.indexOf('hero_workflow_sprint_diagnostic_checkout') < heroBlock.indexOf('hero_start_pro'));
-  assert.ok(heroBlock.indexOf('hero_start_pro') < heroBlock.indexOf('hero_install_cli'));
-  assert.match(heroBlock, /aria-label="Choose the right ThumbGate path"/);
-  assert.match(heroBlock, /Team \/ enterprise: buy proof this week/);
-  assert.match(heroBlock, /data-cta-id="router_pay_diagnostic"/);
-  assert.match(heroBlock, /data-cta-id="router_pay_sprint"/);
-  assert.match(heroBlock, /Solo operator: Start Pro/);
-  assert.match(heroBlock, /data-cta-id="router_start_pro"/);
-  assert.match(heroBlock, /Ideal customer/);
-  assert.match(heroBlock, /enterprise engineering, security, and platform teams/i);
-  assert.match(heroBlock, /Detection and coordination layers can identify drift/);
-  assert.match(heroBlock, /Still evaluating: Free CLI/);
+  assert.ok(heroLede, 'hero lede should exist');
+  assert.ok(normalizeHtmlText(heroLede[1]).split(' ').length <= 25, 'hero lede must stay at or below 25 words');
+  assert.match(aboveFold, /cta_id=nav_install_cli/);
+  assert.match(aboveFold, /data-nav-install/);
+  assert.match(heroBlock, /Stop dangerous AI-agent actions before they run\./);
+  assert.match(heroBlock, /cta_id=hero_install_cli/);
+  assert.match(heroBlock, /class="btn-free btn-install-hero"/);
+  assert.match(heroBlock, /href="#live-proof" class="hero-proof-link"/);
+  assert.match(heroBlock, /id="live-proof"/);
+  assert.match(heroBlock, /Real pre-action decision/);
+  assert.match(heroBlock, /cta_id=hero_team_diagnostic/);
+  assert.match(heroBlock, /See the scoped diagnostic/);
+  assert.doesNotMatch(aboveFold, /nav_pay_diagnostic/);
+  assert.doesNotMatch(heroBlock, /Start \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
+  assert.doesNotMatch(heroBlock, /Scope \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
+  assert.doesNotMatch(heroBlock, /hero_start_pro|offer-router|hero-signals/);
+  assert.match(landingPage, /<body data-revenue-assist="off">/);
   assert.match(landingPage, /function trackRevenueCta/);
   assert.match(landingPage, /plausible\('pricing_cta_click'/);
   assert.match(landingPage, /plausible\('checkout_start'/);
@@ -248,27 +243,17 @@ test('public landing page shows an at-a-glance plan comparison matrix with consi
   assert.match(landingPage, /SSO, SIEM \+ compliance packaging[\s\S]{0,500}Not GA/i);
 });
 
-test('public landing page leads with paid diagnostic/sprint checkout, not retired service ladders', () => {
+test('public landing page keeps paid services on the scoped diagnostic path, not in the hero', () => {
   const landingPage = readLandingPage();
+  const heroStart = landingPage.indexOf('<!-- HERO -->');
+  const heroEnd = landingPage.indexOf('<div class="hero-trust-bar">');
+  const heroBlock = landingPage.slice(heroStart, heroEnd);
 
   assert.match(landingPage, /Have one AI-agent failure that keeps repeating\?/);
   assert.match(landingPage, /one real workflow, one repeated failure pattern, enforceable pre-action gates/);
-  // Canonical money path: diagnostic confirmation page + sprint payment router.
-  assert.match(landingPage, /Start \$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__ diagnostic/);
-  assert.match(landingPage, /Scope \$__WORKFLOW_SPRINT_PRICE_DOLLARS__ sprint/);
-  assert.match(landingPage, /\/diagnostic\?/);
-  assert.match(landingPage, /\/go\/sprint\?/);
-  assert.match(landingPage, /data-sprint-paid-path="diagnostic"/);
-  assert.match(landingPage, /data-sprint-paid-path="sprint"/);
-  assert.match(landingPage, /hero_workflow_sprint_diagnostic_checkout/);
-  assert.match(landingPage, /hero_workflow_sprint_checkout/);
-  assert.match(landingPage, /workflow_sprint_diagnostic_page_opened/);
-  assert.match(landingPage, /workflow_sprint_scope_opened/);
-  assert.match(landingPage, /Send workflow first/);
-  assert.match(landingPage, /hero_workflow_sprint_recovery_intake/);
-  assert.match(landingPage, /workflow_sprint_recovery_intake_clicked/);
-  assert.match(landingPage, /ctaId: 'hero_workflow_sprint'/);
-  assert.match(landingPage, /ctaId: 'hero_workflow_sprint_recovery_intake'/);
+  assert.match(heroBlock, /href="\/diagnostic\?[^\"]*cta_id=hero_team_diagnostic/);
+  assert.doesNotMatch(heroBlock, /data-revenue-cta|data-sprint-paid-path|\/go\/sprint\?/);
+  assert.doesNotMatch(heroBlock, /Start Pro|Start \$|Scope \$/);
   // Retired experimental ladders must stay off the homepage.
   assert.doesNotMatch(landingPage, /Pay \$99 diagnostic/);
   assert.doesNotMatch(landingPage, /Pay \$1 first rule/);

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -436,6 +436,18 @@ test('public landing page gives cold users a first-dollar activation path', () =
   assert.doesNotMatch(landingPage, /in 5 minutes|in 60 seconds/i);
 });
 
+test('public landing page keeps local-first evidence scoped and below activation', () => {
+  const landingPage = readLandingPage();
+  const activationIndex = landingPage.indexOf('First-Dollar Activation Path');
+  const evidenceIndex = landingPage.indexOf('Why local-first?');
+
+  assert.ok(activationIndex > -1);
+  assert.ok(evidenceIndex > activationIndex);
+  assert.match(landingPage, /data ownership requires usable control, governance, portability, and structural independence/i);
+  assert.match(landingPage, /infoq\.com\/news\/2026\/07\/data-ownership-localfirst/);
+  assert.doesNotMatch(landingPage, /the architectural debate is settled/i);
+});
+
 test('Codex plugin page keeps proof and follow-on CTAs close to the install path', () => {
   const codexPluginPage = readCodexPluginPage();
 


### PR DESCRIPTION
## What Changed

- Replaced the mixed paid-offer hero with one free install CTA, one proof CTA, and a quiet scoped team path.
- Reduced the visible hero explanation to 22 words, trimmed the primary navigation, and placed the live enforcement demo above the fold.
- Disabled homepage revenue-assist overlays and restricted abandonment surveys to sessions with a prior checkout visit.
- Updated landing, buyer-intent, Learn-link, Chromium E2E, and post-deploy sentinel contracts.

## Why

- The previous first screen mixed diagnostic, sprint, Pro, free, persona, and survey paths before a visitor could understand or trust the product.
- This change gives a cold visitor one low-friction action and immediate proof while preserving paid routes lower on the page and on dedicated surfaces.
- No pricing, billing, checkout, enforcement, or package behavior changed.

## Verification

- npm test: every package-test command passed in a neutral CI environment; self-heal repeated the full nested suite in 608715 ms.
- npm run test:coverage: terminal green in an isolated temporary home.
- npm run prove:adapters: 48/48 passed.
- npm run prove:automation: 55/55 passed.
- npm run self-heal:check: 6/6 healthy.
- node --test tests/public-landing.test.js tests/buyer-intent-revenue-assist.test.js: 57/57 passed.
- npx playwright test tests/e2e/index-page-clickability.spec.js --project=chromium: 20/20 passed.
- npm run test:learn-hub: 63/63 passed.
- npm run test:check-congruence: 12/12 passed.
- git diff --check and the touched-file secret-pattern scan passed.

## Evidence

- Local desktop and mobile screenshots were manually reviewed for hierarchy, overflow, and popup behavior.
- The post-deploy manifest now requires the new home-page headline, so production verification fails closed on stale HTML.
- Existing verification evidence documents remain unchanged; this PR adds executable landing and deploy-sentinel coverage for the behavior change.

## Risks

- Conversion lift is not yet proven; authenticated funnel telemetry or an experiment is still required.
- Hosted billing-summary authentication remains a separate observability issue and is not changed here.