### PR TITLE
fix(deps): refresh vulnerable transitive packages

### DIFF
--- a/.changeset/refresh-audit-transitives.md
+++ b/.changeset/refresh-audit-transitives.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Refresh vulnerable archive, glob, YAML, and protobuf transitive dependencies to patched releases without changing ThumbGate's public API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "better-sqlite3": "^12.9.0",
         "dotenv": "^17.4.2",
         "playwright-core": "^1.59.1",
-        "protobufjs": "^8.5.0",
+        "protobufjs": "^8.7.1",
         "stripe": "^22.2.0"
       },
       "bin": {
@@ -418,9 +418,9 @@
       }
     },
     "node_modules/@google/genai/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1371,12 +1371,12 @@
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -1554,9 +1554,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -3057,9 +3057,9 @@
       "license": "MIT"
     },
     "node_modules/onnxruntime-web/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3329,9 +3329,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
-      "integrity": "sha512-s4qQPr4pU0W95iYnUInh95skjIg+3aM2sakYsw60QYanU+qWRDY2zQxOAQV6zU7ROJpSNDG9B+VSmk4dqdWWSA==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"

--- a/package.json
+++ b/package.json
@@ -879,20 +879,22 @@
     "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.2",
     "playwright-core": "^1.59.1",
-    "protobufjs": "^8.5.0",
+    "protobufjs": "^8.7.1",
     "stripe": "^22.2.0"
   },
   "overrides": {
+    "adm-zip": "0.6.0",
     "@google/genai": {
-      "protobufjs": "7.6.4"
+      "protobufjs": "7.6.5"
     },
+    "brace-expansion": "5.0.7",
     "onnxruntime-web": {
-      "protobufjs": "7.6.4"
+      "protobufjs": "7.6.5"
     },
     "express@4.22.1": {
       "path-to-regexp": "0.1.13"
     },
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   },
   "mcpName": "io.github.IgorGanapolsky/thumbgate",
   "devDependencies": {


### PR DESCRIPTION
## Why

PR #2966 reached the required root dependency audit and failed after the npm advisory database reported 21 vulnerabilities (18 high, 3 moderate) in the unchanged main lockfile. This focused prerequisite restores the required CI gate without weakening or bypassing it.

## Changes

- pin patched transitive releases for `adm-zip`, `brace-expansion`, `js-yaml`, and nested `protobufjs`
- advance direct `protobufjs` within its existing major line
- add a patch changeset for the dependency refresh

No `npm audit fix --force` or breaking top-level package upgrade was used.

## Verification

- clean `npm ci`: passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- neutral-environment `npm test`: passed with exit code 0
- rate-limiter neutral-environment regression: 11/11 passed
- `npm run changeset:check -- --base=origin/main`: passed
- `git diff --check`: passed
- pre-commit and pre-push guards: passed

## Dependency versions

- `adm-zip` 0.6.0
- `brace-expansion` 5.0.7
- `js-yaml` 4.3.0
- direct `protobufjs` 8.7.1
- nested `protobufjs` 7.6.5

## Relationship

This PR is the CI prerequisite for #2966. Once merged, #2966 will be updated from `main` and revalidated on the exact combined head.
