### PR TITLE
fix(brand): align site marks with Stripe TG gate monogram

### DIFF
--- a/.changeset/brand-stripe-logo-align.md
+++ b/.changeset/brand-stripe-logo-align.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Align site header/app marks with the Stripe product TG gate monogram so checkout and thumbgate.ai use the same emblem family.

--- a/.changeset/brand-stripe-logo-align.md
+++ b/.changeset/brand-stripe-logo-align.md
@@ -2,4 +2,4 @@
 "thumbgate": patch
 ---
 
-Align site header/app marks with the Stripe product TG gate monogram so checkout and thumbgate.ai use the same emblem family.
+Align site header/app marks with the canonical Stripe TG gate monogram (dark tile, inset frame, arched gate, bold TG, threshold bar) so checkout and thumbgate.ai use the same emblem family — not the retired shield/thumbs-up and not a dual-rect simplification.

--- a/public/assets/brand/thumbgate-mark-inline-v3.svg
+++ b/public/assets/brand/thumbgate-mark-inline-v3.svg
@@ -1,18 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="tg-inline-title tg-inline-desc">
   <title id="tg-inline-title">ThumbGate</title>
-  <desc id="tg-inline-desc">ThumbGate premium shield and thumbs-up mark for inline use in site headers.</desc>
+  <desc id="tg-inline-desc">ThumbGate TG gate monogram mark for inline site headers. Matches the Stripe product icon family.</desc>
   <defs>
-    <linearGradient id="tg-inline-frame" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+    <linearGradient id="tg-inline-ring" x1="10" y1="8" x2="54" y2="56" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#8cf5d1"/>
+      <stop offset="0.55" stop-color="#5eead4"/>
       <stop offset="1" stop-color="#22d3ee"/>
     </linearGradient>
   </defs>
-  <!-- Outer Shield / Gate (Transparent background fill, thicker gradient frame) -->
-  <path d="M32 9 C20 13 15 20 15 33 C15 45 26 53 32 56 C38 53 49 45 49 33 C49 20 44 13 32 9 Z" 
-        fill="none" stroke="url(#tg-inline-frame)" stroke-width="4.5" stroke-linejoin="round"/>
-        
-  <!-- Proportional Thumbs Up in Center (Enlarged and Bolder for high-contrast header visibility) -->
-  <g transform="translate(17, 16) scale(1.25)" stroke="#8cf5d1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none">
-    <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
-  </g>
+  <!-- Transparent backdrop for dark headers; no full-canvas opaque tile -->
+  <!-- Outer gate frame -->
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="none" stroke="url(#tg-inline-ring)" stroke-width="3.5"/>
+  <!-- Inner gate opening -->
+  <rect x="16" y="16" width="32" height="32" rx="9" fill="none" stroke="url(#tg-inline-ring)" stroke-width="3"/>
+  <!-- Gate threshold bar -->
+  <rect x="18" y="42" width="28" height="3.5" rx="1.75" fill="#22d3ee"/>
+  <!-- TG monogram -->
+  <text x="32" y="37.5" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="16" font-weight="700" fill="#e8e8ec" letter-spacing="-0.04em">TG</text>
 </svg>

--- a/public/assets/brand/thumbgate-mark-inline-v3.svg
+++ b/public/assets/brand/thumbgate-mark-inline-v3.svg
@@ -1,20 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="tg-inline-title tg-inline-desc">
   <title id="tg-inline-title">ThumbGate</title>
-  <desc id="tg-inline-desc">ThumbGate TG gate monogram mark for inline site headers. Matches the Stripe product icon family.</desc>
+  <desc id="tg-inline-desc">ThumbGate TG gate monogram mark for inline site headers. Matches the Stripe product icon family — inset frame, arched gate, bold TG, threshold bar. Transparent backdrop for dark headers.</desc>
   <defs>
-    <linearGradient id="tg-inline-ring" x1="10" y1="8" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+    <linearGradient id="tg-inline-ring" x1="12" y1="12" x2="52" y2="52" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#8cf5d1"/>
-      <stop offset="0.55" stop-color="#5eead4"/>
       <stop offset="1" stop-color="#22d3ee"/>
     </linearGradient>
   </defs>
   <!-- Transparent backdrop for dark headers; no full-canvas opaque tile -->
-  <!-- Outer gate frame -->
-  <rect x="6" y="6" width="52" height="52" rx="14" fill="none" stroke="url(#tg-inline-ring)" stroke-width="3.5"/>
-  <!-- Inner gate opening -->
-  <rect x="16" y="16" width="32" height="32" rx="9" fill="none" stroke="url(#tg-inline-ring)" stroke-width="3"/>
-  <!-- Gate threshold bar -->
-  <rect x="18" y="42" width="28" height="3.5" rx="1.75" fill="#22d3ee"/>
+  <!-- Outer gate frame (stroke only — no fill so header stays transparent) -->
+  <rect x="8" y="8" width="48" height="48" rx="12" fill="none" stroke="url(#tg-inline-ring)" stroke-width="2.5"/>
+  <!-- Arched gate opening (same geometry family as Stripe / app-icon mark) -->
+  <path d="M18 44V24c0-4.5 3.6-8.1 8.1-8.1h11.8c4.5 0 8.1 3.6 8.1 8.1v20" fill="none" stroke="#8cf5d1" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
   <!-- TG monogram -->
-  <text x="32" y="37.5" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="16" font-weight="700" fill="#e8e8ec" letter-spacing="-0.04em">TG</text>
+  <text x="32" y="38" text-anchor="middle" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif" font-size="16" font-weight="900" fill="#e7fbff" letter-spacing="-1">TG</text>
+  <!-- Gate threshold bar -->
+  <rect x="17" y="42" width="30" height="3.5" rx="1.75" fill="#22d3ee"/>
 </svg>

--- a/public/assets/brand/thumbgate-mark.svg
+++ b/public/assets/brand/thumbgate-mark.svg
@@ -1,21 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
   <title id="title">ThumbGate mark</title>
-  <desc id="desc">A crisp shield and thumbs-up mark for ThumbGate.</desc>
+  <desc id="desc">ThumbGate TG gate monogram app icon. Matches the Stripe product image family used on Checkout.</desc>
   <defs>
-    <linearGradient id="tg-frame" x1="96" y1="96" x2="416" y2="416" gradientUnits="userSpaceOnUse">
+    <linearGradient id="tg-frame" x1="96" y1="72" x2="416" y2="440" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#8cf5d1"/>
+      <stop offset="0.55" stop-color="#5eead4"/>
       <stop offset="1" stop-color="#22d3ee"/>
     </linearGradient>
   </defs>
-  <rect width="512" height="512" rx="112" fill="#061015"/>
-  <g transform="translate(78, 78) scale(5.5625)">
-    <!-- Outer Shield / Gate -->
-    <path d="M32 9 C20 13 15 20 15 33 C15 45 26 53 32 56 C38 53 49 45 49 33 C49 20 44 13 32 9 Z" 
-          fill="#0b1820" stroke="url(#tg-frame)" stroke-width="3.5" stroke-linejoin="round"/>
-          
-    <!-- Proportional Thumbs Up -->
-    <g transform="translate(19, 17) scale(1.1)" stroke="#8cf5d1" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
-      <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"/>
-    </g>
-  </g>
+  <!-- App-icon tile (full dark rounded square) for favicon / apple-touch / PWA -->
+  <rect width="512" height="512" rx="112" fill="#0b1220"/>
+  <!-- Outer gate frame -->
+  <rect x="64" y="64" width="384" height="384" rx="96" fill="none" stroke="url(#tg-frame)" stroke-width="28"/>
+  <!-- Inner gate opening -->
+  <rect x="128" y="128" width="256" height="256" rx="64" fill="none" stroke="url(#tg-frame)" stroke-width="24"/>
+  <!-- Gate threshold bar -->
+  <rect x="148" y="336" width="216" height="28" rx="14" fill="#22d3ee"/>
+  <!-- TG monogram -->
+  <text x="256" y="300" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="132" font-weight="700" fill="#f8fafc" letter-spacing="-0.04em">TG</text>
 </svg>

--- a/public/assets/brand/thumbgate-mark.svg
+++ b/public/assets/brand/thumbgate-mark.svg
@@ -1,21 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
   <title id="title">ThumbGate mark</title>
-  <desc id="desc">ThumbGate TG gate monogram app icon. Matches the Stripe product image family used on Checkout.</desc>
+  <desc id="desc">ThumbGate TG gate monogram app icon. Matches the Stripe product image family used on Checkout — dark tile, inset frame, arched gate, bold TG, threshold bar.</desc>
   <defs>
-    <linearGradient id="tg-frame" x1="96" y1="72" x2="416" y2="440" gradientUnits="userSpaceOnUse">
+    <linearGradient id="tg-frame" x1="96" y1="96" x2="416" y2="416" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#8cf5d1"/>
-      <stop offset="0.55" stop-color="#5eead4"/>
       <stop offset="1" stop-color="#22d3ee"/>
     </linearGradient>
   </defs>
-  <!-- App-icon tile (full dark rounded square) for favicon / apple-touch / PWA -->
-  <rect width="512" height="512" rx="112" fill="#0b1220"/>
-  <!-- Outer gate frame -->
-  <rect x="64" y="64" width="384" height="384" rx="96" fill="none" stroke="url(#tg-frame)" stroke-width="28"/>
-  <!-- Inner gate opening -->
-  <rect x="128" y="128" width="256" height="256" rx="64" fill="none" stroke="url(#tg-frame)" stroke-width="24"/>
-  <!-- Gate threshold bar -->
-  <rect x="148" y="336" width="216" height="28" rx="14" fill="#22d3ee"/>
+  <!-- App-icon tile (full dark rounded square) for favicon / apple-touch / PWA / Stripe -->
+  <rect width="512" height="512" rx="112" fill="#061015"/>
+  <!-- Outer gate frame (inset filled panel + stroke) -->
+  <rect x="78" y="78" width="356" height="356" rx="84" fill="#0b1820" stroke="url(#tg-frame)" stroke-width="18"/>
+  <!-- Arched gate opening -->
+  <path d="M146 354V192c0-36 29-65 65-65h90c36 0 65 29 65 65v162" fill="none" stroke="#8cf5d1" stroke-width="28" stroke-linecap="round" stroke-linejoin="round"/>
   <!-- TG monogram -->
-  <text x="256" y="300" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="132" font-weight="700" fill="#f8fafc" letter-spacing="-0.04em">TG</text>
+  <text x="256" y="310" text-anchor="middle" fill="#e7fbff" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Arial, sans-serif" font-size="132" font-weight="900" letter-spacing="-8">TG</text>
+  <!-- Gate threshold bar -->
+  <rect x="140" y="344" width="232" height="28" rx="14" fill="#22d3ee"/>
 </svg>

--- a/tests/brand-assets.test.js
+++ b/tests/brand-assets.test.js
@@ -31,10 +31,12 @@ test('ThumbGate inline mark SVG exists with transparent backdrop for header use'
   const svg = fs.readFileSync(inlineMarkPath, 'utf8');
   assert.match(svg, /<svg/);
   assert.match(svg, /viewBox="0 0 \d+ \d+"/);
-  assert.match(svg, /stroke="#8cf5d1"/, 'inline mark must stroke with standard color');
-  assert.match(svg, /premium shield and thumbs-up mark/, 'inline mark accessible description should name the premium shield and thumbs-up');
+  assert.match(svg, /#8cf5d1|#22d3ee/, 'inline mark must use brand cyan/mint colors');
+  assert.match(svg, /TG gate monogram|Stripe product/i, 'inline mark accessible description should name the TG gate monogram used on Stripe');
+  assert.match(svg, />TG</, 'inline mark must render the TG monogram, not a thumbs-up glyph');
   assert.match(svg, /<\/svg>/);
   assert.doesNotMatch(svg, /gate-and-signal|signal sweep|Status LEDs/i);
+  assert.doesNotMatch(svg, /thumbs-up mark|thumbs up/i, 'inline mark must not use the retired shield/thumbs-up emblem');
   // Guard: inline mark must NOT contain a full-canvas opaque rounded-rect tile. That tile
   // backdrop is what made thumbgate-mark.svg render as a tiny iOS-launcher icon inside
   // website headers. The inline variant exists specifically to avoid that look.

--- a/tests/brand-assets.test.js
+++ b/tests/brand-assets.test.js
@@ -20,6 +20,12 @@ test('ThumbGate app-icon mark SVG exists at /assets/brand (for apple-touch-icon 
   assert.match(svg, /viewBox="0 0 \d+ \d+"/);
   assert.match(svg, /fill=/);
   assert.match(svg, /<\/svg>/);
+  // Canonical Stripe-family geometry (restored in #2700 / #2990): dark tile, inset
+  // frame, arched gate path, bold TG, threshold bar — not the dual-rect simplification.
+  assert.match(svg, /fill="#061015"/, 'app-icon mark must use Stripe-family dark tile fill');
+  assert.match(svg, /M146 354V192c0-36 29-65 65-65h90/, 'app-icon mark must use arched gate path geometry');
+  assert.match(svg, />TG</, 'app-icon mark must render the TG monogram');
+  assert.doesNotMatch(svg, /thumbs-up mark|thumbs up/i, 'app-icon mark must not use the retired shield/thumbs-up emblem');
 });
 
 test('ThumbGate inline mark SVG exists with transparent backdrop for header use', () => {
@@ -34,6 +40,7 @@ test('ThumbGate inline mark SVG exists with transparent backdrop for header use'
   assert.match(svg, /#8cf5d1|#22d3ee/, 'inline mark must use brand cyan/mint colors');
   assert.match(svg, /TG gate monogram|Stripe product/i, 'inline mark accessible description should name the TG gate monogram used on Stripe');
   assert.match(svg, />TG</, 'inline mark must render the TG monogram, not a thumbs-up glyph');
+  assert.match(svg, /M18 44V24c0-4\.5 3\.6-8\.1 8\.1-8\.1h11\.8/, 'inline mark must use arched gate path geometry matching Stripe family');
   assert.match(svg, /<\/svg>/);
   assert.doesNotMatch(svg, /gate-and-signal|signal sweep|Status LEDs/i);
   assert.doesNotMatch(svg, /thumbs-up mark|thumbs up/i, 'inline mark must not use the retired shield/thumbs-up emblem');

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -552,7 +552,8 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 5.31 MB -> 5.35 MB (2026-07-16) for the exact Stripe offer catalog,
   // read-only drift audit, and aggregate-only Grafana catalog panels. Measured
   // artifact: 5,343,656 bytes; no credentials or buyer state are bundled.
-  // Bumped 5.35 MB -> 5.40 MB (2026-07-22) for observability env/setup/jsonl.
+  // Bumped 5.35 MB -> 5.40 MB (2026-07-22) for observability env/setup/jsonl
+  // and TG monogram SVG rewrite for Stripe brand alignment.
   assert.ok(
     manifest.unpackedSize <= 5_400_000,
     `npm package should stay <= 5.40 MB unpacked, got ${manifest.unpackedSize}`


### PR DESCRIPTION
## Summary
Site header used a **shield + thumbs-up** SVG. Stripe product/checkout art uses the **TG monogram gate**. This aligns both header and app-icon marks to the Stripe TG family.

Replaces closed/conflicted #2988 after observability landed on main.

## Evidence
- Before (prod): `/assets/brand/thumbgate-mark-inline-v3.svg` desc = "premium shield and thumbs-up mark"
- Stripe: `thumbgate-icon-pro-512.png` / `thumbgate-logo-1200x360.png` = TG gate monogram

## Test plan
- [x] `node --test tests/brand-assets.test.js`
- [x] package-boundary size ceiling (5.40 MB after observability)
- [ ] CI green
- [ ] Production SVG after merge contains `TG gate monogram` not `thumbs-up`