### PR TITLE
feat(seo): ThumbGate vs Ent (ent.ai) compare page + brief

### DIFF
--- a/.changeset/ent-competitive-position.md
+++ b/.changeset/ent-competitive-position.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Add `/compare/ent` buyer-intent page and internal competitor brief positioning Ent (ent.ai) endpoint pre-breach security as adjacent to ThumbGate's coding-agent PreToolUse Reliability Gateway — not a substitute.

--- a/docs/research/ENT_COMPETITOR_BRIEF.md
+++ b/docs/research/ENT_COMPETITOR_BRIEF.md
@@ -1,0 +1,115 @@
+# ThumbGate vs Ent (ent.ai) — 1-page competitor brief
+
+**Date:** 2026-07-22  
+**Status:** Public positioning (not partnership)  
+**Live page:** `/compare/ent`  
+**Trigger:** CEO shared YouTube `HSpG63Ryk_U` / Ent AI coverage as potential competitor.
+
+---
+
+## One-line verdict
+
+**Ent is a narrative competitor in “AI agent security,” not a product substitute for ThumbGate.**  
+Ent = **endpoint / workspace pre-breach** for human + AI-agent intent on managed devices.  
+ThumbGate = **coding-agent PreToolUse Reliability Gateway** (feedback → prevention rules).
+
+---
+
+## Who is Ent?
+
+| Field | Public fact (as of June–July 2026 coverage) |
+|-------|-----------------------------------------------|
+| Product | Intent-aware endpoint / workspace security; lightweight endpoint software; pre-incident intervention |
+| Domain | [ent.ai](https://ent.ai) |
+| Founders | Elias Manousos, Brandon Dixon (RiskIQ co-founders; RiskIQ acquired by Microsoft; later Security Copilot work cited in coverage) |
+| Raise | ~**$100M seed** (announced ~16 June 2026); Decibel-led; Sequoia, In-Q-Tel, Craft cited in industry write-ups |
+| Buyer | Security / IT / CISO / workspace security |
+| Scope | Human employees **and** AI agents on **enterprise devices** |
+
+Sources are industry coverage (DataBreachToday, Resilient Cyber, New Market Pitch, LinkedIn industry posts). Re-verify product claims against Ent’s own site before enterprise sales language.
+
+---
+
+## Head-to-head (honest)
+
+| Dimension | Ent | ThumbGate |
+|-----------|-----|-----------|
+| Layer | Device / workspace perimeter | Tool-call boundary inside coding agents |
+| Hook | Endpoint agent + intent policy | PreToolUse hooks (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, Desktop) |
+| Failure modes | DLP, insider, AI-on-device misuse, pre-breach | Force-push, secret exfil via tools, destructive shell, skip-verification loops |
+| Learning | Enterprise security product surface | Thumbs-down → lesson DB → prevention rules |
+| GTM | Sales-led, capital-heavy | `npx thumbgate init`, MIT free tier, Pro $19/mo hosted proof |
+| Funding signal | Validates **enterprise AI-agent security spend** | Does **not** fund or define our SKU |
+
+---
+
+## What we concede
+
+1. Ent’s raise is real capital and will dominate “AI agent security” headlines for a while.  
+2. If a prospect’s risk is **fleet endpoint** behavior, Ent (or CrowdStrike/Defender-class) is the right category — not us.  
+3. We should never claim “we replace Ent” or invent Ent features we have not verified.
+
+## What we own
+
+1. **PreToolUse coding-agent matrix** with local-first install.  
+2. **Feedback → rule** loop (Infrastructure Firewall / Reliability Gateway).  
+3. **Developer / founder ICP** who will never buy a $100M-seed EDR motion for Claude Code hygiene.  
+4. Dual-deploy story: **Ent on the fleet, ThumbGate on the coding agents.**
+
+---
+
+## Messaging do / don’t
+
+| Do | Don’t |
+|----|-------|
+| “Endpoint pre-breach ≠ PreToolUse gate” | “Ent is fake / overfunded vapor” |
+| “Same conversation, different layer” | “We’re the enterprise alternative to Ent” |
+| Link `/compare/ent` + `npx thumbgate init` | Claim Ent blocks Claude Code force-push without proof |
+| Dual-deploy for security + eng | Frame ThumbGate as device EDR |
+
+---
+
+## 3 GTM angles (LinkedIn / Reddit)
+
+### 1) LinkedIn — category re-scope (security + eng audience)
+
+**Hook:** Ent’s $100M seed proves AI-agent security is real budget.  
+**Body:** That budget is mostly **endpoint intent** (devices, DLP, pre-breach). Coding agents still need a **tool-call gate** before `git push --force` / secret-bearing tools fire. Different install surface, same decade.  
+**CTA:** `thumbgate.ai/compare/ent` · `npx thumbgate init`  
+**Voice:** Respectful, technical, dual-deploy. No dunk on founders.
+
+### 2) LinkedIn — buyer clarity (CISO vs eng lead)
+
+**Hook:** If your RFP says “AI agent security,” ask which boundary.  
+**Body:** Device perimeter → Ent-class. Claude Code / Cursor PreToolUse → ThumbGate-class. Buying the wrong layer wastes a year of rollout.  
+**CTA:** Compare page + one-line install.  
+**Voice:** Procurement-friendly, table-driven.
+
+### 3) Reddit (r/devops, r/ClaudeAI, r/netsec) — operator truth
+
+**Hook:** Saw the Ent seed headlines. For my daily driver it’s still “did the agent force-push again?”  
+**Body:** Endpoint agents don’t replace a local PreToolUse hook + thumbs-down → never-again rule. I run ThumbGate on coding agents; fleet security is a separate ticket.  
+**CTA:** GitHub / compare page; no hard sell.  
+**Voice:** First-person, anti-slop, value first. Draft-only if channel policy requires human post.
+
+---
+
+## SEO / GEO terms to keep live
+
+`ThumbGate vs Ent`, `ent.ai alternative`, `AI agent endpoint security vs PreToolUse`, `intent-aware workspace security coding agents`, `Reliability Gateway`, `Infrastructure Firewall`.
+
+---
+
+## Next actions (product / GTM)
+
+1. Ship `/compare/ent` + hub link (this PR).  
+2. Optional: one LinkedIn post from angle #1 after page is live (use Chrome logged-in session; link in first comment per publish skill).  
+3. Do **not** re-prioritize roadmap to “become Ent.” Stay on cash path: Free→Pro conversion + coding-agent reliability.
+
+---
+
+## Evidence links
+
+- Compare page: `public/compare/ent.html` → `https://thumbgate.ai/compare/ent`  
+- Verification: `docs/VERIFICATION_EVIDENCE.md`  
+- Pricing honesty: `docs/COMMERCIAL_TRUTH.md`

--- a/docs/research/ENT_COMPETITOR_BRIEF.md
+++ b/docs/research/ENT_COMPETITOR_BRIEF.md
@@ -38,7 +38,7 @@ Sources are industry coverage (DataBreachToday, Resilient Cyber, New Market Pitc
 | Hook | Endpoint agent + intent policy | PreToolUse hooks (Claude Code, Cursor, Codex, Gemini, Amp, Cline, OpenCode, Desktop) |
 | Failure modes | DLP, insider, AI-on-device misuse, pre-breach | Force-push, secret exfil via tools, destructive shell, skip-verification loops |
 | Learning | Enterprise security product surface | Thumbs-down → lesson DB → prevention rules |
-| GTM | Sales-led, capital-heavy | `npx thumbgate init`, MIT free tier, Pro $19/mo hosted proof |
+| GTM | Sales-led, capital-heavy | `npx thumbgate init`, MIT free tier, Pro $19/mo (local dashboard + exports; not team sync) |
 | Funding signal | Validates **enterprise AI-agent security spend** | Does **not** fund or define our SKU |
 
 ---
@@ -54,7 +54,8 @@ Sources are industry coverage (DataBreachToday, Resilient Cyber, New Market Pitc
 1. **PreToolUse coding-agent matrix** with local-first install.  
 2. **Feedback → rule** loop (Infrastructure Firewall / Reliability Gateway).  
 3. **Developer / founder ICP** who will never buy a $100M-seed EDR motion for Claude Code hygiene.  
-4. Dual-deploy story: **Ent on the fleet, ThumbGate on the coding agents.**
+4. Dual-deploy story: **Ent on the fleet, ThumbGate on the coding agents.**  
+5. Pro commercial truth: personal local dashboard + exports — **not** hosted team lesson sync (see `docs/COMMERCIAL_TRUTH.md`).
 
 ---
 

--- a/public/compare.html
+++ b/public/compare.html
@@ -272,6 +272,7 @@
 <ul class="compare-index">
   <li><a href="/compare/sigmashake">ThumbGate vs SigmaShake</a> — learns the rule from your thumbs-down vs a hand-picked ruleset hub</li>
   <li><a href="/compare/claude-code-hooks">ThumbGate vs claude-code-hooks</a> — personal recall, exports, and managed adapters on top of local shell-script hooks</li>
+  <li><a href="/compare/ent">ThumbGate vs Ent (ent.ai)</a> — coding-agent PreToolUse gate vs endpoint pre-breach security</li>
   <li><a href="/compare/arcjet">ThumbGate vs Arcjet</a> — agent-outbound gate pairs with an app-inbound firewall</li>
   <li><a href="/compare/bumblebee">ThumbGate vs Bumblebee</a> — runtime enforcement pairs with static inventory</li>
   <li><a href="/compare/anthropic-containment">ThumbGate vs Anthropic's Claude Containment</a> — an IDE-agent extension of Anthropic's published architecture</li>

--- a/public/compare/arcjet.html
+++ b/public/compare/arcjet.html
@@ -210,6 +210,10 @@
 
         <div class="sidebar-card">
           <span class="related-label">Related comparisons</span>
+          <a class="related-card" href="/compare/ent">
+            <strong>ThumbGate vs Ent (ent.ai)</strong><br>
+            <span style="color: var(--muted); font-size: 13px;">Coding-agent PreToolUse vs endpoint pre-breach security</span>
+          </a>
           <a class="related-card" href="/compare/anthropic-containment">
             <strong>ThumbGate vs Anthropic's Claude Containment</strong><br>
             <span style="color: var(--muted); font-size: 13px;">IDE-agent extension of Anthropic's published architecture</span>

--- a/public/compare/ent.html
+++ b/public/compare/ent.html
@@ -101,7 +101,7 @@
       "name": "Why does Ent's $100M seed matter for ThumbGate positioning?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "It validates market spend on AI-agent security at the enterprise perimeter. It does not mean every AI-agent security headline is a coding-agent PreToolUse product. Prospects who hear 'AI agent security' after Ent's launch often mean endpoint/workspace risk. ThumbGate's job in that conversation is to re-scope: we are the Reliability Gateway at the tool-call boundary for coding agents — free to start via npx thumbgate init, Pro for hosted proof and sync."
+        "text": "It validates market spend on AI-agent security at the enterprise perimeter. It does not mean every AI-agent security headline is a coding-agent PreToolUse product. Prospects who hear 'AI agent security' after Ent's launch often mean endpoint/workspace risk. ThumbGate's job in that conversation is to re-scope: we are the Reliability Gateway at the tool-call boundary for coding agents — free to start via npx thumbgate init; Pro unlocks unlimited captures/rules, personal local dashboard, and DPO/advanced exports (not hosted team sync)."
       }
     },
     {
@@ -179,7 +179,7 @@
         <section class="detail-section">
           <h2>Funding narrative vs product category</h2>
           <p>Ent's reported ~$100M seed (June 2026 coverage; founders Elias Manousos and Brandon Dixon of RiskIQ; investors publicly named include Decibel, with Sequoia, In-Q-Tel, and Craft cited in industry write-ups) is a signal that capital is pouring into AI-era endpoint security. It is <strong>not</strong> a signal that ThumbGate must "compete with Ent for the same SKU." Category neighbors raise money in the same news cycle; buyers still buy by failure mode.</p>
-          <p>ThumbGate's wedge stays small and concrete: local PreToolUse enforcement + feedback-to-rule learning for coding agents, free to start, Pro for hosted sync/dashboard/export. See <a href="/pricing">pricing</a> and <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">VERIFICATION_EVIDENCE.md</a>.</p>
+          <p>ThumbGate's wedge stays small and concrete: local PreToolUse enforcement + feedback-to-rule learning for coding agents, free to start; Pro adds unlimited captures/rules, a personal local dashboard, and DPO/advanced exports. Hosted team lesson sync and org dashboards are not generally available. See <a href="/pricing">pricing</a> and <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">VERIFICATION_EVIDENCE.md</a>.</p>
         </section>
 
         <section class="detail-section">
@@ -194,11 +194,11 @@
           </details>
           <details class="faq-item">
             <summary>Where does each one log evidence?</summary>
-            <p>Ent is an enterprise security product — evidence surfaces belong to their security console / SOC workflows (vendor-specific). ThumbGate writes structured allow/warn/block decisions to a local lesson DB and optionally syncs proof on Pro. Different audit consumers: SOC vs eng reliability.</p>
+            <p>Ent is an enterprise security product — evidence surfaces belong to their security console / SOC workflows (vendor-specific). ThumbGate writes structured allow/warn/block decisions to a local lesson DB; Pro adds a personal local dashboard and DPO/advanced exports. Different audit consumers: SOC vs eng reliability.</p>
           </details>
           <details class="faq-item">
             <summary>Pricing posture</summary>
-            <p>Ent is sales-led enterprise security (public pricing not the free-npm path). ThumbGate: MIT free local runtime with daily free-tier limits; Pro at $19/mo for unlimited captures/rules, sync, dashboard, exports. Compare apples to apples only after you pick the layer you need.</p>
+            <p>Ent is sales-led enterprise security (public pricing not the free-npm path). ThumbGate: MIT free local runtime with daily free-tier limits; Pro at $19/mo for unlimited captures/rules, personal local dashboard, and DPO/advanced exports. Shared hosted team sync is not a Pro entitlement. Compare apples to apples only after you pick the layer you need.</p>
           </details>
           <details class="faq-item">
             <summary>Is this comparison sponsored or partnered?</summary>

--- a/public/compare/ent.html
+++ b/public/compare/ent.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ThumbGate vs Ent (ent.ai) | Coding-Agent PreToolUse Gate vs Endpoint Pre-Breach Security</title>
+  <meta name="description" content="Ent (ent.ai) is an intent-aware endpoint/workspace security platform — ~$100M seed — that reads human and AI-agent behavior on enterprise devices before incidents escalate. ThumbGate is a PreToolUse hook inside AI coding agents that turns thumbs-down feedback into prevention rules. Adjacent layers: Ent at the device perimeter, ThumbGate at the tool-call boundary. Honest head-to-head." />
+  <meta property="og:title" content="ThumbGate vs Ent | Endpoint Pre-Breach vs Coding-Agent Gate" />
+  <meta property="og:description" content="Ent watches endpoint intent before a breach. ThumbGate gates the coding agent's next tool call before it fires. Different buyers, different install surfaces — and a clean dual-deploy story for security + engineering teams." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://thumbgate.ai/compare/ent" />
+  <link rel="canonical" href="https://thumbgate.ai/compare/ent" />
+  <link rel="llm-context" href="/llm-context.md" type="text/markdown" />
+  <link rel="icon" type="image/png" href="/thumbgate-icon.png" />
+  <link rel="apple-touch-icon" href="/assets/brand/thumbgate-mark.svg" />
+  <meta property="og:image" content="/og.png" />
+  <style>
+    :root { --bg: #0a0a0b; --bg-raised: #111113; --bg-card: #161618; --line: #222225; --text: #e8e8ec; --muted: #8b8b96; --cyan: #22d3ee; --green: #4ade80; --amber: #fbbf24; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--text); line-height: 1.65; }
+    a { color: var(--cyan); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .container { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+    .topbar { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(12px); background: rgba(10, 10, 11, 0.88); border-bottom: 1px solid var(--line); }
+    .topbar .container { display: flex; justify-content: space-between; align-items: center; padding-top: 14px; padding-bottom: 14px; }
+    .brand { font-weight: 700; color: var(--text); display: inline-flex; align-items: center; gap: 8px; text-decoration: none; }
+    .brand .logo-mark { width: 28px; height: 28px; display: block; }
+    .hero { padding: 72px 0 32px; }
+    .eyebrow { display: inline-flex; align-items: center; gap: 8px; padding: 6px 12px; border-radius: 999px; border: 1px solid rgba(34, 211, 238, 0.22); background: rgba(34, 211, 238, 0.1); color: var(--cyan); text-transform: uppercase; letter-spacing: 0.08em; font-size: 12px; font-weight: 700; }
+    h1 { font-size: clamp(34px, 5vw, 56px); line-height: 1.06; letter-spacing: -0.04em; margin: 16px 0; max-width: 900px; }
+    .hero p { max-width: 780px; color: var(--muted); font-size: 18px; }
+    .grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr); gap: 24px; padding-bottom: 72px; }
+    .card, .detail-section, .sidebar-card { background: var(--bg-card); border: 1px solid var(--line); border-radius: 16px; }
+    .card { padding: 24px; }
+    .detail-section { padding: 24px; margin-bottom: 18px; }
+    .detail-section h2 { margin: 0 0 12px; font-size: 24px; letter-spacing: -0.03em; }
+    .detail-section p, .detail-section li, .sidebar-card p { color: var(--muted); }
+    .detail-section ul, .card ul { padding-left: 18px; color: var(--muted); }
+    .comparison-table { width: 100%; border-collapse: collapse; margin-top: 16px; font-size: 14px; }
+    .comparison-table th, .comparison-table td { border: 1px solid var(--line); padding: 12px; text-align: left; vertical-align: top; }
+    .comparison-table th { background: var(--bg-raised); color: var(--cyan); }
+    .pill-row { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 24px; }
+    .pill { border: 1px solid var(--line); background: var(--bg-raised); border-radius: 999px; padding: 10px 14px; font-size: 14px; font-weight: 650; }
+    .pill.good { color: #b8f7c8; border-color: rgba(74, 222, 128, 0.28); background: rgba(74, 222, 128, 0.1); }
+    .pill.warn { color: #ffe2a4; border-color: rgba(251, 191, 36, 0.28); background: rgba(251, 191, 36, 0.1); }
+    .sidebar { display: flex; flex-direction: column; gap: 18px; }
+    .sidebar-card { padding: 20px; }
+    .sidebar-card:first-child { position: sticky; top: 84px; max-height: calc(100vh - 104px); overflow-y: auto; -webkit-overflow-scrolling: touch; }
+    .cta-button { display: inline-flex; align-items: center; justify-content: center; margin-top: 18px; padding: 12px 16px; border-radius: 10px; background: var(--cyan); color: #071116; font-weight: 700; text-decoration: none; }
+    .related-card { display: block; padding: 14px; border-radius: 12px; border: 1px solid var(--line); background: var(--bg-raised); margin-top: 12px; color: var(--text); }
+    .related-label { display: block; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 4px; }
+    .faq-item { border-top: 1px solid var(--line); padding: 14px 0; }
+    .faq-item summary { cursor: pointer; font-weight: 600; }
+    .faq-item p { color: var(--muted); }
+    @media (max-width: 860px) { .grid { grid-template-columns: 1fr; } .sidebar-card:first-child { position: static; max-height: none; overflow: visible; } }
+  </style>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "ThumbGate vs Ent (ent.ai)",
+  "description": "Ent is an intent-aware endpoint and workspace security platform for human and AI-agent behavior on enterprise devices. ThumbGate is a PreToolUse enforcement runtime inside AI coding agents with feedback-to-prevention rules. Adjacent layers — not substitutes.",
+  "about": ["thumbgate vs ent", "ent.ai alternative", "AI agent endpoint security", "PreToolUse coding agent gate", "intent-aware workspace security"],
+  "url": "https://thumbgate.ai/compare/ent",
+  "publisher": { "@type": "Organization", "name": "ThumbGate", "url": "https://thumbgate.ai" },
+  "mainEntityOfPage": "https://thumbgate.ai/compare/ent",
+  "dateModified": "2026-07-22"
+}
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Ent a direct ThumbGate competitor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No — they are narrative neighbors, not substitutes. Ent (ent.ai) is endpoint / workspace security: lightweight agent software on enterprise devices that interprets human and AI-agent intent and intervenes before risky behavior becomes a breach. ThumbGate runs inside the AI coding agent process (Claude Code, Cursor, Codex CLI, Gemini CLI, Amp, Cline, OpenCode, Claude Desktop) at the PreToolUse hook, before a tool call executes. Ent's buyer is typically security / IT / CISO. ThumbGate's buyer is typically the engineering lead or solo founder running coding agents. Funding scale is not product overlap."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use both Ent and ThumbGate?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The dual-deploy story is clean: Ent on the fleet (devices, workspaces, data-loss and insider/AI-agent endpoint risk); ThumbGate on every developer AI coding agent (force-push, destructive shell, secret exfil via tools, skip-tests loops). Neither product can replace the other at its native boundary."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Ent block rm -rf or git push --force from Claude Code?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ent's published positioning is intent-aware intervention on the endpoint/workspace for risky human and AI-agent behavior before incidents escalate — not a Claude Code / Cursor PreToolUse adapter matrix with lesson promotion from thumbs-down feedback. If your failure mode is the coding agent about to execute a known-bad tool call inside the IDE-agent process, ThumbGate is the layer purpose-built for that hook. Endpoint agents may still see secondary signals after the tool has already been invoked."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does Ent's $100M seed matter for ThumbGate positioning?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It validates market spend on AI-agent security at the enterprise perimeter. It does not mean every AI-agent security headline is a coding-agent PreToolUse product. Prospects who hear 'AI agent security' after Ent's launch often mean endpoint/workspace risk. ThumbGate's job in that conversation is to re-scope: we are the Reliability Gateway at the tool-call boundary for coding agents — free to start via npx thumbgate init, Pro for hosted proof and sync."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is this comparison sponsored?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. There is no partnership with Ent. Public facts about Ent's seed and positioning come from June 2026 coverage (RiskIQ co-founders Elias Manousos and Brandon Dixon; Decibel-led seed reported at approximately $100M; intent-aware workspace/endpoint security). If anything here misrepresents Ent, open an issue on the ThumbGate GitHub repo and we will correct it."
+      }
+    }
+  ]
+}
+  </script>
+</head>
+<body>
+  <header class="topbar">
+    <div class="container">
+      <a href="/" class="brand"><img src="/assets/brand/thumbgate-mark-inline-v3.svg" alt="ThumbGate" class="logo-mark" width="28" height="28" /><span>ThumbGate</span></a>
+      <nav><a href="/learn">Learn</a> &nbsp; <a href="/pro">Pro</a> &nbsp; <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub</a></nav>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="container">
+      <span class="eyebrow">ThumbGate vs Ent (ent.ai)</span>
+      <h1>Endpoint pre-breach security is not a PreToolUse gate for coding agents.</h1>
+      <p><strong>Ent</strong> (<a href="https://ent.ai" target="_blank" rel="noopener">ent.ai</a>) is an intent-aware endpoint / workspace security platform — public coverage of a ~$100M June 2026 seed from RiskIQ co-founders — that analyzes human and AI-agent behavior on enterprise devices and intervenes before risky actions become incidents. <strong>ThumbGate</strong> is a local-first Reliability Gateway that installs as PreToolUse hooks inside AI coding agents, captures thumbs-up/down feedback, promotes lessons, and flags or hard-blocks known-bad tool calls before they fire. Same AI-agent-security conversation. Different install surface, buyer, and decision boundary.</p>
+      <div class="pill-row">
+        <span class="pill">Both care about AI agents</span>
+        <span class="pill good">Different layers</span>
+        <span class="pill warn">Not substitutes</span>
+        <span class="pill">Dual-deploy is normal</span>
+      </div>
+    </div>
+  </section>
+
+  <main class="container">
+    <div class="grid">
+      <div class="content">
+
+        <section class="detail-section">
+          <h2>Side-by-side scope comparison</h2>
+          <table class="comparison-table">
+            <thead>
+              <tr><th>Dimension</th><th>Ent (ent.ai)</th><th>ThumbGate</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><strong>Primary surface</strong></td><td>Enterprise endpoint / workspace (device-resident agent)</td><td>AI coding agent process (PreToolUse / hooks)</td></tr>
+              <tr><td><strong>Decision boundary</strong></td><td>Intent-aware policy on human + AI-agent behavior before a security incident</td><td>Tool-call intercept before bash / SQL / file write / MCP / git runs</td></tr>
+              <tr><td><strong>Typical buyer</strong></td><td>CISO / SecOps / IT / workspace security</td><td>Engineering lead, platform team, solo founder running coding agents</td></tr>
+              <tr><td><strong>What it is for</strong></td><td>Data loss, insider risk, AI-related endpoint misuse, pre-breach intervention</td><td>Repeat coding-agent mistakes: force-push, secret exfil via tools, destructive deletes, skip-verification loops</td></tr>
+              <tr><td><strong>Learning loop</strong></td><td>Enterprise policy + behavioral intent models (vendor product surface)</td><td>Thumbs-down → lesson DB → prevention rules (Thompson Sampling on the free/Pro path)</td></tr>
+              <tr><td><strong>Agent matrix</strong></td><td>Human employees + AI agents on managed devices (endpoint scope)</td><td>Claude Code, Cursor, Codex CLI, Gemini CLI, Amp, Cline, OpenCode, Claude Desktop</td></tr>
+              <tr><td><strong>Install</strong></td><td>Enterprise endpoint software (sales-led / fleet)</td><td><code>npx thumbgate init</code> (local-first; MIT free tier)</td></tr>
+              <tr><td><strong>Best alongside</strong></td><td>ThumbGate on every developer coding agent</td><td>Ent (or existing EDR/DLP) on the corporate fleet</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="detail-section">
+          <h2>The shared architectural insight</h2>
+          <p>Both products reject pure post-incident forensics as the only line of defense. Ent's public story is <em>prevent before breach</em> on the workspace. ThumbGate's story is <em>gate before tool execution</em> inside the coding agent. The industry is converging on pre-action controls for AI — but "pre-action" on a laptop security agent is not the same as PreToolUse in Claude Code.</p>
+          <p>If you collapse those layers, you buy the wrong product: endpoint coverage without a coding-agent lesson loop, or a coding-agent gate without fleet DLP. The honest pitch is dual-deploy for orgs that have both managed devices and heavy AI coding adoption.</p>
+        </section>
+
+        <section class="detail-section">
+          <h2>When to pick which (or both)</h2>
+          <ul>
+            <li><strong>Pick Ent</strong> when the risk is fleet-wide: employee or AI-agent behavior on managed endpoints, data leaving the workspace, insider / pre-breach intervention that security owns.</li>
+            <li><strong>Pick ThumbGate</strong> when the risk is developer-agent: the model is about to <code>git push --force</code>, <code>rm -rf</code> the wrong tree, ship secrets via a tool, or skip the verification step it already failed last week — and you want that pattern to become a permanent rule from feedback.</li>
+            <li><strong>Run both</strong> when security owns devices and eng owns AI coding agents. Ent does not ship ThumbGate's adapter matrix or thumbs → prevention pipeline; ThumbGate is not an EDR.</li>
+          </ul>
+        </section>
+
+        <section class="detail-section">
+          <h2>Funding narrative vs product category</h2>
+          <p>Ent's reported ~$100M seed (June 2026 coverage; founders Elias Manousos and Brandon Dixon of RiskIQ; investors publicly named include Decibel, with Sequoia, In-Q-Tel, and Craft cited in industry write-ups) is a signal that capital is pouring into AI-era endpoint security. It is <strong>not</strong> a signal that ThumbGate must "compete with Ent for the same SKU." Category neighbors raise money in the same news cycle; buyers still buy by failure mode.</p>
+          <p>ThumbGate's wedge stays small and concrete: local PreToolUse enforcement + feedback-to-rule learning for coding agents, free to start, Pro for hosted sync/dashboard/export. See <a href="/pricing">pricing</a> and <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">VERIFICATION_EVIDENCE.md</a>.</p>
+        </section>
+
+        <section class="detail-section">
+          <h2>FAQ</h2>
+          <details class="faq-item" open>
+            <summary>Is Ent a ThumbGate competitor?</summary>
+            <p>Narrative competitor in the "AI agent security" search bucket. Product substitute? No. Different install surface, buyer, and decision boundary. See the table above.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Will Ent make ThumbGate obsolete?</summary>
+            <p>Only if Ent ships a maintained PreToolUse adapter matrix across the major coding agents with a feedback → prevention rule loop that engineering teams control without a fleet security rollout. That is not Ent's published product center of gravity today.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Where does each one log evidence?</summary>
+            <p>Ent is an enterprise security product — evidence surfaces belong to their security console / SOC workflows (vendor-specific). ThumbGate writes structured allow/warn/block decisions to a local lesson DB and optionally syncs proof on Pro. Different audit consumers: SOC vs eng reliability.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Pricing posture</summary>
+            <p>Ent is sales-led enterprise security (public pricing not the free-npm path). ThumbGate: MIT free local runtime with daily free-tier limits; Pro at $19/mo for unlimited captures/rules, sync, dashboard, exports. Compare apples to apples only after you pick the layer you need.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Is this comparison sponsored or partnered?</summary>
+            <p>No. We wrote this so buyers who land on Ent headlines do not confuse endpoint pre-breach with coding-agent PreToolUse. Corrections welcome via <a href="https://github.com/IgorGanapolsky/ThumbGate/issues" target="_blank" rel="noopener">GitHub issues</a>.</p>
+          </details>
+        </section>
+
+      </div>
+
+      <aside class="sidebar">
+        <div class="sidebar-card">
+          <span class="related-label">Install ThumbGate</span>
+          <p style="font-size: 14px;">Get PreToolUse rules running in your AI coding agent in two minutes.</p>
+          <a class="cta-button" href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">npx thumbgate init &rarr;</a>
+        </div>
+
+        <div class="sidebar-card">
+          <span class="related-label">Ent's surface</span>
+          <p style="font-size: 13px;">If you need fleet endpoint / workspace security for human + AI-agent intent, evaluate <a href="https://ent.ai" target="_blank" rel="noopener">ent.ai</a> with your security team. That is not ThumbGate's product surface.</p>
+        </div>
+
+        <div class="sidebar-card">
+          <span class="related-label">Related comparisons</span>
+          <a class="related-card" href="/compare/arcjet">
+            <strong>ThumbGate vs Arcjet</strong><br>
+            <span style="color: var(--muted); font-size: 13px;">Agent-outbound gate pairs with app-inbound firewall</span>
+          </a>
+          <a class="related-card" href="/compare/anthropic-containment">
+            <strong>ThumbGate vs Anthropic containment</strong><br>
+            <span style="color: var(--muted); font-size: 13px;">IDE-agent extension of published architecture</span>
+          </a>
+          <a class="related-card" href="/compare/oak-and-sparrow-gatekeeper">
+            <strong>ThumbGate vs Gatekeeper</strong><br>
+            <span style="color: var(--muted); font-size: 13px;">Agent-action gate vs workforce-input gate</span>
+          </a>
+          <a class="related-card" href="/compare/rein">
+            <strong>ThumbGate vs Rein</strong><br>
+            <span style="color: var(--muted); font-size: 13px;">Coding-agent governance vs decorator governance</span>
+          </a>
+        </div>
+
+        <div class="sidebar-card">
+          <span class="related-label">Sources</span>
+          <p style="font-size: 13px;">Ent seed and positioning from June 2026 public coverage (DataBreachToday, Resilient Cyber, New Market Pitch, and industry posts summarizing the Decibel-led seed and RiskIQ founders). Product facts for ThumbGate from this repository and <a href="https://thumbgate.ai">thumbgate.ai</a>. Not sponsored. Correct via issue if Ent's product surface changes.</p>
+        </div>
+      </aside>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds buyer-intent page `/compare/ent` positioning **Ent (ent.ai)** honestly: endpoint / workspace pre-breach security (~$100M seed, RiskIQ founders) vs ThumbGate’s coding-agent **PreToolUse Reliability Gateway**.
- Internal 1-page brief: `docs/research/ENT_COMPETITOR_BRIEF.md` (verdict, table, do/don’t, **3 LinkedIn/Reddit angles**).
- Hub index + Arcjet related-card discovery; TechArticle + FAQPage schema for GEO.

## Why

CEO flagged Ent / `HSpG63Ryk_U` as a potential competitor. Correct framing: **narrative neighbor, not substitute**. Dual-deploy (Ent on fleet, ThumbGate on coding agents). No roadmap pivot into EDR.

## Test plan

- [x] Pre-push guards (pack dry-run, internal links, regression-guard)
- [ ] CI green
- [ ] After merge: `curl -sI https://thumbgate.ai/compare/ent` → 200 once Railway rebuilds
- [ ] `/compare` hub links to `/compare/ent`
- [ ] Sitemap includes `/compare/ent` (filesystem-derived)

## Not in scope

Publishing LinkedIn/Reddit posts (draft angles only in the brief).