### PR TITLE
feat(web): homepage visual-first for conversion

### DIFF
--- a/.changeset/homepage-visual-buy.md
+++ b/.changeset/homepage-visual-buy.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Homepage conversion: larger above-the-fold diagrams, shorter hero copy, Free→Pro cash path, essay sections collapsed behind a deep-dive drawer.

--- a/public/assets/diagrams/before-after.svg
+++ b/public/assets/diagrams/before-after.svg
@@ -1,19 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" role="img" aria-labelledby="t d">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 280" role="img" aria-labelledby="t d">
   <title id="t">Before and after ThumbGate</title>
   <desc id="d">Without ThumbGate the same mistake repeats. With ThumbGate the second attempt is caught.</desc>
-  <rect width="720" height="220" fill="#0a0a0b"/>
+  <rect width="960" height="280" fill="#0a0a0b"/>
   <g font-family="system-ui,sans-serif">
-    <rect x="30" y="30" width="300" height="160" rx="14" fill="#1a1010" stroke="#f87171"/>
-    <text x="180" y="60" text-anchor="middle" fill="#f87171" font-size="14" font-weight="800">WITHOUT</text>
-    <text x="180" y="95" text-anchor="middle" fill="#e8e8ec" font-size="13">Agent force-pushes</text>
-    <text x="180" y="118" text-anchor="middle" fill="#e8e8ec" font-size="13">You fix it. Again.</text>
-    <text x="180" y="141" text-anchor="middle" fill="#e8e8ec" font-size="13">Same mistake returns.</text>
-    <text x="180" y="170" text-anchor="middle" fill="#8b8b96" font-size="12">cost = time × trust × risk</text>
-    <rect x="390" y="30" width="300" height="160" rx="14" fill="#0d1b14" stroke="#4ade80"/>
-    <text x="540" y="60" text-anchor="middle" fill="#4ade80" font-size="14" font-weight="800">WITH THUMBGATE</text>
-    <text x="540" y="95" text-anchor="middle" fill="#e8e8ec" font-size="13">You thumbs-down once</text>
-    <text x="540" y="118" text-anchor="middle" fill="#e8e8ec" font-size="13">Rule is stored locally</text>
-    <text x="540" y="141" text-anchor="middle" fill="#e8e8ec" font-size="13">Next attempt is evaluated</text>
-    <text x="540" y="170" text-anchor="middle" fill="#8b8b96" font-size="12">cost = one correction</text>
+    <!-- WITHOUT -->
+    <rect x="40" y="36" width="400" height="208" rx="20" fill="#1a1012" stroke="#f87171" stroke-width="2"/>
+    <text x="240" y="72" text-anchor="middle" fill="#f87171" font-size="18" font-weight="900">WITHOUT</text>
+    <text x="240" y="118" text-anchor="middle" fill="#f5f5f7" font-size="20" font-weight="700">🔥 force-push / bad shell</text>
+    <text x="240" y="152" text-anchor="middle" fill="#e5e7eb" font-size="16">You clean it up…</text>
+    <text x="240" y="182" text-anchor="middle" fill="#e5e7eb" font-size="16">…and it happens again.</text>
+    <text x="240" y="218" text-anchor="middle" fill="#9ca3af" font-size="14">time × trust × risk</text>
+    <!-- WITH -->
+    <rect x="520" y="36" width="400" height="208" rx="20" fill="#0c1a14" stroke="#4ade80" stroke-width="2"/>
+    <text x="720" y="72" text-anchor="middle" fill="#4ade80" font-size="18" font-weight="900">WITH THUMBGATE</text>
+    <text x="720" y="118" text-anchor="middle" fill="#f5f5f7" font-size="20" font-weight="700">👎 once</text>
+    <text x="720" y="152" text-anchor="middle" fill="#e5e7eb" font-size="16">Rule saved locally</text>
+    <text x="720" y="182" text-anchor="middle" fill="#e5e7eb" font-size="16">Next attempt is checked</text>
+    <text x="720" y="218" text-anchor="middle" fill="#9ca3af" font-size="14">one correction → permanent gate</text>
   </g>
 </svg>

--- a/public/assets/diagrams/decision.svg
+++ b/public/assets/diagrams/decision.svg
@@ -1,27 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 260" role="img" aria-labelledby="t d">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 300" role="img" aria-labelledby="t d">
   <title id="t">Which ThumbGate path to pick</title>
   <desc id="d">Free for solo try, Pro for unlimited personal use, Sprint for one painful team workflow.</desc>
-  <rect width="720" height="260" fill="#0a0a0b"/>
+  <rect width="960" height="300" fill="#0a0a0b"/>
   <g font-family="system-ui,sans-serif">
-    <rect x="250" y="20" width="220" height="48" rx="10" fill="#161618" stroke="#22d3ee"/>
-    <text x="360" y="50" text-anchor="middle" fill="#e8e8ec" font-size="14" font-weight="700">What do you need?</text>
-    <path d="M360 68 L360 90" stroke="#8b8b96" stroke-width="2"/>
-    <path d="M120 90 L600 90" stroke="#8b8b96" stroke-width="2"/>
-    <path d="M120 90 L120 110 M360 90 L360 110 M600 90 L600 110" stroke="#8b8b96" stroke-width="2"/>
-    <rect x="40" y="110" width="160" height="120" rx="12" fill="#161618" stroke="#222225"/>
-    <text x="120" y="140" text-anchor="middle" fill="#22d3ee" font-size="13" font-weight="800">FREE</text>
-    <text x="120" y="165" text-anchor="middle" fill="#e8e8ec" font-size="12">Try locally</text>
-    <text x="120" y="185" text-anchor="middle" fill="#8b8b96" font-size="11">2 captures/day</text>
-    <text x="120" y="205" text-anchor="middle" fill="#8b8b96" font-size="11">3 rules · warn default</text>
-    <rect x="280" y="110" width="160" height="120" rx="12" fill="#0d1b22" stroke="#22d3ee"/>
-    <text x="360" y="140" text-anchor="middle" fill="#22d3ee" font-size="13" font-weight="800">PRO $19/mo</text>
-    <text x="360" y="165" text-anchor="middle" fill="#e8e8ec" font-size="12">Solo cash path</text>
-    <text x="360" y="185" text-anchor="middle" fill="#8b8b96" font-size="11">Unlimited + recall</text>
-    <text x="360" y="205" text-anchor="middle" fill="#8b8b96" font-size="11">dashboard + DPO</text>
-    <rect x="520" y="110" width="160" height="120" rx="12" fill="#161618" stroke="#4ade80"/>
-    <text x="600" y="140" text-anchor="middle" fill="#4ade80" font-size="13" font-weight="800">SPRINT</text>
-    <text x="600" y="165" text-anchor="middle" fill="#e8e8ec" font-size="12">One hard workflow</text>
-    <text x="600" y="185" text-anchor="middle" fill="#8b8b96" font-size="11">intake → scope</text>
-    <text x="600" y="205" text-anchor="middle" fill="#8b8b96" font-size="11">then enterprise</text>
+    <text x="480" y="40" text-anchor="middle" fill="#f5f5f7" font-size="18" font-weight="800">One path. No offer soup.</text>
+    <!-- Free -->
+    <rect x="40" y="70" width="270" height="190" rx="18" fill="#161618" stroke="#333"/>
+    <text x="175" y="110" text-anchor="middle" fill="#9ca3af" font-size="13" font-weight="700">STEP 1</text>
+    <text x="175" y="145" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Free</text>
+    <text x="175" y="175" text-anchor="middle" fill="#9ca3af" font-size="14">npx thumbgate init</text>
+    <text x="175" y="205" text-anchor="middle" fill="#e5e7eb" font-size="14">Catch one real repeat</text>
+    <text x="175" y="235" text-anchor="middle" fill="#4ade80" font-size="13" font-weight="700">prove it works</text>
+    <!-- Pro -->
+    <rect x="345" y="70" width="270" height="190" rx="18" fill="#07151a" stroke="#22d3ee" stroke-width="2.5"/>
+    <text x="480" y="110" text-anchor="middle" fill="#22d3ee" font-size="13" font-weight="700">STEP 2 · BUY</text>
+    <text x="480" y="145" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Pro $19/mo</text>
+    <text x="480" y="175" text-anchor="middle" fill="#9ca3af" font-size="14">Unlimited solo use</text>
+    <text x="480" y="205" text-anchor="middle" fill="#e5e7eb" font-size="14">Dashboard · exports</text>
+    <text x="480" y="235" text-anchor="middle" fill="#22d3ee" font-size="13" font-weight="700">self-serve checkout</text>
+    <!-- Sprint -->
+    <rect x="650" y="70" width="270" height="190" rx="18" fill="#161618" stroke="#333"/>
+    <text x="785" y="110" text-anchor="middle" fill="#9ca3af" font-size="13" font-weight="700">IF NEEDED</text>
+    <text x="785" y="145" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Sprint</text>
+    <text x="785" y="175" text-anchor="middle" fill="#9ca3af" font-size="14">One hard workflow</text>
+    <text x="785" y="205" text-anchor="middle" fill="#e5e7eb" font-size="14">Scoped after intake</text>
+    <text x="785" y="235" text-anchor="middle" fill="#fbbf24" font-size="13" font-weight="700">not self-serve</text>
   </g>
 </svg>

--- a/public/assets/diagrams/decision.svg
+++ b/public/assets/diagrams/decision.svg
@@ -1,29 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 300" role="img" aria-labelledby="t d">
   <title id="t">Which ThumbGate path to pick</title>
-  <desc id="d">Free for solo try, Pro for unlimited personal use, Sprint for one painful team workflow.</desc>
+  <desc id="d">Free try, Pro solo, $499 diagnostic, sprint after intake.</desc>
   <rect width="960" height="300" fill="#0a0a0b"/>
   <g font-family="system-ui,sans-serif">
-    <text x="480" y="40" text-anchor="middle" fill="#f5f5f7" font-size="18" font-weight="800">One path. No offer soup.</text>
+    <text x="480" y="36" text-anchor="middle" fill="#f5f5f7" font-size="17" font-weight="800">Pick the path that matches the pain</text>
     <!-- Free -->
-    <rect x="40" y="70" width="270" height="190" rx="18" fill="#161618" stroke="#333"/>
-    <text x="175" y="110" text-anchor="middle" fill="#9ca3af" font-size="13" font-weight="700">STEP 1</text>
-    <text x="175" y="145" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Free</text>
-    <text x="175" y="175" text-anchor="middle" fill="#9ca3af" font-size="14">npx thumbgate init</text>
-    <text x="175" y="205" text-anchor="middle" fill="#e5e7eb" font-size="14">Catch one real repeat</text>
-    <text x="175" y="235" text-anchor="middle" fill="#4ade80" font-size="13" font-weight="700">prove it works</text>
+    <rect x="28" y="58" width="210" height="210" rx="16" fill="#161618" stroke="#333"/>
+    <text x="133" y="95" text-anchor="middle" fill="#9ca3af" font-size="12" font-weight="700">SOLO TRY</text>
+    <text x="133" y="130" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Free</text>
+    <text x="133" y="160" text-anchor="middle" fill="#9ca3af" font-size="13">npx thumbgate init</text>
+    <text x="133" y="190" text-anchor="middle" fill="#e5e7eb" font-size="13">Catch one repeat</text>
+    <text x="133" y="230" text-anchor="middle" fill="#4ade80" font-size="12" font-weight="700">prove it works</text>
     <!-- Pro -->
-    <rect x="345" y="70" width="270" height="190" rx="18" fill="#07151a" stroke="#22d3ee" stroke-width="2.5"/>
-    <text x="480" y="110" text-anchor="middle" fill="#22d3ee" font-size="13" font-weight="700">STEP 2 · BUY</text>
-    <text x="480" y="145" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Pro $19/mo</text>
-    <text x="480" y="175" text-anchor="middle" fill="#9ca3af" font-size="14">Unlimited solo use</text>
-    <text x="480" y="205" text-anchor="middle" fill="#e5e7eb" font-size="14">Dashboard · exports</text>
-    <text x="480" y="235" text-anchor="middle" fill="#22d3ee" font-size="13" font-weight="700">self-serve checkout</text>
+    <rect x="258" y="58" width="210" height="210" rx="16" fill="#07151a" stroke="#22d3ee" stroke-width="2"/>
+    <text x="363" y="95" text-anchor="middle" fill="#22d3ee" font-size="12" font-weight="700">SELF-SERVE</text>
+    <text x="363" y="130" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Pro $19/mo</text>
+    <text x="363" y="160" text-anchor="middle" fill="#9ca3af" font-size="13">Unlimited solo</text>
+    <text x="363" y="190" text-anchor="middle" fill="#e5e7eb" font-size="13">Dashboard · exports</text>
+    <text x="363" y="230" text-anchor="middle" fill="#22d3ee" font-size="12" font-weight="700">checkout today</text>
+    <!-- Diagnostic $499 - HIGHLIGHT -->
+    <rect x="488" y="58" width="220" height="210" rx="16" fill="#0d1b14" stroke="#4ade80" stroke-width="2.5"/>
+    <text x="598" y="95" text-anchor="middle" fill="#4ade80" font-size="12" font-weight="700">ONE WORKFLOW · PAY TODAY</text>
+    <text x="598" y="130" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">$499</text>
+    <text x="598" y="160" text-anchor="middle" fill="#9ca3af" font-size="13">Diagnostic</text>
+    <text x="598" y="190" text-anchor="middle" fill="#e5e7eb" font-size="13">Map block / warn / review</text>
+    <text x="598" y="230" text-anchor="middle" fill="#4ade80" font-size="12" font-weight="700">not Enterprise</text>
     <!-- Sprint -->
-    <rect x="650" y="70" width="270" height="190" rx="18" fill="#161618" stroke="#333"/>
-    <text x="785" y="110" text-anchor="middle" fill="#9ca3af" font-size="13" font-weight="700">IF NEEDED</text>
-    <text x="785" y="145" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">Sprint</text>
-    <text x="785" y="175" text-anchor="middle" fill="#9ca3af" font-size="14">One hard workflow</text>
-    <text x="785" y="205" text-anchor="middle" fill="#e5e7eb" font-size="14">Scoped after intake</text>
-    <text x="785" y="235" text-anchor="middle" fill="#fbbf24" font-size="13" font-weight="700">not self-serve</text>
+    <rect x="728" y="58" width="204" height="210" rx="16" fill="#161618" stroke="#333"/>
+    <text x="830" y="95" text-anchor="middle" fill="#9ca3af" font-size="12" font-weight="700">IMPLEMENT</text>
+    <text x="830" y="130" text-anchor="middle" fill="#f5f5f7" font-size="22" font-weight="900">$1,500</text>
+    <text x="830" y="160" text-anchor="middle" fill="#9ca3af" font-size="13">Hardening Sprint</text>
+    <text x="830" y="190" text-anchor="middle" fill="#e5e7eb" font-size="13">Wire + prove gates</text>
+    <text x="830" y="230" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="700">after scope</text>
   </g>
 </svg>

--- a/public/assets/diagrams/loop.svg
+++ b/public/assets/diagrams/loop.svg
@@ -1,22 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" role="img" aria-labelledby="t d">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 280" role="img" aria-labelledby="t d">
   <title id="t">ThumbGate feedback loop</title>
   <desc id="d">Agent proposes a tool call, ThumbGate decides allow warn or deny, feedback becomes a rule.</desc>
-  <rect width="720" height="220" fill="#0a0a0b"/>
+  <rect width="960" height="280" fill="#0a0a0b"/>
   <defs>
-    <marker id="a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#22d3ee"/></marker>
+    <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#22d3ee"/></marker>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#22d3ee"/><stop offset="1" stop-color="#4ade80"/></linearGradient>
   </defs>
-  <rect x="20" y="70" width="140" height="70" rx="12" fill="#161618" stroke="#222225"/>
-  <text x="90" y="100" text-anchor="middle" fill="#e8e8ec" font-family="system-ui,sans-serif" font-size="14" font-weight="700">Agent</text>
-  <text x="90" y="120" text-anchor="middle" fill="#8b8b96" font-family="system-ui,sans-serif" font-size="11">proposes tool</text>
-  <line x1="160" y1="105" x2="210" y2="105" stroke="#22d3ee" stroke-width="2" marker-end="url(#a)"/>
-  <rect x="220" y="55" width="170" height="100" rx="12" fill="#0d1b22" stroke="#22d3ee"/>
-  <text x="305" y="90" text-anchor="middle" fill="#22d3ee" font-family="system-ui,sans-serif" font-size="15" font-weight="800">ThumbGate</text>
-  <text x="305" y="112" text-anchor="middle" fill="#e8e8ec" font-family="system-ui,sans-serif" font-size="12">ALLOW · WARN · DENY</text>
-  <text x="305" y="132" text-anchor="middle" fill="#8b8b96" font-family="system-ui,sans-serif" font-size="11">before execution</text>
-  <line x1="390" y1="105" x2="440" y2="105" stroke="#22d3ee" stroke-width="2" marker-end="url(#a)"/>
-  <rect x="450" y="70" width="120" height="70" rx="12" fill="#161618" stroke="#222225"/>
-  <text x="510" y="100" text-anchor="middle" fill="#e8e8ec" font-family="system-ui,sans-serif" font-size="14" font-weight="700">Action</text>
-  <text x="510" y="120" text-anchor="middle" fill="#8b8b96" font-family="system-ui,sans-serif" font-size="11">shell / git / db</text>
-  <path d="M510 140 C510 185 90 185 90 140" fill="none" stroke="#4ade80" stroke-width="2" stroke-dasharray="4 3" marker-end="url(#a)"/>
-  <text x="300" y="200" text-anchor="middle" fill="#4ade80" font-family="system-ui,sans-serif" font-size="12" font-weight="600">👍 / 👎 feedback → lesson → rule</text>
+  <!-- Step 1 -->
+  <rect x="40" y="70" width="180" height="110" rx="18" fill="#161618" stroke="#333"/>
+  <circle cx="70" cy="100" r="16" fill="#222" stroke="#22d3ee" stroke-width="2"/>
+  <text x="70" y="105" text-anchor="middle" fill="#22d3ee" font-family="system-ui,sans-serif" font-size="14" font-weight="800">1</text>
+  <text x="130" y="120" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="18" font-weight="800">Agent</text>
+  <text x="130" y="146" text-anchor="middle" fill="#9ca3af" font-family="system-ui,sans-serif" font-size="13">proposes a tool</text>
+  <line x1="230" y1="125" x2="290" y2="125" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+  <!-- Step 2 -->
+  <rect x="300" y="50" width="240" height="150" rx="18" fill="#07151a" stroke="url(#g)" stroke-width="2.5"/>
+  <circle cx="340" cy="90" r="16" fill="#0d2530" stroke="#22d3ee" stroke-width="2"/>
+  <text x="340" y="95" text-anchor="middle" fill="#22d3ee" font-family="system-ui,sans-serif" font-size="14" font-weight="800">2</text>
+  <text x="420" y="95" text-anchor="middle" fill="#22d3ee" font-family="system-ui,sans-serif" font-size="20" font-weight="900">ThumbGate</text>
+  <text x="420" y="130" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="16" font-weight="700">ALLOW · WARN · DENY</text>
+  <text x="420" y="158" text-anchor="middle" fill="#9ca3af" font-family="system-ui,sans-serif" font-size="13">before the tool runs</text>
+  <line x1="550" y1="125" x2="610" y2="125" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+  <!-- Step 3 -->
+  <rect x="620" y="70" width="180" height="110" rx="18" fill="#161618" stroke="#333"/>
+  <circle cx="650" cy="100" r="16" fill="#222" stroke="#4ade80" stroke-width="2"/>
+  <text x="650" y="105" text-anchor="middle" fill="#4ade80" font-family="system-ui,sans-serif" font-size="14" font-weight="800">3</text>
+  <text x="710" y="120" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="18" font-weight="800">Action</text>
+  <text x="710" y="146" text-anchor="middle" fill="#9ca3af" font-family="system-ui,sans-serif" font-size="13">shell · git · db</text>
+  <!-- Feedback loop -->
+  <path d="M710 185 C710 240 130 240 130 185" fill="none" stroke="#4ade80" stroke-width="3" stroke-dasharray="6 4" marker-end="url(#arr)"/>
+  <rect x="280" y="218" width="280" height="36" rx="18" fill="#0d1b14" stroke="#4ade80"/>
+  <text x="420" y="241" text-anchor="middle" fill="#4ade80" font-family="system-ui,sans-serif" font-size="14" font-weight="700">👍 👎 feedback → lesson → rule</text>
 </svg>

--- a/public/assets/diagrams/stack.svg
+++ b/public/assets/diagrams/stack.svg
@@ -1,22 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img" aria-labelledby="t d">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 240" role="img" aria-labelledby="t d">
   <title id="t">Where ThumbGate sits in the stack</title>
   <desc id="d">Model to agent runtime to ThumbGate pre-action gate to tools.</desc>
-  <rect width="720" height="200" fill="#0a0a0b"/>
+  <rect width="960" height="240" fill="#0a0a0b"/>
   <g font-family="system-ui,sans-serif">
-    <rect x="30" y="60" width="130" height="70" rx="10" fill="#161618" stroke="#222225"/>
-    <text x="95" y="100" text-anchor="middle" fill="#e8e8ec" font-size="14" font-weight="700">Model</text>
-    <text x="170" y="100" fill="#8b8b96" font-size="20">→</text>
-    <rect x="200" y="60" width="140" height="70" rx="10" fill="#161618" stroke="#222225"/>
-    <text x="270" y="95" text-anchor="middle" fill="#e8e8ec" font-size="14" font-weight="700">Agent</text>
-    <text x="270" y="115" text-anchor="middle" fill="#8b8b96" font-size="11">Claude · Cursor · Codex</text>
-    <text x="350" y="100" fill="#8b8b96" font-size="20">→</text>
-    <rect x="380" y="50" width="160" height="90" rx="10" fill="#0d1b22" stroke="#22d3ee" stroke-width="2"/>
-    <text x="460" y="85" text-anchor="middle" fill="#22d3ee" font-size="14" font-weight="800">ThumbGate</text>
-    <text x="460" y="105" text-anchor="middle" fill="#e8e8ec" font-size="12">pre-action gate</text>
-    <text x="460" y="123" text-anchor="middle" fill="#8b8b96" font-size="11">hook / MCP</text>
-    <text x="550" y="100" fill="#8b8b96" font-size="20">→</text>
-    <rect x="580" y="60" width="110" height="70" rx="10" fill="#161618" stroke="#222225"/>
-    <text x="635" y="95" text-anchor="middle" fill="#e8e8ec" font-size="14" font-weight="700">Tools</text>
-    <text x="635" y="115" text-anchor="middle" fill="#8b8b96" font-size="11">shell git db</text>
+    <rect x="60" y="36" width="840" height="40" rx="10" fill="#161618" stroke="#333"/>
+    <text x="480" y="62" text-anchor="middle" fill="#9ca3af" font-size="15" font-weight="600">Model (Claude · GPT · Gemini · local)</text>
+    <text x="480" y="100" text-anchor="middle" fill="#22d3ee" font-size="22">↓</text>
+    <rect x="60" y="112" width="840" height="40" rx="10" fill="#161618" stroke="#333"/>
+    <text x="480" y="138" text-anchor="middle" fill="#e5e7eb" font-size="15" font-weight="600">Agent runtime (Claude Code · Cursor · Codex · …)</text>
+    <text x="480" y="176" text-anchor="middle" fill="#22d3ee" font-size="22">↓</text>
+    <rect x="60" y="188" width="400" height="40" rx="10" fill="#07151a" stroke="#22d3ee" stroke-width="2"/>
+    <text x="260" y="214" text-anchor="middle" fill="#22d3ee" font-size="15" font-weight="800">ThumbGate pre-action gate</text>
+    <text x="490" y="214" text-anchor="middle" fill="#4ade80" font-size="20">→</text>
+    <rect x="520" y="188" width="380" height="40" rx="10" fill="#161618" stroke="#333"/>
+    <text x="710" y="214" text-anchor="middle" fill="#e5e7eb" font-size="15" font-weight="600">shell · git · db · MCP tools</text>
   </g>
 </svg>

--- a/public/index.html
+++ b/public/index.html
@@ -757,7 +757,28 @@ __GA_BOOTSTRAP__
   .deep-dive-drawer .deep-dive-body .section-title { font-size: clamp(22px, 3vw, 32px) !important; }
   .first-check-card { display: none !important; } /* moved to visual path below diagrams */
   .hero aside { display: none !important; } /* local-first essay out of fold */
-  .proof-bar { display: none !important; } /* link farm out of fold — kept in deep dive via anchors */
+  .proof-bar {
+    display: flex !important;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    max-width: 900px;
+    margin: 18px auto 0;
+    padding: 12px 14px;
+    border: 1px solid rgba(34,211,238,0.2);
+    border-radius: 12px;
+    background: rgba(34,211,238,0.04);
+  }
+  .proof-bar a {
+    font-size: 12px;
+    font-weight: 700;
+    color: #22d3ee;
+    text-decoration: none;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(34,211,238,0.25);
+  }
+  .proof-bar a:hover { background: rgba(34,211,238,0.1); }
 </style>
   <!-- PostHog Analytics -->
   <script>

--- a/public/index.html
+++ b/public/index.html
@@ -727,6 +727,37 @@ __GA_BOOTSTRAP__
   @media (max-width: 800px) {
     .diagram-grid { grid-template-columns: 1fr; }
   }
+
+  /* 2026-07-22 conversion: diagrams first, essays last */
+  .diagram-strip { padding: 12px 0 36px !important; background: linear-gradient(180deg, rgba(34,211,238,0.04), transparent 60%); }
+  .diagram-grid { gap: 20px !important; }
+  .diagram-card { box-shadow: 0 18px 50px rgba(0,0,0,0.35); border-color: rgba(34,211,238,0.22) !important; }
+  .diagram-card figcaption { padding: 14px 16px 16px !important; }
+  .diagram-card figcaption strong { font-size: 16px !important; }
+  .diagram-card figcaption span { font-size: 14px !important; }
+  .hero-visual-strip { max-width: 1080px; margin: 20px auto 0; }
+  .hero-visual-strip img { width: 100%; height: auto; border-radius: 16px; border: 1px solid rgba(34,211,238,0.25); background: #0a0a0b; display: block; }
+  .hero-copy { max-width: 720px; margin: 0 auto; text-align: center; }
+  .hero-above-fold { display: block !important; }
+  .hero-proof-card { max-width: 720px; margin: 22px auto 0; }
+  .hero-actions { justify-content: center !important; }
+  .hero-team-link { text-align: center; }
+  .hero-trust-bar { justify-content: center; }
+  .cash-path { padding: 22px !important; border-width: 2px !important; }
+  .cash-path h3 { font-size: 20px !important; }
+  .cash-path-actions a { min-height: 48px; padding: 12px 18px !important; font-size: 15px !important; font-weight: 800; }
+  .btn-pro { background: #22d3ee !important; color: #041018 !important; border-radius: 10px; text-decoration: none; display: inline-flex; align-items: center; }
+  .btn-free { border: 1px solid rgba(255,255,255,0.2); border-radius: 10px; padding: 12px 18px; text-decoration: none; display: inline-flex; align-items: center; }
+  .deep-dive-drawer { max-width: 900px; margin: 24px auto 40px; border: 1px solid var(--border); border-radius: 14px; background: var(--bg-card); }
+  .deep-dive-drawer > summary { cursor: pointer; list-style: none; padding: 16px 20px; font-weight: 800; color: var(--text-muted); }
+  .deep-dive-drawer > summary::-webkit-details-marker { display: none; }
+  .deep-dive-drawer[open] > summary { border-bottom: 1px solid var(--border); color: var(--text); }
+  .deep-dive-drawer .deep-dive-body { padding: 8px 0 16px; }
+  .deep-dive-drawer .deep-dive-body section { padding-top: 28px !important; padding-bottom: 20px !important; }
+  .deep-dive-drawer .deep-dive-body .section-title { font-size: clamp(22px, 3vw, 32px) !important; }
+  .first-check-card { display: none !important; } /* moved to visual path below diagrams */
+  .hero aside { display: none !important; } /* local-first essay out of fold */
+  .proof-bar { display: none !important; } /* link farm out of fold — kept in deep dive via anchors */
 </style>
   <!-- PostHog Analytics -->
   <script>
@@ -764,12 +795,15 @@ __GA_BOOTSTRAP__
       <div class="hero-copy">
         <div class="hero-badge">AI-agent firewall for Claude Code, Cursor, and Codex</div>
         <h1>Stop dangerous AI-agent actions before they run.</h1>
-        <p class="hero-lede">ThumbGate checks tool calls locally, denies detected secret exfiltration and gate-bypass commands by default, and helps turn repeated failures into explicit rules.</p>
+        <p class="hero-lede">Local pre-action gate. Feedback becomes rules. Rules check the next tool call.</p>
         <div class="hero-actions">
           <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault();navigator.clipboard.writeText('npx thumbgate init');this.textContent='Copied ✓ — paste in your repo';setTimeout(()=>{this.textContent='Install Free'},2000);try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-free btn-install-hero" title="Click to copy: npx thumbgate init">Install Free</a>
           <a href="#live-proof" class="hero-proof-link">See it catch a risky command →</a>
         </div>
-        <p class="hero-team-link">Securing a team workflow? <a href="/diagnostic?utm_source=website&utm_medium=hero_text&utm_campaign=team_workflow&cta_id=hero_team_diagnostic&cta_placement=hero">See the scoped diagnostic →</a></p>
+        <p class="hero-team-link">Securing a team workflow? <a href="/diagnostic?utm_source=website&utm_medium=hero_text&utm_campaign=team_workflow&cta_id=hero_team_diagnostic&cta_placement=hero">See the scoped diagnostic →</a> · <a href="#diagrams">Pictures + buy path →</a></p>
+        <div class="hero-visual-strip" aria-hidden="false">
+          <img src="/assets/diagrams/before-after.svg" alt="Without ThumbGate mistakes repeat. With ThumbGate one thumbs-down becomes a permanent check." width="960" height="280" loading="eager" fetchpriority="high" />
+        </div>
       </div>
 
       <figure class="hero-proof-card" id="live-proof" aria-label="ThumbGate evaluating dangerous AI-agent commands in real time">
@@ -889,39 +923,42 @@ __GA_BOOTSTRAP__
   <div class="container">
     <div class="section-label">See it in 10 seconds</div>
     <h2 class="section-title" style="margin-bottom:8px;">Simple pictures. No essay required.</h2>
-    <p style="text-align:center;color:var(--text-muted);max-width:640px;margin:0 auto 20px;font-size:15px;line-height:1.5;">ThumbGate is a local pre-action gate for AI coding agents. Feedback becomes rules. Rules evaluate the next tool call before it runs.</p>
+    <p style="text-align:center;color:var(--text-muted);max-width:560px;margin:0 auto 16px;font-size:15px;line-height:1.45;">Three pictures. Then buy if it fits.</p>
+    <figure class="diagram-card full" style="margin-bottom:18px;">
+      <img src="/assets/diagrams/loop.svg" alt="ThumbGate loop: agent proposes tool, ThumbGate allows warns or denies, feedback becomes a rule" width="960" height="280" loading="eager" />
+      <figcaption><strong>1. The loop</strong><span>Agent proposes → ThumbGate decides ALLOW / WARN / DENY → your feedback becomes the next rule.</span></figcaption>
+    </figure>
     <div class="diagram-grid">
       <figure class="diagram-card">
-        <img src="/assets/diagrams/loop.svg" alt="ThumbGate loop: agent proposes tool, ThumbGate allows warns or denies, feedback becomes a rule" width="720" height="220" loading="lazy" />
-        <figcaption><strong>1. The loop</strong><span>Agent proposes → ThumbGate decides ALLOW / WARN / DENY → your feedback becomes the next rule.</span></figcaption>
+        <img src="/assets/diagrams/stack.svg" alt="Stack diagram showing ThumbGate between agent runtime and tools" width="960" height="240" loading="lazy" />
+        <figcaption><strong>2. Where it sits</strong><span>Between the agent and the tools — not another chatbot memory layer.</span></figcaption>
       </figure>
       <figure class="diagram-card">
-        <img src="/assets/diagrams/stack.svg" alt="Stack diagram showing ThumbGate between agent runtime and tools" width="720" height="200" loading="lazy" />
-        <figcaption><strong>2. Where it sits</strong><span>Model → Agent runtime → ThumbGate pre-action gate → shell / git / db. Not another chatbot memory.</span></figcaption>
+        <img src="/assets/diagrams/before-after.svg" alt="Before and after: repeated mistakes without ThumbGate versus one correction with ThumbGate" width="960" height="280" loading="lazy" />
+        <figcaption><strong>3. Before / after</strong><span>One thumbs-down. Next attempt is checked. No essay.</span></figcaption>
       </figure>
-      <figure class="diagram-card">
-        <img src="/assets/diagrams/before-after.svg" alt="Before and after: repeated mistakes without ThumbGate versus one correction with ThumbGate" width="720" height="220" loading="lazy" />
-        <figcaption><strong>3. Before / after</strong><span>Without: the same force-push returns. With: one thumbs-down becomes a check that evaluates the next attempt.</span></figcaption>
-      </figure>
-      <figure class="diagram-card">
-        <img src="/assets/diagrams/decision.svg" alt="Decision tree Free try, Pro solo cash path, Sprint for one hard workflow" width="720" height="260" loading="lazy" />
-        <figcaption><strong>4. What to buy</strong><span>Free to prove it. Pro ($19/mo) for unlimited solo use. Sprint intake when one workflow is burning the team.</span></figcaption>
+      <figure class="diagram-card full">
+        <img src="/assets/diagrams/decision.svg" alt="Decision tree Free try, Pro solo cash path, Sprint for one hard workflow" width="960" height="300" loading="lazy" />
+        <figcaption><strong>4. What to buy</strong><span>Free → prove it. Pro $19/mo → solo cash path. Sprint → one hard workflow after intake.</span></figcaption>
       </figure>
     </div>
     <div class="cash-path" id="cash-path">
       <h3>One cash path (no offer soup)</h3>
-      <p><strong>Install Free → catch one repeat → Upgrade to Pro $19/mo.</strong> Team / Enterprise is intake-only after you name one repeated failure. No competing experimental ladders on this page.</p>
+      <p><strong>Install free → catch one repeat → Pro $19/mo.</strong></p>
       <div class="cash-path-actions">
         <a href="/go/install?utm_source=website&utm_medium=cash_path&utm_campaign=install_free&cta_id=cash_path_install&cta_placement=diagrams" class="btn-free btn-install-link" onclick="event.preventDefault();navigator.clipboard.writeText('npx thumbgate init');this.textContent='Copied';setTimeout(()=>{this.textContent='Install free.'},2000);">Install free.</a>
         <a href="/checkout/pro?utm_source=website&utm_medium=cash_path&utm_campaign=pro_upgrade&cta_id=cash_path_pro&cta_placement=diagrams&plan_id=pro&landing_path=%2F" class="btn-pro" data-revenue-cta data-cta-id="cash_path_pro" data-cta-placement="diagrams" data-plan-id="pro" data-price="19" onclick="if(typeof trackRevenueCta==='function'){trackRevenueCta(this);}">Upgrade to Pro — $19/mo</a>
-        <a href="#workflow-sprint-intake" class="btn-team" style="padding:10px 14px;font-size:13px;">One hard workflow? Start sprint intake →</a>
+        <a href="#workflow-sprint-intake" class="btn-team" style="padding:10px 14px;font-size:13px;">Team sprint intake →</a>
       </div>
-      <div class="honesty-pill" role="note">Honest defaults: secrets and gate-bypass <strong>deny</strong>; destructive deletes and force-push <strong>warn</strong> unless <code style="color:#fecaca">THUMBGATE_STRICT_ENFORCEMENT=1</code>.</div>
+      <div class="honesty-pill" role="note">Defaults: secrets + gate-bypass <strong>deny</strong>; force-push / destructive deletes <strong>warn</strong> unless <code style="color:#fecaca">THUMBGATE_STRICT_ENFORCEMENT=1</code>.</div>
     </div>
   </div>
 </section>
 
 
+<details class="deep-dive-drawer" id="deep-dive">
+  <summary>Optional deep dive (market context, GPT, comparisons) — closed by default so the page stays visual.</summary>
+  <div class="deep-dive-body">
 <section class="compatibility section-tight" id="why-not-diy" aria-label="Why not write your own hooks">
   <div class="container">
     <h2>“Why not just write my own PreToolUse hooks?”</h2>
@@ -1464,6 +1501,9 @@ __GA_BOOTSTRAP__
     </div>
   </div>
 </section>
+
+  </div>
+</details>
 
 <section id="install" style="padding: 60px 40px; max-width: 900px; margin: 0 auto;">
   <h2 style="font-size: 2em; text-align: center; margin-bottom: 40px;">Install for Your Agent</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -800,7 +800,7 @@ __GA_BOOTSTRAP__
           <a href="/go/install?utm_source=website&utm_medium=hero_cta&utm_campaign=install_free&cta_id=hero_install_cli&cta_placement=hero" onclick="event.preventDefault();navigator.clipboard.writeText('npx thumbgate init');this.textContent='Copied ✓ — paste in your repo';setTimeout(()=>{this.textContent='Install Free'},2000);try{posthog.capture('hero_install_click',{cta:'install_cli'})}catch(_){}" class="btn-free btn-install-hero" title="Click to copy: npx thumbgate init">Install Free</a>
           <a href="#live-proof" class="hero-proof-link">See it catch a risky command →</a>
         </div>
-        <p class="hero-team-link">Securing a team workflow? <a href="/diagnostic?utm_source=website&utm_medium=hero_text&utm_campaign=team_workflow&cta_id=hero_team_diagnostic&cta_placement=hero">See the scoped diagnostic →</a> · <a href="#diagrams">Pictures + buy path →</a></p>
+        <p class="hero-team-link">Need a paid human gate map for one failure? <a href="/diagnostic?utm_source=website&utm_medium=hero_text&utm_campaign=team_workflow&cta_id=hero_team_diagnostic&cta_placement=hero">See the scoped diagnostic →</a> ($499 · not Enterprise) · <a href="#diagrams">Pictures + buy path →</a></p>
         <div class="hero-visual-strip" aria-hidden="false">
           <img src="/assets/diagrams/before-after.svg" alt="Without ThumbGate mistakes repeat. With ThumbGate one thumbs-down becomes a permanent check." width="960" height="280" loading="eager" fetchpriority="high" />
         </div>
@@ -939,7 +939,7 @@ __GA_BOOTSTRAP__
       </figure>
       <figure class="diagram-card full">
         <img src="/assets/diagrams/decision.svg" alt="Decision tree Free try, Pro solo cash path, Sprint for one hard workflow" width="960" height="300" loading="lazy" />
-        <figcaption><strong>4. What to buy</strong><span>Free → prove it. Pro $19/mo → solo cash path. Sprint → one hard workflow after intake.</span></figcaption>
+        <figcaption><strong>4. What to buy</strong><span>Free → prove it. Pro $19/mo → solo. <strong>$499 diagnostic</strong> → one failure, pay today. $1,500 sprint → implement. Enterprise pilot is $15k — separate ladder.</span></figcaption>
       </figure>
     </div>
     <div class="cash-path" id="cash-path">
@@ -948,8 +948,9 @@ __GA_BOOTSTRAP__
       <div class="cash-path-actions">
         <a href="/go/install?utm_source=website&utm_medium=cash_path&utm_campaign=install_free&cta_id=cash_path_install&cta_placement=diagrams" class="btn-free btn-install-link" onclick="event.preventDefault();navigator.clipboard.writeText('npx thumbgate init');this.textContent='Copied';setTimeout(()=>{this.textContent='Install free.'},2000);">Install free.</a>
         <a href="/checkout/pro?utm_source=website&utm_medium=cash_path&utm_campaign=pro_upgrade&cta_id=cash_path_pro&cta_placement=diagrams&plan_id=pro&landing_path=%2F" class="btn-pro" data-revenue-cta data-cta-id="cash_path_pro" data-cta-placement="diagrams" data-plan-id="pro" data-price="19" onclick="if(typeof trackRevenueCta==='function'){trackRevenueCta(this);}">Upgrade to Pro — $19/mo</a>
-        <a href="#workflow-sprint-intake" class="btn-team" style="padding:10px 14px;font-size:13px;">Team sprint intake →</a>
+        <a href="/diagnostic?utm_source=website&utm_medium=cash_path&utm_campaign=money_today&cta_id=cash_path_diagnostic&cta_placement=diagrams&plan_id=sprint_diagnostic" class="btn-team" style="padding:12px 16px;font-size:15px;font-weight:800;background:#4ade80;color:#06120a;border-radius:10px;text-decoration:none;" data-revenue-cta data-cta-id="cash_path_diagnostic" data-cta-placement="diagrams" data-plan-id="sprint_diagnostic" data-price="499">Buy $499 diagnostic →</a>
       </div>
+      <p style="margin:12px 0 0;color:var(--text-muted);font-size:13px;"><strong style="color:var(--text);">$499 = Workflow Hardening Diagnostic</strong> (not Enterprise). Enterprise is $15k pilot / $10k/mo after intake.</p>
       <div class="honesty-pill" role="note">Defaults: secrets + gate-bypass <strong>deny</strong>; force-push / destructive deletes <strong>warn</strong> unless <code style="color:#fecaca">THUMBGATE_STRICT_ENFORCEMENT=1</code>.</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Homepage was a text wall. This makes the **first screen visual and buyable**:

- Short hero: one-line lede + **before/after SVG** above the fold
- **Larger loop / stack / decision diagrams** (960-wide, full-width loop + cash path)
- **Free → Pro $19 cash path** loud and single-lane
- Manifesto / market essays moved into a **closed deep-dive drawer** (content kept for SEO + anchors; not the default scroll)

## Test plan

- [x] `node --test tests/public-landing.test.js` → 55/55
- [x] pre-push guards
- [ ] After merge: curl production and confirm diagram SVGs + shorter fold