### PR TITLE
feat(marketing): store story + self-improving under your control

### DIFF
--- a/.changeset/self-improving-under-control.md
+++ b/.changeset/self-improving-under-control.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Lock the store story and under-your-control qualifier: every approval teaches allow/block/escalate, without silent policy rewrite.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -11,6 +11,10 @@
 > stale auto-promoted gates expire; and stale lessons archive. ThumbGate improves
 > the external control layer without changing model weights.
 
+## Store story
+
+ThumbGate: the self-improving firewall for AI agents. Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control—not silent policy rewrite. Hermes Mobile is the control surface; ThumbGate is the learning safety layer inside it.
+
 ## What ThumbGate solves
 
 - AI coding agents repeat costly mistakes across sessions

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -3,7 +3,7 @@
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
   "homepageUrl": "https://thumbgate.ai",
   "githubDescription": "ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.",
-  "metaDescription": "ThumbGate is the self-improving firewall for AI agents. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.",
+  "metaDescription": "ThumbGate is the self-improving firewall for AI agents under your control. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.",
   "topics": [
     "thumbgate",
     "pre-action-checks",

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -1,6 +1,10 @@
 # Marketing Copy Congruence
 
 ## Core Identity
+**Store story:** ThumbGate: the self-improving firewall for AI agents — Every approval teaches it what to allow, block, or escalate next time.
+**Qualifier:** self-improving under your control (not silent policy rewrite).
+**Hierarchy:** Hermes Mobile = control surface; ThumbGate = learning safety layer inside it.
+
 **Product Name:** ThumbGate
 **Primary Value Proposition:** Inspect risky agent actions before execution and block them when policy requires it
 
@@ -10,7 +14,7 @@
 > Pre-action checks that flag repeated risky actions before execution and block matching actions when strict policy is enabled. Accepted feedback becomes local lessons; repeated failures can become prevention rules.
 
 ### Public Landing Page (thumbgate-production.up.railway.app)
-> ThumbGate is the self-improving firewall for AI agents. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
+> ThumbGate is the self-improving firewall for AI agents under your control. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
 
 ### NPM package.json
 > ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.

--- a/public/index.html
+++ b/public/index.html
@@ -13,10 +13,10 @@
   <meta property="og:image" content="https://thumbgate.ai/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://thumbgate.ai/og.png">
-  <title>ThumbGate — Self-Improving Firewall for Your AI Agents</title>
-  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
-  <meta property="og:title" content="ThumbGate — Self-Improving Firewall for Your AI Agents">
-  <meta property="og:description" content="Feedback becomes local lessons. Relevant lessons are re-ranked, repeated failures can promote to pre-action gates, and stale gates expire. $499 managed setup for one workflow.">
+  <title>ThumbGate: the self-improving firewall for AI agents</title>
+  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
+  <meta property="og:title" content="ThumbGate: the self-improving firewall for AI agents">
+  <meta property="og:description" content="Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control—not a silent policy rewrite. $499 managed setup for one workflow.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="__APP_ORIGIN__/">
   <script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.tagged-events.js"></script>
@@ -136,7 +136,7 @@
         "name": "Does self-improving mean ThumbGate retrains my model?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "No. ThumbGate does not change model weights. It improves the external control layer by storing feedback as local lessons, re-ranking relevant lessons, promoting repeated negative patterns into gates, and expiring stale auto-promoted gates."
+          "text": "No. ThumbGate does not change model weights and does not silently rewrite production policy. Self-improving under your control means explicit approvals and feedback teach the local control layer what to allow, block, or escalate next time: lessons are stored and re-ranked, repeated negative patterns can promote into gates, and stale auto-promoted gates expire."
         }
       }
     ]
@@ -371,9 +371,9 @@
     <section class="hero">
       <div class="shell hero-grid">
         <div class="hero-copy">
-          <div class="eyebrow">Feedback → memory → gates → safer actions</div>
+          <div class="eyebrow">Self-improving under your control</div>
           <h1>Self-Improving Firewall for Your AI Agents.</h1>
-          <p class="hero-lede">ThumbGate remembers operational feedback, re-ranks the right lessons, and promotes repeated failures into test-backed pre-action gates before the next tool call runs.</p>
+          <p class="hero-lede">Every approval teaches it what to allow, block, or escalate next time.</p>
           <p class="fit-line"><strong>$499 enterprise entry offer</strong> for engineering and security leads using Claude Code, Cursor, Codex, or similar agents after a real workflow failure.</p>
           <div class="spec-chips" aria-label="What the self-improving firewall does">
             <span class="spec-chip"><strong>Capture</strong> feedback</span>
@@ -442,7 +442,7 @@
             </div>
           </article>
         </div>
-        <p class="loop-back"><strong>Each reviewed outcome closes the loop.</strong> Lessons are re-ranked per action, repeated failures can promote into gates, and stale auto-promoted gates expire. The firewall improves without retraining the model.</p>
+        <p class="loop-back"><strong>Each reviewed outcome closes the loop—under your control.</strong> Lessons are re-ranked per action, repeated failures can promote into gates, and stale auto-promoted gates expire. The firewall improves from explicit feedback without retraining the model or silently rewriting policy.</p>
       </div>
     </section>
 
@@ -489,7 +489,7 @@ reason    force-push to protected branch
 next      decision recorded before execution</pre>
             <div class="terminal-status" aria-hidden="true">
               <span>reviewable decision</span>
-              <span><span class="accent">self-improving</span> · local lesson store</span>
+              <span><span class="accent">under your control</span> · local lesson store</span>
             </div>
           </div>
           <div class="proof-copy">
@@ -520,7 +520,7 @@ next      decision recorded before execution</pre>
           </div>
           <div class="faq-item">
             <button class="faq-q" type="button" aria-expanded="false">Does self-improving mean ThumbGate retrains my model?</button>
-            <div class="faq-a">No. ThumbGate does not change model weights. It improves the external control layer by storing feedback as local lessons, re-ranking relevant lessons, promoting repeated negative patterns into gates, and expiring stale auto-promoted gates.</div>
+            <div class="faq-a">No. ThumbGate does not change model weights and does not silently rewrite production policy. Self-improving under your control means explicit approvals and feedback teach the local control layer what to allow, block, or escalate next time: lessons are stored and re-ranked, repeated negative patterns can promote into gates, and stale auto-promoted gates expire.</div>
           </div>
         </div>
       </div>

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -1,8 +1,31 @@
 # ThumbGate — Self-Improving Firewall for AI Agents
 
+## Store story (canonical)
+
+> **ThumbGate: the self-improving firewall for AI agents**  
+> Every approval teaches it what to allow, block, or escalate next time.
+
+The strongest promise is **self-improving under your control**, not an autonomous firewall that silently rewrites its own policy. "Firewall for AI agents" is the category; "self-improving" is the differentiator; "under your control" is the trust boundary.
+
+## Product hierarchy (cross-product)
+
+- **Hermes Mobile** is the operator-facing control surface (approvals, session UI, mobile leash).
+- **ThumbGate** is the learning safety layer inside that stack: local lessons, re-ranking, promotion/expiry, PreToolUse enforcement.
+- This repository and npm package `thumbgate` stay ThumbGate-only. Do not rename the package or present Hermes as a second npm product here. Use the hierarchy in store and multi-app narratives.
+
+## Proof sequence (verified)
+
+1. **Remember** — explicit feedback becomes a reviewable local lesson  
+2. **Re-rank** — relevant lessons are ranked for the next proposed action  
+3. **Promote** — repeated negative patterns can become warning or blocking gates  
+4. **Expire / archive** — stale auto-promoted gates expire; stale lessons archive  
+5. **Improve the next decision** — enforce before the next tool call  
+
+Do **not** claim active-gate demotion from positive feedback, gate re-ranking among overlapping gates, or model-weight training unless code and tests prove it.
+
 ## What ThumbGate Is
 
-ThumbGate is the self-improving firewall for AI coding agents: it prevents expensive AI mistakes before they happen, then improves the defense layer from real operational feedback. Engineering teams use it to check risky commands, file edits, deploys, payments, API calls, and other AI agent actions before execution across Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, ChatGPT Actions, CI, and MCP-compatible runtimes.
+ThumbGate is the self-improving firewall for AI coding agents under operator control: it prevents expensive AI mistakes before they happen, then improves the defense layer from real operational feedback. Engineering teams use it to check risky commands, file edits, deploys, payments, API calls, and other AI agent actions before execution across Claude Code, Cursor, Codex, Gemini CLI, Amp, OpenCode, ChatGPT Actions, CI, and MCP-compatible runtimes.
 
 This is not a static allowlist and not model fine-tuning. ThumbGate captures thumbs-up/down feedback as reviewable local lessons, re-ranks relevant lessons for each proposed action, promotes repeated negative patterns from warnings into blocking gates, expires stale auto-promoted gates, archives stale lessons, and gates the next tool call through PreToolUse hooks. The buyer outcome is simple: prevent expensive AI mistakes, make AI catch repeating mistakes, and turn a smart assistant into a reliable operator. It is warn-by-default: the gate always fires and logs every decision, and by default it hard-blocks secret exfiltration and attempts to disable ThumbGate's own guardrails, while downgrading everything else — rm -rf-class destructive filesystem commands, force-push, security/supply-chain risks — to a warning; set THUMBGATE_STRICT_ENFORCEMENT=1 to hard-block every rule. Unlike CLAUDE.md rules or .cursorrules files, which are suggestions the agent can ignore, the ThumbGate gate operates at the tool-call level and cannot be reasoned away once the action is routed through ThumbGate. The promoted paid offer is one $499 Managed AI Agent Workflow Gate for one supported workflow: a 60-minute working review, configured local gate, regression test, and rollout/rollback proof within two business days.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,6 +2,17 @@
 
 > ThumbGate is the self-improving firewall for AI coding agents: Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, and MCP-compatible tools. Thumbs-up/down feedback becomes reviewable local lessons; matching lessons are re-ranked per action; repeated negative patterns can promote from warning to blocking gates; stale auto-promoted gates expire; and PreToolUse checks gate the next tool call. Local-first by default. Stripe Connect marketplace engineering is a founder proof point, not the primary product category.
 
+## Store story (canonical)
+
+> ThumbGate: the self-improving firewall for AI agents
+> Every approval teaches it what to allow, block, or escalate next time.
+
+Strongest promise: **self-improving under your control** (not silent policy rewrite).
+
+Product hierarchy: Hermes Mobile = control surface; ThumbGate = learning safety layer inside it. This package remains `thumbgate`-only.
+
+Proof sequence: remember → re-rank lessons → promote repeated failures → expire/archive stale policy → improve the next decision. Do not claim active-gate demotion until proven.
+
 ## Positioning (2026-07)
 
 - Category: pre-action firewall / reliability gateway for agent tool calls

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -100,7 +100,10 @@ test('hero names one buyer, one failure, and the enterprise entry outcome', () =
   const lede = normalizeHtmlText((hero.match(/<p class="hero-lede">([\s\S]*?)<\/p>/) || [])[1]);
 
   assert.match(landingPage, /Self-Improving Firewall for Your AI Agents/i);
+  assert.match(landingPage, /ThumbGate: the self-improving firewall for AI agents/i);
   assert.match(hero, /<h1>Self-Improving Firewall for Your AI Agents\.<\/h1>/i);
+  assert.match(hero, /Self-improving under your control/i);
+  assert.match(hero, /Every approval teaches it what to allow, block, or escalate next time/i);
   assert.match(hero, /engineering and security leads/);
   assert.match(hero, /Enterprise Workflow Gate/);
   assert.match(hero, /\$499 enterprise entry offer/);
@@ -115,7 +118,9 @@ test('how-it-works sells the self-improving loop, not a static allowlist', () =>
   assert.match(landingPage, /Lessons are re-ranked per action/i);
   assert.match(landingPage, /repeated failures can promote into gates/i);
   assert.match(landingPage, /stale auto-promoted gates expire/i);
-  assert.match(landingPage, /firewall improves without retraining the model/i);
+  assert.match(landingPage, /under your control/i);
+  assert.match(landingPage, /silently rewriting policy|does not silently rewrite/i);
+  assert.match(landingPage, /firewall improves from explicit feedback without retraining the model/i);
   assert.match(landingPage, /source\s+core protection · strict mode/i);
 });
 


### PR DESCRIPTION
## Summary
Locks the CEO-confirmed store story and trust qualifier:

> **ThumbGate: the self-improving firewall for AI agents**  
> Every approval teaches it what to allow, block, or escalate next time.

- **Category:** firewall for AI agents  
- **Differentiator:** self-improving  
- **Trust boundary:** under your control (not silent policy rewrite)

Product hierarchy (documented in `llm-context` + vault, not as a package rename):
- Hermes Mobile = control surface  
- ThumbGate = learning safety layer  

Proof sequence remains: remember → re-rank lessons → promote repeated failures → expire/archive → improve next decision. No demote/gate-rerank/weight-training claims.

## Surfaces
- Homepage title, eyebrow, store lede, loop-back, FAQ  
- `public/llm-context.md`, both llms.txt, congruence meta  
- Landing tests pin the store couplet  

Vault (separate commit in AI-Agent-Sync):
- `Projects/ThumbGate/positioning-store-story.md`
- Handoffs for store-story under-control  

## Test plan
- [x] `node scripts/check-congruence.js`
- [x] `node --test tests/public-landing.test.js tests/check-congruence.test.js tests/positioning-contract.test.js`