### PR TITLE
feat(marketing): open-by-design FAQ for the self-improving firewall

### DIFF
--- a/.changeset/open-by-design-faq.md
+++ b/.changeset/open-by-design-faq.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Add a fifth landing-page FAQ item (and matching FAQPage JSON-LD entry) stating that the self-improving promotion/demotion/ranking logic ships publicly under MIT — not withheld behind a paywall.

--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,14 @@
           "@type": "Answer",
           "text": "No. ThumbGate does not change model weights. It improves the external control layer by storing feedback as local lessons, re-ranking relevant lessons, promoting repeated negative patterns into gates, and expiring stale auto-promoted gates."
         }
+      },
+      {
+        "@type": "Question",
+        "name": "Is the self-improving logic a black box I have to trust blindly?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "No. The promotion, demotion, and lesson-ranking logic ships in the public npm bundle under an MIT license — run npm pack thumbgate and read it yourself. Your lessons live in a local SQLite file you own, not a server you can't query. Paid tiers add hosted sync, the dashboard, and adapter coverage, not access to intelligence withheld from the free install."
+        }
       }
     ]
   }
@@ -504,7 +512,7 @@ next      decision recorded before execution</pre>
     <section id="faq">
       <div class="shell">
         <div class="section-kicker">Before you buy</div>
-        <h2 class="section-title">Four questions, answered plainly.</h2>
+        <h2 class="section-title">Five questions, answered plainly.</h2>
         <div class="faq-list">
           <div class="faq-item open">
             <button class="faq-q" type="button" aria-expanded="true">What do I get for $499?</button>
@@ -521,6 +529,10 @@ next      decision recorded before execution</pre>
           <div class="faq-item">
             <button class="faq-q" type="button" aria-expanded="false">Does self-improving mean ThumbGate retrains my model?</button>
             <div class="faq-a">No. ThumbGate does not change model weights. It improves the external control layer by storing feedback as local lessons, re-ranking relevant lessons, promoting repeated negative patterns into gates, and expiring stale auto-promoted gates.</div>
+          </div>
+          <div class="faq-item">
+            <button class="faq-q" type="button" aria-expanded="false">Is the self-improving logic a black box I have to trust blindly?</button>
+            <div class="faq-a">No. The promotion, demotion, and lesson-ranking logic ships in the public npm bundle under an MIT license — run <code>npm pack thumbgate</code> and read it yourself. Your lessons live in a local SQLite file you own, not a server you can't query. Paid tiers add hosted sync, the dashboard, and adapter coverage, not access to intelligence withheld from the free install.</div>
           </div>
         </div>
       </div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,6 +6,7 @@
 
 - Category: pre-action firewall / reliability gateway for agent tool calls
 - Differentiator: self-improving control plane (capture → rank lessons → promote repeated failures → expire stale gates → check the next action), not static policy alone and not model-weight updates
+- Transparency: the promotion/demotion/ranking logic ships in the public npm bundle (MIT licensed), not withheld behind a paywall — `npm pack thumbgate` to inspect it
 - Paid entry: $499 Managed AI Agent Workflow Gate for one supported repeated workflow failure
 - Free wedge: `npx thumbgate init` local evaluate
 

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -147,7 +147,7 @@ test('enforcement promise distinguishes default denies from strict-mode blocks',
   assert.match(landingPage, /mode\s+strict enforcement[\s\S]*decision\s+<span class="red">DENY<\/span>/i);
 });
 
-test('FAQPage JSON-LD matches the four visible buyer questions', () => {
+test('FAQPage JSON-LD matches the five visible buyer questions', () => {
   const jsonLd = parseJsonLd(landingPage);
   const faqSchema = jsonLd.find((document) => document['@type'] === 'FAQPage');
   const visibleFaq = visibleFaqAnswers(landingPage);
@@ -155,8 +155,8 @@ test('FAQPage JSON-LD matches the four visible buyer questions', () => {
   assert.ok(jsonLd.some((document) => document['@type'] === 'SoftwareApplication'));
   assert.ok(jsonLd.some((document) => document['@type'] === 'Service'));
   assert.ok(faqSchema);
-  assert.equal(faqSchema.mainEntity.length, 4);
-  assert.equal(visibleFaq.size, 4);
+  assert.equal(faqSchema.mainEntity.length, 5);
+  assert.equal(visibleFaq.size, 5);
   for (const entity of faqSchema.mainEntity) {
     const question = normalizeHtmlText(entity.name);
     const answer = normalizeHtmlText(entity.acceptedAnswer.text);


### PR DESCRIPTION
## Summary
- Adds a 5th landing-page FAQ item answering "is the self-improving logic a black box?" — points buyers at `npm pack thumbgate` and their own local SQLite lesson file as proof, not a claim to trust.
- Mirrors the FAQPage JSON-LD entry so structured data stays in sync with visible copy.
- Adds one `llms.txt` positioning bullet for the same transparency point.

## Why
Follow-up to the already-merged #3001 (Self-Improving Firewall / Poolside playbook pitch). Poolside treats "we work in the open" as a first-class claim, not a footnote — ThumbGate's promotion/demotion/ranking logic already ships publicly under MIT, but nothing on the landing page said so explicitly.

## Test plan
- [x] `node --test` on the 7 test files touching this content (api-server, pro-landing, public-landing, public-static-assets, seo-gsd, seo-guides, version-metadata) — 594/594 pass
- [x] Updated `FAQPage JSON-LD matches the five visible buyer questions` in `tests/public-landing.test.js` (was hardcoded to 4; now 5, still asserts full HTML↔schema parity)
- [x] `node scripts/sync-version.js --check` — 38/38 targets in sync
- [x] Manually validated all 5 JSON-LD blocks on the page parse and FAQPage has 5 entries matching 5 visible `faq-item` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2W8sjquSF36xGRcjuBfGF