### PR TITLE
fix(web): Pro $19/mo + Enterprise $499 cash paths on homepage

### DIFF
--- a/.changeset/homepage-pro-and-enterprise-ctas.md
+++ b/.changeset/homepage-pro-and-enterprise-ctas.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Restore both cash paths on homepage and pricing: self-serve Pro at $19/mo plus the $499 enterprise workflow gate, so operators are not forced into a single enterprise CTA.

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -3,7 +3,6 @@
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
   "homepageUrl": "https://thumbgate.ai",
   "githubDescription": "ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.",
-  "metaDescription": "ThumbGate is the self-improving firewall for AI agents under your control. Pro is $19/mo self-serve; the $499 enterprise entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.",
   "topics": [
     "thumbgate",
     "pre-action-checks",
@@ -23,5 +22,6 @@
     "opencode",
     "thompson-sampling",
     "self-improving-agents"
-  ]
+  ],
+  "metaDescription": "ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days."
 }

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -3,7 +3,7 @@
   "repositoryUrl": "https://github.com/IgorGanapolsky/ThumbGate",
   "homepageUrl": "https://thumbgate.ai",
   "githubDescription": "ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.",
-  "metaDescription": "ThumbGate is the self-improving firewall for AI agents under your control. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.",
+  "metaDescription": "ThumbGate is the self-improving firewall for AI agents under your control. Pro is $19/mo self-serve; the $499 enterprise entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.",
   "topics": [
     "thumbgate",
     "pre-action-checks",

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -14,7 +14,7 @@
 > Pre-action checks that flag repeated risky actions before execution and block matching actions when strict policy is enabled. Accepted feedback becomes local lessons; repeated failures can become prevention rules.
 
 ### Public Landing Page (thumbgate-production.up.railway.app)
-> ThumbGate is the self-improving firewall for AI agents under your control. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
+> ThumbGate is the self-improving firewall for AI agents under your control. Pro is $19/mo self-serve; the $499 enterprise entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
 
 ### NPM package.json
 > ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -14,7 +14,7 @@
 > Pre-action checks that flag repeated risky actions before execution and block matching actions when strict policy is enabled. Accepted feedback becomes local lessons; repeated failures can become prevention rules.
 
 ### Public Landing Page (thumbgate-production.up.railway.app)
-> ThumbGate is the self-improving firewall for AI agents under your control. Pro is $19/mo self-serve; the $499 enterprise entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
+> ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
 
 ### NPM package.json
 > ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.

--- a/public/index.html
+++ b/public/index.html
@@ -427,7 +427,7 @@
           <div class="eyebrow">Self-improving under your control</div>
           <h1>Self-Improving Firewall for Your AI Agents.</h1>
           <p class="hero-lede">Every approval teaches it what to allow, block, or escalate next time.</p>
-          <p class="fit-line"><strong>Two paid paths:</strong> self-serve <strong>Pro at $19/mo</strong> for operators, or the <strong>$499 enterprise entry offer</strong> for one managed workflow after a real failure.</p>
+          <p class="fit-line"><strong>Two paid paths:</strong> self-serve <strong>Pro at $19/mo</strong> for operators, or the <strong>$499 enterprise entry offer</strong> for engineering and security leads using Claude Code, Cursor, Codex, or similar agents after a real workflow failure.</p>
           <div class="spec-chips" aria-label="What the self-improving firewall does">
             <span class="spec-chip"><strong>Capture</strong> feedback</span>
             <span class="spec-chip"><strong>Rank</strong> lessons</span>

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://thumbgate.ai/og.png">
   <title>ThumbGate: the self-improving firewall for AI agents</title>
-  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. Pro is $19/mo self-serve; the $499 enterprise entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
+  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days."description" content="9/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
   <meta property="og:title" content="ThumbGate: the self-improving firewall for AI agents">
   <meta property="og:description" content="Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control. Pro $19/mo self-serve, or $499 managed setup for one workflow.">
   <meta property="og:type" content="website">

--- a/public/index.html
+++ b/public/index.html
@@ -14,9 +14,9 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://thumbgate.ai/og.png">
   <title>ThumbGate: the self-improving firewall for AI agents</title>
-  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days."description" content="9/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
+  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
   <meta property="og:title" content="ThumbGate: the self-improving firewall for AI agents">
-  <meta property="og:description" content="Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control. Pro $19/mo self-serve, or $499 managed setup for one workflow.">
+  <meta property="og:description" content="Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control. Self-serve $19/mo, or $499 managed setup for one workflow.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="__APP_ORIGIN__/">
   <script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.tagged-events.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -14,9 +14,9 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://thumbgate.ai/og.png">
   <title>ThumbGate: the self-improving firewall for AI agents</title>
-  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. The $499 offer installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
+  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. Pro is $19/mo self-serve; the $499 enterprise entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
   <meta property="og:title" content="ThumbGate: the self-improving firewall for AI agents">
-  <meta property="og:description" content="Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control—not a silent policy rewrite. $499 managed setup for one workflow.">
+  <meta property="og:description" content="Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control. Pro $19/mo self-serve, or $499 managed setup for one workflow.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="__APP_ORIGIN__/">
   <script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.tagged-events.js"></script>
@@ -193,7 +193,7 @@
     .nav-links { display: flex; align-items: center; gap: 24px; }
     .nav-links > a { color: var(--muted); text-decoration: none; font-size: 14px; font-weight: 700; }
     .nav-links > a:hover { color: var(--text); }
-    .nav-buy, .button-primary {
+    .nav-buy, .button-primary, .button-pro {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -207,6 +207,49 @@
       font-weight: 850 !important;
       text-decoration: none;
     }
+    .nav-enterprise {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 40px;
+      border: 1px solid rgba(86, 227, 159, 0.45);
+      border-radius: 10px;
+      padding: 0 14px;
+      color: var(--green) !important;
+      background: rgba(86, 227, 159, 0.08);
+      font-weight: 800 !important;
+      font-size: 13px !important;
+      text-decoration: none;
+    }
+    .nav-enterprise:hover { background: rgba(86, 227, 159, 0.14); color: var(--text) !important; }
+    .offer-stack { display: grid; gap: 14px; }
+    .pro-card {
+      padding: 22px 24px;
+      border: 1px solid rgba(56, 215, 255, 0.35);
+      border-radius: 16px;
+      background: linear-gradient(160deg, rgba(18, 28, 40, 0.98), rgba(12, 16, 24, 0.98));
+    }
+    .pro-card .price strong { color: var(--cyan); }
+    .pro-card h2 { margin: 0 0 6px; font-size: 20px; }
+    .pro-card > p { margin: 0 0 14px; color: var(--muted); font-size: 14px; }
+    .pro-card .button-pro { width: 100%; min-height: 48px; background: var(--cyan); color: #041016 !important; box-shadow: 0 12px 35px rgba(56, 215, 255, 0.18); }
+    .pro-card .checkout-note { margin: 10px 0 0 !important; color: var(--muted) !important; font-size: 12px; text-align: center; }
+    .offer-points { margin: 14px 0 0; padding: 0; list-style: none; display: grid; gap: 8px; }
+    .offer-points li {
+      position: relative;
+      padding-left: 18px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.4;
+    }
+    .offer-points li::before {
+      content: "✓";
+      position: absolute;
+      left: 0;
+      color: var(--green);
+      font-weight: 900;
+    }
+    .checkout-card .button-primary { width: 100%; }
     .hero { padding: clamp(72px, 10vw, 128px) 0 72px; }
     .hero-grid { display: grid; grid-template-columns: minmax(0, 1.08fr) minmax(340px, 0.92fr); gap: clamp(42px, 7vw, 88px); align-items: center; }
     .eyebrow, .section-kicker { color: var(--green); font: 800 12px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.13em; text-transform: uppercase; }
@@ -343,7 +386,8 @@
     .footer-links { display: flex; flex-wrap: wrap; gap: 18px; }
     .footer-links a { color: var(--muted); }
     @media (max-width: 840px) {
-      .nav-links > a:not(.nav-buy) { display: none; }
+      .nav-links > a:not(.nav-buy):not(.nav-enterprise) { display: none; }
+      .nav-links { gap: 10px; }
       .hero-grid, .proof-grid { grid-template-columns: 1fr; }
       .loop, .deliverables { grid-template-columns: 1fr; }
       .loop-step:not(:last-child)::after { content: "↓"; top: auto; right: 50%; bottom: -28px; transform: translateX(50%); }
@@ -351,10 +395,10 @@
     @media (max-width: 520px) {
       .shell { width: min(calc(100% - 24px), var(--max)); }
       .nav-inner { min-height: 62px; }
-      .nav-buy { padding: 0 13px; font-size: 13px; }
+      .nav-buy, .nav-enterprise { padding: 0 10px; font-size: 12px; min-height: 38px; }
       .hero { padding-top: 62px; }
       h1 { font-size: 46px; }
-      .checkout-card { padding: 22px 18px; }
+      .checkout-card, .pro-card { padding: 22px 18px; }
     }
   </style>
 </head>
@@ -367,9 +411,10 @@
       </a>
       <div class="nav-links">
         <a href="#how-it-works">How it works</a>
-        <a href="#deliverables">What you get</a>
+        <a href="#offers">Pricing</a>
         <a href="#proof">Proof</a>
-        <a class="nav-buy" href="#buy" data-offer-link data-cta-id="nav_diagnostic_buy">Enterprise gate · $499</a>
+        <a class="nav-buy" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_nav&amp;utm_campaign=pro_self_serve&amp;cta_id=nav_pro_buy&amp;cta_placement=nav&amp;plan_id=pro" data-offer-link data-cta-id="nav_pro_buy">Pro · $19/mo</a>
+        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="nav_diagnostic_buy">Enterprise · $499</a>
       </div>
     </div>
   </nav>
@@ -382,7 +427,7 @@
           <div class="eyebrow">Self-improving under your control</div>
           <h1>Self-Improving Firewall for Your AI Agents.</h1>
           <p class="hero-lede">Every approval teaches it what to allow, block, or escalate next time.</p>
-          <p class="fit-line"><strong>$499 enterprise entry offer</strong> for engineering and security leads using Claude Code, Cursor, Codex, or similar agents after a real workflow failure.</p>
+          <p class="fit-line"><strong>Two paid paths:</strong> self-serve <strong>Pro at $19/mo</strong> for operators, or the <strong>$499 enterprise entry offer</strong> for one managed workflow after a real failure.</p>
           <div class="spec-chips" aria-label="What the self-improving firewall does">
             <span class="spec-chip"><strong>Capture</strong> feedback</span>
             <span class="spec-chip"><strong>Rank</strong> lessons</span>
@@ -390,31 +435,46 @@
             <span class="spec-chip"><strong>Check</strong> next action</span>
           </div>
           <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
-          <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · <a href="/guide">setup guide</a></p>
+          <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · <a href="/guide">setup guide</a> · <a href="/pricing">full pricing</a></p>
         </div>
-        <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout>
-          <span id="workflow-sprint-intake" data-legacy-intake-alias aria-hidden="true"></span>
-          <input type="hidden" name="utm_source" value="website">
-          <input type="hidden" name="utm_medium" value="homepage_checkout">
-          <input type="hidden" name="utm_campaign" value="managed_workflow_gate">
-          <input type="hidden" name="utm_content" value="hero_direct_checkout">
-          <input type="hidden" name="cta_id" value="homepage_diagnostic_buy">
-          <input type="hidden" name="cta_placement" value="hero">
-          <input type="hidden" name="plan_id" value="sprint_diagnostic">
-          <input type="hidden" name="landing_path" value="/">
-          <div class="price"><strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</strong><span>one time</span></div>
-          <h2>Enterprise Workflow Gate</h2>
-          <p><strong>Managed AI Agent Workflow Gate.</strong> Bring the failure. Leave with one configured gate and proof it works.</p>
-          <label for="buyer-email">Work email for the receipt</label>
-          <input id="buyer-email" type="email" name="customer_email" autocomplete="email" required placeholder="you@company.com">
-          <button class="button-primary" type="submit" data-revenue-cta data-cta-id="homepage_diagnostic_buy" data-cta-placement="hero">Buy the $499 enterprise gate</button>
-          <p class="checkout-note">Secure Stripe checkout. No subscription.</p>
-          <ul class="offer-points">
-            <li>60-minute working review for one workflow</li>
-            <li>One configured local gate and its regression test</li>
-            <li>Rollout and rollback proof within two business days</li>
-          </ul>
-        </form>
+        <div id="offers" class="offer-stack">
+          <aside class="pro-card" id="pro" aria-label="ThumbGate Pro subscription">
+            <div class="price"><strong>$19</strong><span>/mo · or $149/yr</span></div>
+            <h2>Pro</h2>
+            <p><strong>Self-serve for individual operators.</strong> Local enforcement proof, dashboard evidence, recall, and DPO export—start today.</p>
+            <a class="button-pro" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_hero&amp;utm_campaign=pro_self_serve&amp;cta_id=homepage_pro_buy&amp;cta_placement=hero&amp;plan_id=pro" data-offer-link data-cta-id="homepage_pro_buy" data-revenue-cta data-cta-placement="hero">Start Pro — $19/mo</a>
+            <p class="checkout-note">Hosted checkout · cancel anytime · free local evaluate stays free</p>
+            <ul class="offer-points">
+              <li>Personal enforcement proof and local dashboard</li>
+              <li>Recall, managed adapter coverage, proof-ready exports</li>
+              <li>DPO export for model-hardening workflows</li>
+            </ul>
+          </aside>
+          <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout>
+            <span id="workflow-sprint-intake" data-legacy-intake-alias aria-hidden="true"></span>
+            <span id="enterprise-gate"></span>
+            <input type="hidden" name="utm_source" value="website">
+            <input type="hidden" name="utm_medium" value="homepage_checkout">
+            <input type="hidden" name="utm_campaign" value="managed_workflow_gate">
+            <input type="hidden" name="utm_content" value="hero_direct_checkout">
+            <input type="hidden" name="cta_id" value="homepage_diagnostic_buy">
+            <input type="hidden" name="cta_placement" value="hero">
+            <input type="hidden" name="plan_id" value="sprint_diagnostic">
+            <input type="hidden" name="landing_path" value="/">
+            <div class="price"><strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</strong><span>one time</span></div>
+            <h2>Enterprise Workflow Gate</h2>
+            <p><strong>Managed AI Agent Workflow Gate.</strong> Bring the failure. Leave with one configured gate and proof it works.</p>
+            <label for="buyer-email">Work email for the receipt</label>
+            <input id="buyer-email" type="email" name="customer_email" autocomplete="email" required placeholder="you@company.com">
+            <button class="button-primary" type="submit" data-revenue-cta data-cta-id="homepage_diagnostic_buy" data-cta-placement="hero">Buy the $499 enterprise gate</button>
+            <p class="checkout-note">Secure Stripe checkout. No subscription. One workflow, not an org-wide platform license.</p>
+            <ul class="offer-points">
+              <li>60-minute working review for one workflow</li>
+              <li>One configured local gate and its regression test</li>
+              <li>Rollout and rollback proof within two business days</li>
+            </ul>
+          </form>
+        </div>
       </div>
     </section>
 
@@ -540,10 +600,13 @@ next      decision recorded before execution</pre>
 
     <section class="final">
       <div class="shell">
-        <div class="section-kicker">One cash path</div>
-        <h2 class="section-title">Bring the failure that already cost you time.</h2>
-        <p class="section-lede">We install the first gate, wire the proof, and leave the firewall better for the next attempt—not another policy deck.</p>
-        <a class="nav-buy" href="#buy" data-offer-link data-cta-id="final_diagnostic_buy">Buy the $499 enterprise gate</a>
+        <div class="section-kicker">Two cash paths</div>
+        <h2 class="section-title">Start self-serve, or bring the failure that already cost you time.</h2>
+        <p class="section-lede">Pro is the self-serve subscription for operators. The $499 enterprise gate is a managed install for one painful workflow—not another policy deck.</p>
+        <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;margin-top:22px">
+          <a class="nav-buy" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_final&amp;utm_campaign=pro_self_serve&amp;cta_id=final_pro_buy&amp;cta_placement=final&amp;plan_id=pro" data-offer-link data-cta-id="final_pro_buy">Start Pro — $19/mo</a>
+          <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="final_diagnostic_buy">Buy the $499 enterprise gate</a>
+        </div>
       </div>
     </section>
   </main>

--- a/public/index.html
+++ b/public/index.html
@@ -441,13 +441,13 @@
           <aside class="pro-card" id="pro" aria-label="ThumbGate Pro subscription">
             <div class="price"><strong>$19</strong><span>/mo · or $149/yr</span></div>
             <h2>Pro</h2>
-            <p><strong>Self-serve for individual operators.</strong> Local enforcement proof, dashboard evidence, recall, and DPO export—start today.</p>
+            <p><strong>Self-serve for individual operators.</strong> Local enforcement proof, dashboard evidence, recall, and proof-ready exports—start today.</p>
             <a class="button-pro" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_hero&amp;utm_campaign=pro_self_serve&amp;cta_id=homepage_pro_buy&amp;cta_placement=hero&amp;plan_id=pro" data-offer-link data-cta-id="homepage_pro_buy" data-revenue-cta data-cta-placement="hero">Start Pro — $19/mo</a>
             <p class="checkout-note">Hosted checkout · cancel anytime · free local evaluate stays free</p>
             <ul class="offer-points">
               <li>Personal enforcement proof and local dashboard</li>
               <li>Recall, managed adapter coverage, proof-ready exports</li>
-              <li>DPO export for model-hardening workflows</li>
+              <li>Preference-pair export for model-hardening workflows</li>
             </ul>
           </aside>
           <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout>

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Enterprise Workflow Gate — $499 | Self-Improving Firewall | ThumbGate</title>
-  <meta name="description" content="Self-improving firewall for AI agents: ThumbGate's $499 enterprise entry offer reviews one risky AI-agent workflow, installs one local pre-action gate, adds a regression test, and hands back rollout and rollback proof.">
+  <title>Pricing — Pro $19/mo and Enterprise Gate $499 | ThumbGate</title>
+  <meta name="description" content="ThumbGate pricing: Pro at $19/mo (or $149/yr) for self-serve operators, and the $499 enterprise entry offer for one managed AI-agent workflow gate with regression and rollout proof.">
   <link rel="canonical" href="__APP_ORIGIN__/pricing">
   <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
-  <meta property="og:title" content="Enterprise Workflow Gate — $499">
-  <meta property="og:description" content="One repeated AI-agent failure. One configured gate. One regression test. Rollout and rollback proof.">
+  <meta property="og:title" content="ThumbGate Pricing — Pro $19/mo · Enterprise Gate $499">
+  <meta property="og:description" content="Self-serve Pro for operators, or a $499 managed gate for one repeated AI-agent failure.">
   <meta property="og:url" content="__APP_ORIGIN__/pricing">
   <meta property="og:type" content="product">
   <style>
@@ -23,8 +23,14 @@
     .nav-links { display:flex; align-items:center; gap:18px; color:var(--muted); font-size:.92rem; }
     .nav-buy,.button { display:inline-flex; justify-content:center; align-items:center; border:0; border-radius:10px; background:var(--green); color:#fff; padding:12px 18px; font:inherit; font-weight:800; text-decoration:none; cursor:pointer; }
     .nav-buy:hover,.button:hover { background:var(--green2); }
+    .nav-pro { display:inline-flex; justify-content:center; align-items:center; border:0; border-radius:10px; background:var(--green); color:#fff; padding:12px 18px; font:inherit; font-weight:800; text-decoration:none; }
+    .nav-enterprise { display:inline-flex; justify-content:center; align-items:center; border:1px solid var(--green); border-radius:10px; color:var(--green); padding:10px 14px; font:inherit; font-weight:800; text-decoration:none; background:transparent; }
     main { padding:70px 0 84px; }
-    .hero { display:grid; grid-template-columns:minmax(0,1.1fr) minmax(330px,.9fr); gap:52px; align-items:start; }
+    .hero { display:grid; grid-template-columns:minmax(0,1.05fr) minmax(300px,.95fr); gap:28px; align-items:start; }
+    .offer-grid { display:grid; grid-template-columns:1fr 1fr; gap:18px; }
+    .pro-card { border:1px solid var(--line); border-radius:18px; background:var(--card); box-shadow:0 18px 50px rgba(38,45,41,.09); padding:30px; }
+    .pro-card .price { color:var(--green); }
+    @media (max-width:900px) { .offer-grid { grid-template-columns:1fr; } }
     .eyebrow { color:var(--green); font-size:.76rem; font-weight:850; letter-spacing:.14em; text-transform:uppercase; }
     h1 { max-width:760px; margin:14px 0 18px; font-size:clamp(2.5rem,6vw,5.15rem); line-height:.96; letter-spacing:-.055em; }
     .lede { max-width:660px; margin:0 0 28px; color:var(--muted); font-size:1.13rem; }
@@ -103,7 +109,8 @@
       <div class="nav-links">
         <a href="/guide">Technical setup</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Proof</a>
-        <a class="nav-buy" href="#buy" data-offer-link data-cta-id="pricing_nav_buy">Enterprise gate · $499</a>
+        <a class="nav-pro" href="/checkout/pro?utm_source=pricing&amp;utm_medium=nav&amp;utm_campaign=pro_self_serve&amp;cta_id=pricing_nav_pro&amp;plan_id=pro" data-offer-link data-cta-id="pricing_nav_pro">Pro · $19/mo</a>
+        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="pricing_nav_buy">Enterprise · $499</a>
       </div>
     </div>
   </nav>
@@ -111,35 +118,44 @@
   <main class="shell">
     <div class="hero">
       <div>
-        <div class="eyebrow">One offer · one workflow · one fixed price</div>
-        <h1>Stop one expensive agent mistake before it repeats.</h1>
-        <p class="lede">Bring a real failure involving Git, shell, files, databases, deployment, browser actions, or outbound messages. ThumbGate turns it into a local pre-action gate your agent must pass.</p>
+        <div class="eyebrow">Two paid paths · one product</div>
+        <h1>Self-serve Pro, or a managed gate for one expensive mistake.</h1>
+        <p class="lede">Start with <strong>Pro at $19/mo</strong> for personal enforcement proof, or bring a real failure for the <strong>$499 enterprise entry</strong>—one local pre-action gate, a regression test, and rollout proof.</p>
         <div class="outcome">
-          <div class="outcome-row"><span class="tick">✓</span><span>One risky workflow reviewed with the person who owns it.</span></div>
-          <div class="outcome-row"><span class="tick">✓</span><span>One configured gate plus a regression test for the failure.</span></div>
-          <div class="outcome-row"><span class="tick">✓</span><span>Rollout, rollback, and verification proof within two business days.</span></div>
+          <div class="outcome-row"><span class="tick">✓</span><span><strong>Pro ($19/mo or $149/yr):</strong> self-serve dashboard, recall, adapter coverage, DPO export.</span></div>
+          <div class="outcome-row"><span class="tick">✓</span><span><strong>Enterprise gate ($499 one-time):</strong> one workflow reviewed, configured, tested, and proved.</span></div>
+          <div class="outcome-row"><span class="tick">✓</span><span>Free local evaluate stays free: <code>npx thumbgate init</code>.</span></div>
         </div>
       </div>
 
-      <aside class="card" id="buy">
-        <div class="eyebrow">Enterprise Workflow Gate</div>
-        <div class="price">$499</div>
-        <p class="price-note">Enterprise entry offer. Fixed price. One supported local workflow.</p>
-        <form action="/go/diagnostic-pay" method="POST" data-primary-checkout>
-          <label for="pricing-email">Work email for the receipt and scheduling</label>
-          <input id="pricing-email" name="customer_email" type="email" autocomplete="email" placeholder="you@company.com" required>
-          <input type="hidden" name="plan_id" value="sprint_diagnostic">
-          <input type="hidden" name="utm_source" value="pricing">
-          <input type="hidden" name="utm_medium" value="direct_checkout">
-          <input type="hidden" name="utm_campaign" value="managed_workflow_gate">
-          <input type="hidden" name="cta_id" value="pricing_managed_gate_buy">
-          <input type="hidden" name="cta_placement" value="pricing">
-          <input type="hidden" name="landing_path" value="/pricing">
-          <button class="button" type="submit">Buy the $499 enterprise gate</button>
-        </form>
-        <p class="fine">Secure payment. We reply with scheduling and the workflow checklist.</p>
-        <div class="boundary">Detected secret exfiltration and gate-process bypass attempts deny by default. Other destructive actions warn by default and deny when strict enforcement is enabled.</div>
-      </aside>
+      <div class="offer-grid" id="buy">
+        <aside class="pro-card" id="pro" aria-label="ThumbGate Pro">
+          <div class="eyebrow">Self-serve</div>
+          <div class="price">$19<span style="font-size:1rem;font-weight:700">/mo</span></div>
+          <p class="price-note">Or $149/yr. Individual operators. Cancel anytime.</p>
+          <a class="button" href="/checkout/pro?utm_source=pricing&amp;utm_medium=card&amp;utm_campaign=pro_self_serve&amp;cta_id=pricing_pro_buy&amp;plan_id=pro" data-offer-link data-cta-id="pricing_pro_buy" style="width:100%;box-sizing:border-box">Start Pro — $19/mo</a>
+          <p class="fine">Hosted checkout. Free local evaluate remains free after you subscribe.</p>
+        </aside>
+        <aside class="card" id="enterprise-gate">
+          <div class="eyebrow">Enterprise Workflow Gate</div>
+          <div class="price">$499</div>
+          <p class="price-note">Enterprise entry offer. Fixed price. One supported local workflow. No subscription.</p>
+          <form action="/go/diagnostic-pay" method="POST" data-primary-checkout>
+            <label for="pricing-email">Work email for the receipt and scheduling</label>
+            <input id="pricing-email" name="customer_email" type="email" autocomplete="email" placeholder="you@company.com" required>
+            <input type="hidden" name="plan_id" value="sprint_diagnostic">
+            <input type="hidden" name="utm_source" value="pricing">
+            <input type="hidden" name="utm_medium" value="direct_checkout">
+            <input type="hidden" name="utm_campaign" value="managed_workflow_gate">
+            <input type="hidden" name="cta_id" value="pricing_managed_gate_buy">
+            <input type="hidden" name="cta_placement" value="pricing">
+            <input type="hidden" name="landing_path" value="/pricing">
+            <button class="button" type="submit">Buy the $499 enterprise gate</button>
+          </form>
+          <p class="fine">Secure payment. We reply with scheduling and the workflow checklist.</p>
+          <div class="boundary">Detected secret exfiltration and gate-process bypass attempts deny by default. Other destructive actions warn by default and deny when strict enforcement is enabled.</div>
+        </aside>
+      </div>
     </div>
 
     <section>

--- a/scripts/check-congruence.js
+++ b/scripts/check-congruence.js
@@ -357,23 +357,31 @@ async function main() {
   check(
     /\$(?:499|__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__)/.test(landingHtml)
       && /Managed AI Agent Workflow Gate/i.test(landingHtml),
-    'public/index.html must expose the one $499 managed gate offer'
+    'public/index.html must expose the $499 managed gate offer'
   );
   check(
-    !/\/checkout\/pro|\/go\/sprint|href="[^"]*workflow-sprint-intake/i.test(landingHtml),
-    'public/index.html must not expose a competing Pro, sprint, or Enterprise cash path'
+    /\/checkout\/pro/i.test(landingHtml) && /\$19\/mo/i.test(landingHtml),
+    'public/index.html must expose self-serve Pro at $19/mo alongside the managed gate'
+  );
+  check(
+    !/\/go\/sprint|href="[^"]*workflow-sprint-intake/i.test(landingHtml),
+    'public/index.html must not reintroduce retired sprint intake cash paths'
   );
   check(
     /id="workflow-sprint-intake"[^>]*data-legacy-intake-alias/i.test(landingHtml),
-    'public/index.html must preserve old intake hashes as an alias to the one managed-gate checkout'
+    'public/index.html must preserve old intake hashes as an alias to the managed-gate checkout'
   );
   check(
     /action="\/go\/diagnostic-pay"[^>]*method="POST"/i.test(pricingHtml),
     'public/pricing.html must use the same canonical managed-gate checkout route'
   );
   check(
-    !/\/checkout\/pro|\/go\/sprint|workflow-sprint-intake/i.test(pricingHtml),
-    'public/pricing.html must not expose a competing Pro, sprint, or Enterprise cash path'
+    /\/checkout\/pro/i.test(pricingHtml) && /\$19\/mo/i.test(pricingHtml),
+    'public/pricing.html must expose self-serve Pro at $19/mo alongside the managed gate'
+  );
+  check(
+    !/\/go\/sprint|workflow-sprint-intake/i.test(pricingHtml),
+    'public/pricing.html must not reintroduce retired sprint intake cash paths'
   );
   check(
     /ThumbGate Pre-Action Checks/i.test(githubAbout.githubDescription),

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -823,12 +823,14 @@ test('root serves the landing page by default', async () => {
   assert.match(body, /Enterprise Workflow Gate/i);
   assert.match(body, /action="\/go\/diagnostic-pay" method="POST"/);
   assert.match(body, /Buy the \$499 enterprise gate/i);
+  assert.match(body, /Start Pro — \$19\/mo/i);
+  assert.match(body, /\/checkout\/pro/);
   assert.match(body, /One configured local gate and its regression test/i);
   assert.match(body, /warn by default/i);
   assert.match(body, /strict mode/i);
   assert.doesNotMatch(body, /learns from every mistake/i);
-  assert.doesNotMatch(body, /Thompson Sampling|DPO|LanceDB|MemAlign|FTS5/i);
-  assert.doesNotMatch(body, /\/checkout\/pro|\/go\/sprint|href="[^"]*workflow-sprint-intake/i);
+  assert.doesNotMatch(body, /Thompson Sampling|LanceDB|MemAlign|FTS5/i);
+  assert.doesNotMatch(body, /\/go\/sprint|href="[^"]*workflow-sprint-intake/i);
   assert.match(body, /id="workflow-sprint-intake"[^>]*data-legacy-intake-alias/);
   assert.match(body, /FAQPage/);
   assert.match(body, /SoftwareApplication/);
@@ -1018,15 +1020,19 @@ test('pricing page is the single source of truth for what ThumbGate sells', asyn
   const body = await res.text();
   assert.match(body, /Enterprise Workflow Gate/i);
   assert.match(body, /\$499/);
+  assert.match(body, /\$19/);
+  assert.match(body, /\$149/);
+  assert.match(body, /Start Pro — \$19\/mo/);
+  assert.match(body, /\/checkout\/pro/);
   assert.match(body, /action="\/go\/diagnostic-pay" method="POST"/);
   assert.match(body, /name="customer_email"[^>]*required/);
   assert.match(body, /one configured local pre-action gate/i);
   assert.match(body, /regression test/i);
   assert.match(body, /rollout and rollback proof/i);
-  assert.doesNotMatch(body, /\$19|\$149|\$1,500|\$3,000|\$10,000|\$15,000/);
+  assert.doesNotMatch(body, /\$1,500|\$3,000|\$10,000|\$15,000/);
   assert.doesNotMatch(body, /buy\.stripe\.com/);
   assert.doesNotMatch(body, /mailto:igor\.ganapolsky@gmail\.com/);
-  assert.doesNotMatch(body, /\/checkout\/pro|\/go\/sprint|workflow-sprint-intake/);
+  assert.doesNotMatch(body, /\/go\/sprint|workflow-sprint-intake/);
   assert.match(body, /href="\/support"/);
 });
 

--- a/tests/check-congruence.test.js
+++ b/tests/check-congruence.test.js
@@ -82,7 +82,9 @@ test('GitHub About config keeps a focused cash-path description and a valid GitH
   assert.match(about.metaDescription, /one hard, test-backed safety gate/i);
   assert.match(about.metaDescription, /supported AI-agent workflow/i);
   assert.match(about.metaDescription, /two business days/i);
-  assert.doesNotMatch(about.metaDescription, /\bPro\b|\bEnterprise\b|Thompson Sampling|LanceDB/i);
+  assert.match(about.metaDescription, /\$19\/mo/);
+  assert.match(about.metaDescription, /\$499/);
+  assert.doesNotMatch(about.metaDescription, /Thompson Sampling|LanceDB/i);
   assert.match(about.githubDescription, /ThumbGate Pre-Action Checks/i);
   assert.match(about.githubDescription, /hard-block detected secret leaks/i);
   assert.equal(packageJson.description, about.githubDescription);

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -1,12 +1,12 @@
 const { test, expect } = require('@playwright/test');
 const { mockDashboardApis } = require('./helpers/mock-api');
 
-test.describe('/ single-offer conversion path', () => {
+test.describe('/ dual-offer conversion path', () => {
   test.beforeEach(async ({ page }) => {
     await mockDashboardApis(page);
   });
 
-  test('renders one managed-gate offer and the enforcement loop', async ({ page }) => {
+  test('renders Pro $19/mo and Enterprise $499 offers plus the enforcement loop', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.locator('.hero h1')).toHaveText('Self-Improving Firewall for Your AI Agents.');
@@ -14,23 +14,23 @@ test.describe('/ single-offer conversion path', () => {
     await expect(page.locator('[data-primary-checkout] .price')).toContainText('$499');
     await expect(page.locator('[data-primary-checkout]')).toContainText('Enterprise Workflow Gate');
     await expect(page.locator('[data-primary-checkout]')).toContainText('Buy the $499 enterprise gate');
+    await expect(page.getByRole('link', { name: 'Start Pro — $19/mo' }).first()).toBeVisible();
+    await expect(page.locator('a[href*="/checkout/pro"]')).not.toHaveCount(0);
     await expect(page.locator('.loop-step')).toHaveCount(4);
     await expect(page.locator('.decision')).toHaveText(['ALLOW', 'WARN', 'DENY']);
-
-    await expect(page.locator('a[href*="/checkout/pro"]')).toHaveCount(0);
     await expect(page.locator('#workflow-sprint-intake[data-legacy-intake-alias]')).toHaveCount(1);
   });
 
-  test('navigation and final CTA both return to the same checkout form', async ({ page }) => {
+  test('Pro nav goes to checkout; Enterprise nav returns to managed form', async ({ page }) => {
     await page.goto('/');
 
-    const navBuy = page.locator('nav [data-offer-link]');
-    await navBuy.click();
-    await expect(page).toHaveURL(/#buy$/);
+    await expect(page.locator('nav [data-cta-id="nav_pro_buy"]')).toHaveAttribute('href', /\/checkout\/pro/);
+    await page.locator('nav [data-cta-id="nav_diagnostic_buy"]').click();
+    await expect(page).toHaveURL(/#enterprise-gate$/);
     await expect(page.locator('[data-primary-checkout]')).toBeVisible();
 
-    await page.locator('.final [data-offer-link]').click();
-    await expect(page).toHaveURL(/#buy$/);
+    await page.locator('.final [data-cta-id="final_diagnostic_buy"]').click();
+    await expect(page).toHaveURL(/#enterprise-gate$/);
     await expect(page.locator('form[action="/go/diagnostic-pay"]')).toHaveCount(1);
   });
 

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -1,19 +1,20 @@
 const { test, expect } = require('@playwright/test');
 
-test.describe('/pricing single-offer cash path', () => {
-  test('shows one fixed-price managed gate', async ({ page }) => {
+test.describe('/pricing dual-offer cash path', () => {
+  test('shows Pro self-serve and fixed-price managed gate', async ({ page }) => {
     await page.goto('/pricing');
-    await expect(page.getByRole('heading', { level: 1 })).toContainText('Stop one expensive agent mistake');
-    await expect(page.locator('.price')).toHaveText('$499');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Self-serve Pro, or a managed gate');
+    await expect(page.getByRole('link', { name: 'Start Pro — $19/mo' })).toBeVisible();
+    await expect(page.locator('a[href*="/checkout/pro"]')).not.toHaveCount(0);
+    await expect(page.locator('#enterprise-gate .price')).toHaveText('$499');
     await expect(page.locator('form[data-primary-checkout]')).toHaveCount(1);
-    await expect(page.getByText('$19', { exact: true })).toHaveCount(0);
     await expect(page.getByText('$1,500', { exact: true })).toHaveCount(0);
   });
 
-  test('nav CTA moves to the same checkout form', async ({ page }) => {
+  test('nav Enterprise CTA moves to the managed checkout form', async ({ page }) => {
     await page.goto('/pricing');
     await page.locator('[data-cta-id="pricing_nav_buy"]').click();
-    await expect(page).toHaveURL(/\/pricing#buy$/);
+    await expect(page).toHaveURL(/\/pricing#enterprise-gate$/);
     await expect(page.locator('#pricing-email')).toBeVisible();
   });
 

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -10,22 +10,29 @@ const HOME_HTML = fs.readFileSync(path.join(ROOT, 'public', 'index.html'), 'utf8
 const PRICING_HTML = fs.readFileSync(path.join(ROOT, 'public', 'pricing.html'), 'utf8');
 const PRO_HTML = fs.readFileSync(path.join(ROOT, 'public', 'pro.html'), 'utf8');
 
-test('homepage commercial contract stays one $499 enterprise entry offer', () => {
+test('homepage commercial contract offers Pro $19/mo and Enterprise $499', () => {
   assert.match(HOME_HTML, /Enterprise Workflow Gate/);
   assert.match(HOME_HTML, /\$499 enterprise entry offer/i);
   assert.match(HOME_HTML, /action="\/go\/diagnostic-pay"/);
   assert.match(HOME_HTML, /\$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__/);
-  assert.doesNotMatch(HOME_HTML, /\/checkout\/pro|href="[^"]*workflow-sprint-intake|\/go\/sprint/i);
+  assert.match(HOME_HTML, /\/checkout\/pro/);
+  assert.match(HOME_HTML, /Start Pro — \$19\/mo/);
+  assert.match(HOME_HTML, /Pro · \$19\/mo/);
+  assert.doesNotMatch(HOME_HTML, /href="[^"]*workflow-sprint-intake|\/go\/sprint/i);
   assert.match(HOME_HTML, /id="workflow-sprint-intake"[^>]*data-legacy-intake-alias/);
 });
 
-test('pricing repeats the same offer without a competing cash path', () => {
+test('pricing surfaces Pro self-serve and Enterprise managed gate together', () => {
   assert.match(PRICING_HTML, /Enterprise Workflow Gate/);
   assert.match(PRICING_HTML, /Enterprise entry offer/i);
   assert.match(PRICING_HTML, /action="\/go\/diagnostic-pay"/);
   assert.match(PRICING_HTML, /\$499/);
-  assert.doesNotMatch(PRICING_HTML, /\/checkout\/pro|workflow-sprint-intake|\/go\/sprint/i);
-  assert.doesNotMatch(PRICING_HTML, /\$19|\$149|\$1,500|\$3,000|\$10,000|\$15,000/);
+  assert.match(PRICING_HTML, /\/checkout\/pro/);
+  assert.match(PRICING_HTML, /Start Pro — \$19\/mo/);
+  assert.match(PRICING_HTML, /\$19/);
+  assert.match(PRICING_HTML, /\$149/);
+  assert.doesNotMatch(PRICING_HTML, /workflow-sprint-intake|\/go\/sprint/i);
+  assert.doesNotMatch(PRICING_HTML, /\$1,500|\$3,000|\$10,000|\$15,000/);
 });
 
 test('free-tier limits remain code truth without crowding the cash path', () => {
@@ -38,7 +45,7 @@ test('free-tier limits remain code truth without crowding the cash path', () => 
   assert.doesNotMatch(PRICING_HTML, /2 captures\/day|10 total|3 active prevention rules/i);
 });
 
-test('legacy Pro detail stays code-backed off the primary cash path', () => {
+test('Pro detail stays code-backed and is linked from primary cash paths', () => {
   const server = fs.readFileSync(path.join(ROOT, 'src', 'api', 'server.js'), 'utf8');
   const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
 
@@ -46,8 +53,8 @@ test('legacy Pro detail stays code-backed off the primary cash path', () => {
   assert.match(PRO_HTML, /DPO/i);
   assert.match(server, /'\/v1\/dpo\/export'/);
   assert.ok(pkg.files.includes('public/dashboard.html'));
-  assert.doesNotMatch(HOME_HTML, /\/checkout\/pro/i);
-  assert.doesNotMatch(PRICING_HTML, /\/checkout\/pro/i);
+  assert.match(HOME_HTML, /\/checkout\/pro/i);
+  assert.match(PRICING_HTML, /\/checkout\/pro/i);
 });
 
 test('pricing hides hosted team offers and states the availability boundary', () => {

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -229,7 +229,7 @@ test('continuity guide frames the gateway as downstream reliability, not a new o
 // part of the post-Reddit credibility cleanup (file admitted "$0 revenue"
 // publicly and read as launch-theater).
 
-test('public landing copy stays vendor-neutral while keeping the primary offer focused', () => {
+test('public landing copy stays vendor-neutral while offering Pro and Enterprise cash paths', () => {
   const congruence = readText(path.join('docs', 'MARKETING_COPY_CONGRUENCE.md'));
   const landingPage = readText(path.join('public', 'index.html'));
 
@@ -241,7 +241,8 @@ test('public landing copy stays vendor-neutral while keeping the primary offer f
   assert.match(landingPage, /or similar agents/i);
   assert.match(landingPage, /Managed AI Agent Workflow Gate/i);
   assert.match(landingPage, /\$499/);
-  assert.doesNotMatch(landingPage, /\bPro\b/i);
+  assert.match(landingPage, /Pro · \$19\/mo/);
+  assert.match(landingPage, /\/checkout\/pro/);
   assert.doesNotMatch(landingPage, /Enterprise pilot|\/enterprise/i);
   assert.doesNotMatch(landingPage, /auto-detects supported local agent installs/i);
   assert.doesNotMatch(landingPage, /claude --mcp thumbgate/i);

--- a/tests/pricing-page-telemetry.test.js
+++ b/tests/pricing-page-telemetry.test.js
@@ -18,12 +18,16 @@ test('pricing page emits first-party telemetry for views and buyer actions', () 
   assert.match(pricingHtml, /href="https:\/\/github\.com\/IgorGanapolsky\/ThumbGate\/blob\/main\/docs\/VERIFICATION_EVIDENCE\.md"/);
 });
 
-test('pricing exposes one direct $499 cash path and no competing offer', () => {
+test('pricing exposes Pro self-serve and direct $499 managed-gate checkout', () => {
   assert.match(pricingHtml, /action="\/go\/diagnostic-pay" method="POST"/);
   assert.match(pricingHtml, /Buy the \$499 enterprise gate/);
   assert.match(pricingHtml, /name="customer_email"[^>]*required/);
   assert.match(pricingHtml, /"name": "ThumbGate Enterprise Workflow Gate"/);
   assert.match(pricingHtml, /"price": "499"/);
-  assert.doesNotMatch(pricingHtml, /\/checkout\/pro|\/go\/sprint|workflow-sprint-intake/);
-  assert.doesNotMatch(pricingHtml, /\$19|\$149|\$1,500|\$3,000|\$10,000|\$15,000/);
+  assert.match(pricingHtml, /\/checkout\/pro/);
+  assert.match(pricingHtml, /Start Pro — \$19\/mo/);
+  assert.match(pricingHtml, /\$19/);
+  assert.match(pricingHtml, /\$149/);
+  assert.doesNotMatch(pricingHtml, /\/go\/sprint|workflow-sprint-intake/);
+  assert.doesNotMatch(pricingHtml, /\$1,500|\$3,000|\$10,000|\$15,000/);
 });

--- a/tests/public-enterprise-capability-boundary.test.js
+++ b/tests/public-enterprise-capability-boundary.test.js
@@ -73,7 +73,9 @@ test('proposal-only expansion prices remain internal catalog truth', () => {
   assert.equal(pilot.priceCents, 1500000);
   assert.equal(enterpriseOps.priceCents, 1000000);
   assert.doesNotMatch(pricing, /\$3,000|\$15,000|\$10,000/);
-  assert.match(pricing, /one offer · one workflow · one fixed price/i);
+  assert.match(pricing, /Two paid paths · one product/i);
+  assert.match(pricing, /\$19/);
+  assert.match(pricing, /\$499/);
 });
 
 test('public pricing hides proposal-only Enterprise expansion', () => {

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -52,17 +52,23 @@ function visibleFaqAnswers(html) {
   ]));
 }
 
-test('homepage has one priced offer and one checkout form', () => {
+test('homepage exposes both Pro $19/mo and Enterprise $499 offers', () => {
   const visibleText = visibleBodyText(landingPage);
   const prices = [...visibleText.matchAll(/\$\d[\d,]*/g)].map((match) => match[0]);
   const uniquePrices = [...new Set(prices)];
 
-  assert.deepEqual(uniquePrices, ['$499']);
-  assert.equal((landingPage.match(/data-primary-checkout/g) || []).length, 2);
+  assert.ok(uniquePrices.includes('$19'), `expected $19 among ${uniquePrices.join(', ')}`);
+  assert.ok(uniquePrices.includes('$499'), `expected $499 among ${uniquePrices.join(', ')}`);
+  assert.equal((landingPage.match(/data-primary-checkout/g) || []).length, 2); // form attr + querySelector
   assert.equal((landingPage.match(/<form[^>]+action="\/go\/diagnostic-pay"/g) || []).length, 1);
   assert.match(landingPage, /method="POST"/);
   assert.match(landingPage, /name="customer_email"[^>]*required/);
   assert.match(landingPage, /name="plan_id" value="sprint_diagnostic"/);
+  assert.match(landingPage, /\/checkout\/pro/);
+  assert.match(landingPage, /Start Pro — \$19\/mo/);
+  assert.match(landingPage, /Buy the \$499 enterprise gate/);
+  assert.match(landingPage, /Pro · \$19\/mo/);
+  assert.match(landingPage, /Enterprise · \$499/);
 });
 
 test('visible text filtering consumes the complete script and style end tags', () => {
@@ -70,10 +76,9 @@ test('visible text filtering consumes the complete script and style end tags', (
   assert.equal(visibleBodyText(html), 'shown after done');
 });
 
-test('homepage removes competing commercial funnels and conversion overlays', () => {
-  assert.doesNotMatch(landingPage, /\/checkout\/pro|\/go\/sprint|href="[^"]*workflow-sprint-intake/i);
+test('homepage keeps conversion noise off while offering both paid paths', () => {
   assert.match(landingPage, /id="workflow-sprint-intake"[^>]*data-legacy-intake-alias/);
-  assert.doesNotMatch(landingPage, /Start Pro|Upgrade to Pro|Enterprise pilot|newsletter/i);
+  assert.doesNotMatch(landingPage, /Enterprise pilot|newsletter/i);
   assert.doesNotMatch(landingPage, /offer-router|sticky-cta|buyer-intent\.js|revenue-assist-panel/i);
   assert.match(landingPage, /<body data-revenue-assist="off">/);
 });
@@ -84,15 +89,17 @@ test('homepage stays human-scannable instead of becoming a product monorepo', ()
   const h2Count = (landingPage.match(/<h2\b/g) || []).length;
   const h3Count = (landingPage.match(/<h3\b/g) || []).length;
 
-  assert.ok(words.length <= 900, `visible homepage is ${words.length} words`);
-  assert.ok(h2Count <= 6, `homepage has ${h2Count} H2 headings`);
-  assert.ok(h3Count <= 7, `homepage has ${h3Count} H3 headings`);
+  assert.ok(words.length <= 1100, `visible homepage is ${words.length} words`);
+  assert.ok(h2Count <= 8, `homepage has ${h2Count} H2 headings`);
+  assert.ok(h3Count <= 10, `homepage has ${h3Count} H3 headings`);
   for (const jargon of ['Thompson Sampling', 'DPO', 'LanceDB', 'ContextFS', 'MemAlign', 'FTS5']) {
+    // DPO may appear in Pro bullets intentionally — only ban heavy infra jargon
+    if (jargon === 'DPO') continue;
     assert.doesNotMatch(visibleText, new RegExp(jargon, 'i'));
   }
 });
 
-test('hero names one buyer, one failure, and the enterprise entry outcome', () => {
+test('hero names both paid paths and the self-improving product outcome', () => {
   const hero = landingPage.slice(
     landingPage.indexOf('<!-- HERO -->'),
     landingPage.indexOf('</section>', landingPage.indexOf('<!-- HERO -->'))
@@ -104,9 +111,9 @@ test('hero names one buyer, one failure, and the enterprise entry outcome', () =
   assert.match(hero, /<h1>Self-Improving Firewall for Your AI Agents\.<\/h1>/i);
   assert.match(hero, /Self-improving under your control/i);
   assert.match(hero, /Every approval teaches it what to allow, block, or escalate next time/i);
-  assert.match(hero, /engineering and security leads/);
-  assert.match(hero, /Enterprise Workflow Gate/);
+  assert.match(hero, /Pro at \$19\/mo/);
   assert.match(hero, /\$499 enterprise entry offer/);
+  assert.match(hero, /Enterprise Workflow Gate/);
   assert.match(hero, /Rank[\s\S]*lessons/i);
   assert.match(hero, /Promote[\s\S]*gates/i);
   assert.match(hero, /npx thumbgate init/);
@@ -137,7 +144,7 @@ test('homepage explains the product with one four-stage self-improving loop', ()
 });
 
 test('paid wedge includes managed implementation, regression, and rollout proof', () => {
-  assert.match(landingPage, /Enterprise gate · \$499/);
+  assert.match(landingPage, /Enterprise · \$499/);
   assert.match(landingPage, /enterprise entry offer for one workflow/i);
   assert.match(landingPage, /One configured local gate and its regression test/);
   assert.match(landingPage, /Rollout and rollback proof within two business days/);

--- a/tests/public-static-assets.test.js
+++ b/tests/public-static-assets.test.js
@@ -120,11 +120,13 @@ test('landing page does not render empty revenue links', async () => {
   assert.doesNotMatch(html, /https:\/\/buy\.stripe\.com\/6oU00j8aw2iWdWh9uj3sI2K/);
   assert.match(html, /action="\/go\/diagnostic-pay" method="POST"/);
   assert.match(html, /Buy the \$499 enterprise gate/);
-  assert.doesNotMatch(html, /\/checkout\/pro|\/go\/sprint|href="[^"]*workflow-sprint-intake/i);
+  assert.match(html, /\/checkout\/pro/);
+  assert.match(html, /Start Pro — \$19\/mo/);
+  assert.doesNotMatch(html, /\/go\/sprint|href="[^"]*workflow-sprint-intake/i);
   assert.match(html, /id="workflow-sprint-intake"[^>]*data-legacy-intake-alias/);
 });
 
-test('landing page presents one fixed-price managed offer clearly', async () => {
+test('landing page presents Pro self-serve and fixed-price managed offer clearly', async () => {
   const res = await fetch(`${origin}/`);
   assert.equal(res.status, 200);
   const html = await res.text();
@@ -133,7 +135,10 @@ test('landing page presents one fixed-price managed offer clearly', async () => 
   assert.match(html, /One configured local gate and its regression test/);
   assert.match(html, /Rollout and rollback proof within two business days/);
   assert.match(html, /one supported local workflow/i);
-  assert.doesNotMatch(html, /\$19|\$149|\$1,500|\$3,000|\$10,000|\$15,000/);
+  assert.match(html, /\$19/);
+  assert.match(html, /\$149/);
+  assert.match(html, /\/checkout\/pro/);
+  assert.doesNotMatch(html, /\$1,500|\$3,000|\$10,000|\$15,000/);
 });
 
 test('landing page explains pre-action enforcement instead of passive logging', async () => {

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -277,7 +277,9 @@ test('hosted origin and repository metadata stay canonical across live-facing ar
   assert.match(publicLanding, /\$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__/);
   assert.match(publicLanding, /Managed AI Agent Workflow Gate/);
   assert.match(publicLanding, /action="\/go\/diagnostic-pay" method="POST"/);
-  assert.doesNotMatch(publicLanding, /\$19|\$149|__PRO_PRICE_DOLLARS__/);
+  assert.match(publicLanding, /\$19/);
+  assert.match(publicLanding, /\$149/);
+  assert.match(publicLanding, /\/checkout\/pro/);
   assert.match(publicLanding, /__GA_BOOTSTRAP__/);
   assert.match(publicLanding, /__GOOGLE_SITE_VERIFICATION_META__/);
   assert.match(publicLanding, /Self-Improving Firewall for Your AI Agents/i);


### PR DESCRIPTION
## Summary
- Restore **both** paid paths buyers need: self-serve **Pro at $19/mo** and the **$499 Enterprise Workflow Gate**.
- Homepage nav: primary `Pro · $19/mo` → `/checkout/pro`; secondary `Enterprise · $499` → managed form.
- Hero: dual offer cards (Pro self-serve + $499 checkout form).
- `/pricing`: same dual-offer layout.
- Congruence + landing tests updated so CI requires both paths (no more single-$499 gate).

## Why
Production was $499-only. That hid the self-serve product and forced every visitor into enterprise pricing.

## Test plan
- [x] `node --test tests/public-landing.test.js tests/landing-page-claims.test.js`
- [x] `node scripts/check-congruence.js`
- [ ] After merge: curl production for `$19` + `$499` + `/checkout/pro`