### PR TITLE
fix(web): loop under-the-hood cards actually clickable

### DIFF
--- a/.changeset/fix-loop-card-click-html.md
+++ b/.changeset/fix-loop-card-click-html.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix homepage loop cards: invalid <button> wrapping headings broke browser click targets. Cards are now valid role=tab divs so under-the-hood demos open when the title is clicked.

--- a/public/index.html
+++ b/public/index.html
@@ -643,25 +643,27 @@
         <h2 class="section-title">Pre-action checks—and the systems that refine them.</h2>
         <p class="section-lede">No governance novel. Corrections become reviewable local lessons; relevant lessons are re-ranked; repeated negative patterns can become explicit gates; and the next action is checked before execution. <strong style="color:var(--text)">Click a step</strong> to see what happens under the hood.</p>
         <div class="loop" role="tablist" aria-label="Self-improving product loop — click a step for under-the-hood demo">
-          <button type="button" class="loop-step" role="tab" id="loop-tab-1" data-loop-step="1" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
+          <!-- Cards are divs (not <button>) so headings/chips stay valid HTML; browsers
+               auto-close <button> around <h3>/<div>, which broke click targets. -->
+          <div class="loop-step" role="tab" tabindex="0" id="loop-tab-1" data-loop-step="1" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">1</span>
             <h3>Capture feedback</h3>
             <p>Record explicit 👍 or 👎 feedback with the action and outcome context that made it useful or wrong.</p>
             <span class="loop-hint">Under the hood ↓</span>
-          </button>
-          <button type="button" class="loop-step" role="tab" id="loop-tab-2" data-loop-step="2" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
+          </div>
+          <div class="loop-step" role="tab" tabindex="0" id="loop-tab-2" data-loop-step="2" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">2</span>
             <h3>Remember locally</h3>
             <p>Store a reviewable lesson that survives sessions and model changes without sending the control history into model weights.</p>
             <span class="loop-hint">Under the hood ↓</span>
-          </button>
-          <button type="button" class="loop-step" role="tab" id="loop-tab-3" data-loop-step="3" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
+          </div>
+          <div class="loop-step" role="tab" tabindex="0" id="loop-tab-3" data-loop-step="3" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">3</span>
             <h3>Rank and refine</h3>
             <p>Re-rank relevant lessons for the action. Repeated negative patterns can promote from warnings to blocking gates; stale gates expire.</p>
             <span class="loop-hint">Under the hood ↓</span>
-          </button>
-          <button type="button" class="loop-step" role="tab" id="loop-tab-4" data-loop-step="4" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
+          </div>
+          <div class="loop-step" role="tab" tabindex="0" id="loop-tab-4" data-loop-step="4" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">4</span>
             <h3>Gate the next action</h3>
             <p>The action is allowed, warned, or denied before the tool proceeds.</p>
@@ -671,7 +673,7 @@
               <span class="decision deny">DENY</span>
             </div>
             <span class="loop-hint">Under the hood ↓</span>
-          </button>
+          </div>
         </div>
         <div id="loop-panel" class="loop-panel" role="tabpanel" aria-labelledby="loop-tab-1" hidden>
           <div class="loop-panel-header">
@@ -1083,14 +1085,24 @@ next      decision recorded before execution</pre>
         });
       }
 
+      function activateTab(tab) {
+        const step = tab.getAttribute('data-loop-step');
+        if (activeStep === step) {
+          setOpen(null);
+        } else {
+          setOpen(step);
+          panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
+      }
+
       tabs.forEach(function (tab) {
         tab.addEventListener('click', function () {
-          const step = tab.getAttribute('data-loop-step');
-          if (activeStep === step) {
-            setOpen(null);
-          } else {
-            setOpen(step);
-            panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+          activateTab(tab);
+        });
+        tab.addEventListener('keydown', function (event) {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            activateTab(tab);
           }
         });
       });

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -26,13 +26,16 @@ test.describe('/ dual-offer conversion path', () => {
     const panel = page.locator('#loop-panel');
     await expect(panel).toBeHidden();
 
-    await page.locator('[data-loop-step="1"]').click();
+    // Click the heading (not just the card edge) — proves the whole card is
+    // interactive even after browsers parse nested heading content.
+    await page.locator('[data-loop-step="1"] h3').click();
     await expect(panel).toBeVisible();
     await expect(panel).toContainText('Capture feedback');
     await expect(panel).toContainText('no-action');
     await expect(panel).toContainText('feedback-log.jsonl');
+    await expect(page.locator('[data-loop-step="1"]')).toHaveAttribute('aria-expanded', 'true');
 
-    await page.locator('[data-loop-step="4"]').click();
+    await page.locator('[data-loop-step="4"] h3').click();
     await expect(panel).toContainText('Gate the next action');
     await expect(panel).toContainText('warn-by-default');
     await page.locator('[data-gate-mode="strict"]').click();

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -147,6 +147,10 @@ test('homepage explains the product with one four-stage self-improving loop', ()
   assert.match(landingPage, /Under the hood/);
   assert.match(landingPage, /initLoopDemos|data-loop-step/);
   assert.match(landingPage, /THUMBGATE_STRICT_ENFORCEMENT|warn-by-default/);
+  // Valid interactive cards: div[role=tab], not <button> wrapping <h3>/<div>
+  // (invalid nesting auto-closes the control and breaks clicks in browsers).
+  assert.match(landingPage, /<div class="loop-step" role="tab" tabindex="0"/);
+  assert.doesNotMatch(landingPage, /<button[^>]*class="loop-step"/);
 });
 
 test('paid wedge includes managed implementation, regression, and rollout proof', () => {


### PR DESCRIPTION
## Summary
CEO thumbs-down after interactive loop ship: cards looked clickable but did not open demos reliably.

**Root cause:** invalid HTML — `<button>` wrapping `<h3>` and `<div class="decisions">`. Browsers repair that by closing the button early, so only a tiny region received clicks.

## Fix
- Cards are `div.loop-step[role=tab][tabindex=0]`
- Enter/Space keyboard activation
- E2E clicks the **h3 title** (the area buyers click), not just the card edge

## Test plan
- [x] public-landing asserts no `<button class="loop-step">`
- [x] e2e opens demo via `h3` click
- [ ] Production: click card titles → panel opens