### PR TITLE
fix(gtm): restore CLI Zernio wiring for social:publish:launch

### DIFF
--- a/.changeset/fix-zernio-cli-runner.md
+++ b/.changeset/fix-zernio-cli-runner.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Restore social:publish:launch CLI wiring so Creator Platform Promo can inject the live social adapter again (fixes bare direct_platform_publisher_required failures).

--- a/package.json
+++ b/package.json
@@ -680,7 +680,7 @@
     "test:utm": "node --test tests/utm.test.js",
     "test:product-feedback": "node --test tests/product-feedback.test.js",
     "test:feedback-root-consolidator": "node --test tests/feedback-root-consolidator.test.js",
-    "social:publish:launch": "node scripts/social-analytics/publish-thumbgate-launch.js",
+    "social:publish:launch": "node scripts/social-analytics/run-publish-thumbgate-launch.js",
     "social:publish:latest-release-article": "node scripts/social-analytics/publish-latest-release-article.js",
     "social:publish:latest-release-fallbacks": "node scripts/social-analytics/publish-latest-release-fallbacks.js",
     "social:verify:latest-release": "node scripts/social-analytics/verify-latest-release-posts.js",

--- a/scripts/social-analytics/run-publish-thumbgate-launch.js
+++ b/scripts/social-analytics/run-publish-thumbgate-launch.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * CLI / CI entry for ThumbGate launch + paid-offer social publish.
+ *
+ * Unit-tested library (`publish-thumbgate-launch.js`) requires an injected
+ * direct-platform adapter and forbids embedding aggregator names so buyer-path
+ * congruence tests stay clean. This thin runner supplies the live adapter.
+ */
+
+const path = require('node:path');
+const {
+  parseArgs,
+  publishLaunchCampaign,
+} = require('./publish-thumbgate-launch');
+const {
+  getConnectedAccounts,
+  groupAccountsByPlatform,
+  publishPost,
+  schedulePost,
+  uploadLocalMedia,
+} = require('./publishers/zernio');
+const { publishInstagramThumbGate } = require('./publish-instagram-thumbgate');
+
+function buildLivePublisher() {
+  return {
+    getConnectedAccounts,
+    groupAccountsByPlatform,
+    publishPost,
+    schedulePost,
+    publishInstagramThumbGate,
+    uploadLocalMedia,
+  };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const publisher = options.dryRun === true ? {} : buildLivePublisher();
+  const results = await publishLaunchCampaign(options, publisher);
+  process.stdout.write(`${JSON.stringify(results, null, 2)}\n`);
+
+  if (results.errors && results.errors.length > 0) {
+    process.exitCode = 1;
+  }
+  if (
+    Array.isArray(results.skipped)
+    && results.skipped.some((row) => row.reason === 'not_connected')
+    && (!results.published || results.published.length === 0)
+    && (!results.scheduled || results.scheduled.length === 0)
+    && options.dryRun !== true
+  ) {
+    process.exitCode = 1;
+  }
+  return results;
+}
+
+const isDirectRun = (() => {
+  try {
+    return path.resolve(process.argv[1] || '') === path.resolve(__filename);
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(error && error.message ? error.message : error);
+    process.exit(1);
+  });
+}
+
+module.exports = { main, buildLivePublisher };


### PR DESCRIPTION
## Summary
- Creator Platform Promo workflows failed immediately with `direct_platform_publisher_required` even when `ZERNIO_API_KEY` was set.
- Root cause: `publishLaunchCampaign` requires an injected direct-platform adapter (library purity + buyer-path congruence). CLI/CI called it without one.
- Fix: thin runner `scripts/social-analytics/run-publish-thumbgate-launch.js` injects the live adapter; `social:publish:launch` points there.

## Test plan
- [x] `node --test tests/publish-thumbgate-launch.test.js tests/buyer-paths.test.js` (23/23)
- [ ] Re-run Creator Platform Promo `mode=publish offer=paid-sprint platforms=linkedin,threads,bluesky`
- [ ] Confirm publish results are not the bare `direct_platform_publisher_required` throw