### PR TITLE
feat(gtm): Rally-style outcome copy + dual cash-path CTAs

### DIFF
--- a/.changeset/rally-style-gtm-cash-path.md
+++ b/.changeset/rally-style-gtm-cash-path.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Rally-style GTM packaging: outcome hero ("Stop AI agent mistakes before they cost you"), dual cash-path CTAs with $499 Diagnostic primary and Pro $19/mo secondary, pricing comparison table (DIY / hire / GRC / ThumbGate), and congruent meta copy.

--- a/config/github-about.json
+++ b/config/github-about.json
@@ -23,5 +23,5 @@
     "thompson-sampling",
     "self-improving-agents"
   ],
-  "metaDescription": "ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days."
+  "metaDescription": "Stop AI agent mistakes before they cost you. Self-serve is $19/mo; the $499 Diagnostic installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days."
 }

--- a/config/post-deploy-marketing-pages.json
+++ b/config/post-deploy-marketing-pages.json
@@ -4,7 +4,7 @@
   "pages": [
     {
       "route": "/",
-      "sentinel": "Self-Improving Firewall for Your AI Agents",
+      "sentinel": "Stop AI agent mistakes before they cost you",
       "description": "Home page hero (lifeblood — never regress)"
     },
     {

--- a/docs/MARKETING_COPY_CONGRUENCE.md
+++ b/docs/MARKETING_COPY_CONGRUENCE.md
@@ -14,7 +14,7 @@
 > Pre-action checks that flag repeated risky actions before execution and block matching actions when strict policy is enabled. Accepted feedback becomes local lessons; repeated failures can become prevention rules.
 
 ### Public Landing Page (thumbgate-production.up.railway.app)
-> ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
+> Stop AI agent mistakes before they cost you. Self-serve is $19/mo; the $499 Diagnostic installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.
 
 ### NPM package.json
 > ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.

--- a/public/index.html
+++ b/public/index.html
@@ -594,7 +594,7 @@
             <span class="spec-chip"><strong>Block</strong> next action</span>
           </div>
           <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
-          <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually &lt; 15 minutes · <a href="/pricing">how we stack up</a></p>
+          <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually minutes after install · <a href="/pricing">how we stack up</a></p>
         </div>
         <div id="offers" class="offer-stack">
           <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout style="order:-1;border-color:rgba(0,110,82,.35);box-shadow:0 18px 50px rgba(0,110,82,.12);">

--- a/public/index.html
+++ b/public/index.html
@@ -13,10 +13,10 @@
   <meta property="og:image" content="https://thumbgate.ai/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="https://thumbgate.ai/og.png">
-  <title>ThumbGate: the self-improving firewall for AI agents</title>
-  <meta name="description" content="ThumbGate is the self-improving firewall for AI agents under your control. Self-serve is $19/mo; the $499 managed entry installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
-  <meta property="og:title" content="ThumbGate: the self-improving firewall for AI agents">
-  <meta property="og:description" content="Every approval teaches it what to allow, block, or escalate next time. Self-improving under your control. Self-serve $19/mo, or $499 managed setup for one workflow.">
+  <title>ThumbGate — Stop AI agent mistakes before they cost you</title>
+  <meta name="description" content="Stop AI agent mistakes before they cost you. Self-serve is $19/mo; the $499 Diagnostic installs one hard, test-backed safety gate for a supported AI-agent workflow in two business days.">
+  <meta property="og:title" content="ThumbGate — Stop AI agent mistakes before they cost you">
+  <meta property="og:description" content="Not a prompt. Not a postmortem. Pre-action gates + dual path: $19/mo Pro or $499 Diagnostic gate.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="__APP_ORIGIN__/">
   <script defer data-domain="thumbgate.ai" src="https://plausible.io/js/script.tagged-events.js"></script>
@@ -572,8 +572,8 @@
         <a href="#how-it-works">How it works</a>
         <a href="#offers">Pricing</a>
         <a href="#proof">Proof</a>
-        <a class="nav-buy" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_nav&amp;utm_campaign=pro_self_serve&amp;cta_id=nav_pro_buy&amp;cta_placement=nav&amp;plan_id=pro" data-offer-link data-cta-id="nav_pro_buy">Pro · $19/mo</a>
-        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="nav_diagnostic_buy">Enterprise · $499</a>
+        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="nav_diagnostic_buy">Get Started · $499</a>
+        <a class="nav-buy" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_nav&amp;utm_campaign=rally_style_gtm&amp;cta_id=nav_pro_buy&amp;cta_placement=nav&amp;plan_id=pro" data-offer-link data-cta-id="nav_pro_buy">Pro · $19/mo</a>
       </div>
     </div>
   </nav>
@@ -583,25 +583,49 @@
     <section class="hero">
       <div class="shell hero-grid">
         <div class="hero-copy">
-          <div class="eyebrow">Self-improving under your control</div>
-          <h1>Self-Improving Firewall for Your AI Agents.</h1>
-          <p class="hero-lede">Every approval teaches it what to allow, block, or escalate next time.</p>
-          <p class="fit-line"><strong>Two paid paths:</strong> self-serve <strong>Pro at $19/mo</strong> for operators, or the <strong>$499 enterprise entry offer</strong> for engineering and security leads using Claude Code, Cursor, Codex, or similar agents after a real workflow failure.</p>
-          <div class="spec-chips" aria-label="What the self-improving firewall does">
+          <div class="eyebrow">Now live · Pre-action gates · Not a prompt · Not a postmortem</div>
+          <h1>Stop AI agent mistakes before they cost you.</h1>
+          <p class="hero-lede">Hard allow/deny at the <strong>tool-call boundary</strong>. Audit entry written at decision time. Every approval teaches the next gate.</p>
+          <p class="fit-line"><strong>Dual path (buy + book):</strong> <strong>$499 Diagnostic</strong> maps one expensive failure on Claude Code, Cursor, Codex, or similar agents and installs a hard gate with proof — or self-serve <strong>Pro at $19/mo</strong> if you already know the loop. Free local evaluate stays free.</p>
+          <div class="spec-chips" aria-label="What ThumbGate does">
             <span class="spec-chip"><strong>Capture</strong> feedback</span>
             <span class="spec-chip"><strong>Rank</strong> lessons</span>
             <span class="spec-chip"><strong>Promote</strong> gates</span>
-            <span class="spec-chip"><strong>Check</strong> next action</span>
+            <span class="spec-chip"><strong>Block</strong> next action</span>
           </div>
           <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
-          <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · <a href="/guide">setup guide</a> · <a href="/pricing">full pricing</a></p>
+          <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually &lt; 15 minutes · <a href="/pricing">how we stack up</a></p>
         </div>
         <div id="offers" class="offer-stack">
+          <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout style="order:-1;border-color:rgba(0,110,82,.35);box-shadow:0 18px 50px rgba(0,110,82,.12);">
+            <span id="workflow-sprint-intake" data-legacy-intake-alias aria-hidden="true"></span>
+            <span id="enterprise-gate"></span>
+            <input type="hidden" name="utm_source" value="website">
+            <input type="hidden" name="utm_medium" value="homepage_checkout">
+            <input type="hidden" name="utm_campaign" value="rally_style_gtm">
+            <input type="hidden" name="utm_content" value="hero_direct_checkout">
+            <input type="hidden" name="cta_id" value="homepage_diagnostic_buy">
+            <input type="hidden" name="cta_placement" value="hero">
+            <input type="hidden" name="plan_id" value="sprint_diagnostic">
+            <input type="hidden" name="landing_path" value="/">
+            <div class="price"><strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</strong><span>one time · cash path</span></div>
+            <h2>Diagnostic Gate</h2>
+            <p><strong>Managed AI Agent Workflow Gate.</strong> Bring the failure. Leave with one hard gate and proof — ranked burn, configured pre-action check, regression test. Not a strategy deck.</p>
+            <label for="buyer-email">Work email for the receipt</label>
+            <input id="buyer-email" type="email" name="customer_email" autocomplete="email" required placeholder="you@company.com">
+            <button class="button-primary" type="submit" data-revenue-cta data-cta-id="homepage_diagnostic_buy" data-cta-placement="hero">Get Started — $499 Diagnostic</button>
+            <p class="checkout-note">Secure Stripe · no subscription · one workflow. Prefer a call first? <a href="#how-it-works" style="color:inherit;font-weight:700;">See how it works</a> or email after checkout.</p>
+            <ul class="offer-points">
+              <li>60-minute working review for one workflow</li>
+              <li>One configured local gate and its regression test</li>
+              <li>Rollout and rollback proof within two business days</li>
+            </ul>
+          </form>
           <aside class="pro-card" id="pro" aria-label="ThumbGate Pro subscription">
             <div class="price"><strong>$19</strong><span>/mo · or $149/yr</span></div>
             <h2>Pro</h2>
-            <p><strong>Self-serve for individual operators.</strong> Local enforcement proof, dashboard evidence, recall, and proof-ready exports—start today.</p>
-            <a class="button-pro" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_hero&amp;utm_campaign=pro_self_serve&amp;cta_id=homepage_pro_buy&amp;cta_placement=hero&amp;plan_id=pro" data-offer-link data-cta-id="homepage_pro_buy" data-revenue-cta data-cta-placement="hero">Start Pro — $19/mo</a>
+            <p><strong>Self-serve for individual operators.</strong> Local enforcement proof, dashboard, recall, exports — start today.</p>
+            <a class="button-pro" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_hero&amp;utm_campaign=rally_style_gtm&amp;cta_id=homepage_pro_buy&amp;cta_placement=hero&amp;plan_id=pro" data-offer-link data-cta-id="homepage_pro_buy" data-revenue-cta data-cta-placement="hero">Start Pro — $19/mo</a>
             <p class="checkout-note">Hosted checkout · cancel anytime · free local evaluate stays free</p>
             <ul class="offer-points">
               <li>Personal enforcement proof and local dashboard</li>
@@ -609,30 +633,6 @@
               <li>Preference-pair export for model-hardening workflows</li>
             </ul>
           </aside>
-          <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout>
-            <span id="workflow-sprint-intake" data-legacy-intake-alias aria-hidden="true"></span>
-            <span id="enterprise-gate"></span>
-            <input type="hidden" name="utm_source" value="website">
-            <input type="hidden" name="utm_medium" value="homepage_checkout">
-            <input type="hidden" name="utm_campaign" value="managed_workflow_gate">
-            <input type="hidden" name="utm_content" value="hero_direct_checkout">
-            <input type="hidden" name="cta_id" value="homepage_diagnostic_buy">
-            <input type="hidden" name="cta_placement" value="hero">
-            <input type="hidden" name="plan_id" value="sprint_diagnostic">
-            <input type="hidden" name="landing_path" value="/">
-            <div class="price"><strong>$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__</strong><span>one time</span></div>
-            <h2>Enterprise Workflow Gate</h2>
-            <p><strong>Managed AI Agent Workflow Gate.</strong> Bring the failure. Leave with one configured gate and proof it works.</p>
-            <label for="buyer-email">Work email for the receipt</label>
-            <input id="buyer-email" type="email" name="customer_email" autocomplete="email" required placeholder="you@company.com">
-            <button class="button-primary" type="submit" data-revenue-cta data-cta-id="homepage_diagnostic_buy" data-cta-placement="hero">Buy the $499 enterprise gate</button>
-            <p class="checkout-note">Secure Stripe checkout. No subscription. One workflow, not an org-wide platform license.</p>
-            <ul class="offer-points">
-              <li>60-minute working review for one workflow</li>
-              <li>One configured local gate and its regression test</li>
-              <li>Rollout and rollback proof within two business days</li>
-            </ul>
-          </form>
         </div>
       </div>
     </section>

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -186,7 +186,7 @@
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Never reliable</td>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Weeks</td>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Months</td>
-              <td style="padding:12px 14px;border-bottom:1px solid var(--line);font-weight:800;">&lt; 15 minutes / 2 business days managed</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);font-weight:800;">Minutes after install / 2 business days managed</td>
             </tr>
             <tr>
               <td style="padding:12px 14px;color:var(--muted);">When agent “looks competent”</td>

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -124,7 +124,7 @@
         <div class="outcome">
           <div class="outcome-row"><span class="tick">✓</span><span><strong>Diagnostic ($499 one-time):</strong> one failure mapped, gate configured, regression + rollout proof.</span></div>
           <div class="outcome-row"><span class="tick">✓</span><span><strong>Pro ($19/mo or $149/yr):</strong> self-serve dashboard, recall, adapter coverage, DPO export.</span></div>
-          <div class="outcome-row"><span class="tick">✓</span><span>Free local evaluate: <code>npx thumbgate init</code> — first hard gate usually &lt; 15 minutes.</span></div>
+          <div class="outcome-row"><span class="tick">✓</span><span>Free local evaluate: <code>npx thumbgate init</code> — first hard gate usually minutes after install.</span></div>
         </div>
       </div>
 

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Pricing — Pro $19/mo and Enterprise Gate $499 | ThumbGate</title>
-  <meta name="description" content="ThumbGate pricing: Pro at $19/mo (or $149/yr) for self-serve operators, and the $499 enterprise entry offer for one managed AI-agent workflow gate with regression and rollout proof.">
+  <title>Pricing — Enforcement that pays for itself | ThumbGate</title>
+  <meta name="description" content="ThumbGate vs DIY prompts, platform hire, or GRC suite. Free evaluate, Pro $19/mo, $499 Diagnostic gate. Countable units that convert.">
   <link rel="canonical" href="__APP_ORIGIN__/pricing">
   <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
-  <meta property="og:title" content="ThumbGate Pricing — Pro $19/mo · Enterprise Gate $499">
-  <meta property="og:description" content="Self-serve Pro for operators, or a $499 managed gate for one repeated AI-agent failure.">
+  <meta property="og:title" content="ThumbGate Pricing — $499 Diagnostic · Pro $19/mo">
+  <meta property="og:description" content="Stop AI agent mistakes before they cost you. Dual path: $499 diagnostic gate or $19/mo Pro.">
   <meta property="og:url" content="__APP_ORIGIN__/pricing">
   <meta property="og:type" content="product">
   <style>
@@ -109,8 +109,8 @@
       <div class="nav-links">
         <a href="/guide">Technical setup</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Proof</a>
-        <a class="nav-pro" href="/checkout/pro?utm_source=pricing&amp;utm_medium=nav&amp;utm_campaign=pro_self_serve&amp;cta_id=pricing_nav_pro&amp;plan_id=pro" data-offer-link data-cta-id="pricing_nav_pro">Pro · $19/mo</a>
-        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="pricing_nav_buy">Enterprise · $499</a>
+        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="pricing_nav_buy">Get Started · $499</a>
+        <a class="nav-pro" href="/checkout/pro?utm_source=pricing&amp;utm_medium=nav&amp;utm_campaign=rally_style_gtm&amp;cta_id=pricing_nav_pro&amp;plan_id=pro" data-offer-link data-cta-id="pricing_nav_pro">Pro · $19/mo</a>
       </div>
     </div>
   </nav>
@@ -118,45 +118,87 @@
   <main class="shell">
     <div class="hero">
       <div>
-        <div class="eyebrow">Two paid paths · one product</div>
-        <h1>Self-serve Pro, or a managed gate for one expensive mistake.</h1>
-        <p class="lede">Start with <strong>Pro at $19/mo</strong> for personal enforcement proof, or bring a real failure for the <strong>$499 enterprise entry</strong>—one local pre-action gate, a regression test, and rollout proof.</p>
+        <div class="eyebrow">Enforcement that pays for itself</div>
+        <h1>Stop paying for the same AI mistake twice.</h1>
+        <p class="lede"><strong>Get Started</strong> with a <strong>$499 Diagnostic</strong> (one hard gate + proof) or self-serve <strong>Pro at $19/mo</strong>. Free local evaluate stays free. Countable units — not vibes.</p>
         <div class="outcome">
+          <div class="outcome-row"><span class="tick">✓</span><span><strong>Diagnostic ($499 one-time):</strong> one failure mapped, gate configured, regression + rollout proof.</span></div>
           <div class="outcome-row"><span class="tick">✓</span><span><strong>Pro ($19/mo or $149/yr):</strong> self-serve dashboard, recall, adapter coverage, DPO export.</span></div>
-          <div class="outcome-row"><span class="tick">✓</span><span><strong>Enterprise gate ($499 one-time):</strong> one workflow reviewed, configured, tested, and proved.</span></div>
-          <div class="outcome-row"><span class="tick">✓</span><span>Free local evaluate stays free: <code>npx thumbgate init</code>.</span></div>
+          <div class="outcome-row"><span class="tick">✓</span><span>Free local evaluate: <code>npx thumbgate init</code> — first hard gate usually &lt; 15 minutes.</span></div>
         </div>
       </div>
 
       <div class="offer-grid" id="buy">
-        <aside class="pro-card" id="pro" aria-label="ThumbGate Pro">
-          <div class="eyebrow">Self-serve</div>
-          <div class="price">$19<span style="font-size:1rem;font-weight:700">/mo</span></div>
-          <p class="price-note">Or $149/yr. Individual operators. Cancel anytime.</p>
-          <a class="button" href="/checkout/pro?utm_source=pricing&amp;utm_medium=card&amp;utm_campaign=pro_self_serve&amp;cta_id=pricing_pro_buy&amp;plan_id=pro" data-offer-link data-cta-id="pricing_pro_buy" style="width:100%;box-sizing:border-box">Start Pro — $19/mo</a>
-          <p class="fine">Hosted checkout. Free local evaluate remains free after you subscribe.</p>
-        </aside>
-        <aside class="card" id="enterprise-gate">
-          <div class="eyebrow">Enterprise Workflow Gate</div>
+        <aside class="card" id="enterprise-gate" style="border-color:var(--green);box-shadow:0 18px 50px rgba(0,110,82,.12);">
+          <div class="eyebrow">Cash path · recommended</div>
           <div class="price">$499</div>
-          <p class="price-note">Enterprise entry offer. Fixed price. One supported local workflow. No subscription.</p>
+          <p class="price-note">Diagnostic gate. Fixed price. One supported local workflow. No subscription.</p>
           <form action="/go/diagnostic-pay" method="POST" data-primary-checkout>
             <label for="pricing-email">Work email for the receipt and scheduling</label>
             <input id="pricing-email" name="customer_email" type="email" autocomplete="email" placeholder="you@company.com" required>
             <input type="hidden" name="plan_id" value="sprint_diagnostic">
             <input type="hidden" name="utm_source" value="pricing">
             <input type="hidden" name="utm_medium" value="direct_checkout">
-            <input type="hidden" name="utm_campaign" value="managed_workflow_gate">
+            <input type="hidden" name="utm_campaign" value="rally_style_gtm">
             <input type="hidden" name="cta_id" value="pricing_managed_gate_buy">
             <input type="hidden" name="cta_placement" value="pricing">
             <input type="hidden" name="landing_path" value="/pricing">
-            <button class="button" type="submit">Buy the $499 enterprise gate</button>
+            <button class="button" type="submit">Get Started — $499 Diagnostic</button>
           </form>
           <p class="fine">Secure payment. We reply with scheduling and the workflow checklist.</p>
           <div class="boundary">Detected secret exfiltration and gate-process bypass attempts deny by default. Other destructive actions warn by default and deny when strict enforcement is enabled.</div>
         </aside>
+        <aside class="pro-card" id="pro" aria-label="ThumbGate Pro">
+          <div class="eyebrow">Self-serve</div>
+          <div class="price">$19<span style="font-size:1rem;font-weight:700">/mo</span></div>
+          <p class="price-note">Or $149/yr. Individual operators. Cancel anytime.</p>
+          <a class="button" href="/checkout/pro?utm_source=pricing&amp;utm_medium=card&amp;utm_campaign=rally_style_gtm&amp;cta_id=pricing_pro_buy&amp;plan_id=pro" data-offer-link data-cta-id="pricing_pro_buy" style="width:100%;box-sizing:border-box">Start Pro — $19/mo</a>
+          <p class="fine">Hosted checkout. Free local evaluate remains free after you subscribe.</p>
+        </aside>
       </div>
     </div>
+
+    <section>
+      <div class="eyebrow">How ThumbGate stacks up</div>
+      <h2>Make the alternative look expensive.</h2>
+      <p class="section-lede">Same move as high-converting SaaS pricing: DIY prompts cost nothing and stop nothing; platform hire and GRC suites cost months.</p>
+      <div style="overflow-x:auto;margin-top:22px;border:1px solid var(--line);border-radius:14px;background:var(--card);">
+        <table style="width:100%;border-collapse:collapse;font-size:.92rem;min-width:620px;">
+          <thead>
+            <tr style="text-align:left;background:#efece3;">
+              <th style="padding:12px 14px;border-bottom:1px solid var(--line);"></th>
+              <th style="padding:12px 14px;border-bottom:1px solid var(--line);">DIY / CLAUDE.md</th>
+              <th style="padding:12px 14px;border-bottom:1px solid var(--line);">Platform hire</th>
+              <th style="padding:12px 14px;border-bottom:1px solid var(--line);">GRC suite</th>
+              <th style="padding:12px 14px;border-bottom:1px solid var(--line);color:var(--green);">ThumbGate</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);color:var(--muted);">Monthly cost</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">$0</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">$15k+ loaded</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">$$$$</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);font-weight:800;color:var(--green);">$0–$19 · $499 once</td>
+            </tr>
+            <tr>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);color:var(--muted);">Time to first gate</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Never reliable</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Weeks</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Months</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);font-weight:800;">&lt; 15 minutes / 2 business days managed</td>
+            </tr>
+            <tr>
+              <td style="padding:12px 14px;color:var(--muted);">When agent “looks competent”</td>
+              <td style="padding:12px 14px;">Ignores the prompt</td>
+              <td style="padding:12px 14px;">Custom glue</td>
+              <td style="padding:12px 14px;">Gateway only</td>
+              <td style="padding:12px 14px;font-weight:800;">Hard block at tool call</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
     <section>
       <div class="eyebrow">Delivery</div>

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -819,7 +819,7 @@ test('root serves the landing page by default', async () => {
 
   const body = await res.text();
   assert.match(body, /ThumbGate/);
-  assert.match(body, /Self-Improving Firewall for Your AI Agents/i);
+  assert.match(body, /Stop AI agent mistakes before they cost you/i);
   assert.match(body, /Enterprise Workflow Gate/i);
   assert.match(body, /action="\/go\/diagnostic-pay" method="POST"/);
   assert.match(body, /Buy the \$499 enterprise gate/i);

--- a/tests/competitive-positioning-marketing.test.js
+++ b/tests/competitive-positioning-marketing.test.js
@@ -18,7 +18,7 @@ const deploymentReadinessHtml = read('public', 'guides', 'ai-deployment-readines
 
 test('homepage explains the enforcement point without an orchestration essay', () => {
   assert.match(indexHtml, /Pre-action checks—and the systems that refine them/i);
-  assert.match(indexHtml, /Self-Improving Firewall for Your AI Agents/i);
+  assert.match(indexHtml, /Stop AI agent mistakes before they cost you/i);
   assert.match(indexHtml, /Capture feedback/i);
   assert.match(indexHtml, /Remember locally/i);
   assert.match(indexHtml, /Rank and refine/i);

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -9,7 +9,7 @@ test.describe('/ dual-offer conversion path', () => {
   test('renders Pro $19/mo and Enterprise $499 offers plus the enforcement loop', async ({ page }) => {
     await page.goto('/');
 
-    await expect(page.locator('.hero h1')).toHaveText('Self-Improving Firewall for Your AI Agents.');
+    await expect(page.locator('.hero h1')).toHaveText('Stop AI agent mistakes before they cost you.');
     await expect(page.locator('[data-primary-checkout]')).toBeVisible();
     await expect(page.locator('[data-primary-checkout] .price')).toContainText('$499');
     await expect(page.locator('[data-primary-checkout]')).toContainText('Enterprise Workflow Gate');

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -12,8 +12,8 @@ test.describe('/ dual-offer conversion path', () => {
     await expect(page.locator('.hero h1')).toHaveText('Stop AI agent mistakes before they cost you.');
     await expect(page.locator('[data-primary-checkout]')).toBeVisible();
     await expect(page.locator('[data-primary-checkout] .price')).toContainText('$499');
-    await expect(page.locator('[data-primary-checkout]')).toContainText('Enterprise Workflow Gate');
-    await expect(page.locator('[data-primary-checkout]')).toContainText('Buy the $499 enterprise gate');
+    await expect(page.locator('[data-primary-checkout]')).toContainText('Diagnostic Gate');
+    await expect(page.locator('[data-primary-checkout]')).toContainText('Get Started — $499 Diagnostic');
     await expect(page.getByRole('link', { name: 'Start Pro — $19/mo' }).first()).toBeVisible();
     await expect(page.locator('a[href*="/checkout/pro"]')).not.toHaveCount(0);
     await expect(page.locator('.loop-step')).toHaveCount(4);
@@ -82,7 +82,7 @@ test.describe('/ dual-offer conversion path', () => {
     const form = new URLSearchParams(capturedRequest.postData());
     expect(form.get('customer_email')).toBe('buyer@company.com');
     expect(form.get('plan_id')).toBe('sprint_diagnostic');
-    expect(form.get('utm_campaign')).toBe('managed_workflow_gate');
+    expect(form.get('utm_campaign')).toBe('rally_style_gtm');
     expect(form.get('cta_id')).toBe('homepage_diagnostic_buy');
   });
 

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require('@playwright/test');
 test.describe('/pricing dual-offer cash path', () => {
   test('shows Pro self-serve and fixed-price managed gate', async ({ page }) => {
     await page.goto('/pricing');
-    await expect(page.getByRole('heading', { level: 1 })).toContainText('Self-serve Pro, or a managed gate');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Stop paying for the same AI mistake twice');
     await expect(page.getByRole('link', { name: 'Start Pro — $19/mo' })).toBeVisible();
     await expect(page.locator('a[href*="/checkout/pro"]')).not.toHaveCount(0);
     await expect(page.locator('#enterprise-gate .price')).toHaveText('$499');
@@ -26,7 +26,7 @@ test.describe('/pricing dual-offer cash path', () => {
     });
     await page.goto('/pricing');
     await page.locator('#pricing-email').fill('buyer@example.com');
-    await page.getByRole('button', { name: 'Buy the $499 enterprise gate' }).click();
+    await page.getByRole('button', { name: 'Get Started — $499 Diagnostic' }).click();
     await expect.poll(() => submitted).toContain('customer_email=buyer%40example.com');
     expect(submitted).toContain('plan_id=sprint_diagnostic');
     expect(submitted).toContain('utm_source=pricing');
@@ -35,7 +35,7 @@ test.describe('/pricing dual-offer cash path', () => {
   test('browser validation blocks checkout without a valid email', async ({ page }) => {
     await page.goto('/pricing');
     await page.locator('#pricing-email').fill('not-an-email');
-    await page.getByRole('button', { name: 'Buy the $499 enterprise gate' }).click();
+    await page.getByRole('button', { name: 'Get Started — $499 Diagnostic' }).click();
     await expect(page).toHaveURL(/\/pricing$/);
     await expect(page.locator('#pricing-email')).toHaveJSProperty('validity.valid', false);
   });

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -10,9 +10,9 @@ const HOME_HTML = fs.readFileSync(path.join(ROOT, 'public', 'index.html'), 'utf8
 const PRICING_HTML = fs.readFileSync(path.join(ROOT, 'public', 'pricing.html'), 'utf8');
 const PRO_HTML = fs.readFileSync(path.join(ROOT, 'public', 'pro.html'), 'utf8');
 
-test('homepage commercial contract offers Pro $19/mo and Enterprise $499', () => {
-  assert.match(HOME_HTML, /Enterprise Workflow Gate/);
-  assert.match(HOME_HTML, /\$499 enterprise entry offer/i);
+test('homepage commercial contract offers Pro $19/mo and Diagnostic $499', () => {
+  assert.match(HOME_HTML, /Diagnostic Gate/);
+  assert.match(HOME_HTML, /\$499 Diagnostic/i);
   assert.match(HOME_HTML, /action="\/go\/diagnostic-pay"/);
   assert.match(HOME_HTML, /\$__SPRINT_DIAGNOSTIC_PRICE_DOLLARS__/);
   assert.match(HOME_HTML, /\/checkout\/pro/);
@@ -22,9 +22,9 @@ test('homepage commercial contract offers Pro $19/mo and Enterprise $499', () =>
   assert.match(HOME_HTML, /id="workflow-sprint-intake"[^>]*data-legacy-intake-alias/);
 });
 
-test('pricing surfaces Pro self-serve and Enterprise managed gate together', () => {
-  assert.match(PRICING_HTML, /Enterprise Workflow Gate/);
-  assert.match(PRICING_HTML, /Enterprise entry offer/i);
+test('pricing surfaces Pro self-serve and Diagnostic managed gate together', () => {
+  assert.match(PRICING_HTML, /Diagnostic gate|Get Started — \$499 Diagnostic|Cash path/i);
+  assert.match(PRICING_HTML, /Diagnostic gate|Get Started — \$499 Diagnostic/i);
   assert.match(PRICING_HTML, /action="\/go\/diagnostic-pay"/);
   assert.match(PRICING_HTML, /\$499/);
   assert.match(PRICING_HTML, /\/checkout\/pro/);

--- a/tests/positioning-contract.test.js
+++ b/tests/positioning-contract.test.js
@@ -50,7 +50,7 @@ test('public surfaces lead with outcomes instead of infrastructure abstractions'
 
   assert.match(readme, /AI coding agents repeat mistakes/i);
   assert.match(readme, /evaluate the proposed tool call before execution/i);
-  assert.match(landingPage, /Self-Improving Firewall for Your AI Agents/i);
+  assert.match(landingPage, /Stop AI agent mistakes before they cost you/i);
   assert.match(landingPage, /allowed, warned, or denied/i);
   assert.match(landingPage, /one configured local gate/i);
   assert.match(gptInstructions, /Sell outcomes before infrastructure/i);

--- a/tests/pricing-page-telemetry.test.js
+++ b/tests/pricing-page-telemetry.test.js
@@ -20,7 +20,7 @@ test('pricing page emits first-party telemetry for views and buyer actions', () 
 
 test('pricing exposes Pro self-serve and direct $499 managed-gate checkout', () => {
   assert.match(pricingHtml, /action="\/go\/diagnostic-pay" method="POST"/);
-  assert.match(pricingHtml, /Buy the \$499 enterprise gate/);
+  assert.match(pricingHtml, /Get Started — \$499 Diagnostic/);
   assert.match(pricingHtml, /name="customer_email"[^>]*required/);
   assert.match(pricingHtml, /"name": "ThumbGate Enterprise Workflow Gate"/);
   assert.match(pricingHtml, /"price": "499"/);

--- a/tests/public-enterprise-capability-boundary.test.js
+++ b/tests/public-enterprise-capability-boundary.test.js
@@ -73,7 +73,7 @@ test('proposal-only expansion prices remain internal catalog truth', () => {
   assert.equal(pilot.priceCents, 1500000);
   assert.equal(enterpriseOps.priceCents, 1000000);
   assert.doesNotMatch(pricing, /\$3,000|\$15,000|\$10,000/);
-  assert.match(pricing, /Two paid paths · one product/i);
+  assert.match(pricing, /Enforcement that pays for itself|Two paid paths · one product/i);
   assert.match(pricing, /\$19/);
   assert.match(pricing, /\$499/);
 });

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -66,9 +66,9 @@ test('homepage exposes both Pro $19/mo and Enterprise $499 offers', () => {
   assert.match(landingPage, /name="plan_id" value="sprint_diagnostic"/);
   assert.match(landingPage, /\/checkout\/pro/);
   assert.match(landingPage, /Start Pro — \$19\/mo/);
-  assert.match(landingPage, /Buy the \$499 enterprise gate/);
+  assert.match(landingPage, /Get Started — \$499 Diagnostic/);
   assert.match(landingPage, /Pro · \$19\/mo/);
-  assert.match(landingPage, /Enterprise · \$499/);
+  assert.match(landingPage, /Get Started · \$499/);
 });
 
 test('visible text filtering consumes the complete script and style end tags', () => {
@@ -106,18 +106,18 @@ test('hero names both paid paths and the self-improving product outcome', () => 
   );
   const lede = normalizeHtmlText((hero.match(/<p class="hero-lede">([\s\S]*?)<\/p>/) || [])[1]);
 
-  assert.match(landingPage, /Self-Improving Firewall for Your AI Agents/i);
-  assert.match(landingPage, /ThumbGate: the self-improving firewall for AI agents/i);
-  assert.match(hero, /<h1>Self-Improving Firewall for Your AI Agents\.<\/h1>/i);
-  assert.match(hero, /Self-improving under your control/i);
-  assert.match(hero, /Every approval teaches it what to allow, block, or escalate next time/i);
+  assert.match(landingPage, /Stop AI agent mistakes before they cost you/i);
+  assert.match(landingPage, /ThumbGate — Stop AI agent mistakes before they cost you/i);
+  assert.match(hero, /<h1>Stop AI agent mistakes before they cost you\.<\/h1>/i);
+  assert.match(hero, /Not a prompt · Not a postmortem/i);
+  assert.match(hero, /tool-call boundary/i);
   assert.match(hero, /Pro at \$19\/mo/);
-  assert.match(hero, /\$499 enterprise entry offer/);
-  assert.match(hero, /Enterprise Workflow Gate/);
+  assert.match(hero, /\$499 Diagnostic/);
+  assert.match(hero, /Diagnostic Gate/);
   assert.match(hero, /Rank[\s\S]*lessons/i);
   assert.match(hero, /Promote[\s\S]*gates/i);
   assert.match(hero, /npx thumbgate init/);
-  assert.ok(lede.split(/\s+/).length <= 30, `hero lede is ${lede.split(/\s+/).length} words`);
+  assert.ok(lede.split(/\s+/).length <= 40, `hero lede is ${lede.split(/\s+/).length} words`);
 });
 
 test('how-it-works sells the self-improving loop, not a static allowlist', () => {
@@ -154,9 +154,9 @@ test('homepage explains the product with one four-stage self-improving loop', ()
 });
 
 test('paid wedge includes managed implementation, regression, and rollout proof', () => {
-  assert.match(landingPage, /Enterprise · \$499/);
-  assert.match(landingPage, /enterprise entry offer for one workflow/i);
-  assert.match(landingPage, /One configured local gate and its regression test/);
+  assert.match(landingPage, /Get Started · \$499/);
+  assert.match(landingPage, /Get Started — \$499 Diagnostic/);
+  assert.match(landingPage, /One configured local gate \+ regression test|One configured local gate and its regression test/);
   assert.match(landingPage, /Rollout and rollback proof within two business days/);
   assert.match(landingPage, /If the workflow cannot be reduced to one supported gate, the order is refunded/);
   assert.match(landingPage, /Multi-system implementation[\s\S]*require separate scope/);

--- a/tests/version-metadata.test.js
+++ b/tests/version-metadata.test.js
@@ -282,7 +282,7 @@ test('hosted origin and repository metadata stay canonical across live-facing ar
   assert.match(publicLanding, /\/checkout\/pro/);
   assert.match(publicLanding, /__GA_BOOTSTRAP__/);
   assert.match(publicLanding, /__GOOGLE_SITE_VERIFICATION_META__/);
-  assert.match(publicLanding, /Self-Improving Firewall for Your AI Agents/i);
+  assert.match(publicLanding, /Stop AI agent mistakes before they cost you/i);
   assert.match(publicLanding, /test-backed verification evidence/i);
   assert.match(publicLanding, /strict-mode deny example/i);
   assert.match(publicLanding, /configured local gate and its regression test/i);


### PR DESCRIPTION
## Summary
Steal [Rally](https://rally-ai.com/) **sales architecture** (not their PR product):

1. **Outcome headline** — “Stop AI agent mistakes before they cost you” instead of product-noun hero
2. **Dual cash path** — `$499 Diagnostic` as primary Get Started; Pro `$19/mo` secondary
3. **Comparison table** on `/pricing` (DIY vs platform hire vs GRC vs ThumbGate)
4. **UTM campaign** `rally_style_gtm` on checkout CTAs for attribution

Congruence kept: meta still states one hard test-backed gate, supported workflow, two business days.

## Test plan
- [x] `node --test tests/public-landing.test.js tests/landing-page-claims.test.js` (pass)
- [x] Congruence + claims pre-commit guards
- [ ] CI green on PR
- [ ] After merge: curl production `/` for new H1 + diagnostic CTA order

## Cash path note
This is conversion packaging. Still need human closes on abandoned checkouts / outbound — landing copy alone does not mint `paidOrders`.