### PR TITLE
feat: highlight thumbgate-dashboard on README and landing page

### DIFF
--- a/.changeset/highlight-thumbgate-dashboard-command.md
+++ b/.changeset/highlight-thumbgate-dashboard-command.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Highlight the `thumbgate-dashboard` / `/thumbgate-dashboard` command on the GitHub README and thumbgate.ai landing page so operators can open the project-scoped local dashboard without hunting the CLI reference.

--- a/.changeset/highlight-thumbgate-dashboard-command.md
+++ b/.changeset/highlight-thumbgate-dashboard-command.md
@@ -3,3 +3,5 @@ thumbgate: patch
 ---
 
 Highlight the `thumbgate-dashboard` / `/thumbgate-dashboard` command on the GitHub README and thumbgate.ai landing page so operators can open the project-scoped local dashboard without hunting the CLI reference.
+
+Also bumps the brace-expansion override 5.0.7 → 5.0.8 to clear GHSA-mh99-v99m-4gvg so CI npm audit passes.

--- a/.claude/commands/dashboard.md
+++ b/.claude/commands/dashboard.md
@@ -1,15 +1,25 @@
 ---
 name: dashboard
 description: Open the local HTTP dashboard for the current project in your web browser.
+allowed-tools: Bash(npx thumbgate dashboard:*)
 ---
 
 # Open Dashboard
 
 Open the local HTTP dashboard for the current project in your web browser.
 
+This command wraps existing ThumbGate capability — **no new logic**.
+
 ## Instructions
+
 Execute the following command in the project directory to open the browser dashboard scoped to the current repository:
+
+```bash
+npx thumbgate dashboard --open
+```
+
+Standalone shortcut:
+
 ```bash
 thumbgate-dashboard
 ```
-

--- a/.claude/commands/thumbgate-dashboard.md
+++ b/.claude/commands/thumbgate-dashboard.md
@@ -1,15 +1,30 @@
 ---
 name: thumbgate-dashboard
-description: Open the local HTTP dashboard for the current project in your web browser.
+description: Open the local HTTP dashboard for the current project in your web browser. Use for "open dashboard", "thumbgate-dashboard", "show my gates in the browser", "project dashboard", or "open the local ThumbGate UI".
+allowed-tools: Bash(npx thumbgate dashboard:*)
 ---
 
-# Open Scoped ThumbGate Dashboard
+# ThumbGate Dashboard
 
-Open the local HTTP dashboard for the current project in your web browser.
+Open the local HTTP dashboard for the current project so you can inspect lessons, checks, gate stats, and tokens saved in the browser.
 
-## Instructions
-Execute the following command in the project directory to open the browser dashboard:
-```bash
-thumbgate-dashboard
+This command wraps existing ThumbGate capability — **no new logic**. It runs the existing project-scoped dashboard opener.
+
+## Steps
+
+1. Open the project-scoped dashboard:
+   ```bash
+   npx thumbgate dashboard --open
+   ```
+   Equivalent standalone shortcut after a global install:
+   ```bash
+   thumbgate-dashboard
+   ```
+2. Confirm the browser lands on the local dashboard for this repo (lessons, checks, gate stats, tokens saved).
+3. If the command fails, run `npx thumbgate doctor` — a missing install is usually fixed by `npx thumbgate init`.
+
+## Example
+
 ```
-
+/thumbgate-dashboard
+```

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ Spec-driven agent frameworks like **GSD** (get-shit-done) and **GitHub Spec Kit*
 
 | Command | What it does | Wraps (existing capability) |
 |---------|--------------|------------------------------|
-| **`/thumbgate-dashboard`** | **Open the local project dashboard in your browser** (lessons, checks, tokens saved) | **`npx thumbgate dashboard --open`** / **`thumbgate-dashboard`** |
+| **`/thumbgate-dashboard`** | **Open the local project dashboard in your browser** (lessons, checks, tokens saved) | **`npx thumbgate dashboard --open`** (global bin after `npm i -g`) |
 | `/thumbgate-guard` | Turn the last agent mistake into a hard prevention rule | `capture_feedback` + `thumbgate force-gate` |
 | `/thumbgate-rules` | List the active prevention rules + lessons guarding this repo | `prevention_rules`, `get_reliability_rules`, `search_lessons` |
 | `/thumbgate-blocked` | Show what's actually been blocked — gate stats + enforcement matrix | `gate_stats`, `enforcement_matrix` |
 | `/thumbgate-protect` | Show branch/release governance; grant a scoped, expiring approval | `get_branch_governance`, `approve_protected_action` |
 | `/thumbgate-doctor` | Health-check the wiring (hooks, MCP, agent-readiness) | `thumbgate doctor` |
 
-> **Open the dashboard anytime:** after `npx thumbgate init`, run **`thumbgate-dashboard`** (or `npx thumbgate dashboard --open`) — or type **`/thumbgate-dashboard`** in Claude Code / Grok / Cursor so the agent opens the project-scoped browser UI for you.
+> **Open the dashboard anytime:** after `npx thumbgate init`, run **`npx thumbgate dashboard --open`** (works without a global install). Type **`/thumbgate-dashboard`** in Claude Code / Cursor, or **`/project:thumbgate-dashboard`** in Grok. After `npm i -g thumbgate`, the **`thumbgate-dashboard`** bin is also on your PATH.
 
 Each is a thin wrapper over an existing MCP tool or CLI command — **no new enforcement logic, just discoverability**.
 
@@ -388,7 +388,7 @@ npx thumbgate background-governance  # review background-agent run risk
 npx thumbgate model-candidates --workload=dashboard-analysis --provider=openai --json  # evaluate GPT-5.5 routing
 npx thumbgate native-messaging-audit  # inspect local browser bridges and extension hosts
 npx thumbgate dashboard --open                                  # open local project-scoped dashboard in browser
-thumbgate-dashboard                                             # standalone shortcut (same as above; also /thumbgate-dashboard in agent palette)
+thumbgate-dashboard                                             # global bin after npm i -g thumbgate; agents: /thumbgate-dashboard (Claude/Cursor) or /project:thumbgate-dashboard (Grok)
 npx thumbgate check-update                                      # check if a new version is available on npm/GitHub
 npx thumbgate self-update                                       # update ThumbGate to the latest version globally
 npx thumbgate serve      # start MCP server on stdio

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ Spec-driven agent frameworks like **GSD** (get-shit-done) and **GitHub Spec Kit*
 
 | Command | What it does | Wraps (existing capability) |
 |---------|--------------|------------------------------|
+| **`/thumbgate-dashboard`** | **Open the local project dashboard in your browser** (lessons, checks, tokens saved) | **`npx thumbgate dashboard --open`** / **`thumbgate-dashboard`** |
 | `/thumbgate-guard` | Turn the last agent mistake into a hard prevention rule | `capture_feedback` + `thumbgate force-gate` |
 | `/thumbgate-rules` | List the active prevention rules + lessons guarding this repo | `prevention_rules`, `get_reliability_rules`, `search_lessons` |
 | `/thumbgate-blocked` | Show what's actually been blocked — gate stats + enforcement matrix | `gate_stats`, `enforcement_matrix` |
 | `/thumbgate-protect` | Show branch/release governance; grant a scoped, expiring approval | `get_branch_governance`, `approve_protected_action` |
 | `/thumbgate-doctor` | Health-check the wiring (hooks, MCP, agent-readiness) | `thumbgate doctor` |
+
+> **Open the dashboard anytime:** after `npx thumbgate init`, run **`thumbgate-dashboard`** (or `npx thumbgate dashboard --open`) — or type **`/thumbgate-dashboard`** in Claude Code / Grok / Cursor so the agent opens the project-scoped browser UI for you.
 
 Each is a thin wrapper over an existing MCP tool or CLI command — **no new enforcement logic, just discoverability**.
 
@@ -385,7 +388,7 @@ npx thumbgate background-governance  # review background-agent run risk
 npx thumbgate model-candidates --workload=dashboard-analysis --provider=openai --json  # evaluate GPT-5.5 routing
 npx thumbgate native-messaging-audit  # inspect local browser bridges and extension hosts
 npx thumbgate dashboard --open                                  # open local project-scoped dashboard in browser
-thumbgate-dashboard                                             # standalone browser dashboard shortcut (run '/project:thumbgate-dashboard' in Claude/Grok)
+thumbgate-dashboard                                             # standalone shortcut (same as above; also /thumbgate-dashboard in agent palette)
 npx thumbgate check-update                                      # check if a new version is available on npm/GitHub
 npx thumbgate self-update                                       # update ThumbGate to the latest version globally
 npx thumbgate serve      # start MCP server on stdio

--- a/commands/dashboard.md
+++ b/commands/dashboard.md
@@ -1,15 +1,25 @@
 ---
 name: dashboard
 description: Open the local HTTP dashboard for the current project in your web browser.
+allowed-tools: Bash(npx thumbgate dashboard:*), Bash(thumbgate-dashboard:*)
 ---
 
 # Open Dashboard
 
 Open the local HTTP dashboard for the current project in your web browser.
 
+This command wraps existing ThumbGate capability — **no new logic**.
+
 ## Instructions
+
 Execute the following command in the project directory to open the browser dashboard scoped to the current repository:
+
+```bash
+npx thumbgate dashboard --open
+```
+
+Standalone shortcut:
+
 ```bash
 thumbgate-dashboard
 ```
-

--- a/commands/thumbgate-dashboard.md
+++ b/commands/thumbgate-dashboard.md
@@ -1,15 +1,30 @@
 ---
 name: thumbgate-dashboard
-description: Open the local HTTP dashboard for the current project in your web browser.
+description: Open the local HTTP dashboard for the current project in your web browser. Use for "open dashboard", "thumbgate-dashboard", "show my gates in the browser", "project dashboard", or "open the local ThumbGate UI".
+allowed-tools: Bash(npx thumbgate dashboard:*)
 ---
 
-# Open Scoped ThumbGate Dashboard
+# ThumbGate Dashboard
 
-Open the local HTTP dashboard for the current project in your web browser.
+Open the local HTTP dashboard for the current project so you can inspect lessons, checks, gate stats, and tokens saved in the browser.
 
-## Instructions
-Execute the following command in the project directory to open the browser dashboard:
-```bash
-thumbgate-dashboard
+This command wraps existing ThumbGate capability — **no new logic**. It runs the existing project-scoped dashboard opener.
+
+## Steps
+
+1. Open the project-scoped dashboard:
+   ```bash
+   npx thumbgate dashboard --open
+   ```
+   Equivalent standalone shortcut after a global install:
+   ```bash
+   thumbgate-dashboard
+   ```
+2. Confirm the browser lands on the local dashboard for this repo (lessons, checks, gate stats, tokens saved).
+3. If the command fails, run `npx thumbgate doctor` — a missing install is usually fixed by `npx thumbgate init`.
+
+## Example
+
 ```
-
+/thumbgate-dashboard
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1034,16 +1034,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -895,7 +895,7 @@
     "@google/genai": {
       "protobufjs": "7.6.5"
     },
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "onnxruntime-web": {
       "protobufjs": "7.6.5"
     },

--- a/public/index.html
+++ b/public/index.html
@@ -595,6 +595,7 @@
           </div>
           <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
           <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually minutes after install · <a href="/pricing">how we stack up</a></p>
+          <p class="install-hint" id="thumbgate-dashboard-command" style="margin-top:10px;">Open project dashboard: <code>thumbgate-dashboard</code> · agent palette <code>/thumbgate-dashboard</code> · <code>npx thumbgate dashboard --open</code> · <a href="/dashboard#insights">live demo</a></p>
         </div>
         <div id="offers" class="offer-stack">
           <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout style="order:-1;border-color:rgba(0,110,82,.35);box-shadow:0 18px 50px rgba(0,110,82,.12);">
@@ -816,6 +817,7 @@ next      decision recorded before execution</pre>
         <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub</a>
         <a href="/guide">Technical setup</a>
         <a href="/dashboard#insights">Live enforcement dashboard</a>
+        <a href="#thumbgate-dashboard-command"><code>thumbgate-dashboard</code> command</a>
         <a href="/guides/developer-machine-supply-chain-guardrails">Developer Machine Supply Chain Guardrails — npm, PyPI, Docker, and CLI compromise paths</a>
         <a href="/learn">Browse the guide library</a>
         <a href="/llm-context.md">Machine-readable context</a>

--- a/public/index.html
+++ b/public/index.html
@@ -595,7 +595,7 @@
           </div>
           <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
           <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually minutes after install · <a href="/pricing">how we stack up</a></p>
-          <p class="install-hint" id="thumbgate-dashboard-command" style="margin-top:10px;">Open project dashboard: <code>thumbgate-dashboard</code> · agent palette <code>/thumbgate-dashboard</code> · <code>npx thumbgate dashboard --open</code> · <a href="/dashboard#insights">live demo</a></p>
+          <p class="install-hint" id="thumbgate-dashboard-command" style="margin-top:10px;">Dashboard: <code>npx thumbgate dashboard --open</code> · <code>/thumbgate-dashboard</code> · bin <code>thumbgate-dashboard</code> if global · <a href="/dashboard#insights">demo</a></p>
         </div>
         <div id="offers" class="offer-stack">
           <form id="buy" class="checkout-card" action="/go/diagnostic-pay" method="POST" data-primary-checkout style="order:-1;border-color:rgba(0,110,82,.35);box-shadow:0 18px 50px rgba(0,110,82,.12);">

--- a/public/llm-context.md
+++ b/public/llm-context.md
@@ -239,7 +239,10 @@ ThumbGate auto-detects your AI coding agent (Claude Code, Cursor, Codex, Gemini 
 
 ```bash
 npx thumbgate init --agent claude-code
+# Project-scoped local dashboard (lessons, checks, tokens saved)
 npx thumbgate dashboard --open
+thumbgate-dashboard
+# Agent palette: /thumbgate-dashboard
 ```
 
 ## Comparison vs Alternatives

--- a/tests/discoverable-skills.test.js
+++ b/tests/discoverable-skills.test.js
@@ -20,6 +20,7 @@ const { TOOLS } = require(path.join(ROOT, 'scripts', 'tool-registry.js'));
 
 // The discoverable wrapper set (4–6 by design — keep it tight).
 const COMMANDS = [
+  'thumbgate-dashboard',
   'thumbgate-guard',
   'thumbgate-rules',
   'thumbgate-blocked',

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -117,6 +117,10 @@ test('hero names both paid paths and the self-improving product outcome', () => 
   assert.match(hero, /Rank[\s\S]*lessons/i);
   assert.match(hero, /Promote[\s\S]*gates/i);
   assert.match(hero, /npx thumbgate init/);
+  assert.match(hero, /thumbgate-dashboard/);
+  assert.match(hero, /\/thumbgate-dashboard/);
+  assert.match(hero, /npx thumbgate dashboard --open/);
+  assert.match(hero, /id="thumbgate-dashboard-command"/);
   assert.ok(lede.split(/\s+/).length <= 40, `hero lede is ${lede.split(/\s+/).length} words`);
 });
 


### PR DESCRIPTION
## Summary
- Promote **`/thumbgate-dashboard`** into the discoverable slash-command table on the GitHub README (first row, bold callout + install tip).
- Hero install hint on **thumbgate.ai** surfaces `thumbgate-dashboard`, `/thumbgate-dashboard`, and `npx thumbgate dashboard --open`, with footer link back to the command anchor.
- Upgrade the slash-command wrappers to the same “no new logic” wrapper contract as guard/rules/doctor, and pin the surface with discoverable-skills + public-landing tests.

## Test plan
- [x] `node --test tests/discoverable-skills.test.js tests/public-landing.test.js` (44/44)
- [x] pre-commit package parity / congruence / landing claims
- [x] pre-push regression-guard + internal link check
- [ ] After merge: confirm live https://thumbgate.ai hero shows the dashboard command and README on main lists `/thumbgate-dashboard`