### PR TITLE
fix(ci): add Dependabot 7-day cooldown

### DIFF
--- a/.changeset/dependabot-cooldown-7d.md
+++ b/.changeset/dependabot-cooldown-7d.md
@@ -2,4 +2,4 @@
 thumbgate: patch
 ---
 
-Add Dependabot 7-day cooldown on npm/github-actions/docker ecosystems so newly published packages aren't auto-proposed immediately.
+Add Dependabot 7-day cooldown on npm and github-actions ecosystems so newly published packages and actions aren't auto-proposed immediately.

--- a/.changeset/dependabot-cooldown-7d.md
+++ b/.changeset/dependabot-cooldown-7d.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Add Dependabot 7-day cooldown on npm/github-actions/docker ecosystems so newly published packages aren't auto-proposed immediately.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -20,6 +22,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:05"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -35,6 +39,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:15"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary
- Add `cooldown.default-days: 7` to all Dependabot ecosystems (npm, github-actions, docker).
- Supersedes external PR #3024 which could not satisfy full required status checks.

## Test plan
- [x] Diff matches intended dependabot.yml cooldown shape
- [ ] CI green on this branch
- [ ] Close #3024 as superseded after merge