### PR TITLE
fix(feedback): separate human review provenance

### DIFF
--- a/.changeset/human-feedback-provenance.md
+++ b/.changeset/human-feedback-provenance.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Separate human-reviewed feedback from automated and imported lessons using explicit provenance, conservative legacy classification, and duplicate-resistant CLI statistics.

--- a/.claude/scripts/feedback/capture-feedback.js
+++ b/.claude/scripts/feedback/capture-feedback.js
@@ -37,7 +37,7 @@ function refreshStatuslineCacheBestEffort() {
     // wrong for the cache merge.
     let stats;
     try {
-      stats = analyzeFeedback() || {};
+      stats = analyzeFeedback(undefined, { humanOnly: true }) || {};
     } catch (_err) {
       stats = {};
     }
@@ -138,6 +138,7 @@ function main() {
     guardrails: args.guardrails,
     tags: args.tags,
     skill: args.skill,
+    reviewOrigin: 'human',
   });
 
   if (result.accepted) {

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -890,11 +890,11 @@ async function callToolInner(name, args) {
       const pairedFeedback = pairFeedbackWithReceipt(args);
       return toCaptureFeedbackTextResult(captureFeedback({
         ...pairedFeedback,
-        reviewOrigin: 'human',
+        reviewOrigin: 'automated',
       }));
     }
     case 'feedback_summary':
-      return toTextResult(feedbackSummary(Number(args.recent || 20)));
+      return toTextResult(feedbackSummary(Number(args.recent || 20), { humanOnly: true }));
     case 'search_lessons': {
       const module = loadPrivateMcpModule('lessonSearch');
       if (!module) return unavailablePrivateMcpFeature('search_lessons');

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -888,7 +888,10 @@ async function callToolInner(name, args) {
       // action receipt (this action -> this outcome) before promotion. Returns
       // args unchanged when there is no matching receipt (non-breaking).
       const pairedFeedback = pairFeedbackWithReceipt(args);
-      return toCaptureFeedbackTextResult(captureFeedback(pairedFeedback));
+      return toCaptureFeedbackTextResult(captureFeedback({
+        ...pairedFeedback,
+        reviewOrigin: 'human',
+      }));
     }
     case 'feedback_summary':
       return toTextResult(feedbackSummary(Number(args.recent || 20)));
@@ -970,7 +973,7 @@ async function callToolInner(name, args) {
       return toTextResult(document);
     }
     case 'feedback_stats':
-      return toTextResult(analyzeFeedback());
+      return toTextResult(analyzeFeedback(undefined, { humanOnly: true }));
     case 'diagnose_failure':
       return buildDiagnoseFailureResponse(args);
     case 'reflect_on_feedback':

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1271,6 +1271,7 @@ function capture() {
     whatWorked: args['what-worked'],
     tags: args.tags,
     gateAction: gateAction || undefined,
+    reviewOrigin: 'human',
   });
 
   if (result.accepted) {
@@ -1386,6 +1387,7 @@ function feedbackSelfTest() {
         ? (args['what-worked'] || 'Feedback capture persisted and was verified by a self-test')
         : undefined,
       tags: args.tags || 'self-test,dogfood,feedback-capture',
+      reviewOrigin: 'automated',
     });
 
     const paths = getFeedbackPaths();
@@ -1444,7 +1446,7 @@ function stats() {
   trackEvent('cli_stats', { command: 'stats' });
   const args = parseArgs(process.argv.slice(3));
   const { analyzeFeedback } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
-  const data = analyzeFeedback();
+  const data = analyzeFeedback(undefined, { humanOnly: true });
 
   // Gate enforcement stats — runtime intercepts + configured gates
   let gateData = { blocked: 0, warned: 0, passed: 0, byGate: {} };
@@ -1761,7 +1763,7 @@ function summary() {
   const args = parseArgs(process.argv.slice(3));
   const { feedbackSummary, analyzeFeedback } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
   if (args.json) {
-    const data = analyzeFeedback();
+    const data = analyzeFeedback(undefined, { humanOnly: true });
     console.log(JSON.stringify({
       total: data.total,
       positives: data.totalPositive,
@@ -2861,7 +2863,7 @@ function sessionStart() {
   } catch (_) { /* best-effort fallback sync */ }
   const { analyzeFeedback } = require(path.join(PKG_ROOT, 'scripts', 'feedback-loop'));
   const { refreshStatuslineCache } = require(path.join(PKG_ROOT, 'scripts', 'hook-thumbgate-cache-updater'));
-  refreshStatuslineCache(analyzeFeedback());
+  refreshStatuslineCache(analyzeFeedback(undefined, { humanOnly: true }));
 
   // Build a top-level <system-reminder> block that Claude Code's SessionStart
   // hook surfaces to the agent as first-class context — not buried stderr.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1185,7 +1185,7 @@ function capture() {
   }
 
   if (args.summary) {
-    console.log(feedbackSummary(Number(args.recent || 20)));
+    console.log(feedbackSummary(Number(args.recent || 20), { humanOnly: true }));
     return;
   }
 
@@ -1773,7 +1773,7 @@ function summary() {
     }, null, 2));
     return;
   }
-  console.log(feedbackSummary(Number(args.recent || 20)));
+  console.log(feedbackSummary(Number(args.recent || 20), { humanOnly: true }));
 }
 
 function lessons() {

--- a/package.json
+++ b/package.json
@@ -655,7 +655,7 @@
     "test:control-tower": "node --test tests/control-tower.test.js",
     "test:pii-scanner": "node --test tests/pii-scanner.test.js",
     "test:data-governance": "node --test tests/data-governance.test.js",
-    "test:lesson-inference": "node --test tests/conversation-context.test.js tests/lesson-inference.test.js tests/lesson-prompt-shape.test.js",
+    "test:lesson-inference": "node --test tests/conversation-context.test.js tests/lesson-inference.test.js tests/lesson-prompt-shape.test.js tests/lesson-stats-review-origin.test.js",
     "test:lesson-retrieval": "node --test tests/lesson-retrieval.test.js",
     "test:lesson-semantic-retrieval": "node --test tests/lesson-semantic-retrieval.test.js",
     "test:cross-encoder": "node --test tests/cross-encoder-reranker.test.js",

--- a/scripts/activation-quickstart.js
+++ b/scripts/activation-quickstart.js
@@ -93,6 +93,7 @@ async function runActivationFlow({ ask, out, isTTY, deps = {} }) {
         whatToChange: `Block this action: ${mistake}`,
         tags: 'quickstart,activation,first-rule',
         gateAction: 'block',
+        reviewOrigin: 'human',
       });
     } catch {
       // Capture failure should not abort the activation aha.

--- a/scripts/claude-feedback-sync.js
+++ b/scripts/claude-feedback-sync.js
@@ -8,7 +8,6 @@ const {
   buildFeedbackSourceIdentity,
   getFeedbackPaths,
   readJSONL,
-  analyzeFeedback,
 } = require('./feedback-loop');
 const { detectFeedbackSignal, normalizeFeedbackText } = require('./feedback-quality');
 const {
@@ -279,6 +278,7 @@ function syncClaudeHistoryFeedback(options = {}) {
         whatWorked: candidate.signal === 'up' ? candidate.promptText : undefined,
         tags: ['claude-history-sync', 'auto-capture-fallback'],
         sourceEvent,
+        reviewOrigin: 'human',
       });
 
       if (captureResult?.duplicate) {
@@ -300,7 +300,8 @@ function syncClaudeHistoryFeedback(options = {}) {
     }, { feedbackDir });
 
     if (importedCount > 0) {
-      refreshStatuslineCache(analyzeFeedback(path.join(feedbackDir, 'feedback-log.jsonl')), path.join(feedbackDir, 'statusline_cache.json'));
+      const { analyzeFeedback } = require('./feedback-loop');
+      refreshStatuslineCache(analyzeFeedback(path.join(feedbackDir, 'feedback-log.jsonl'), { humanOnly: true }), path.join(feedbackDir, 'statusline_cache.json'));
     }
 
     return {

--- a/scripts/cli-feedback.js
+++ b/scripts/cli-feedback.js
@@ -13,13 +13,9 @@
  *   node scripts/cli-feedback.js down "what went wrong"
  */
 
-const { captureFeedback } = require('./feedback-loop');
+const { captureFeedback, analyzeFeedback } = require('./feedback-loop');
 const { loadOptionalModule } = require('./private-core-boundary');
-// `history-distiller` is a PRIVATE_CORE_MODULE — present in this checkout and
-// in ThumbGate-Core, but intentionally excluded from the public npm tarball.
-// The hard `require('./history-distiller')` form crashed `hook-auto-capture`
-// in published 1.19.0 with MODULE_NOT_FOUND. Public-shell fallback returns
-// null distillation; caller already handles a null distillResult.
+// Keep the optional distiller from breaking the public package.
 const { distillFromHistory } = loadOptionalModule('./history-distiller', () => ({
   distillFromHistory: () => null,
 }));
@@ -60,6 +56,7 @@ function processInlineFeedback({ signal, context, chatHistory, whatWentWrong, wh
       whatWorked: whatWorked || undefined,
       chatHistory,
       sourceEvent,
+      reviewOrigin: 'human',
     });
   } catch (err) {
     feedbackResult = { accepted: false, reason: err.message };
@@ -75,7 +72,16 @@ function processInlineFeedback({ signal, context, chatHistory, whatWentWrong, wh
 
   // 3. Get the most recent lesson and stats
   const recentLesson = getRecentLesson();
-  const stats = getLessonStats();
+  const lessonStats = getLessonStats();
+  const feedbackStats = analyzeFeedback(undefined, { humanOnly: true });
+  const stats = {
+    ...lessonStats,
+    total: feedbackStats.total,
+    positive: feedbackStats.totalPositive,
+    negative: feedbackStats.totalNegative,
+    rawTotal: feedbackStats.rawTotal,
+    excludedTotal: feedbackStats.excludedTotal,
+  };
 
   // 4. If the user wrote an explicit "never …" / "always …" directive, surface
   //    an OFFER (never auto-act): "never" on a thumbs-down → offer force-gate now.

--- a/scripts/feedback-aggregate.js
+++ b/scripts/feedback-aggregate.js
@@ -239,11 +239,12 @@ function trendFromRateWindows(windows) {
 function computeAggregateFeedbackStats(options = {}) {
   const { entries, stores } = collectAggregateLogEntries(FEEDBACK_LOG, options);
   const memory = collectAggregateLogEntries(MEMORY_LOG, options);
-  const { totalPositive, totalNegative, rubricSamples } = summarizeFeedbackEntries(entries);
+  const humanReviewedEntries = entries.filter((entry) => entry.reviewOrigin === 'human');
+  const { totalPositive, totalNegative, rubricSamples } = summarizeFeedbackEntries(humanReviewedEntries);
   const total = totalPositive + totalNegative;
   const approvalRate = total > 0 ? Math.round((totalPositive / total) * 1000) / 1000 : 0;
   const windows = createRateWindows(total, totalPositive, approvalRate);
-  updateRateWindows(windows, entries);
+  updateRateWindows(windows, humanReviewedEntries);
   finalizeRateWindows(windows);
   const trend = trendFromRateWindows(windows);
 
@@ -255,6 +256,8 @@ function computeAggregateFeedbackStats(options = {}) {
     recentRate: windows['7d'].rate || approvalRate,
     trend,
     windows,
+    rawTotal: entries.length,
+    excludedTotal: entries.length - humanReviewedEntries.length,
     rubric: { samples: rubricSamples || memory.entries.length, blockedPromotions: 0, failingCriteria: {} },
     aggregate: {
       enabled: true,

--- a/scripts/feedback-loop.js
+++ b/scripts/feedback-loop.js
@@ -2372,7 +2372,10 @@ function writePreventionRules(filePath, minOccurrences = 2) {
 
 function feedbackSummary(recentN = 20, options = {}) {
   const { FEEDBACK_LOG_PATH } = getFeedbackPaths(options);
-  const entries = readJSONL(FEEDBACK_LOG_PATH);
+  let entries = readJSONL(FEEDBACK_LOG_PATH);
+  if (options.humanOnly) {
+    entries = entries.filter((entry) => normalizeReviewOrigin(entry.reviewOrigin) === 'human');
+  }
   if (entries.length === 0) {
     return '## Feedback Summary\nNo feedback recorded yet.';
   }
@@ -2382,7 +2385,7 @@ function feedbackSummary(recentN = 20, options = {}) {
   const negative = recent.filter((e) => e.signal === 'negative').length;
   const pct = Math.round((positive / recent.length) * 100);
 
-  const analysis = analyzeFeedback(FEEDBACK_LOG_PATH);
+  const analysis = analyzeFeedback(FEEDBACK_LOG_PATH, { humanOnly: options.humanOnly });
 
   const lines = [
     `## Feedback Summary (last ${recent.length})`,
@@ -2455,7 +2458,7 @@ function runCli() {
   }
 
   if (args.summary) {
-    console.log(feedbackSummary(Number(args.recent || 20)));
+    console.log(feedbackSummary(Number(args.recent || 20), { humanOnly: true }));
     return;
   }
 

--- a/scripts/feedback-loop.js
+++ b/scripts/feedback-loop.js
@@ -1922,22 +1922,22 @@ function captureFeedbackIdempotent(params = {}) {
   }
 }
 
-function incrementFeedbackBucket(buckets, key, signal) {
+function incrementBucket(buckets, key, signal) {
   if (!key) return;
   if (!buckets[key]) buckets[key] = { positive: 0, negative: 0, total: 0 };
   buckets[key][signal] += 1;
   buckets[key].total += 1;
 }
 
-function summarizeFeedbackRubric(entry, summary) {
+function summarizeRubric(entry, summary) {
   if (entry.actionType === 'no-action' && typeof entry.actionReason === 'string' && entry.actionReason.includes('Rubric gate')) {
-    summary.blockedPromotions += 1;
+    summary.blocked += 1;
   }
-  if (entry.rubric?.weightedScore != null) summary.rubricSamples += 1;
+  if (entry.rubric?.weightedScore != null) summary.samples += 1;
 
   for (const criterion of entry.rubric?.failingCriteria || []) {
-    if (!summary.rubricCriteria[criterion]) summary.rubricCriteria[criterion] = { failures: 0 };
-    summary.rubricCriteria[criterion].failures += 1;
+    if (!summary.criteria[criterion]) summary.criteria[criterion] = { failures: 0 };
+    summary.criteria[criterion].failures += 1;
   }
 }
 
@@ -1945,22 +1945,22 @@ function summarizeFeedbackEntries(entries) {
   const summary = {
     skills: {},
     tags: {},
-    rubricCriteria: {},
-    rubricSamples: 0,
-    blockedPromotions: 0,
-    totalPositive: 0,
-    totalNegative: 0,
+    criteria: {},
+    samples: 0,
+    blocked: 0,
+    positive: 0,
+    negative: 0,
   };
 
   for (const entry of entries) {
-    if (entry.signal === 'positive') summary.totalPositive += 1;
-    if (entry.signal === 'negative') summary.totalNegative += 1;
+    if (entry.signal === 'positive') summary.positive += 1;
+    if (entry.signal === 'negative') summary.negative += 1;
 
-    incrementFeedbackBucket(summary.skills, entry.skill, entry.signal);
+    incrementBucket(summary.skills, entry.skill, entry.signal);
     for (const tag of entry.tags || []) {
-      incrementFeedbackBucket(summary.tags, tag, entry.signal);
+      incrementBucket(summary.tags, tag, entry.signal);
     }
-    summarizeFeedbackRubric(entry, summary);
+    summarizeRubric(entry, summary);
   }
 
   return summary;
@@ -1970,14 +1970,19 @@ function roundedRate(numerator, denominator) {
   return denominator > 0 ? Math.round((numerator / denominator) * 1000) / 1000 : 0;
 }
 
-function determineFeedbackTrend(windowStats, rate7d, rate30d) {
+function addRec(output, message, remediation) {
+  output.messages.push(message);
+  output.remediations.push(remediation);
+}
+
+function feedbackTrend(windowStats, rate7d, rate30d) {
   if (windowStats['7d'].total === 0 || windowStats['30d'].total === 0) return 'stable';
   if (rate7d > rate30d + 0.05) return 'improving';
   if (rate7d < rate30d - 0.05) return 'degrading';
   return 'stable';
 }
 
-function buildFeedbackWindows(entries, totalPositive, total) {
+function feedbackWindows(entries, positive, total) {
   const now = Date.now();
   const windowStats = {
     '7d': { total: 0, positive: 0 },
@@ -2001,7 +2006,7 @@ function buildFeedbackWindows(entries, totalPositive, total) {
 
   const rate7d = roundedRate(windowStats['7d'].positive, windowStats['7d'].total);
   const rate30d = roundedRate(windowStats['30d'].positive, windowStats['30d'].total);
-  const trend = determineFeedbackTrend(windowStats, rate7d, rate30d);
+  const trend = feedbackTrend(windowStats, rate7d, rate30d);
 
   return {
     rate7d,
@@ -2010,17 +2015,16 @@ function buildFeedbackWindows(entries, totalPositive, total) {
     windows: {
       '7d': { ...windowStats['7d'], rate: rate7d },
       '30d': { ...windowStats['30d'], rate: rate30d },
-      lifetime: { total, positive: totalPositive, rate: roundedRate(totalPositive, total) },
+      lifetime: { total, positive, rate: roundedRate(positive, total) },
     },
   };
 }
 
-function appendSkillRecommendations(skills, output) {
+function addSkillRecs(skills, output) {
   for (const [skill, stat] of Object.entries(skills)) {
-    const negativeRate = stat.total > 0 ? stat.negative / stat.total : 0;
-    if (stat.total < 3 || negativeRate < 0.5) continue;
-    output.recommendations.push(`IMPROVE skill '${skill}' (${stat.negative}/${stat.total} negative)`);
-    output.actionableRemediations.push({
+    const negRate = stat.total > 0 ? stat.negative / stat.total : 0;
+    if (stat.total < 3 || negRate < 0.5) continue;
+    addRec(output, `IMPROVE skill '${skill}' (${stat.negative}/${stat.total} negative)`, {
       type: 'skill-improve',
       target: skill,
       evidence: {
@@ -2030,17 +2034,16 @@ function appendSkillRecommendations(skills, output) {
         negativeRate: roundedRate(stat.negative, stat.total),
       },
       action: 'review-and-update-skill',
-      rationale: `Skill '${skill}' has ${stat.negative}/${stat.total} negative feedback events (${Math.round(negativeRate * 100)}% negative rate).`,
+      rationale: `Skill '${skill}' has ${stat.negative}/${stat.total} negative feedback events (${Math.round(negRate * 100)}% negative rate).`,
     });
   }
 }
 
-function appendTagRecommendations(tags, output) {
+function addTagRecs(tags, output) {
   for (const [tag, stat] of Object.entries(tags)) {
-    const positiveRate = stat.total > 0 ? stat.positive / stat.total : 0;
-    if (stat.total < 3 || positiveRate < 0.8) continue;
-    output.recommendations.push(`REUSE pattern '${tag}' (${stat.positive}/${stat.total} positive)`);
-    output.actionableRemediations.push({
+    const posRate = stat.total > 0 ? stat.positive / stat.total : 0;
+    if (stat.total < 3 || posRate < 0.8) continue;
+    addRec(output, `REUSE pattern '${tag}' (${stat.positive}/${stat.total} positive)`, {
       type: 'pattern-reuse',
       target: tag,
       evidence: {
@@ -2050,16 +2053,15 @@ function appendTagRecommendations(tags, output) {
         positiveRate: roundedRate(stat.positive, stat.total),
       },
       action: 'replicate-pattern',
-      rationale: `Pattern '${tag}' has ${stat.positive}/${stat.total} positive feedback events (${Math.round(positiveRate * 100)}% positive rate).`,
+      rationale: `Pattern '${tag}' has ${stat.positive}/${stat.total} positive feedback events (${Math.round(posRate * 100)}% positive rate).`,
     });
   }
 }
 
-function appendTrendRecommendations(metrics, output) {
+function addTrendRecs(metrics, output) {
   const { recent, recentRate, approvalRate, trend, rate7d, rate30d } = metrics;
   if (recent.length >= 10 && recentRate < approvalRate - 0.1) {
-    output.recommendations.push('DECLINING trend in last 20 signals; tighten verification before response.');
-    output.actionableRemediations.push({
+    addRec(output, 'DECLINING trend in last 20 signals; tighten verification before response.', {
       type: 'trend-declining',
       target: 'recent-signals',
       evidence: { recentRate, approvalRate, sampleSize: recent.length },
@@ -2068,8 +2070,7 @@ function appendTrendRecommendations(metrics, output) {
     });
   }
   if (trend !== 'degrading') return;
-  output.recommendations.push(`DEGRADING 7d trend (${rate7d}) vs 30d (${rate30d}); increase prevention rule injection.`);
-  output.actionableRemediations.push({
+  addRec(output, `DEGRADING 7d trend (${rate7d}) vs 30d (${rate30d}); increase prevention rule injection.`, {
     type: 'trend-degrading',
     target: '7d-window',
     evidence: { rate7d, rate30d, delta: Math.round((rate7d - rate30d) * 1000) / 1000 },
@@ -2078,10 +2079,9 @@ function appendTrendRecommendations(metrics, output) {
   });
 }
 
-function appendRiskBuckets(buckets, kind, output) {
+function addRiskBuckets(buckets, kind, output) {
   for (const bucket of buckets.slice(0, 2)) {
-    output.recommendations.push(`CHECK high-risk ${kind} '${bucket.key}' (${bucket.highRisk}/${bucket.total} high-risk)`);
-    output.actionableRemediations.push({
+    addRec(output, `CHECK high-risk ${kind} '${bucket.key}' (${bucket.highRisk}/${bucket.total} high-risk)`, {
       type: `high-risk-${kind}`,
       target: bucket.key,
       evidence: { highRisk: bucket.highRisk, total: bucket.total, riskRate: bucket.riskRate },
@@ -2091,28 +2091,27 @@ function appendRiskBuckets(buckets, kind, output) {
   }
 }
 
-function appendRiskRecommendations(feedbackDir, output) {
+function addRiskRecs(feedbackDir, output) {
   try {
     const riskScorer = getRiskScorerModule();
     if (!riskScorer) return null;
     const boostedRisk = riskScorer.getRiskSummary(feedbackDir);
     if (!boostedRisk) return null;
-    appendRiskBuckets(boostedRisk.highRiskDomains, 'domain', output);
-    appendRiskBuckets(boostedRisk.highRiskTags, 'tag', output);
+    addRiskBuckets(boostedRisk.highRiskDomains, 'domain', output);
+    addRiskBuckets(boostedRisk.highRiskTags, 'tag', output);
     return boostedRisk;
   } catch {
     return null;
   }
 }
 
-function appendDelegationRecommendations(feedbackDir, output) {
+function addDelegationRecs(feedbackDir, output) {
   try {
     const delegationRuntime = getDelegationRuntimeModule();
     if (!delegationRuntime || typeof delegationRuntime.summarizeDelegation !== 'function') return null;
     const delegation = delegationRuntime.summarizeDelegation(feedbackDir);
     if (delegation.attemptCount >= 3 && delegation.verificationFailureRate >= 0.5) {
-      output.recommendations.push(`REDUCE delegation: verification failure rate is ${Math.round(delegation.verificationFailureRate * 100)}%`);
-      output.actionableRemediations.push({
+      addRec(output, `REDUCE delegation: verification failure rate is ${Math.round(delegation.verificationFailureRate * 100)}%`, {
         type: 'delegation-reduce',
         target: 'verification-failure-rate',
         evidence: {
@@ -2124,8 +2123,7 @@ function appendDelegationRecommendations(feedbackDir, output) {
       });
     }
     if (delegation.avoidedDelegationCount >= 3) {
-      output.recommendations.push(`REVIEW delegation policy: ${delegation.avoidedDelegationCount} handoff starts were blocked before execution`);
-      output.actionableRemediations.push({
+      addRec(output, `REVIEW delegation policy: ${delegation.avoidedDelegationCount} handoff starts were blocked before execution`, {
         type: 'delegation-policy-review',
         target: 'handoff-blocks',
         evidence: { avoidedDelegationCount: delegation.avoidedDelegationCount },
@@ -2139,10 +2137,9 @@ function appendDelegationRecommendations(feedbackDir, output) {
   }
 }
 
-function appendDiagnosticRecommendations(diagnostics, output) {
+function addDiagnosticRecs(diagnostics, output) {
   for (const bucket of diagnostics.categories.slice(0, 2)) {
-    output.recommendations.push(`DIAGNOSE '${bucket.key}' failures (${bucket.count})`);
-    output.actionableRemediations.push({
+    addRec(output, `DIAGNOSE '${bucket.key}' failures (${bucket.count})`, {
       type: 'diagnose-failure-category',
       target: bucket.key,
       evidence: { count: bucket.count },
@@ -2152,8 +2149,8 @@ function appendDiagnosticRecommendations(diagnostics, output) {
   }
 }
 
-function getSQLiteAnalysisFallback(shouldUseSQLite, entries) {
-  const db = shouldUseSQLite ? getLessonDB() : null;
+function getSQLiteFallback(useSQLite, entries) {
+  const db = useSQLite ? getLessonDB() : null;
   if (!db || entries.length > 0) return null;
   try {
     const { getStatsFromDB } = require('./lesson-db');
@@ -2166,41 +2163,41 @@ function getSQLiteAnalysisFallback(shouldUseSQLite, entries) {
 
 function analyzeFeedback(logPath, options = {}) {
   const { FEEDBACK_LOG_PATH } = getFeedbackPaths();
-  const resolvedLogPath = logPath || FEEDBACK_LOG_PATH;
-  const feedbackDir = path.dirname(resolvedLogPath);
+  const resolvedPath = logPath || FEEDBACK_LOG_PATH;
+  const feedbackDir = path.dirname(resolvedPath);
   const paths = buildFeedbackPathsFromDir(feedbackDir);
-  const shouldUseSQLite = !options.humanOnly && (!logPath || path.resolve(resolvedLogPath) === path.resolve(FEEDBACK_LOG_PATH));
-  let entries = readJSONL(resolvedLogPath, { maxLines: 0 });
+  const useSQLite = !options.humanOnly && (!logPath || path.resolve(resolvedPath) === path.resolve(FEEDBACK_LOG_PATH));
+  let entries = readJSONL(resolvedPath, { maxLines: 0 });
   const rawTotal = entries.length;
   if (options.humanOnly) {
     entries = entries.filter((entry) => normalizeReviewOrigin(entry.reviewOrigin) === 'human');
   }
-  const sqliteFallback = getSQLiteAnalysisFallback(shouldUseSQLite, entries);
-  if (sqliteFallback) return sqliteFallback;
+  const fallback = getSQLiteFallback(useSQLite, entries);
+  if (fallback) return fallback;
 
   const diagnosticEntries = readDiagnosticEntries(path.join(feedbackDir, 'diagnostic-log.jsonl'));
   const summary = summarizeFeedbackEntries(entries);
-  const { skills, tags, rubricCriteria, rubricSamples, blockedPromotions, totalPositive, totalNegative } = summary;
-  const total = totalPositive + totalNegative;
-  const approvalRate = roundedRate(totalPositive, total);
+  const { skills, tags, criteria, samples, blocked, positive, negative } = summary;
+  const total = positive + negative;
+  const approvalRate = roundedRate(positive, total);
   const recent = entries.slice(-20);
   const recentPos = recent.filter((e) => e.signal === 'positive').length;
   const recentRate = roundedRate(recentPos, recent.length);
-  const { rate7d, rate30d, trend, windows } = buildFeedbackWindows(entries, totalPositive, total);
-  const recommendationOutput = { recommendations: [], actionableRemediations: [] };
+  const { rate7d, rate30d, trend, windows } = feedbackWindows(entries, positive, total);
+  const recs = { messages: [], remediations: [] };
 
-  appendSkillRecommendations(skills, recommendationOutput);
-  appendTagRecommendations(tags, recommendationOutput);
-  appendTrendRecommendations({ recent, recentRate, approvalRate, trend, rate7d, rate30d }, recommendationOutput);
-  const boostedRisk = appendRiskRecommendations(paths.FEEDBACK_DIR, recommendationOutput);
+  addSkillRecs(skills, recs);
+  addTagRecs(tags, recs);
+  addTrendRecs({ recent, recentRate, approvalRate, trend, rate7d, rate30d }, recs);
+  const boostedRisk = addRiskRecs(paths.FEEDBACK_DIR, recs);
   const diagnostics = aggregateFailureDiagnostics([...entries, ...diagnosticEntries]);
-  const delegation = appendDelegationRecommendations(paths.FEEDBACK_DIR, recommendationOutput);
-  appendDiagnosticRecommendations(diagnostics, recommendationOutput);
+  const delegation = addDelegationRecs(paths.FEEDBACK_DIR, recs);
+  addDiagnosticRecs(diagnostics, recs);
 
   return normalizeAnalysisShape({
     total,
-    totalPositive,
-    totalNegative,
+    totalPositive: positive,
+    totalNegative: negative,
     approvalRate,
     recentRate,
     windows,
@@ -2208,15 +2205,15 @@ function analyzeFeedback(logPath, options = {}) {
     skills,
     tags,
     rubric: {
-      samples: rubricSamples,
-      blockedPromotions,
-      failingCriteria: rubricCriteria,
+      samples,
+      blockedPromotions: blocked,
+      failingCriteria: criteria,
     },
     diagnostics,
     delegation,
     boostedRisk,
-    recommendations: recommendationOutput.recommendations,
-    actionableRemediations: recommendationOutput.actionableRemediations,
+    recommendations: recs.messages,
+    actionableRemediations: recs.remediations,
     rawTotal,
     excludedTotal: rawTotal - entries.length,
   });

--- a/scripts/feedback-loop.js
+++ b/scripts/feedback-loop.js
@@ -62,6 +62,11 @@ const FEEDBACK_EVENT_CLAIM_STALE_MS = 60 * 1000;
 const FEEDBACK_EVENT_CLAIM_WAIT_MS = 15 * 1000;
 const FEEDBACK_EVENT_CLAIM_POLL_MS = 25;
 
+function normalizeReviewOrigin(value) {
+  const origin = String(value || '').trim().toLowerCase();
+  return ['human', 'automated', 'imported'].includes(origin) ? origin : 'unverified';
+}
+
 function isSelfHarnessOptimizerEnabled(env = process.env) {
   return /^(?:1|true)$/i.test(String(env.THUMBGATE_SELF_HARNESS_OPTIMIZER || '').trim());
 }
@@ -387,6 +392,8 @@ function normalizeAnalysisShape(analysis = {}) {
     byImportance: Array.isArray(analysis.byImportance) ? analysis.byImportance : [],
     recentLessons: Array.isArray(analysis.recentLessons) ? analysis.recentLessons : [],
     sessionCount: Number.isFinite(analysis.sessionCount) ? analysis.sessionCount : 0,
+    rawTotal: analysis.rawTotal ?? total,
+    excludedTotal: analysis.excludedTotal ?? 0,
   };
 }
 
@@ -1431,6 +1438,7 @@ function captureFeedback(params) {
     structuredRule: structuredRule || null,
     ...(reflection && { reflection }),
     gateAction: params.gateAction || null,
+    reviewOrigin: normalizeReviewOrigin(params.reviewOrigin),
     sourceEvent: publicFeedbackSourceMetadata(params.sourceEvent),
     timestamp: now,
   };
@@ -1562,6 +1570,7 @@ function captureFeedback(params) {
     diagnosis: storedDiagnosis,
     structuredRule: structuredRule || null,
     sourceFeedbackId: feedbackEvent.id,
+    reviewOrigin: feedbackEvent.reviewOrigin,
     timestamp: now,
   };
 
@@ -1885,6 +1894,9 @@ function captureFeedback(params) {
         inferredLesson: memoryRecord ? memoryRecord.title : (feedbackEvent.context || '').slice(0, 200),
         confidence: memoryRecord ? 70 : 40,
         tags: feedbackEvent.tags || [],
+        metadata: {
+          reviewOrigin: feedbackEvent.reviewOrigin,
+        },
       });
     } catch { /* non-critical — lesson creation should never block feedback */ }
   });
@@ -1910,13 +1922,17 @@ function captureFeedbackIdempotent(params = {}) {
   }
 }
 
-function analyzeFeedback(logPath) {
+function analyzeFeedback(logPath, options = {}) {
   const { FEEDBACK_LOG_PATH } = getFeedbackPaths();
   const resolvedLogPath = logPath || FEEDBACK_LOG_PATH;
   const feedbackDir = path.dirname(resolvedLogPath);
   const paths = buildFeedbackPathsFromDir(feedbackDir);
-  const shouldUseSQLite = !logPath || path.resolve(resolvedLogPath) === path.resolve(FEEDBACK_LOG_PATH);
-  const entries = readJSONL(resolvedLogPath, { maxLines: 0 });
+  const shouldUseSQLite = !options.humanOnly && (!logPath || path.resolve(resolvedLogPath) === path.resolve(FEEDBACK_LOG_PATH));
+  let entries = readJSONL(resolvedLogPath, { maxLines: 0 });
+  const rawTotal = entries.length;
+  if (options.humanOnly) {
+    entries = entries.filter((entry) => normalizeReviewOrigin(entry.reviewOrigin) === 'human');
+  }
   const diagnosticLogPath = path.join(feedbackDir, 'diagnostic-log.jsonl');
   const diagnosticEntries = readDiagnosticEntries(diagnosticLogPath);
 
@@ -2157,6 +2173,8 @@ function analyzeFeedback(logPath) {
     boostedRisk,
     recommendations,
     actionableRemediations,
+    rawTotal,
+    excludedTotal: rawTotal - entries.length,
   });
 }
 

--- a/scripts/feedback-loop.js
+++ b/scripts/feedback-loop.js
@@ -1922,6 +1922,248 @@ function captureFeedbackIdempotent(params = {}) {
   }
 }
 
+function incrementFeedbackBucket(buckets, key, signal) {
+  if (!key) return;
+  if (!buckets[key]) buckets[key] = { positive: 0, negative: 0, total: 0 };
+  buckets[key][signal] += 1;
+  buckets[key].total += 1;
+}
+
+function summarizeFeedbackRubric(entry, summary) {
+  if (entry.actionType === 'no-action' && typeof entry.actionReason === 'string' && entry.actionReason.includes('Rubric gate')) {
+    summary.blockedPromotions += 1;
+  }
+  if (entry.rubric?.weightedScore != null) summary.rubricSamples += 1;
+
+  for (const criterion of entry.rubric?.failingCriteria || []) {
+    if (!summary.rubricCriteria[criterion]) summary.rubricCriteria[criterion] = { failures: 0 };
+    summary.rubricCriteria[criterion].failures += 1;
+  }
+}
+
+function summarizeFeedbackEntries(entries) {
+  const summary = {
+    skills: {},
+    tags: {},
+    rubricCriteria: {},
+    rubricSamples: 0,
+    blockedPromotions: 0,
+    totalPositive: 0,
+    totalNegative: 0,
+  };
+
+  for (const entry of entries) {
+    if (entry.signal === 'positive') summary.totalPositive += 1;
+    if (entry.signal === 'negative') summary.totalNegative += 1;
+
+    incrementFeedbackBucket(summary.skills, entry.skill, entry.signal);
+    for (const tag of entry.tags || []) {
+      incrementFeedbackBucket(summary.tags, tag, entry.signal);
+    }
+    summarizeFeedbackRubric(entry, summary);
+  }
+
+  return summary;
+}
+
+function roundedRate(numerator, denominator) {
+  return denominator > 0 ? Math.round((numerator / denominator) * 1000) / 1000 : 0;
+}
+
+function determineFeedbackTrend(windowStats, rate7d, rate30d) {
+  if (windowStats['7d'].total === 0 || windowStats['30d'].total === 0) return 'stable';
+  if (rate7d > rate30d + 0.05) return 'improving';
+  if (rate7d < rate30d - 0.05) return 'degrading';
+  return 'stable';
+}
+
+function buildFeedbackWindows(entries, totalPositive, total) {
+  const now = Date.now();
+  const windowStats = {
+    '7d': { total: 0, positive: 0 },
+    '30d': { total: 0, positive: 0 },
+  };
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+  const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+
+  for (const entry of entries) {
+    const timestamp = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
+    const age = now - timestamp;
+    if (age <= sevenDaysMs) {
+      windowStats['7d'].total += 1;
+      if (entry.signal === 'positive') windowStats['7d'].positive += 1;
+    }
+    if (age <= thirtyDaysMs) {
+      windowStats['30d'].total += 1;
+      if (entry.signal === 'positive') windowStats['30d'].positive += 1;
+    }
+  }
+
+  const rate7d = roundedRate(windowStats['7d'].positive, windowStats['7d'].total);
+  const rate30d = roundedRate(windowStats['30d'].positive, windowStats['30d'].total);
+  const trend = determineFeedbackTrend(windowStats, rate7d, rate30d);
+
+  return {
+    rate7d,
+    rate30d,
+    trend,
+    windows: {
+      '7d': { ...windowStats['7d'], rate: rate7d },
+      '30d': { ...windowStats['30d'], rate: rate30d },
+      lifetime: { total, positive: totalPositive, rate: roundedRate(totalPositive, total) },
+    },
+  };
+}
+
+function appendSkillRecommendations(skills, output) {
+  for (const [skill, stat] of Object.entries(skills)) {
+    const negativeRate = stat.total > 0 ? stat.negative / stat.total : 0;
+    if (stat.total < 3 || negativeRate < 0.5) continue;
+    output.recommendations.push(`IMPROVE skill '${skill}' (${stat.negative}/${stat.total} negative)`);
+    output.actionableRemediations.push({
+      type: 'skill-improve',
+      target: skill,
+      evidence: {
+        positive: stat.positive,
+        negative: stat.negative,
+        total: stat.total,
+        negativeRate: roundedRate(stat.negative, stat.total),
+      },
+      action: 'review-and-update-skill',
+      rationale: `Skill '${skill}' has ${stat.negative}/${stat.total} negative feedback events (${Math.round(negativeRate * 100)}% negative rate).`,
+    });
+  }
+}
+
+function appendTagRecommendations(tags, output) {
+  for (const [tag, stat] of Object.entries(tags)) {
+    const positiveRate = stat.total > 0 ? stat.positive / stat.total : 0;
+    if (stat.total < 3 || positiveRate < 0.8) continue;
+    output.recommendations.push(`REUSE pattern '${tag}' (${stat.positive}/${stat.total} positive)`);
+    output.actionableRemediations.push({
+      type: 'pattern-reuse',
+      target: tag,
+      evidence: {
+        positive: stat.positive,
+        negative: stat.negative,
+        total: stat.total,
+        positiveRate: roundedRate(stat.positive, stat.total),
+      },
+      action: 'replicate-pattern',
+      rationale: `Pattern '${tag}' has ${stat.positive}/${stat.total} positive feedback events (${Math.round(positiveRate * 100)}% positive rate).`,
+    });
+  }
+}
+
+function appendTrendRecommendations(metrics, output) {
+  const { recent, recentRate, approvalRate, trend, rate7d, rate30d } = metrics;
+  if (recent.length >= 10 && recentRate < approvalRate - 0.1) {
+    output.recommendations.push('DECLINING trend in last 20 signals; tighten verification before response.');
+    output.actionableRemediations.push({
+      type: 'trend-declining',
+      target: 'recent-signals',
+      evidence: { recentRate, approvalRate, sampleSize: recent.length },
+      action: 'tighten-verification-before-response',
+      rationale: `Recent approval rate (${Math.round(recentRate * 100)}%) has dropped ≥10pp below lifetime (${Math.round(approvalRate * 100)}%).`,
+    });
+  }
+  if (trend !== 'degrading') return;
+  output.recommendations.push(`DEGRADING 7d trend (${rate7d}) vs 30d (${rate30d}); increase prevention rule injection.`);
+  output.actionableRemediations.push({
+    type: 'trend-degrading',
+    target: '7d-window',
+    evidence: { rate7d, rate30d, delta: Math.round((rate7d - rate30d) * 1000) / 1000 },
+    action: 'increase-prevention-rule-injection',
+    rationale: `7d rate (${rate7d}) is below 30d rate (${rate30d}) by more than threshold.`,
+  });
+}
+
+function appendRiskBuckets(buckets, kind, output) {
+  for (const bucket of buckets.slice(0, 2)) {
+    output.recommendations.push(`CHECK high-risk ${kind} '${bucket.key}' (${bucket.highRisk}/${bucket.total} high-risk)`);
+    output.actionableRemediations.push({
+      type: `high-risk-${kind}`,
+      target: bucket.key,
+      evidence: { highRisk: bucket.highRisk, total: bucket.total, riskRate: bucket.riskRate },
+      action: `audit-${kind}-failures`,
+      rationale: `${kind === 'domain' ? 'Domain' : 'Tag'} '${bucket.key}' has ${bucket.highRisk}/${bucket.total} high-risk events (${Math.round((bucket.riskRate || 0) * 100)}% risk rate).`,
+    });
+  }
+}
+
+function appendRiskRecommendations(feedbackDir, output) {
+  try {
+    const riskScorer = getRiskScorerModule();
+    if (!riskScorer) return null;
+    const boostedRisk = riskScorer.getRiskSummary(feedbackDir);
+    if (!boostedRisk) return null;
+    appendRiskBuckets(boostedRisk.highRiskDomains, 'domain', output);
+    appendRiskBuckets(boostedRisk.highRiskTags, 'tag', output);
+    return boostedRisk;
+  } catch {
+    return null;
+  }
+}
+
+function appendDelegationRecommendations(feedbackDir, output) {
+  try {
+    const delegationRuntime = getDelegationRuntimeModule();
+    if (!delegationRuntime || typeof delegationRuntime.summarizeDelegation !== 'function') return null;
+    const delegation = delegationRuntime.summarizeDelegation(feedbackDir);
+    if (delegation.attemptCount >= 3 && delegation.verificationFailureRate >= 0.5) {
+      output.recommendations.push(`REDUCE delegation: verification failure rate is ${Math.round(delegation.verificationFailureRate * 100)}%`);
+      output.actionableRemediations.push({
+        type: 'delegation-reduce',
+        target: 'verification-failure-rate',
+        evidence: {
+          verificationFailureRate: delegation.verificationFailureRate,
+          attemptCount: delegation.attemptCount,
+        },
+        action: 'reduce-delegation-use',
+        rationale: `Delegation verification failure rate is ${Math.round(delegation.verificationFailureRate * 100)}% across ${delegation.attemptCount} attempts.`,
+      });
+    }
+    if (delegation.avoidedDelegationCount >= 3) {
+      output.recommendations.push(`REVIEW delegation policy: ${delegation.avoidedDelegationCount} handoff starts were blocked before execution`);
+      output.actionableRemediations.push({
+        type: 'delegation-policy-review',
+        target: 'handoff-blocks',
+        evidence: { avoidedDelegationCount: delegation.avoidedDelegationCount },
+        action: 'review-delegation-policy',
+        rationale: `${delegation.avoidedDelegationCount} handoff starts were blocked before execution.`,
+      });
+    }
+    return delegation;
+  } catch {
+    return null;
+  }
+}
+
+function appendDiagnosticRecommendations(diagnostics, output) {
+  for (const bucket of diagnostics.categories.slice(0, 2)) {
+    output.recommendations.push(`DIAGNOSE '${bucket.key}' failures (${bucket.count})`);
+    output.actionableRemediations.push({
+      type: 'diagnose-failure-category',
+      target: bucket.key,
+      evidence: { count: bucket.count },
+      action: 'investigate-failure-category',
+      rationale: `Failure category '${bucket.key}' has ${bucket.count} diagnosed events.`,
+    });
+  }
+}
+
+function getSQLiteAnalysisFallback(shouldUseSQLite, entries) {
+  const db = shouldUseSQLite ? getLessonDB() : null;
+  if (!db || entries.length > 0) return null;
+  try {
+    const { getStatsFromDB } = require('./lesson-db');
+    const sqliteStats = getStatsFromDB(db);
+    return sqliteStats.total > 0 ? normalizeAnalysisShape(sqliteStats) : null;
+  } catch {
+    return null;
+  }
+}
+
 function analyzeFeedback(logPath, options = {}) {
   const { FEEDBACK_LOG_PATH } = getFeedbackPaths();
   const resolvedLogPath = logPath || FEEDBACK_LOG_PATH;
@@ -1933,225 +2175,27 @@ function analyzeFeedback(logPath, options = {}) {
   if (options.humanOnly) {
     entries = entries.filter((entry) => normalizeReviewOrigin(entry.reviewOrigin) === 'human');
   }
-  const diagnosticLogPath = path.join(feedbackDir, 'diagnostic-log.jsonl');
-  const diagnosticEntries = readDiagnosticEntries(diagnosticLogPath);
+  const sqliteFallback = getSQLiteAnalysisFallback(shouldUseSQLite, entries);
+  if (sqliteFallback) return sqliteFallback;
 
-  // Prefer the JSONL mirror for full analytics fidelity. Fall back to SQLite only
-  // when the mirror is unavailable so dashboards and proof paths keep their full shape.
-  const db = shouldUseSQLite ? getLessonDB() : null;
-  if (db && entries.length === 0) {
-    try {
-      const { getStatsFromDB } = require('./lesson-db');
-      const sqliteStats = getStatsFromDB(db);
-      if (sqliteStats.total > 0) return normalizeAnalysisShape(sqliteStats);
-    } catch { /* fall through to JSONL scan */ }
-  }
-
-  const skills = {};
-  const tags = {};
-  const rubricCriteria = {};
-  let rubricSamples = 0;
-  let blockedPromotions = 0;
-
-  let totalPositive = 0;
-  let totalNegative = 0;
-
-  for (const entry of entries) {
-    if (entry.signal === 'positive') totalPositive++;
-    if (entry.signal === 'negative') totalNegative++;
-
-    if (entry.skill) {
-      if (!skills[entry.skill]) skills[entry.skill] = { positive: 0, negative: 0, total: 0 };
-      skills[entry.skill][entry.signal] += 1;
-      skills[entry.skill].total += 1;
-    }
-
-    for (const tag of entry.tags || []) {
-      if (!tags[tag]) tags[tag] = { positive: 0, negative: 0, total: 0 };
-      tags[tag][entry.signal] += 1;
-      tags[tag].total += 1;
-    }
-
-    if (entry.actionType === 'no-action' && typeof entry.actionReason === 'string' && entry.actionReason.includes('Rubric gate')) {
-      blockedPromotions += 1;
-    }
-
-    if (entry.rubric && entry.rubric.weightedScore != null) {
-      rubricSamples += 1;
-    }
-
-    if (entry.rubric && Array.isArray(entry.rubric.failingCriteria)) {
-      for (const criterion of entry.rubric.failingCriteria) {
-        if (!rubricCriteria[criterion]) rubricCriteria[criterion] = { failures: 0 };
-        rubricCriteria[criterion].failures += 1;
-      }
-    }
-  }
-
+  const diagnosticEntries = readDiagnosticEntries(path.join(feedbackDir, 'diagnostic-log.jsonl'));
+  const summary = summarizeFeedbackEntries(entries);
+  const { skills, tags, rubricCriteria, rubricSamples, blockedPromotions, totalPositive, totalNegative } = summary;
   const total = totalPositive + totalNegative;
-  const approvalRate = total > 0 ? Math.round((totalPositive / total) * 1000) / 1000 : 0;
+  const approvalRate = roundedRate(totalPositive, total);
   const recent = entries.slice(-20);
   const recentPos = recent.filter((e) => e.signal === 'positive').length;
-  const recentRate = recent.length > 0 ? Math.round((recentPos / recent.length) * 1000) / 1000 : 0;
+  const recentRate = roundedRate(recentPos, recent.length);
+  const { rate7d, rate30d, trend, windows } = buildFeedbackWindows(entries, totalPositive, total);
+  const recommendationOutput = { recommendations: [], actionableRemediations: [] };
 
-  // Rolling windows: 7-day, 30-day, lifetime (#204)
-  const now = Date.now();
-  const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-  const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-  const windowStats = { '7d': { total: 0, positive: 0 }, '30d': { total: 0, positive: 0 } };
-  for (const entry of entries) {
-    const ts = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
-    const age = now - ts;
-    if (age <= SEVEN_DAYS_MS) {
-      windowStats['7d'].total++;
-      if (entry.signal === 'positive') windowStats['7d'].positive++;
-    }
-    if (age <= THIRTY_DAYS_MS) {
-      windowStats['30d'].total++;
-      if (entry.signal === 'positive') windowStats['30d'].positive++;
-    }
-  }
-  const rate7d = windowStats['7d'].total > 0
-    ? Math.round((windowStats['7d'].positive / windowStats['7d'].total) * 1000) / 1000 : 0;
-  const rate30d = windowStats['30d'].total > 0
-    ? Math.round((windowStats['30d'].positive / windowStats['30d'].total) * 1000) / 1000 : 0;
-  const TREND_THRESHOLD = 0.05;
-  const hasTrendData = windowStats['7d'].total > 0 && windowStats['30d'].total > 0;
-  const trend = !hasTrendData ? 'stable'
-    : rate7d > rate30d + TREND_THRESHOLD ? 'improving'
-      : rate7d < rate30d - TREND_THRESHOLD ? 'degrading' : 'stable';
-  const windows = {
-    '7d': { ...windowStats['7d'], rate: rate7d },
-    '30d': { ...windowStats['30d'], rate: rate30d },
-    lifetime: { total, positive: totalPositive, rate: approvalRate },
-  };
-
-  const recommendations = [];
-  // Structured counterpart to `recommendations` — machine-actionable shape so
-  // hooks/agents can act on each item without regex-parsing prose strings.
-  // Each entry: { type, target, evidence, action, rationale }.
-  const actionableRemediations = [];
-
-  for (const [skill, stat] of Object.entries(skills)) {
-    const negRate = stat.total > 0 ? stat.negative / stat.total : 0;
-    if (stat.total >= 3 && negRate >= 0.5) {
-      recommendations.push(`IMPROVE skill '${skill}' (${stat.negative}/${stat.total} negative)`);
-      actionableRemediations.push({
-        type: 'skill-improve',
-        target: skill,
-        evidence: { positive: stat.positive, negative: stat.negative, total: stat.total, negativeRate: Math.round(negRate * 1000) / 1000 },
-        action: 'review-and-update-skill',
-        rationale: `Skill '${skill}' has ${stat.negative}/${stat.total} negative feedback events (${Math.round(negRate * 100)}% negative rate).`,
-      });
-    }
-  }
-
-  for (const [tag, stat] of Object.entries(tags)) {
-    const posRate = stat.total > 0 ? stat.positive / stat.total : 0;
-    if (stat.total >= 3 && posRate >= 0.8) {
-      recommendations.push(`REUSE pattern '${tag}' (${stat.positive}/${stat.total} positive)`);
-      actionableRemediations.push({
-        type: 'pattern-reuse',
-        target: tag,
-        evidence: { positive: stat.positive, negative: stat.negative, total: stat.total, positiveRate: Math.round(posRate * 1000) / 1000 },
-        action: 'replicate-pattern',
-        rationale: `Pattern '${tag}' has ${stat.positive}/${stat.total} positive feedback events (${Math.round(posRate * 100)}% positive rate).`,
-      });
-    }
-  }
-
-  if (recent.length >= 10 && recentRate < approvalRate - 0.1) {
-    recommendations.push('DECLINING trend in last 20 signals; tighten verification before response.');
-    actionableRemediations.push({
-      type: 'trend-declining',
-      target: 'recent-signals',
-      evidence: { recentRate, approvalRate, sampleSize: recent.length },
-      action: 'tighten-verification-before-response',
-      rationale: `Recent approval rate (${Math.round(recentRate * 100)}%) has dropped ≥10pp below lifetime (${Math.round(approvalRate * 100)}%).`,
-    });
-  }
-  if (trend === 'degrading') {
-    recommendations.push(`DEGRADING 7d trend (${rate7d}) vs 30d (${rate30d}); increase prevention rule injection.`);
-    actionableRemediations.push({
-      type: 'trend-degrading',
-      target: '7d-window',
-      evidence: { rate7d, rate30d, delta: Math.round((rate7d - rate30d) * 1000) / 1000 },
-      action: 'increase-prevention-rule-injection',
-      rationale: `7d rate (${rate7d}) is below 30d rate (${rate30d}) by more than threshold.`,
-    });
-  }
-
-  let boostedRisk = null;
-  try {
-    const riskScorer = getRiskScorerModule();
-    if (riskScorer) {
-      boostedRisk = riskScorer.getRiskSummary(paths.FEEDBACK_DIR);
-      if (boostedRisk) {
-        boostedRisk.highRiskDomains.slice(0, 2).forEach((bucket) => {
-          recommendations.push(`CHECK high-risk domain '${bucket.key}' (${bucket.highRisk}/${bucket.total} high-risk)`);
-          actionableRemediations.push({
-            type: 'high-risk-domain',
-            target: bucket.key,
-            evidence: { highRisk: bucket.highRisk, total: bucket.total, riskRate: bucket.riskRate },
-            action: 'audit-domain-failures',
-            rationale: `Domain '${bucket.key}' has ${bucket.highRisk}/${bucket.total} high-risk events (${Math.round((bucket.riskRate || 0) * 100)}% risk rate).`,
-          });
-        });
-        boostedRisk.highRiskTags.slice(0, 2).forEach((bucket) => {
-          recommendations.push(`CHECK high-risk tag '${bucket.key}' (${bucket.highRisk}/${bucket.total} high-risk)`);
-          actionableRemediations.push({
-            type: 'high-risk-tag',
-            target: bucket.key,
-            evidence: { highRisk: bucket.highRisk, total: bucket.total, riskRate: bucket.riskRate },
-            action: 'audit-tag-failures',
-            rationale: `Tag '${bucket.key}' has ${bucket.highRisk}/${bucket.total} high-risk events (${Math.round((bucket.riskRate || 0) * 100)}% risk rate).`,
-          });
-        });
-      }
-    }
-  } catch {
-    boostedRisk = null;
-  }
+  appendSkillRecommendations(skills, recommendationOutput);
+  appendTagRecommendations(tags, recommendationOutput);
+  appendTrendRecommendations({ recent, recentRate, approvalRate, trend, rate7d, rate30d }, recommendationOutput);
+  const boostedRisk = appendRiskRecommendations(paths.FEEDBACK_DIR, recommendationOutput);
   const diagnostics = aggregateFailureDiagnostics([...entries, ...diagnosticEntries]);
-  let delegation = null;
-  try {
-    const delegationRuntime = getDelegationRuntimeModule();
-    if (delegationRuntime && typeof delegationRuntime.summarizeDelegation === 'function') {
-      delegation = delegationRuntime.summarizeDelegation(paths.FEEDBACK_DIR);
-      if (delegation.attemptCount >= 3 && delegation.verificationFailureRate >= 0.5) {
-        recommendations.push(`REDUCE delegation: verification failure rate is ${Math.round(delegation.verificationFailureRate * 100)}%`);
-        actionableRemediations.push({
-          type: 'delegation-reduce',
-          target: 'verification-failure-rate',
-          evidence: { verificationFailureRate: delegation.verificationFailureRate, attemptCount: delegation.attemptCount },
-          action: 'reduce-delegation-use',
-          rationale: `Delegation verification failure rate is ${Math.round(delegation.verificationFailureRate * 100)}% across ${delegation.attemptCount} attempts.`,
-        });
-      }
-      if (delegation.avoidedDelegationCount >= 3) {
-        recommendations.push(`REVIEW delegation policy: ${delegation.avoidedDelegationCount} handoff starts were blocked before execution`);
-        actionableRemediations.push({
-          type: 'delegation-policy-review',
-          target: 'handoff-blocks',
-          evidence: { avoidedDelegationCount: delegation.avoidedDelegationCount },
-          action: 'review-delegation-policy',
-          rationale: `${delegation.avoidedDelegationCount} handoff starts were blocked before execution.`,
-        });
-      }
-    }
-  } catch {
-    delegation = null;
-  }
-  diagnostics.categories.slice(0, 2).forEach((bucket) => {
-    recommendations.push(`DIAGNOSE '${bucket.key}' failures (${bucket.count})`);
-    actionableRemediations.push({
-      type: 'diagnose-failure-category',
-      target: bucket.key,
-      evidence: { count: bucket.count },
-      action: 'investigate-failure-category',
-      rationale: `Failure category '${bucket.key}' has ${bucket.count} diagnosed events.`,
-    });
-  });
+  const delegation = appendDelegationRecommendations(paths.FEEDBACK_DIR, recommendationOutput);
+  appendDiagnosticRecommendations(diagnostics, recommendationOutput);
 
   return normalizeAnalysisShape({
     total,
@@ -2171,8 +2215,8 @@ function analyzeFeedback(logPath, options = {}) {
     diagnostics,
     delegation,
     boostedRisk,
-    recommendations,
-    actionableRemediations,
+    recommendations: recommendationOutput.recommendations,
+    actionableRemediations: recommendationOutput.actionableRemediations,
     rawTotal,
     excludedTotal: rawTotal - entries.length,
   });

--- a/scripts/ingest-manual-feedback.js
+++ b/scripts/ingest-manual-feedback.js
@@ -26,6 +26,7 @@ function ingestFile(filePath) {
     context: content.slice(0, 500),
     whatWorked: signal === 'up' ? content : undefined,
     whatWentWrong: signal === 'down' ? content : undefined,
+    reviewOrigin: 'human',
     tags: ['manual-ingest', 'markdown-migration'],
   });
 

--- a/scripts/ingest-manual-feedback.js
+++ b/scripts/ingest-manual-feedback.js
@@ -26,7 +26,7 @@ function ingestFile(filePath) {
     context: content.slice(0, 500),
     whatWorked: signal === 'up' ? content : undefined,
     whatWentWrong: signal === 'down' ? content : undefined,
-    reviewOrigin: 'human',
+    reviewOrigin: 'imported',
     tags: ['manual-ingest', 'markdown-migration'],
   });
 

--- a/scripts/jsonl-watcher.js
+++ b/scripts/jsonl-watcher.js
@@ -71,6 +71,7 @@ function ingestEntry(entry) {
     whatWorked: entry.whatWorked || undefined,
     tags: [...(entry.tags || []), WATCHER_SOURCE_TAG, `bridged-from:${entry.source}`],
     skill: entry.skill || undefined,
+    reviewOrigin: entry.reviewOrigin || 'imported',
   });
 
   return result;

--- a/scripts/lesson-inference.js
+++ b/scripts/lesson-inference.js
@@ -170,6 +170,20 @@ function isPositiveSignal(signal) {
   return signal === 'positive' || signal === 'up';
 }
 
+function isHumanReviewedLesson(lesson = {}) {
+  return (lesson.metadata?.reviewOrigin || lesson.reviewOrigin) === 'human';
+}
+
+function dedupeHumanReviewedLessons(lessons = []) {
+  const byFeedback = new Map();
+  for (const lesson of lessons) {
+    if (isHumanReviewedLesson(lesson) && lesson.feedbackId) {
+      byFeedback.set(lesson.feedbackId, lesson);
+    }
+  }
+  return [...byFeedback.values()];
+}
+
 function selectStatusbarLesson() {
   const lessons = readJsonl(getLessonsPath())
     .slice()
@@ -242,10 +256,14 @@ function searchLessons({ query = '', limit = 10, signal } = {}) {
  */
 function getLessonStats() {
   const lessons = readJsonl(getLessonsPath());
-  const positive = lessons.filter((l) => l.signal === 'positive' || l.signal === 'up').length;
-  const negative = lessons.filter((l) => l.signal === 'negative' || l.signal === 'down').length;
-  const avgConfidence = lessons.length > 0 ? Math.round(lessons.reduce((s, l) => s + (l.confidence || 0), 0) / lessons.length) : 0;
-  return { total: lessons.length, positive, negative, avgConfidence };
+  const humanReviewed = dedupeHumanReviewedLessons(lessons);
+  const positive = humanReviewed.filter((lesson) => isPositiveSignal(lesson.signal)).length;
+  const negative = humanReviewed.filter((lesson) => isNegativeSignal(lesson.signal)).length;
+  const avgConfidence = humanReviewed.length > 0
+    ? Math.round(humanReviewed.reduce((sum, lesson) => sum + (lesson.confidence || 0), 0) / humanReviewed.length)
+    : 0;
+  return { total: positive + negative, positive, negative, avgConfidence,
+    rawTotal: lessons.length, excludedTotal: lessons.length - humanReviewed.length };
 }
 
 // ---------------------------------------------------------------------------
@@ -650,6 +668,7 @@ async function inferStructuredLessonLLM(conversationWindow, signal, context) {
 module.exports = {
   inferFromSurroundingMessages, createLesson, getRecentLesson,
   searchLessons, getLessonStats, getStatusbarLessonData, getAllLessonsForContext,
+  isHumanReviewedLesson,
   getLessonsPath, getRecentLessonPath,
   selectStatusbarLesson, getLessonKind, stripLessonPrefix,
   formatLessonTimestamp, buildStatusbarLessonLabel,

--- a/scripts/prove-packaged-runtime.js
+++ b/scripts/prove-packaged-runtime.js
@@ -219,8 +219,8 @@ async function runPackagedRuntimeSmoke(options = {}) {
   fs.writeFileSync(
     path.join(feedbackDir, 'feedback-log.jsonl'),
     [
-      JSON.stringify({ signal: 'positive', timestamp: '2026-04-08T20:00:00.000Z', context: 'packaged runtime smoke pass' }),
-      JSON.stringify({ signal: 'negative', timestamp: '2026-04-08T20:01:00.000Z', context: 'packaged runtime smoke fail path' }),
+      JSON.stringify({ signal: 'positive', reviewOrigin: 'human', timestamp: '2026-04-08T20:00:00.000Z', context: 'packaged runtime smoke pass' }),
+      JSON.stringify({ signal: 'negative', reviewOrigin: 'human', timestamp: '2026-04-08T20:01:00.000Z', context: 'packaged runtime smoke fail path' }),
     ].join('\n') + '\n'
   );
 

--- a/scripts/statusline-local-stats.js
+++ b/scripts/statusline-local-stats.js
@@ -16,7 +16,7 @@ try {
   const scope = String(process.env.THUMBGATE_STATUSLINE_SCOPE || 'global').toLowerCase();
   const stats = scope !== 'project' && shouldAggregateFeedback({ env: process.env })
     ? computeAggregateFeedbackStats({ projectDir, env: process.env })
-    : analyzeFeedback();
+    : analyzeFeedback(undefined, { humanOnly: true });
   const payload = {
     ...normalizeStatsPayload(stats),
     aggregate: stats.aggregate || { enabled: false },

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5684,10 +5684,31 @@ function createApiServer() {
       return;
     }
 
-    // Quick feedback capture via GET — for statusline clickable links
-    if (isGetLikeRequest && pathname === '/feedback/quick') {
+    // GET/HEAD only render a confirmation. Capture requires an authenticated
+    // POST so prefetchers and link checkers cannot create human feedback.
+    if ((isGetLikeRequest || req.method === 'POST') && pathname === '/feedback/quick') {
       const signal = parsed.searchParams.get('signal');
       if (signal === 'up' || signal === 'down') {
+        const emoji = signal === 'up' ? '👍' : '👎';
+        const label = signal === 'up' ? 'Positive' : 'Negative';
+        if (isHeadRequest) {
+          sendHtml(res, 200, '', {}, { headOnly: true });
+          return;
+        }
+        if (req.method === 'GET') {
+          sendHtml(res, 200, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>ThumbGate feedback</title></head>
+<body style="background:#0a0a0a;color:#fff;font-family:system-ui;display:grid;place-items:center;height:100vh;margin:0">
+<form method="post" action="/feedback/quick?signal=${signal}" style="text-align:center;background:#141414;padding:40px;border-radius:16px">
+<div style="font-size:64px">${emoji}</div><h1>Record ${label.toLowerCase()} feedback?</h1>
+<p>This confirmation prevents previews and crawlers from recording feedback.</p>
+<button type="submit" style="padding:10px 20px;font-weight:700">Record ${emoji} feedback</button>
+</form></body></html>`);
+          return;
+        }
+        if (!isAuthorized(req, expectedApiKey)) {
+          sendJson(res, 401, { error: 'Authentication required to record human feedback' });
+          return;
+        }
         const chatHistory = readRecentConversationWindow({
           feedbackDir: requestSafeDataDir,
           limit: 10,
@@ -5699,34 +5720,15 @@ function createApiServer() {
           tags: ['statusline', 'quick-capture'],
           reviewOrigin: 'human',
         });
-        const emoji = signal === 'up' ? '👍' : '👎';
-        const color = signal === 'up' ? '#22c55e' : '#ef4444';
-        const label = signal === 'up' ? 'Positive' : 'Negative';
         const opposite = signal === 'up' ? 'down' : 'up';
         const oppEmoji = signal === 'up' ? '👎' : '👍';
         const feedbackId = result.feedbackEvent?.id || 'saved';
         const promoted = result.accepted ? 'Promoted to memory' : 'Stored';
         sendHtml(res, 200, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>ThumbGate — ${label} feedback</title>
 <style>
-*{box-sizing:border-box}
 body{background:#0a0a0a;color:#fff;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
 .card{text-align:center;background:#141414;border:1px solid #222;border-radius:16px;padding:48px 40px;max-width:420px;width:90%;box-shadow:0 8px 32px rgba(0,0,0,.5)}
-.emoji{font-size:80px;margin-bottom:12px;animation:pop .4s ease-out}
-@keyframes pop{0%{transform:scale(0)}50%{transform:scale(1.2)}100%{transform:scale(1)}}
-.msg{font-size:22px;color:${color};font-weight:700;margin-bottom:4px}
-.sub{font-size:13px;color:#666;margin-top:6px;font-family:ui-monospace,monospace}
-.context-form{margin-top:20px;text-align:left}
-.context-form label{font-size:12px;color:#888;display:block;margin-bottom:6px}
-.context-form textarea{width:100%;background:#1a1a1a;border:1px solid #333;border-radius:8px;color:#ccc;padding:10px;font-size:13px;resize:vertical;min-height:60px;font-family:system-ui}
-.context-form textarea:focus{outline:none;border-color:${color}}
-.context-form button{margin-top:8px;background:${color};color:#000;border:none;border-radius:8px;padding:8px 20px;font-size:13px;font-weight:600;cursor:pointer}
-.context-form button:hover{opacity:.85}
-.actions{margin-top:24px;display:flex;gap:12px;justify-content:center;flex-wrap:wrap}
-.actions a{color:#22d3ee;text-decoration:none;font-size:13px;padding:8px 16px;border:1px solid #333;border-radius:8px;transition:all .15s}
-.actions a:hover{background:#1a2a2e;border-color:#22d3ee}
-.toast{position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:#22c55e;color:#000;padding:10px 24px;border-radius:8px;font-size:14px;font-weight:600;display:none;animation:slideUp .3s ease-out}
-@keyframes slideUp{from{opacity:0;transform:translateX(-50%) translateY(12px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
-.badge{display:inline-block;font-size:11px;padding:2px 8px;border-radius:4px;background:#1a1a1a;border:1px solid #333;color:#888;margin-top:8px}
+.emoji{font-size:64px}.sub,label{color:#888}textarea{width:100%;min-height:60px}.actions{margin-top:20px}.actions a{color:#22d3ee;margin:8px}
 </style></head><body>
 <div class="card">
   <div class="emoji">${emoji}</div>
@@ -5739,7 +5741,7 @@ body{background:#0a0a0a;color:#fff;font-family:system-ui,-apple-system,sans-seri
   </div>
   <div class="actions">
     <a href="/lessons/${feedbackId}" title="View the full lesson and edit it">📋 View Lesson</a>
-    <a href="/feedback/quick?signal=${opposite}" title="Meant to click ${oppEmoji}?">Undo → send ${oppEmoji} instead</a>
+    <a href="/feedback/quick?signal=${opposite}" title="Meant to click ${oppEmoji}?">Record ${oppEmoji} instead</a>
     <a href="/dashboard">Dashboard →</a>
   </div>
 </div>
@@ -5763,6 +5765,10 @@ async function addContext(){
     }
 
     if (req.method === 'POST' && pathname === '/feedback/quick/context') {
+      if (!isAuthorized(req, expectedApiKey)) {
+        sendJson(res, 401, { error: 'Authentication required to update human feedback' });
+        return;
+      }
       const body = await parseJsonBody(req);
       const signal = body.signal;
       const context = typeof body.context === 'string' ? body.context.trim() : '';

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5697,6 +5697,7 @@ function createApiServer() {
           context: 'Quick capture from Claude Code statusline',
           chatHistory,
           tags: ['statusline', 'quick-capture'],
+          reviewOrigin: 'human',
         });
         const emoji = signal === 'up' ? '👍' : '👎';
         const color = signal === 'up' ? '#22c55e' : '#ef4444';
@@ -8514,7 +8515,7 @@ a{color:#8b9}</style></head><body><form class="card" method="post" action="/oaut
       if (req.method === 'GET' && pathname === '/v1/feedback/stats') {
         const stats = shouldAggregateFeedback()
           ? computeAggregateFeedbackStats({ feedbackDir: requestFeedbackPaths.FEEDBACK_DIR })
-          : analyzeFeedback(requestFeedbackPaths.FEEDBACK_LOG_PATH);
+          : analyzeFeedback(requestFeedbackPaths.FEEDBACK_LOG_PATH, { humanOnly: true });
         try {
           const { getStatuslineMeta } = require('../../scripts/statusline-meta');
           const meta = getStatuslineMeta({ env: process.env });
@@ -9329,6 +9330,7 @@ a{color:#8b9}</style></head><body><form class="card" method="post" action="/oaut
           guardrails: body.guardrails,
           tags: extractTags(body.tags),
           skill: body.skill,
+          reviewOrigin: 'human',
         });
         const actionIntegration = inferActionIntegration(body, req.headers);
         appendBestEffortTelemetry(requestFeedbackDir, {

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -2062,6 +2062,7 @@ test('feedback capture accepts valid payload', async () => {
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.accepted, true);
+  assert.equal(body.feedbackEvent.reviewOrigin, 'human');
   assert.ok(body.memoryRecord);
 });
 
@@ -2414,14 +2415,16 @@ test('default feedback stats stay on THUMBGATE_FEEDBACK_DIR even when INIT_CWD i
   const savedInitCwd = process.env.INIT_CWD;
   const feedbackLogPath = path.join(tmpFeedbackDir, 'feedback-log.jsonl');
   const baselineEntries = fs.existsSync(feedbackLogPath) ? readJsonl(feedbackLogPath) : [];
-  const baselineTotal = baselineEntries.length;
-  const baselinePositive = baselineEntries.filter((entry) => entry.signal === 'positive').length;
-  const baselineNegative = baselineEntries.filter((entry) => entry.signal === 'negative').length;
   process.env.INIT_CWD = path.join(os.tmpdir(), 'thumbgate-init-cwd-project');
   try {
+    const baselineRes = await fetch(apiUrl('/v1/feedback/stats'), { headers: authHeader });
+    assert.equal(baselineRes.status, 200);
+    const baseline = await baselineRes.json();
+
     fs.appendFileSync(feedbackLogPath, `${JSON.stringify({
       id: 'fb_initcwd_scope_guard',
       signal: 'positive',
+      reviewOrigin: 'human',
       context: 'Explicit feedback dir should remain authoritative',
       timestamp: '2026-04-08T10:00:00.000Z',
     })}\n`);
@@ -2429,9 +2432,9 @@ test('default feedback stats stay on THUMBGATE_FEEDBACK_DIR even when INIT_CWD i
     const updatedRes = await fetch(apiUrl('/v1/feedback/stats'), { headers: authHeader });
     assert.equal(updatedRes.status, 200);
     const updatedBody = await updatedRes.json();
-    assert.equal(updatedBody.total, baselineTotal + 1);
-    assert.equal(updatedBody.totalPositive, baselinePositive + 1);
-    assert.equal(updatedBody.totalNegative, baselineNegative);
+    assert.equal(updatedBody.total, baseline.total + 1);
+    assert.equal(updatedBody.totalPositive, baseline.totalPositive + 1);
+    assert.equal(updatedBody.totalNegative, baseline.totalNegative);
   } finally {
     if (baselineEntries.length > 0) {
       fs.writeFileSync(feedbackLogPath, `${baselineEntries.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
@@ -2453,6 +2456,7 @@ test('project-scoped endpoints honor explicit project selection for stats, lesso
       JSON.stringify({
         id: 'fb_project_positive',
         signal: 'positive',
+        reviewOrigin: 'human',
         context: 'Verified project alpha release flow',
         tags: ['verification', 'alpha'],
         timestamp: '2026-04-08T09:00:00.000Z',
@@ -2460,6 +2464,7 @@ test('project-scoped endpoints honor explicit project selection for stats, lesso
       JSON.stringify({
         id: 'fb_project_negative',
         signal: 'negative',
+        reviewOrigin: 'human',
         context: 'Skipped rollback checklist for project alpha',
         tags: ['release', 'alpha'],
         timestamp: '2026-04-08T09:05:00.000Z',

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -2170,20 +2170,42 @@ test('feedback capture promotes specific positive feedback even when tags are om
   assert.ok(body.memoryRecord.tags.includes('thumbgate'));
 });
 
-test('quick feedback capture via GET /feedback/quick?signal=up returns HTML confirmation', async () => {
+test('quick feedback GET renders a deliberate confirmation without recording feedback', async () => {
+  const { feedbackLogPath } = getConversationPaths(tmpFeedbackDir);
+  const before = readJsonl(feedbackLogPath).length;
   const res = await fetch(apiUrl('/feedback/quick?signal=up'), { headers: authHeader });
   assert.equal(res.status, 200);
   const html = await res.text();
   assert.ok(html.includes('👍'), 'should show thumbs up emoji');
-  assert.ok(html.includes('Positive feedback recorded'), 'should confirm capture with friendly label');
-  assert.ok(html.includes('Undo'), 'should offer undo action');
-  assert.ok(html.includes('signal=down'), 'undo link should point to opposite signal');
-  assert.ok(html.includes('Add follow-up context'), 'should offer follow-up context input');
-  assert.ok(html.includes('/feedback/quick/context'), 'should post follow-up notes to the public quick-feedback endpoint');
-  assert.match(html, /feedbackSessionId:'fbs_/i, 'quick-feedback page should carry the open feedback session id forward');
+  assert.ok(html.includes('Record positive feedback?'));
+  assert.match(html, /<form method="post" action="\/feedback\/quick\?signal=up"/);
+  assert.equal(readJsonl(feedbackLogPath).length, before);
 });
 
-test('quick feedback capture via GET /feedback/quick?signal=down returns HTML confirmation', async () => {
+test('quick feedback HEAD and unauthenticated POST never record human feedback', async () => {
+  const { feedbackLogPath } = getConversationPaths(tmpFeedbackDir);
+  const before = readJsonl(feedbackLogPath).length;
+  const headRes = await fetch(apiUrl('/feedback/quick?signal=up'), { method: 'HEAD' });
+  assert.equal(headRes.status, 200);
+  const postRes = await fetch(apiUrl('/feedback/quick?signal=up'), { method: 'POST' });
+  assert.equal(postRes.status, 401);
+  assert.equal(readJsonl(feedbackLogPath).length, before);
+});
+
+test('authenticated quick feedback POST records explicit human provenance', async () => {
+  const res = await fetch(apiUrl('/feedback/quick?signal=up'), {
+    method: 'POST',
+    headers: authHeader,
+  });
+  assert.equal(res.status, 200);
+  const html = await res.text();
+  assert.ok(html.includes('Positive feedback recorded'));
+  const { feedbackLogPath } = getConversationPaths(tmpFeedbackDir);
+  const latest = readJsonl(feedbackLogPath).at(-1);
+  assert.equal(latest.reviewOrigin, 'human');
+});
+
+test('authenticated quick feedback POST distills negative conversation context', async () => {
   recordConversationEntry({
     author: 'user',
     text: 'Never skip tests before claiming done.',
@@ -2195,13 +2217,16 @@ test('quick feedback capture via GET /feedback/quick?signal=down returns HTML co
     source: 'statusline-test',
   }, { feedbackDir: tmpFeedbackDir });
 
-  const res = await fetch(apiUrl('/feedback/quick?signal=down'), { headers: authHeader });
+  const res = await fetch(apiUrl('/feedback/quick?signal=down'), {
+    method: 'POST',
+    headers: authHeader,
+  });
   assert.equal(res.status, 200);
   const html = await res.text();
   assert.ok(html.includes('👎'), 'should show thumbs down emoji');
   assert.ok(html.includes('Negative feedback recorded'), 'should confirm capture with friendly label');
-  assert.ok(html.includes('Undo'), 'should offer undo action');
-  assert.ok(html.includes('signal=up'), 'undo link should point to opposite signal');
+  assert.ok(html.includes('Record 👍 instead'), 'should offer a deliberate opposite-signal action');
+  assert.ok(html.includes('signal=up'), 'opposite-signal link should point to the confirmation page');
 
   const { feedbackLogPath } = getConversationPaths(tmpFeedbackDir);
   const logEntries = readJsonl(feedbackLogPath);
@@ -2217,7 +2242,10 @@ test('quick feedback capture without signal returns 400', async () => {
 });
 
 test('quick feedback follow-up context endpoint enriches the original lesson without creating a duplicate record', async () => {
-  const captureRes = await fetch(apiUrl('/feedback/quick?signal=up'), { headers: authHeader });
+  const captureRes = await fetch(apiUrl('/feedback/quick?signal=up'), {
+    method: 'POST',
+    headers: authHeader,
+  });
   assert.equal(captureRes.status, 200);
   const captureHtml = await captureRes.text();
   const relatedFeedbackId = captureHtml.match(/\/lessons\/([^"']+)/)?.[1];
@@ -2227,7 +2255,7 @@ test('quick feedback follow-up context endpoint enriches the original lesson wit
 
   const res = await fetch(apiUrl('/feedback/quick/context'), {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...authHeader },
     body: JSON.stringify({
       signal: 'up',
       context: 'Thorough PR review',

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1297,6 +1297,28 @@ describe('bin/cli.js', () => {
     fs.rmSync(freeHome, { recursive: true, force: true });
   });
 
+  test('summary text excludes automated and imported feedback like summary JSON', () => {
+    const feedbackDir = makeTmpDir();
+    fs.writeFileSync(path.join(feedbackDir, 'feedback-log.jsonl'), [
+      JSON.stringify({ signal: 'positive', reviewOrigin: 'human', timestamp: new Date().toISOString() }),
+      JSON.stringify({ signal: 'negative', reviewOrigin: 'automated', timestamp: new Date().toISOString() }),
+      JSON.stringify({ signal: 'negative', reviewOrigin: 'imported', timestamp: new Date().toISOString() }),
+    ].join('\n') + '\n');
+
+    const result = runCliSync(['summary'], {
+      env: {
+        ...process.env,
+        THUMBGATE_FEEDBACK_DIR: feedbackDir,
+        THUMBGATE_NO_NUDGE: '1',
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Feedback Summary \(last 1\)/);
+    assert.match(result.stdout, /Positive: 1/);
+    assert.match(result.stdout, /Negative: 0/);
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
+  });
+
   test('help command shows Pro nudge on stderr', () => {
     // proNudge gates on isProTier(); CI sets THUMBGATE_API_KEY at the workflow
     // level, so we must build an explicitly-unlicensed env to exercise the

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -727,6 +727,7 @@ describe('bin/cli.js', () => {
     const memoryLog = fs.readFileSync(path.join(feedbackDir, 'memory-log.jsonl'), 'utf8');
     assert.match(feedbackLog, new RegExp(payload.feedbackId));
     assert.match(memoryLog, new RegExp(payload.memoryId));
+    assert.equal(JSON.parse(feedbackLog.trim()).reviewOrigin, 'automated');
 
     fs.rmSync(feedbackDir, { recursive: true, force: true });
   });
@@ -985,6 +986,7 @@ describe('bin/cli.js', () => {
         submittedContext: 'thumbs up Thorough PR review',
         whatWorked: 'thumbs up Thorough PR review',
         actionType: 'store-learning',
+        reviewOrigin: 'human',
         timestamp: '2026-04-09T15:07:34.046Z',
       })}\n`
     );
@@ -2857,6 +2859,7 @@ describe('bin/cli.js', () => {
       .split(/\r?\n/)
       .map((line) => JSON.parse(line));
     assert.equal(feedbackRows[0].context, 'skipped verification proof');
+    assert.equal(feedbackRows[0].reviewOrigin, 'human');
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(feedbackDir, { recursive: true, force: true });
   });

--- a/tests/e2e-product-flows.test.js
+++ b/tests/e2e-product-flows.test.js
@@ -362,9 +362,7 @@ test('E2E: vague thumbs-down distills a lesson and preserves linked follow-up co
 
   const followUpRes = await fetch(apiUrl(port, '/feedback/quick/context'), {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: adminHeaders,
     body: JSON.stringify({
       signal: 'down',
       context: 'Also ignored the design-system rule in the same pass.',

--- a/tests/jsonl-watcher.test.js
+++ b/tests/jsonl-watcher.test.js
@@ -85,6 +85,10 @@ test('processNewEntries: processes new bridged entries and returns correct count
   const result = processNewEntries(tmpDir, logPath);
   assert.strictEqual(result.processed, 2);
   assert.strictEqual(typeof result.promoted, 'number');
+  const rows = fs.readFileSync(logPath, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+  const bridged = rows.filter((entry) => entry.tags?.includes('watcher-ingested'));
+  assert.ok(bridged.length >= 1);
+  assert.ok(bridged.every((entry) => entry.reviewOrigin === 'imported'));
 });
 
 test('processNewEntries: skips already-processed entries (idempotency via offset)', (t) => {

--- a/tests/lesson-stats-review-origin.test.js
+++ b/tests/lesson-stats-review-origin.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  captureFeedback,
+  analyzeFeedback,
+} = require('../scripts/feedback-loop');
+const {
+  createLesson,
+  getLessonStats,
+  isHumanReviewedLesson,
+} = require('../scripts/lesson-inference');
+
+const savedFeedbackDir = process.env.THUMBGATE_FEEDBACK_DIR;
+const savedTelemetryOptOut = process.env.THUMBGATE_DISABLE_TELEMETRY;
+
+test.after(() => {
+  if (savedFeedbackDir === undefined) delete process.env.THUMBGATE_FEEDBACK_DIR;
+  else process.env.THUMBGATE_FEEDBACK_DIR = savedFeedbackDir;
+  if (savedTelemetryOptOut === undefined) delete process.env.THUMBGATE_DISABLE_TELEMETRY;
+  else process.env.THUMBGATE_DISABLE_TELEMETRY = savedTelemetryOptOut;
+});
+
+function useTemporaryFeedbackDir(t) {
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-review-origin-'));
+  process.env.THUMBGATE_FEEDBACK_DIR = feedbackDir;
+  process.env.THUMBGATE_DISABLE_TELEMETRY = '1';
+  t.after(() => fs.rmSync(feedbackDir, { recursive: true, force: true }));
+  return feedbackDir;
+}
+
+test('getLessonStats counts explicit human review once and excludes automation', async (t) => {
+  useTemporaryFeedbackDir(t);
+
+  const humanResult = captureFeedback({
+    signal: 'up',
+    context: 'The verified deployment evidence matched the production build.',
+    whatWorked: 'The response included the exact merge and production SHAs.',
+    tags: ['verification'],
+    reviewOrigin: 'human',
+  });
+  const automatedResult = captureFeedback({
+    signal: 'down',
+    context: 'Synthetic proof fixture for an internal retry policy.',
+    whatWentWrong: 'Fixture failure used to exercise automated evaluation.',
+    whatToChange: 'Keep synthetic evaluations isolated from human feedback metrics.',
+    tags: ['synthetic', 'test-suite'],
+    reviewOrigin: 'automated',
+  });
+
+  assert.equal(humanResult.accepted, true);
+  assert.equal(automatedResult.accepted, true);
+  assert.equal(humanResult.feedbackEvent.reviewOrigin, 'human');
+  assert.equal(automatedResult.feedbackEvent.reviewOrigin, 'automated');
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const stats = getLessonStats();
+  assert.deepEqual(stats, {
+    total: 1,
+    positive: 1,
+    negative: 0,
+    avgConfidence: 70,
+    rawTotal: 2,
+    excludedTotal: 1,
+  });
+  const humanStats = analyzeFeedback(undefined, { humanOnly: true });
+  assert.equal(humanStats.totalPositive, 1);
+  assert.equal(humanStats.totalNegative, 0);
+  assert.equal(humanStats.total, 1);
+  assert.equal(humanStats.approvalRate, 1);
+  assert.equal(humanStats.rawTotal, 2);
+  assert.equal(humanStats.excludedTotal, 1);
+});
+
+test('unverified legacy rows are excluded and explicit human reviews are deduplicated', (t) => {
+  useTemporaryFeedbackDir(t);
+
+  const legacyHuman = {
+    feedbackId: 'fb_legacy_human',
+    signal: 'negative',
+    inferredLesson: 'Verify production before making a deployment claim.',
+    triggerMessage: 'The CEO asked whether the release was really deployed.',
+    confidence: 80,
+    metadata: { reviewOrigin: 'human' },
+  };
+  createLesson(legacyHuman);
+  createLesson(legacyHuman);
+  createLesson({
+    feedbackId: 'fb_legacy_unverified',
+    signal: 'negative',
+    inferredLesson: 'A legacy row without provenance.',
+    triggerMessage: 'Concrete but unverified historical context',
+    confidence: 90,
+  });
+  createLesson({
+    feedbackId: 'fb_automated',
+    signal: 'positive',
+    inferredLesson: 'Synthetic evaluation passed.',
+    triggerMessage: 'Automated evaluator result',
+    confidence: 100,
+    metadata: {
+      source: 'session-analyzer',
+    },
+  });
+
+  assert.equal(isHumanReviewedLesson({
+    metadata: { reviewOrigin: 'human' },
+  }), true);
+  assert.equal(isHumanReviewedLesson({
+    feedbackId: 'fb_legacy_unverified',
+    triggerMessage: 'Concrete but unverified historical context',
+  }), false);
+  assert.equal(isHumanReviewedLesson({
+    feedbackId: 'fb_automated',
+    triggerMessage: 'Automated evaluator result',
+    metadata: { source: 'session-analyzer' },
+  }), false);
+
+  assert.deepEqual(getLessonStats(), {
+    total: 1,
+    positive: 0,
+    negative: 1,
+    avgConfidence: 80,
+    rawTotal: 4,
+    excludedTotal: 3,
+  });
+});

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -547,6 +547,8 @@ test('capture_feedback tool can be called', async () => {
 
   assert.equal(Array.isArray(result.content), true);
   assert.match(result.content[0].text, /accepted|Feedback/i);
+  const payload = JSON.parse(result.content[0].text);
+  assert.equal(payload.feedbackEvent.reviewOrigin, 'automated');
 });
 
 test('capture_feedback applies rubric anti-hacking gate', async () => {

--- a/tests/statusline-aggregation.test.js
+++ b/tests/statusline-aggregation.test.js
@@ -32,6 +32,7 @@ function feedback(id, signal, daysAgo = 0, extra = {}) {
     signal,
     context: `${signal} feedback ${id}`,
     timestamp,
+    reviewOrigin: 'human',
     ...extra,
   };
 }
@@ -168,5 +169,35 @@ test('aggregate entry reader keeps temp feedback dirs isolated unless roots are 
   assert.equal(stats.totalPositive, 1);
   assert.equal(rows.entries.length, 1);
 
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('statusline aggregation excludes automated and unverified feedback rows', () => {
+  const root = tmpDir('thumbgate-human-only-');
+  const store = path.join(root, 'feedback');
+  writeJsonl(path.join(store, 'feedback-log.jsonl'), [
+    feedback('human-up', 'positive'),
+    feedback('automated-down', 'negative', 0, { reviewOrigin: 'automated' }),
+    {
+      id: 'legacy-unverified',
+      signal: 'negative',
+      timestamp: new Date().toISOString(),
+    },
+  ]);
+
+  const stats = computeAggregateFeedbackStats({
+    feedbackDir: store,
+    env: {
+      ...process.env,
+      HOME: path.join(root, 'home'),
+      USERPROFILE: path.join(root, 'home'),
+    },
+  });
+
+  assert.equal(stats.total, 1);
+  assert.equal(stats.totalPositive, 1);
+  assert.equal(stats.totalNegative, 0);
+  assert.equal(stats.rawTotal, 3);
+  assert.equal(stats.excludedTotal, 2);
   fs.rmSync(root, { recursive: true, force: true });
 });

--- a/tests/statusline-e2e.test.js
+++ b/tests/statusline-e2e.test.js
@@ -68,7 +68,10 @@ function dedupedSummary(...entryGroups) {
 function writeLog(dir, entries) {
   fs.mkdirSync(dir, { recursive: true });
   const logPath = path.join(dir, 'feedback-log.jsonl');
-  fs.writeFileSync(logPath, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+  fs.writeFileSync(
+    logPath,
+    entries.map((entry) => JSON.stringify({ ...entry, reviewOrigin: 'human' })).join('\n') + '\n'
+  );
   return logPath;
 }
 

--- a/tests/statusline.test.js
+++ b/tests/statusline.test.js
@@ -164,9 +164,9 @@ test('statusline rebuilds counters from local feedback logs when cache is empty'
   fs.writeFileSync(
     path.join(tmpDir, 'feedback-log.jsonl'),
     [
-      JSON.stringify({ signal: 'positive', timestamp: '2026-04-08T10:00:00.000Z', context: 'verified fix' }),
-      JSON.stringify({ signal: 'negative', timestamp: '2026-04-08T10:01:00.000Z', context: 'unverified claim' }),
-      JSON.stringify({ signal: 'negative', timestamp: '2026-04-08T10:02:00.000Z', context: 'scope creep' }),
+      JSON.stringify({ signal: 'positive', timestamp: '2026-04-08T10:00:00.000Z', context: 'verified fix', reviewOrigin: 'human' }),
+      JSON.stringify({ signal: 'negative', timestamp: '2026-04-08T10:01:00.000Z', context: 'unverified claim', reviewOrigin: 'human' }),
+      JSON.stringify({ signal: 'negative', timestamp: '2026-04-08T10:02:00.000Z', context: 'scope creep', reviewOrigin: 'human' }),
     ].join('\n') + '\n'
   );
   fs.writeFileSync(
@@ -352,9 +352,9 @@ test('statusline resolves project feedback from Claude cwd instead of the runtim
   fs.writeFileSync(
     path.join(feedbackDir, 'feedback-log.jsonl'),
     [
-      JSON.stringify({ signal: 'positive', timestamp: '2026-04-09T18:00:00.000Z', context: 'kept scope tight' }),
-      JSON.stringify({ signal: 'positive', timestamp: '2026-04-09T18:01:00.000Z', context: 'verified clean worktree' }),
-      JSON.stringify({ signal: 'negative', timestamp: '2026-04-09T18:02:00.000Z', context: 'stale runtime cwd' }),
+      JSON.stringify({ signal: 'positive', reviewOrigin: 'human', timestamp: '2026-04-09T18:00:00.000Z', context: 'kept scope tight' }),
+      JSON.stringify({ signal: 'positive', reviewOrigin: 'human', timestamp: '2026-04-09T18:01:00.000Z', context: 'verified clean worktree' }),
+      JSON.stringify({ signal: 'negative', reviewOrigin: 'human', timestamp: '2026-04-09T18:02:00.000Z', context: 'stale runtime cwd' }),
     ].join('\n') + '\n'
   );
 

--- a/tests/truth-and-proof.test.js
+++ b/tests/truth-and-proof.test.js
@@ -3,6 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { execSync, execFileSync } = require('child_process');
 
@@ -67,16 +68,26 @@ test('require-proof.js - allows commit when tests_passed is tracked', (t) => {
 
 test('ingest-manual-feedback.js - ingests and marks files as ingested', (t) => {
   const memoryDir = path.join(REPO_ROOT, 'memory');
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-ingest-test-'));
+  t.after(() => fs.rmSync(feedbackDir, { recursive: true, force: true }));
   if (!fs.existsSync(memoryDir)) fs.mkdirSync(memoryDir, { recursive: true });
   
   const feedbackFile = path.join(memoryDir, 'feedback_test_mistake.md');
   const content = 'MISTAKE: This is a test failure';
   fs.writeFileSync(feedbackFile, content);
 
-  execFileSync(process.execPath, [INGEST_FEEDBACK], { cwd: REPO_ROOT });
+  execFileSync(process.execPath, [INGEST_FEEDBACK], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, THUMBGATE_FEEDBACK_DIR: feedbackDir },
+  });
 
   assert.ok(!fs.existsSync(feedbackFile), 'Original file should be gone');
   assert.ok(fs.existsSync(`${feedbackFile}.ingested`), 'File should be marked as ingested');
-  
+  const feedbackRows = fs.readFileSync(path.join(feedbackDir, 'feedback-log.jsonl'), 'utf8')
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => JSON.parse(line));
+  assert.equal(feedbackRows.at(-1).reviewOrigin, 'imported');
+
   if (fs.existsSync(`${feedbackFile}.ingested`)) fs.unlinkSync(`${feedbackFile}.ingested`);
 });


### PR DESCRIPTION
## What changed

- adds canonical `reviewOrigin` provenance (`human`, `automated`, `imported`, or `unverified`) to feedback events, memories, and inferred lessons
- stamps authenticated user-facing capture paths as human while keeping self-tests and imports out of human KPI totals
- makes CLI, API, MCP, and statusline metrics report verified human feedback only, with raw/excluded counts for observability
- deduplicates lesson statistics by feedback event and excludes unverified legacy rows
- fixes immediate CLI stats so the just-captured human signal is visible before deferred lesson indexing completes

## Why

The existing feedback totals mixed synthetic proof fixtures, automated evaluations, imports, duplicate lesson writes, and genuine user ratings. PR #3011 attempted to distinguish them by checking `triggerMessage`, but that field is not reliable provenance and can both exclude real feedback and include automated session analysis.

This PR replaces that heuristic with explicit, validated provenance. Unknown historical data remains `unverified` instead of being guessed as human.

Supersedes #3011.

## Impact

- human approval and thumbs counts become conservative, evidence-backed KPIs
- automation data remains available in raw operational analytics but cannot inflate human feedback
- existing unproven historical events are visible through `rawTotal` and `excludedTotal`
- packaged runtime size remains within the 5.40 MB boundary

## Verification

- `npm ci` — 0 vulnerabilities
- `npm test` — pass
- `npm run test:coverage` — 87.05% lines, 74.55% branches, 88.61% functions
- `npm run prove:adapters` — 48/48
- `npm run prove:automation` — 55/55
- `npm run self-heal:check` — 6/6 healthy
- post-rebase affected suite — 347/347
- packaged runtime proof — 7/7
- unpacked npm artifact — 5,399,787 bytes

See [VERIFICATION_EVIDENCE.md](https://github.com/IgorGanapolsky/ThumbGate/blob/main/VERIFICATION_EVIDENCE.md) for the repository-wide proof contract.
