### PR TITLE
feat(growth): verify campaign conversion outcomes

### DIFF
--- a/.changeset/campaign-conversion-proof.md
+++ b/.changeset/campaign-conversion-proof.md
@@ -1,0 +1,6 @@
+---
+thumbgate: patch
+---
+
+Add canonical campaign attribution, safe buyer-route verification, and hourly
+hosted outcome monitoring for the seven-channel marketing-agent campaign.

--- a/package.json
+++ b/package.json
@@ -697,6 +697,7 @@
     "social:publish:latest-release-article": "node scripts/social-analytics/publish-latest-release-article.js",
     "social:publish:latest-release-fallbacks": "node scripts/social-analytics/publish-latest-release-fallbacks.js",
     "social:verify:latest-release": "node scripts/social-analytics/verify-latest-release-posts.js",
+    "social:verify:marketing-agent": "node scripts/social-analytics/verify-marketing-agent-campaign.js",
     "social:schedule:campaign": "node scripts/social-analytics/schedule-thumbgate-campaign.js",
     "social:install:growth": "node scripts/social-analytics/install-growth-automation.js",
     "social:reconcile:campaign": "node scripts/social-analytics/reconcile-thumbgate-campaign.js",

--- a/scripts/billing.js
+++ b/scripts/billing.js
@@ -30,6 +30,7 @@ const {
   resolveFallbackArtifactPath,
 } = require('./feedback-paths');
 const { getTelemetryAnalytics, getTelemetrySourceDiagnostics } = require('./telemetry-analytics');
+const { normalizeCampaignId } = require('./growth-campaigns');
 const {
   PRO_MONTHLY_PRICE_ID,
   PRO_ANNUAL_PRICE_ID,
@@ -1154,7 +1155,7 @@ function extractAttribution(metadata = {}) {
   return {
     source: normalizeText(safe.utmSource || safe.source),
     medium: normalizeText(safe.utmMedium || safe.medium),
-    campaign: normalizeText(safe.utmCampaign || safe.campaign),
+    campaign: normalizeCampaignId(safe.utmCampaign || safe.campaign),
     content: normalizeText(safe.utmContent || safe.content),
     term: normalizeText(safe.utmTerm || safe.term),
     creator: normalizeText(safe.creator || safe.creatorHandle || safe.creator_handle),
@@ -4237,6 +4238,7 @@ module.exports = {
   _TRIAL_EMAIL_LEDGER_PATH: () => CONFIG.TRIAL_EMAIL_LEDGER_PATH,
   _ORDER_EMAIL_LEDGER_PATH: () => CONFIG.ORDER_EMAIL_LEDGER_PATH,
   _LOCAL_MODE: () => LOCAL_MODE(),
+  _extractAttribution: extractAttribution,
   _withTimeout: withTimeout,
   _mailer: mailer,
 };

--- a/scripts/growth-campaigns.js
+++ b/scripts/growth-campaigns.js
@@ -1,6 +1,146 @@
 #!/usr/bin/env node
 'use strict';
 
+const MARKETING_AGENT_CAMPAIGN_ID = 'marketing_agent_governance_20260727';
+const CAMPAIGN_ALIASES = Object.freeze({
+  mg27: MARKETING_AGENT_CAMPAIGN_ID,
+});
+const MARKETING_AGENT_CAMPAIGN = Object.freeze({
+  campaignId: MARKETING_AGENT_CAMPAIGN_ID,
+  aliases: ['mg27'],
+  episode: {
+    title: 'Marketing Agents Are Too Good Now',
+    url: 'https://www.youtube.com/watch?v=U2hogriGmEw',
+  },
+  channels: [
+    {
+      channel: 'linkedin',
+      status: 'LIVE',
+      permalink: 'https://www.linkedin.com/feed/update/urn:li:share:7487654549785128960/',
+      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=linkedin&utm_medium=organic_social&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_response',
+    },
+    {
+      channel: 'hashnode',
+      status: 'LIVE',
+      permalink: 'https://ai-agent-blog-12345.hashnode.dev/your-marketing-agent-can-publish-and-pause-ads-who-gates-the-write',
+      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=hashnode&utm_medium=organic_article&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_deep_dive',
+    },
+    {
+      channel: 'bluesky',
+      status: 'LIVE',
+      permalink: 'https://bsky.app/profile/iganapolsky.bsky.social/post/3mro3mkmrzc2y',
+      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=bluesky&utm_medium=social&utm_campaign=mg27',
+    },
+    {
+      channel: 'threads',
+      status: 'LIVE',
+      permalink: 'https://www.threads.com/@igorganapolsky/post/DbUMBzXDlj8',
+      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=threads&utm_medium=social&utm_campaign=mg27',
+    },
+    {
+      channel: 'instagram',
+      status: 'LIVE',
+      permalink: 'https://www.instagram.com/igorganapolsky/p/DbUNjFsDQz3/',
+      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=instagram&utm_medium=organic_social&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_card',
+    },
+    {
+      channel: 'reddit',
+      status: 'LIVE',
+      permalink: 'https://www.reddit.com/r/SideProject/comments/1v8i0it/i_built_a_preaction_firewall_for_ai_agents_that/',
+      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=reddit&utm_medium=organic_social&utm_campaign=marketing_agent_governance_20260727&utm_content=sideproject_build',
+    },
+    {
+      channel: 'youtube',
+      status: 'LIVE',
+      permalink: 'https://www.youtube.com/post/UgkxERIbGUvSgCkGQ_dx2W0nbTl5_abcF17O',
+      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=youtube&utm_medium=community_post&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_response',
+    },
+  ],
+});
+
+function normalizeCampaignId(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) return null;
+  return CAMPAIGN_ALIASES[normalized] || normalized;
+}
+
+function campaignAttributionKeys(campaign = MARKETING_AGENT_CAMPAIGN) {
+  return [...new Set([
+    campaign.campaignId,
+    ...(campaign.aliases || []),
+  ].map((value) => String(value || '').trim()).filter(Boolean))];
+}
+
+function validateMarketingAgentCampaign(campaign = MARKETING_AGENT_CAMPAIGN) {
+  const issues = [];
+  const channels = Array.isArray(campaign.channels) ? campaign.channels : [];
+  const seenChannels = new Set();
+  const seenSources = new Set();
+
+  if (normalizeCampaignId(campaign.campaignId) !== MARKETING_AGENT_CAMPAIGN_ID) {
+    issues.push('campaign_id_must_be_canonical');
+  }
+  if (campaign.episode?.url !== 'https://www.youtube.com/watch?v=U2hogriGmEw') {
+    issues.push('episode_url_mismatch');
+  }
+  if (channels.length !== 7) {
+    issues.push('expected_seven_channels');
+  }
+
+  for (const entry of channels) {
+    const channel = String(entry.channel || '').trim().toLowerCase();
+    if (!channel || seenChannels.has(channel)) {
+      issues.push(`duplicate_or_missing_channel:${channel || 'unknown'}`);
+    }
+    seenChannels.add(channel);
+
+    if (entry.status !== 'LIVE') {
+      issues.push(`channel_not_live:${channel || 'unknown'}`);
+    }
+
+    let permalink;
+    let trackedBuyerUrl;
+    try {
+      permalink = new URL(entry.permalink);
+      trackedBuyerUrl = new URL(entry.trackedBuyerUrl);
+    } catch {
+      issues.push(`invalid_url:${channel || 'unknown'}`);
+      continue;
+    }
+
+    if (permalink.protocol !== 'https:') {
+      issues.push(`permalink_not_https:${channel}`);
+    }
+    if (
+      trackedBuyerUrl.protocol !== 'https:'
+      || trackedBuyerUrl.hostname !== 'thumbgate-production.up.railway.app'
+      || trackedBuyerUrl.pathname !== '/go/pro'
+    ) {
+      issues.push(`buyer_path_not_canonical:${channel}`);
+    }
+
+    const source = trackedBuyerUrl.searchParams.get('utm_source');
+    if (source !== channel || seenSources.has(source)) {
+      issues.push(`source_mismatch_or_duplicate:${channel}`);
+    }
+    seenSources.add(source);
+
+    if (normalizeCampaignId(trackedBuyerUrl.searchParams.get('utm_campaign')) !== campaign.campaignId) {
+      issues.push(`campaign_mismatch:${channel}`);
+    }
+    if (!trackedBuyerUrl.searchParams.get('utm_medium')) {
+      issues.push(`missing_medium:${channel}`);
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+    channelCount: channels.length,
+    campaignId: campaign.campaignId,
+  };
+}
+
 function buildCreatorGrowthCampaign(input = {}) {
   const appUrl = input.appUrl || 'https://thumbgate-production.up.railway.app';
   const webinarTitle = input.webinarTitle || 'Stop AI Agents From Repeating Expensive Mistakes';
@@ -45,5 +185,11 @@ function buildCreatorGrowthCampaign(input = {}) {
 }
 
 module.exports = {
+  CAMPAIGN_ALIASES,
+  MARKETING_AGENT_CAMPAIGN,
+  MARKETING_AGENT_CAMPAIGN_ID,
   buildCreatorGrowthCampaign,
+  campaignAttributionKeys,
+  normalizeCampaignId,
+  validateMarketingAgentCampaign,
 };

--- a/scripts/growth-campaigns.js
+++ b/scripts/growth-campaigns.js
@@ -5,6 +5,28 @@ const MARKETING_AGENT_CAMPAIGN_ID = 'marketing_agent_governance_20260727';
 const CAMPAIGN_ALIASES = Object.freeze({
   mg27: MARKETING_AGENT_CAMPAIGN_ID,
 });
+const CAMPAIGN_BUYER_ORIGIN = 'https://thumbgate-production.up.railway.app';
+
+function campaignChannel(
+  channel,
+  permalink,
+  medium,
+  content = null,
+  campaignId = MARKETING_AGENT_CAMPAIGN_ID
+) {
+  const buyerUrl = new URL('/go/pro', CAMPAIGN_BUYER_ORIGIN);
+  buyerUrl.searchParams.set('utm_source', channel);
+  buyerUrl.searchParams.set('utm_medium', medium);
+  buyerUrl.searchParams.set('utm_campaign', campaignId);
+  if (content) buyerUrl.searchParams.set('utm_content', content);
+  return Object.freeze({
+    channel,
+    status: 'LIVE',
+    permalink,
+    trackedBuyerUrl: buyerUrl.toString(),
+  });
+}
+
 const MARKETING_AGENT_CAMPAIGN = Object.freeze({
   campaignId: MARKETING_AGENT_CAMPAIGN_ID,
   aliases: ['mg27'],
@@ -13,48 +35,50 @@ const MARKETING_AGENT_CAMPAIGN = Object.freeze({
     url: 'https://www.youtube.com/watch?v=U2hogriGmEw',
   },
   channels: [
-    {
-      channel: 'linkedin',
-      status: 'LIVE',
-      permalink: 'https://www.linkedin.com/feed/update/urn:li:share:7487654549785128960/',
-      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=linkedin&utm_medium=organic_social&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_response',
-    },
-    {
-      channel: 'hashnode',
-      status: 'LIVE',
-      permalink: 'https://ai-agent-blog-12345.hashnode.dev/your-marketing-agent-can-publish-and-pause-ads-who-gates-the-write',
-      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=hashnode&utm_medium=organic_article&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_deep_dive',
-    },
-    {
-      channel: 'bluesky',
-      status: 'LIVE',
-      permalink: 'https://bsky.app/profile/iganapolsky.bsky.social/post/3mro3mkmrzc2y',
-      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=bluesky&utm_medium=social&utm_campaign=mg27',
-    },
-    {
-      channel: 'threads',
-      status: 'LIVE',
-      permalink: 'https://www.threads.com/@igorganapolsky/post/DbUMBzXDlj8',
-      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=threads&utm_medium=social&utm_campaign=mg27',
-    },
-    {
-      channel: 'instagram',
-      status: 'LIVE',
-      permalink: 'https://www.instagram.com/igorganapolsky/p/DbUNjFsDQz3/',
-      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=instagram&utm_medium=organic_social&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_card',
-    },
-    {
-      channel: 'reddit',
-      status: 'LIVE',
-      permalink: 'https://www.reddit.com/r/SideProject/comments/1v8i0it/i_built_a_preaction_firewall_for_ai_agents_that/',
-      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=reddit&utm_medium=organic_social&utm_campaign=marketing_agent_governance_20260727&utm_content=sideproject_build',
-    },
-    {
-      channel: 'youtube',
-      status: 'LIVE',
-      permalink: 'https://www.youtube.com/post/UgkxERIbGUvSgCkGQ_dx2W0nbTl5_abcF17O',
-      trackedBuyerUrl: 'https://thumbgate-production.up.railway.app/go/pro?utm_source=youtube&utm_medium=community_post&utm_campaign=marketing_agent_governance_20260727&utm_content=episode_response',
-    },
+    campaignChannel(
+      'linkedin',
+      'https://www.linkedin.com/feed/update/urn:li:share:7487654549785128960/',
+      'organic_social',
+      'episode_response'
+    ),
+    campaignChannel(
+      'hashnode',
+      'https://ai-agent-blog-12345.hashnode.dev/your-marketing-agent-can-publish-and-pause-ads-who-gates-the-write',
+      'organic_article',
+      'episode_deep_dive'
+    ),
+    campaignChannel(
+      'bluesky',
+      'https://bsky.app/profile/iganapolsky.bsky.social/post/3mro3mkmrzc2y',
+      'social',
+      null,
+      'mg27'
+    ),
+    campaignChannel(
+      'threads',
+      'https://www.threads.com/@igorganapolsky/post/DbUMBzXDlj8',
+      'social',
+      null,
+      'mg27'
+    ),
+    campaignChannel(
+      'instagram',
+      'https://www.instagram.com/igorganapolsky/p/DbUNjFsDQz3/',
+      'organic_social',
+      'episode_card'
+    ),
+    campaignChannel(
+      'reddit',
+      'https://www.reddit.com/r/SideProject/comments/1v8i0it/i_built_a_preaction_firewall_for_ai_agents_that/',
+      'organic_social',
+      'sideproject_build'
+    ),
+    campaignChannel(
+      'youtube',
+      'https://www.youtube.com/post/UgkxERIbGUvSgCkGQ_dx2W0nbTl5_abcF17O',
+      'community_post',
+      'episode_response'
+    ),
   ],
 });
 
@@ -69,6 +93,57 @@ function campaignAttributionKeys(campaign = MARKETING_AGENT_CAMPAIGN) {
     campaign.campaignId,
     ...(campaign.aliases || []),
   ].map((value) => String(value || '').trim()).filter(Boolean))];
+}
+
+function validateCampaignChannel(entry, campaign, seenChannels, seenSources) {
+  const issues = [];
+  const channel = String(entry.channel || '').trim().toLowerCase();
+  if (!channel || seenChannels.has(channel)) {
+    issues.push(`duplicate_or_missing_channel:${channel || 'unknown'}`);
+  }
+  seenChannels.add(channel);
+
+  if (entry.status !== 'LIVE') {
+    issues.push(`channel_not_live:${channel || 'unknown'}`);
+  }
+
+  let permalink;
+  let trackedBuyerUrl;
+  try {
+    permalink = new URL(entry.permalink);
+    trackedBuyerUrl = new URL(entry.trackedBuyerUrl);
+  } catch {
+    issues.push(`invalid_url:${channel || 'unknown'}`);
+    return issues;
+  }
+
+  if (permalink.protocol !== 'https:') {
+    issues.push(`permalink_not_https:${channel}`);
+  }
+  if (
+    trackedBuyerUrl.protocol !== 'https:'
+    || trackedBuyerUrl.origin !== CAMPAIGN_BUYER_ORIGIN
+    || trackedBuyerUrl.pathname !== '/go/pro'
+  ) {
+    issues.push(`buyer_path_not_canonical:${channel}`);
+  }
+
+  const source = trackedBuyerUrl.searchParams.get('utm_source');
+  if (source !== channel || seenSources.has(source)) {
+    issues.push(`source_mismatch_or_duplicate:${channel}`);
+  }
+  seenSources.add(source);
+
+  if (
+    normalizeCampaignId(trackedBuyerUrl.searchParams.get('utm_campaign'))
+    !== campaign.campaignId
+  ) {
+    issues.push(`campaign_mismatch:${channel}`);
+  }
+  if (!trackedBuyerUrl.searchParams.get('utm_medium')) {
+    issues.push(`missing_medium:${channel}`);
+  }
+  return issues;
 }
 
 function validateMarketingAgentCampaign(campaign = MARKETING_AGENT_CAMPAIGN) {
@@ -86,51 +161,13 @@ function validateMarketingAgentCampaign(campaign = MARKETING_AGENT_CAMPAIGN) {
   if (channels.length !== 7) {
     issues.push('expected_seven_channels');
   }
-
   for (const entry of channels) {
-    const channel = String(entry.channel || '').trim().toLowerCase();
-    if (!channel || seenChannels.has(channel)) {
-      issues.push(`duplicate_or_missing_channel:${channel || 'unknown'}`);
-    }
-    seenChannels.add(channel);
-
-    if (entry.status !== 'LIVE') {
-      issues.push(`channel_not_live:${channel || 'unknown'}`);
-    }
-
-    let permalink;
-    let trackedBuyerUrl;
-    try {
-      permalink = new URL(entry.permalink);
-      trackedBuyerUrl = new URL(entry.trackedBuyerUrl);
-    } catch {
-      issues.push(`invalid_url:${channel || 'unknown'}`);
-      continue;
-    }
-
-    if (permalink.protocol !== 'https:') {
-      issues.push(`permalink_not_https:${channel}`);
-    }
-    if (
-      trackedBuyerUrl.protocol !== 'https:'
-      || trackedBuyerUrl.hostname !== 'thumbgate-production.up.railway.app'
-      || trackedBuyerUrl.pathname !== '/go/pro'
-    ) {
-      issues.push(`buyer_path_not_canonical:${channel}`);
-    }
-
-    const source = trackedBuyerUrl.searchParams.get('utm_source');
-    if (source !== channel || seenSources.has(source)) {
-      issues.push(`source_mismatch_or_duplicate:${channel}`);
-    }
-    seenSources.add(source);
-
-    if (normalizeCampaignId(trackedBuyerUrl.searchParams.get('utm_campaign')) !== campaign.campaignId) {
-      issues.push(`campaign_mismatch:${channel}`);
-    }
-    if (!trackedBuyerUrl.searchParams.get('utm_medium')) {
-      issues.push(`missing_medium:${channel}`);
-    }
+    issues.push(...validateCampaignChannel(
+      entry,
+      campaign,
+      seenChannels,
+      seenSources
+    ));
   }
 
   return {

--- a/scripts/social-analytics/install-growth-automation.js
+++ b/scripts/social-analytics/install-growth-automation.js
@@ -13,6 +13,11 @@ const CAMPAIGN_REPORT_PATH = path.join(
   'marketing-agent-campaign',
   'latest.json'
 );
+const RETIRED_GROWTH_SCHEDULE_IDS = Object.freeze([
+  'thumbgate-growth-schedule-campaign',
+  'thumbgate-growth-poll-zernio',
+  'thumbgate-growth-sync-launch-assets',
+]);
 
 function buildNodeEvalCommand(scriptPath, args = []) {
   const absolutePath = path.resolve(scriptPath);
@@ -33,30 +38,6 @@ function buildNodeEvalCommand(scriptPath, args = []) {
 function buildGrowthSchedules() {
   return [
     {
-      id: 'thumbgate-growth-schedule-campaign',
-      name: 'ThumbGate Growth Campaign Scheduler',
-      description: 'Schedules the next day of tracked Zernio launch posts.',
-      schedule: 'daily 21:15',
-      command: buildNodeEvalCommand(path.join(__dirname, 'schedule-thumbgate-campaign.js')),
-      workingDirectory: REPO_ROOT,
-    },
-    {
-      id: 'thumbgate-growth-poll-zernio',
-      name: 'ThumbGate Growth Poll Zernio',
-      description: 'Polls Zernio analytics into the local engagement store every hour.',
-      schedule: 'hourly',
-      command: buildNodeEvalCommand(path.join(__dirname, 'pollers', 'zernio.js')),
-      workingDirectory: REPO_ROOT,
-    },
-    {
-      id: 'thumbgate-growth-sync-launch-assets',
-      name: 'ThumbGate Growth Sync Launch Assets',
-      description: 'Syncs published and scheduled launch assets from Zernio into a durable local registry.',
-      schedule: 'hourly',
-      command: buildNodeEvalCommand(path.join(__dirname, 'sync-launch-assets.js')),
-      workingDirectory: REPO_ROOT,
-    },
-    {
       id: 'thumbgate-growth-reply-monitor',
       name: 'ThumbGate Growth Reply Monitor',
       description: 'Checks social replies and posts supported follow-ups or drafts them for review.',
@@ -76,6 +57,7 @@ function buildGrowthSchedules() {
         'verify-marketing-agent-campaign.js'
       ), [
         '--json',
+        '--window=lifetime',
         `--out=${CAMPAIGN_REPORT_PATH}`,
       ]),
       workingDirectory: REPO_ROOT,
@@ -114,9 +96,12 @@ function buildGrowthSchedules() {
 
 function installGrowthAutomation(manager = scheduleManager) {
   const schedules = buildGrowthSchedules();
-
+  const retired = RETIRED_GROWTH_SCHEDULE_IDS.map((id) => (
+    manager.deleteSchedule(id)
+  ));
   const installed = schedules.map((schedule) => manager.createSchedule(schedule));
   return {
+    retired,
     installed,
     schedules: manager.listSchedules().filter((schedule) => schedule.id.startsWith('thumbgate-growth-')),
   };
@@ -132,6 +117,7 @@ if (require.main === module) {
 
 module.exports = {
   CAMPAIGN_REPORT_PATH,
+  RETIRED_GROWTH_SCHEDULE_IDS,
   buildNodeEvalCommand,
   buildGrowthSchedules,
   installGrowthAutomation,

--- a/scripts/social-analytics/install-growth-automation.js
+++ b/scripts/social-analytics/install-growth-automation.js
@@ -6,6 +6,13 @@ const scheduleManager = require('../schedule-manager');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const GROWTH_REPORT_DIR = path.join(REPO_ROOT, '.thumbgate', 'reports', 'gtm-revenue-loop');
+const CAMPAIGN_REPORT_PATH = path.join(
+  REPO_ROOT,
+  '.thumbgate',
+  'reports',
+  'marketing-agent-campaign',
+  'latest.json'
+);
 
 function buildNodeEvalCommand(scriptPath, args = []) {
   const absolutePath = path.resolve(scriptPath);
@@ -55,6 +62,22 @@ function buildGrowthSchedules() {
       description: 'Checks social replies and posts supported follow-ups or drafts them for review.',
       schedule: 'hourly',
       command: buildNodeEvalCommand(path.join(REPO_ROOT, 'scripts', 'social-reply-monitor.js')),
+      workingDirectory: REPO_ROOT,
+    },
+    {
+      id: 'thumbgate-growth-campaign-conversion',
+      name: 'ThumbGate Marketing-Agent Campaign Conversion Monitor',
+      description: 'Verifies all seven tracked buyer routes and records campaign-specific hosted outcome truth without creating provider sessions.',
+      schedule: 'hourly',
+      command: buildNodeEvalCommand(path.join(
+        REPO_ROOT,
+        'scripts',
+        'social-analytics',
+        'verify-marketing-agent-campaign.js'
+      ), [
+        '--json',
+        `--out=${CAMPAIGN_REPORT_PATH}`,
+      ]),
       workingDirectory: REPO_ROOT,
     },
     {
@@ -108,6 +131,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  CAMPAIGN_REPORT_PATH,
   buildNodeEvalCommand,
   buildGrowthSchedules,
   installGrowthAutomation,

--- a/scripts/social-analytics/verify-marketing-agent-campaign.js
+++ b/scripts/social-analytics/verify-marketing-agent-campaign.js
@@ -10,8 +10,13 @@ const {
   validateMarketingAgentCampaign,
 } = require('../growth-campaigns');
 
+const APPROVED_CHECKOUT_ORIGINS = Object.freeze([
+  'https://thumbgate.ai',
+]);
+
 function classifyPublicationStatus(status) {
-  if (status >= 200 && status < 400) return 'LIVE';
+  if (status >= 200 && status < 300) return 'LIVE';
+  if (status >= 300 && status < 400) return 'PARTIAL';
   if ([401, 403, 405, 429].includes(status)) return 'PARTIAL';
   if ([404, 410].includes(status)) return 'NOT DONE';
   return 'PARTIAL';
@@ -61,6 +66,10 @@ async function probeTrackedBuyerPath(entry, options = {}) {
     sourceUrl.pathname + sourceUrl.search,
     options.appOrigin || sourceUrl.origin
   );
+  const approvedCheckoutOrigins = new Set([
+    probeUrl.origin,
+    ...(options.approvedCheckoutOrigins || APPROVED_CHECKOUT_ORIGINS),
+  ]);
 
   try {
     const response = await fetchImpl(probeUrl, {
@@ -77,6 +86,7 @@ async function probeTrackedBuyerPath(entry, options = {}) {
       destination?.searchParams.get('utm_campaign')
     );
     const ok = [302, 303].includes(response.status)
+      && approvedCheckoutOrigins.has(destination?.origin)
       && destination?.pathname === '/checkout/pro'
       && destination.searchParams.get('utm_source') === entry.channel
       && actualCampaign === expectedCampaign;
@@ -87,6 +97,7 @@ async function probeTrackedBuyerPath(entry, options = {}) {
       httpStatus: response.status,
       trackedBuyerUrl: entry.trackedBuyerUrl,
       location,
+      destinationOrigin: destination?.origin || null,
       destinationPath: destination?.pathname || null,
       source: destination?.searchParams.get('utm_source') || null,
       campaign: actualCampaign,
@@ -152,6 +163,19 @@ function summarizeCampaignOutcome(summary = {}, campaign = MARKETING_AGENT_CAMPA
   };
 }
 
+function resolveReportStatus(
+  routeProofPassed,
+  publicationProofPassed,
+  publicationProofFullyLive,
+  verifiedHostedLedger,
+  skipPermalinks
+) {
+  if (!routeProofPassed || !publicationProofPassed) return 'NOT DONE';
+  if (!verifiedHostedLedger) return 'PARTIAL';
+  if (!skipPermalinks && !publicationProofFullyLive) return 'PARTIAL';
+  return 'VERIFIED';
+}
+
 async function buildMarketingAgentCampaignReport(options = {}) {
   const campaign = options.campaign || MARKETING_AGENT_CAMPAIGN;
   const manifest = validateMarketingAgentCampaign(campaign);
@@ -177,7 +201,7 @@ async function buildMarketingAgentCampaignReport(options = {}) {
 
   try {
     const result = await getOperationalSummary({
-      window: options.window || '30d',
+      window: options.window || 'lifetime',
     });
     outcome = {
       source: result.source,
@@ -214,14 +238,13 @@ async function buildMarketingAgentCampaignReport(options = {}) {
       channels: publications,
     },
     outcomeProof: outcome,
-    status: !routeProofPassed || !publicationProofPassed
-      ? 'NOT DONE'
-      : (
-        outcome.verifiedHostedLedger
-        && (options.skipPermalinks || publicationProofFullyLive)
-          ? 'VERIFIED'
-          : 'PARTIAL'
-      ),
+    status: resolveReportStatus(
+      routeProofPassed,
+      publicationProofPassed,
+      publicationProofFullyLive,
+      outcome.verifiedHostedLedger,
+      options.skipPermalinks
+    ),
     claimBoundary: (
       'Route and publication proof do not prove a lead, checkout completion, '
       + 'buyer, or captured payment. Provider verification is separate.'
@@ -236,7 +259,7 @@ function parseArgs(argv = []) {
     strictHosted: false,
     outPath: null,
     appOrigin: null,
-    window: '30d',
+    window: 'lifetime',
   };
 
   for (const arg of argv) {
@@ -248,10 +271,23 @@ function parseArgs(argv = []) {
     } else if (arg.startsWith('--app-origin=')) {
       options.appOrigin = arg.slice('--app-origin='.length).trim() || null;
     } else if (arg.startsWith('--window=')) {
-      options.window = arg.slice('--window='.length).trim() || '30d';
+      options.window = arg.slice('--window='.length).trim() || 'lifetime';
     }
   }
   return options;
+}
+
+function formatCliOutput(report, json, output) {
+  if (json) return output;
+  const buyerRouteStatus = report.routeProof.passed ? 'PASS' : 'FAIL';
+  const hostedOutcomeStatus = report.outcomeProof.verifiedHostedLedger
+    ? 'VERIFIED'
+    : 'UNVERIFIED';
+  return (
+    `Marketing-agent campaign: ${report.status}\n`
+    + `Buyer routes: ${buyerRouteStatus}\n`
+    + `Hosted outcome ledger: ${hostedOutcomeStatus}\n`
+  );
 }
 
 async function runCli(argv = process.argv.slice(2)) {
@@ -263,15 +299,7 @@ async function runCli(argv = process.argv.slice(2)) {
     fs.mkdirSync(path.dirname(resolved), { recursive: true });
     fs.writeFileSync(resolved, output, 'utf8');
   }
-  process.stdout.write(options.json
-    ? output
-    : (
-      `Marketing-agent campaign: ${report.status}\n`
-      + `Buyer routes: ${report.routeProof.passed ? 'PASS' : 'FAIL'}\n`
-      + `Hosted outcome ledger: ${
-        report.outcomeProof.verifiedHostedLedger ? 'VERIFIED' : 'UNVERIFIED'
-      }\n`
-    ));
+  process.stdout.write(formatCliOutput(report, options.json, output));
   if (
     report.status === 'NOT DONE'
     || (options.strictHosted && !report.outcomeProof.verifiedHostedLedger)
@@ -282,17 +310,20 @@ async function runCli(argv = process.argv.slice(2)) {
 }
 
 module.exports = {
+  APPROVED_CHECKOUT_ORIGINS,
   buildMarketingAgentCampaignReport,
   classifyPublicationStatus,
+  formatCliOutput,
   parseArgs,
   probePublication,
   probeTrackedBuyerPath,
   runCli,
+  resolveReportStatus,
   sumCampaignCounter,
   summarizeCampaignOutcome,
 };
 
-if (require.main === module) {
+if (path.resolve(process.argv[1] || '') === path.resolve(__filename)) {
   runCli().catch((error) => {
     process.stderr.write(`${error?.message || String(error)}\n`);
     process.exit(1);

--- a/scripts/social-analytics/verify-marketing-agent-campaign.js
+++ b/scripts/social-analytics/verify-marketing-agent-campaign.js
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  MARKETING_AGENT_CAMPAIGN,
+  campaignAttributionKeys,
+  normalizeCampaignId,
+  validateMarketingAgentCampaign,
+} = require('../growth-campaigns');
+
+function classifyPublicationStatus(status) {
+  if (status >= 200 && status < 400) return 'LIVE';
+  if ([401, 403, 405, 429].includes(status)) return 'PARTIAL';
+  if ([404, 410].includes(status)) return 'NOT DONE';
+  return 'PARTIAL';
+}
+
+async function probePublication(entry, fetchImpl = globalThis.fetch) {
+  try {
+    const headResponse = await fetchImpl(entry.permalink, {
+      method: 'HEAD',
+      redirect: 'manual',
+      headers: { 'user-agent': 'thumbgate-campaign-monitor/1.0' },
+    });
+    const response = headResponse.status >= 200 && headResponse.status < 400
+      ? headResponse
+      : await fetchImpl(entry.permalink, {
+        method: 'GET',
+        redirect: 'manual',
+        headers: {
+          accept: 'text/html',
+          range: 'bytes=0-1023',
+          'user-agent': 'Mozilla/5.0 (compatible; ThumbGateCampaignMonitor/1.0)',
+        },
+      });
+    return {
+      channel: entry.channel,
+      status: classifyPublicationStatus(response.status),
+      httpStatus: response.status,
+      headStatus: headResponse.status,
+      method: response === headResponse ? 'HEAD' : 'GET',
+      permalink: entry.permalink,
+    };
+  } catch (error) {
+    return {
+      channel: entry.channel,
+      status: 'PARTIAL',
+      httpStatus: null,
+      permalink: entry.permalink,
+      error: error?.message || String(error),
+    };
+  }
+}
+
+async function probeTrackedBuyerPath(entry, options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const sourceUrl = new URL(entry.trackedBuyerUrl);
+  const probeUrl = new URL(
+    sourceUrl.pathname + sourceUrl.search,
+    options.appOrigin || sourceUrl.origin
+  );
+
+  try {
+    const response = await fetchImpl(probeUrl, {
+      method: 'HEAD',
+      redirect: 'manual',
+      headers: { 'user-agent': 'thumbgate-campaign-monitor/1.0' },
+    });
+    const location = response.headers.get('location');
+    const destination = location ? new URL(location, probeUrl) : null;
+    const expectedCampaign = normalizeCampaignId(
+      sourceUrl.searchParams.get('utm_campaign')
+    );
+    const actualCampaign = normalizeCampaignId(
+      destination?.searchParams.get('utm_campaign')
+    );
+    const ok = [302, 303].includes(response.status)
+      && destination?.pathname === '/checkout/pro'
+      && destination.searchParams.get('utm_source') === entry.channel
+      && actualCampaign === expectedCampaign;
+
+    return {
+      channel: entry.channel,
+      ok,
+      httpStatus: response.status,
+      trackedBuyerUrl: entry.trackedBuyerUrl,
+      location,
+      destinationPath: destination?.pathname || null,
+      source: destination?.searchParams.get('utm_source') || null,
+      campaign: actualCampaign,
+      createsProviderSession: false,
+    };
+  } catch (error) {
+    return {
+      channel: entry.channel,
+      ok: false,
+      httpStatus: null,
+      trackedBuyerUrl: entry.trackedBuyerUrl,
+      location: null,
+      error: error?.message || String(error),
+      createsProviderSession: false,
+    };
+  }
+}
+
+function sumCampaignCounter(counter = {}, campaign = MARKETING_AGENT_CAMPAIGN) {
+  return campaignAttributionKeys(campaign)
+    .reduce((total, key) => total + Number(counter[key] || 0), 0);
+}
+
+function summarizeCampaignOutcome(summary = {}, campaign = MARKETING_AGENT_CAMPAIGN) {
+  const attribution = summary.attribution || {};
+  const acquisitionByCampaign = (
+    attribution.acquisitionByCampaign
+    || summary.signups?.byCampaign
+    || {}
+  );
+  const acquisition = sumCampaignCounter(acquisitionByCampaign, campaign);
+  const paidOrders = sumCampaignCounter(
+    attribution.paidByCampaign || {},
+    campaign
+  );
+  const bookedRevenueCents = sumCampaignCounter(
+    attribution.bookedRevenueByCampaignCents || {},
+    campaign
+  );
+  const bySource = {};
+
+  for (const entry of campaign.channels || []) {
+    bySource[entry.channel] = {
+      acquisition: Number(
+        attribution.acquisitionBySource?.[entry.channel] || 0
+      ),
+      paidOrders: Number(attribution.paidBySource?.[entry.channel] || 0),
+      bookedRevenueCents: Number(
+        attribution.bookedRevenueBySourceCents?.[entry.channel] || 0
+      ),
+    };
+  }
+
+  return {
+    campaignId: campaign.campaignId,
+    acquisition,
+    paidOrders,
+    bookedRevenueCents,
+    conversionRate: acquisition
+      ? Number((paidOrders / acquisition).toFixed(4))
+      : 0,
+    bySource,
+  };
+}
+
+async function buildMarketingAgentCampaignReport(options = {}) {
+  const campaign = options.campaign || MARKETING_AGENT_CAMPAIGN;
+  const manifest = validateMarketingAgentCampaign(campaign);
+  const buyerPaths = await Promise.all(
+    campaign.channels.map((entry) => probeTrackedBuyerPath(entry, options))
+  );
+  const publications = options.skipPermalinks
+    ? []
+    : await Promise.all(
+      campaign.channels.map((entry) => (
+        probePublication(entry, options.fetchImpl || globalThis.fetch)
+      ))
+    );
+  const getOperationalSummary = options.getOperationalSummary
+    || require('../operational-summary').getOperationalBillingSummary;
+  let outcome = {
+    source: 'unverified',
+    verifiedHostedLedger: false,
+    paymentProviderVerified: false,
+    error: null,
+    metrics: summarizeCampaignOutcome({}, campaign),
+  };
+
+  try {
+    const result = await getOperationalSummary({
+      window: options.window || '30d',
+    });
+    outcome = {
+      source: result.source,
+      verifiedHostedLedger: result.source === 'hosted',
+      paymentProviderVerified: false,
+      fallbackReason: result.fallbackReason || null,
+      metrics: summarizeCampaignOutcome(result.summary || {}, campaign),
+    };
+  } catch (error) {
+    outcome.error = error?.message || String(error);
+  }
+
+  const routeProofPassed = manifest.ok
+    && buyerPaths.every((entry) => entry.ok);
+  const publicationProofPassed = publications.every(
+    (entry) => entry.status !== 'NOT DONE'
+  );
+  const publicationProofFullyLive = publications.every(
+    (entry) => entry.status === 'LIVE'
+  );
+  return {
+    generatedAt: new Date().toISOString(),
+    campaignId: campaign.campaignId,
+    manifest,
+    routeProof: {
+      passed: routeProofPassed,
+      buyerPaths,
+      createsProviderSession: false,
+    },
+    publicationProof: {
+      checked: !options.skipPermalinks,
+      passed: publicationProofPassed,
+      fullyLive: publicationProofFullyLive,
+      channels: publications,
+    },
+    outcomeProof: outcome,
+    status: !routeProofPassed || !publicationProofPassed
+      ? 'NOT DONE'
+      : (
+        outcome.verifiedHostedLedger
+        && (options.skipPermalinks || publicationProofFullyLive)
+          ? 'VERIFIED'
+          : 'PARTIAL'
+      ),
+    claimBoundary: (
+      'Route and publication proof do not prove a lead, checkout completion, '
+      + 'buyer, or captured payment. Provider verification is separate.'
+    ),
+  };
+}
+
+function parseArgs(argv = []) {
+  const options = {
+    json: false,
+    skipPermalinks: false,
+    strictHosted: false,
+    outPath: null,
+    appOrigin: null,
+    window: '30d',
+  };
+
+  for (const arg of argv) {
+    if (arg === '--json') options.json = true;
+    else if (arg === '--skip-permalinks') options.skipPermalinks = true;
+    else if (arg === '--strict-hosted') options.strictHosted = true;
+    else if (arg.startsWith('--out=')) {
+      options.outPath = arg.slice('--out='.length).trim() || null;
+    } else if (arg.startsWith('--app-origin=')) {
+      options.appOrigin = arg.slice('--app-origin='.length).trim() || null;
+    } else if (arg.startsWith('--window=')) {
+      options.window = arg.slice('--window='.length).trim() || '30d';
+    }
+  }
+  return options;
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const report = await buildMarketingAgentCampaignReport(options);
+  const output = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.outPath) {
+    const resolved = path.resolve(options.outPath);
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+    fs.writeFileSync(resolved, output, 'utf8');
+  }
+  process.stdout.write(options.json
+    ? output
+    : (
+      `Marketing-agent campaign: ${report.status}\n`
+      + `Buyer routes: ${report.routeProof.passed ? 'PASS' : 'FAIL'}\n`
+      + `Hosted outcome ledger: ${
+        report.outcomeProof.verifiedHostedLedger ? 'VERIFIED' : 'UNVERIFIED'
+      }\n`
+    ));
+  if (
+    report.status === 'NOT DONE'
+    || (options.strictHosted && !report.outcomeProof.verifiedHostedLedger)
+  ) {
+    process.exitCode = 1;
+  }
+  return report;
+}
+
+module.exports = {
+  buildMarketingAgentCampaignReport,
+  classifyPublicationStatus,
+  parseArgs,
+  probePublication,
+  probeTrackedBuyerPath,
+  runCli,
+  sumCampaignCounter,
+  summarizeCampaignOutcome,
+};
+
+if (require.main === module) {
+  runCli().catch((error) => {
+    process.stderr.write(`${error?.message || String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1271,7 +1271,7 @@ function inferSearchQuery(referrer) {
 
 function getAttributionValue(params, key, fallbackValue) {
   const value = params.get(key);
-  const resolved = value && value.trim() ? value.trim() : fallbackValue;
+  const resolved = value?.trim() || fallbackValue;
   return key === 'utm_campaign' ? normalizeCampaignId(resolved) : resolved;
 }
 
@@ -2688,10 +2688,10 @@ function appendTrackedLinkQueryParams(destinationUrl, parsed, target) {
   for (const key of TRACKED_LINK_QUERY_KEYS) {
     const value = params.get(key);
     if (value && value.trim()) {
-      destinationUrl.searchParams.set(
-        key,
-        key === 'utm_campaign' ? normalizeCampaignId(value) : value.trim()
-      );
+      const normalizedValue = key === 'utm_campaign'
+        ? normalizeCampaignId(value)
+        : value.trim();
+      destinationUrl.searchParams.set(key, normalizedValue);
     }
   }
   if (target.allowCustomerEmail) {
@@ -2732,7 +2732,7 @@ function buildTrackedLinkAttribution(target, parsed, req, journeyState, destinat
   const source = pickFirstText(
     params.get('source'),
     params.get('utm_source'),
-    target.defaults && target.defaults.utm_source,
+    target.defaults?.utm_source,
     inferSource(referrerHost)
   );
 
@@ -2746,9 +2746,9 @@ function buildTrackedLinkAttribution(target, parsed, req, journeyState, destinat
     traceId: pickFirstText(params.get('trace_id')),
     source,
     utmSource: pickFirstText(params.get('utm_source'), source),
-    utmMedium: pickFirstText(params.get('utm_medium'), target.defaults && target.defaults.utm_medium, 'link_router'),
+    utmMedium: pickFirstText(params.get('utm_medium'), target.defaults?.utm_medium, 'link_router'),
     utmCampaign: normalizeCampaignId(
-      pickFirstText(params.get('utm_campaign'), target.defaults && target.defaults.utm_campaign, 'first_party_redirect')
+      pickFirstText(params.get('utm_campaign'), target.defaults?.utm_campaign, 'first_party_redirect')
     ),
     utmContent: pickFirstText(params.get('utm_content')),
     utmTerm: pickFirstText(params.get('utm_term')),
@@ -2756,11 +2756,11 @@ function buildTrackedLinkAttribution(target, parsed, req, journeyState, destinat
     community: pickFirstText(params.get('community'), params.get('subreddit')),
     postId: pickFirstText(params.get('post_id')),
     commentId: pickFirstText(params.get('comment_id')),
-    campaignVariant: pickFirstText(params.get('campaign_variant'), target.defaults && target.defaults.campaign_variant),
+    campaignVariant: pickFirstText(params.get('campaign_variant'), target.defaults?.campaign_variant),
     offerCode: pickFirstText(params.get('offer_code')),
     ctaId: pickFirstText(params.get('cta_id'), target.ctaId),
     ctaPlacement: pickFirstText(params.get('cta_placement'), target.ctaPlacement),
-    planId: pickFirstText(params.get('plan_id'), target.defaults && target.defaults.plan_id),
+    planId: pickFirstText(params.get('plan_id'), target.defaults?.plan_id),
     landingPath: pickFirstText(params.get('landing_path'), `/go/${target.slug}`),
     page: `/go/${target.slug}`,
     referrer,

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -238,6 +238,7 @@ const { sendProblem, PROBLEM_TYPES } = require('../../scripts/problem-detail');
 const { TOOLS: MCP_TOOLS } = require('../../scripts/tool-registry');
 const mcpOauth = require('../../scripts/mcp-oauth');
 const { packCheckoutReference } = require('../../scripts/checkout-attribution-reference');
+const { normalizeCampaignId } = require('../../scripts/growth-campaigns');
 // OAuth 2.1 (PKCE) authorization-server state for the remote MCP connector
 // (Claude Connectors Directory requires OAuth for authenticated services).
 const oauthStore = mcpOauth.createStore();
@@ -1270,7 +1271,8 @@ function inferSearchQuery(referrer) {
 
 function getAttributionValue(params, key, fallbackValue) {
   const value = params.get(key);
-  return value && value.trim() ? value.trim() : fallbackValue;
+  const resolved = value && value.trim() ? value.trim() : fallbackValue;
+  return key === 'utm_campaign' ? normalizeCampaignId(resolved) : resolved;
 }
 
 function parseUrlSearchParams(urlValue) {
@@ -2686,7 +2688,10 @@ function appendTrackedLinkQueryParams(destinationUrl, parsed, target) {
   for (const key of TRACKED_LINK_QUERY_KEYS) {
     const value = params.get(key);
     if (value && value.trim()) {
-      destinationUrl.searchParams.set(key, value.trim());
+      destinationUrl.searchParams.set(
+        key,
+        key === 'utm_campaign' ? normalizeCampaignId(value) : value.trim()
+      );
     }
   }
   if (target.allowCustomerEmail) {
@@ -2742,7 +2747,9 @@ function buildTrackedLinkAttribution(target, parsed, req, journeyState, destinat
     source,
     utmSource: pickFirstText(params.get('utm_source'), source),
     utmMedium: pickFirstText(params.get('utm_medium'), target.defaults && target.defaults.utm_medium, 'link_router'),
-    utmCampaign: pickFirstText(params.get('utm_campaign'), target.defaults && target.defaults.utm_campaign, 'first_party_redirect'),
+    utmCampaign: normalizeCampaignId(
+      pickFirstText(params.get('utm_campaign'), target.defaults && target.defaults.utm_campaign, 'first_party_redirect')
+    ),
     utmContent: pickFirstText(params.get('utm_content')),
     utmTerm: pickFirstText(params.get('utm_term')),
     creator: pickFirstText(params.get('creator'), params.get('creator_handle')),

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -859,6 +859,21 @@ test('/go/pro 302 redirects to /checkout/pro with caller-provided UTM params pre
   assert.equal(url.searchParams.get('cta_id'), 'go_pro');
 });
 
+test('/go/pro canonicalizes the short marketing-agent campaign alias on a side-effect-free HEAD probe', async () => {
+  const res = await fetch(
+    apiUrl('/go/pro?utm_source=bluesky&utm_medium=social&utm_campaign=mg27'),
+    { method: 'HEAD', redirect: 'manual' }
+  );
+  assert.equal(res.status, 302);
+  const url = new URL(res.headers.get('location'));
+  assert.equal(url.pathname, '/checkout/pro');
+  assert.equal(url.searchParams.get('utm_source'), 'bluesky');
+  assert.equal(
+    url.searchParams.get('utm_campaign'),
+    'marketing_agent_governance_20260727'
+  );
+});
+
 test('/go/teams 302 redirects to Pro per CEO pivot', async () => {
   const res = await fetch(apiUrl('/go/teams?utm_source=aiventyx&utm_medium=marketplace&utm_campaign=aiventyx_teams_listing&cta_id=aiventyx_teams_listing&cta_placement=marketplace_listing'), { redirect: 'manual' });
   assert.equal(res.status, 302);

--- a/tests/billing.test.js
+++ b/tests/billing.test.js
@@ -233,6 +233,29 @@ function writeNewsletterSubscribers(entries) {
   return newsletterPath;
 }
 
+test('billing attribution canonicalizes short campaign aliases before rollup', () => {
+  const billing = requireFreshBilling('');
+  assert.deepEqual(billing._extractAttribution({
+    utmSource: 'bluesky',
+    utmCampaign: 'mg27',
+  }), {
+    source: 'bluesky',
+    medium: null,
+    campaign: 'marketing_agent_governance_20260727',
+    content: null,
+    term: null,
+    creator: null,
+    community: null,
+    postId: null,
+    commentId: null,
+    campaignVariant: null,
+    offerCode: null,
+    referrer: null,
+    landingPath: null,
+    ctaId: null,
+  });
+});
+
 describe('billing.js — provisionApiKey', () => {
   let keyStorePath;
   beforeEach(() => { keyStorePath = setupTempStore(); });

--- a/tests/high-roi-agent-workflows.test.js
+++ b/tests/high-roi-agent-workflows.test.js
@@ -97,8 +97,10 @@ const {
 } = require('../scripts/growth-campaigns');
 const {
   buildMarketingAgentCampaignReport,
+  formatCliOutput: formatMarketingAgentCliOutput,
   probePublication,
   probeTrackedBuyerPath,
+  resolveReportStatus,
   summarizeCampaignOutcome,
 } = require('../scripts/social-analytics/verify-marketing-agent-campaign');
 const {
@@ -439,6 +441,23 @@ test('marketing-agent buyer-path probe is side-effect free and requires canonica
   assert.equal(fetchCalls[0].options.redirect, 'manual');
 });
 
+test('marketing-agent buyer-path probe rejects a matching checkout path on another origin', async () => {
+  const entry = MARKETING_AGENT_CAMPAIGN.channels.find((channel) => channel.channel === 'bluesky');
+  const result = await probeTrackedBuyerPath(entry, {
+    fetchImpl: async () => ({
+      status: 302,
+      headers: {
+        get: (name) => name === 'location'
+          ? 'https://malicious.example/checkout/pro?utm_source=bluesky&utm_campaign=marketing_agent_governance_20260727'
+          : null,
+      },
+    }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.destinationOrigin, 'https://malicious.example');
+});
+
 test('publication probe retries with a bounded GET before treating a HEAD-only 404 as missing', async () => {
   const calls = [];
   const result = await probePublication({
@@ -455,6 +474,16 @@ test('publication probe retries with a bounded GET before treating a HEAD-only 4
   assert.equal(result.method, 'GET');
   assert.deepEqual(calls.map((entry) => entry.method), ['HEAD', 'GET']);
   assert.equal(calls[1].headers.range, 'bytes=0-1023');
+});
+
+test('publication probe treats an unverified redirect as partial', async () => {
+  const result = await probePublication({
+    channel: 'bluesky',
+    permalink: 'https://social.example/post/1',
+  }, async () => ({ status: 302 }));
+
+  assert.equal(result.status, 'PARTIAL');
+  assert.equal(result.httpStatus, 302);
 });
 
 test('marketing-agent outcome summary combines campaign aliases but keeps channel truth separate', () => {
@@ -494,6 +523,7 @@ test('marketing-agent outcome summary combines campaign aliases but keeps channe
 });
 
 test('marketing-agent report separates verified routes from hosted and provider outcome proof', async () => {
+  let requestedWindow = null;
   const report = await buildMarketingAgentCampaignReport({
     skipPermalinks: true,
     fetchImpl: async (url) => {
@@ -507,19 +537,22 @@ test('marketing-agent report separates verified routes from hosted and provider 
         },
       };
     },
-    getOperationalSummary: async () => ({
-      source: 'hosted',
-      fallbackReason: null,
-      summary: {
-        attribution: {
-          acquisitionByCampaign: {
-            marketing_agent_governance_20260727: 4,
+    getOperationalSummary: async (options) => {
+      requestedWindow = options.window;
+      return {
+        source: 'hosted',
+        fallbackReason: null,
+        summary: {
+          attribution: {
+            acquisitionByCampaign: {
+              marketing_agent_governance_20260727: 4,
+            },
+            paidByCampaign: {},
+            bookedRevenueByCampaignCents: {},
           },
-          paidByCampaign: {},
-          bookedRevenueByCampaignCents: {},
         },
-      },
-    }),
+      };
+    },
   });
 
   assert.equal(report.routeProof.passed, true);
@@ -529,7 +562,27 @@ test('marketing-agent report separates verified routes from hosted and provider 
   assert.equal(report.outcomeProof.paymentProviderVerified, false);
   assert.equal(report.outcomeProof.metrics.acquisition, 4);
   assert.equal(report.outcomeProof.metrics.paidOrders, 0);
+  assert.equal(requestedWindow, 'lifetime');
   assert.match(report.claimBoundary, /do not prove/);
+});
+
+test('marketing-agent report status and CLI formatter preserve proof boundaries', () => {
+  assert.equal(resolveReportStatus(false, true, true, true, false), 'NOT DONE');
+  assert.equal(resolveReportStatus(true, false, true, true, false), 'NOT DONE');
+  assert.equal(resolveReportStatus(true, true, true, false, false), 'PARTIAL');
+  assert.equal(resolveReportStatus(true, true, false, true, false), 'PARTIAL');
+  assert.equal(resolveReportStatus(true, true, false, true, true), 'VERIFIED');
+
+  const report = {
+    status: 'PARTIAL',
+    routeProof: { passed: true },
+    outcomeProof: { verifiedHostedLedger: false },
+  };
+  assert.match(
+    formatMarketingAgentCliOutput(report, false, '{}\n'),
+    /Buyer routes: PASS\nHosted outcome ledger: UNVERIFIED/
+  );
+  assert.equal(formatMarketingAgentCliOutput(report, true, '{}\n'), '{}\n');
 });
 
 test('AI org governance plans persistent agent teams with budget and approval gates', () => {

--- a/tests/high-roi-agent-workflows.test.js
+++ b/tests/high-roi-agent-workflows.test.js
@@ -90,8 +90,17 @@ const {
   evaluateProductionAgentReadiness,
 } = require('../scripts/production-agent-readiness');
 const {
+  MARKETING_AGENT_CAMPAIGN,
   buildCreatorGrowthCampaign,
+  normalizeCampaignId,
+  validateMarketingAgentCampaign,
 } = require('../scripts/growth-campaigns');
+const {
+  buildMarketingAgentCampaignReport,
+  probePublication,
+  probeTrackedBuyerPath,
+  summarizeCampaignOutcome,
+} = require('../scripts/social-analytics/verify-marketing-agent-campaign');
 const {
   buildMemoryStoreGovernance,
   classifyMemoryFile,
@@ -392,6 +401,135 @@ test('creator growth campaign packages webinar, paywall, and posts', () => {
   assert.ok(campaign.channelFit.includes('beehiiv'));
   assert.match(campaign.webinar.cta, /utm_campaign=creator_webinar_agent_governance/);
   assert.ok(campaign.paywall.paidContent.some((item) => item.includes('Data Table Agent')));
+});
+
+test('marketing-agent campaign registry pins seven live tracked buyer paths', () => {
+  const validation = validateMarketingAgentCampaign();
+
+  assert.equal(validation.ok, true);
+  assert.equal(validation.channelCount, 7);
+  assert.equal(normalizeCampaignId('mg27'), 'marketing_agent_governance_20260727');
+  assert.equal(normalizeCampaignId('another_campaign'), 'another_campaign');
+  assert.ok(MARKETING_AGENT_CAMPAIGN.channels.every((entry) => (
+    new URL(entry.trackedBuyerUrl).pathname === '/go/pro'
+  )));
+});
+
+test('marketing-agent buyer-path probe is side-effect free and requires canonical attribution', async () => {
+  const entry = MARKETING_AGENT_CAMPAIGN.channels.find((channel) => channel.channel === 'bluesky');
+  const fetchCalls = [];
+  const result = await probeTrackedBuyerPath(entry, {
+    fetchImpl: async (url, options) => {
+      fetchCalls.push({ url: String(url), options });
+      return {
+        status: 302,
+        headers: {
+          get: (name) => name === 'location'
+            ? '/checkout/pro?utm_source=bluesky&utm_medium=social&utm_campaign=marketing_agent_governance_20260727'
+            : null,
+        },
+      };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.campaign, 'marketing_agent_governance_20260727');
+  assert.equal(result.createsProviderSession, false);
+  assert.equal(fetchCalls[0].options.method, 'HEAD');
+  assert.equal(fetchCalls[0].options.redirect, 'manual');
+});
+
+test('publication probe retries with a bounded GET before treating a HEAD-only 404 as missing', async () => {
+  const calls = [];
+  const result = await probePublication({
+    channel: 'bluesky',
+    permalink: 'https://social.example/post/1',
+  }, async (_url, options) => {
+    calls.push(options);
+    return { status: options.method === 'HEAD' ? 404 : 200 };
+  });
+
+  assert.equal(result.status, 'LIVE');
+  assert.equal(result.headStatus, 404);
+  assert.equal(result.httpStatus, 200);
+  assert.equal(result.method, 'GET');
+  assert.deepEqual(calls.map((entry) => entry.method), ['HEAD', 'GET']);
+  assert.equal(calls[1].headers.range, 'bytes=0-1023');
+});
+
+test('marketing-agent outcome summary combines campaign aliases but keeps channel truth separate', () => {
+  const outcome = summarizeCampaignOutcome({
+    attribution: {
+      acquisitionByCampaign: {
+        marketing_agent_governance_20260727: 3,
+        mg27: 2,
+      },
+      paidByCampaign: {
+        mg27: 1,
+      },
+      bookedRevenueByCampaignCents: {
+        mg27: 1900,
+      },
+      acquisitionBySource: {
+        bluesky: 2,
+      },
+      paidBySource: {
+        bluesky: 1,
+      },
+      bookedRevenueBySourceCents: {
+        bluesky: 1900,
+      },
+    },
+  });
+
+  assert.equal(outcome.acquisition, 5);
+  assert.equal(outcome.paidOrders, 1);
+  assert.equal(outcome.bookedRevenueCents, 1900);
+  assert.equal(outcome.conversionRate, 0.2);
+  assert.deepEqual(outcome.bySource.bluesky, {
+    acquisition: 2,
+    paidOrders: 1,
+    bookedRevenueCents: 1900,
+  });
+});
+
+test('marketing-agent report separates verified routes from hosted and provider outcome proof', async () => {
+  const report = await buildMarketingAgentCampaignReport({
+    skipPermalinks: true,
+    fetchImpl: async (url) => {
+      const parsed = new URL(url);
+      return {
+        status: 302,
+        headers: {
+          get: (name) => name === 'location'
+            ? `/checkout/pro?utm_source=${parsed.searchParams.get('utm_source')}&utm_campaign=marketing_agent_governance_20260727`
+            : null,
+        },
+      };
+    },
+    getOperationalSummary: async () => ({
+      source: 'hosted',
+      fallbackReason: null,
+      summary: {
+        attribution: {
+          acquisitionByCampaign: {
+            marketing_agent_governance_20260727: 4,
+          },
+          paidByCampaign: {},
+          bookedRevenueByCampaignCents: {},
+        },
+      },
+    }),
+  });
+
+  assert.equal(report.routeProof.passed, true);
+  assert.equal(report.routeProof.createsProviderSession, false);
+  assert.equal(report.status, 'VERIFIED');
+  assert.equal(report.outcomeProof.verifiedHostedLedger, true);
+  assert.equal(report.outcomeProof.paymentProviderVerified, false);
+  assert.equal(report.outcomeProof.metrics.acquisition, 4);
+  assert.equal(report.outcomeProof.metrics.paidOrders, 0);
+  assert.match(report.claimBoundary, /do not prove/);
 });
 
 test('AI org governance plans persistent agent teams with budget and approval gates', () => {

--- a/tests/install-growth-automation.test.js
+++ b/tests/install-growth-automation.test.js
@@ -45,9 +45,6 @@ test('buildGrowthSchedules includes revenue, reply, and money-watch automation',
   const schedules = buildGrowthSchedules();
   const ids = schedules.map((entry) => entry.id);
   assert.deepEqual(ids, [
-    'thumbgate-growth-schedule-campaign',
-    'thumbgate-growth-poll-zernio',
-    'thumbgate-growth-sync-launch-assets',
     'thumbgate-growth-reply-monitor',
     'thumbgate-growth-campaign-conversion',
     'thumbgate-growth-money-watch',
@@ -62,35 +59,41 @@ test('buildGrowthSchedules includes revenue, reply, and money-watch automation',
     /verify-marketing-agent-campaign\.js/
   );
   assert.match(byId['thumbgate-growth-campaign-conversion'].command, /marketing-agent-campaign/);
+  assert.match(byId['thumbgate-growth-campaign-conversion'].command, /--window=lifetime/);
   assert.match(byId['thumbgate-growth-money-watch'].command, /money-watcher\.js/);
-  assert.match(byId['thumbgate-growth-sync-launch-assets'].command, /sync-launch-assets\.js/);
 });
 
-test('installGrowthAutomation registers eight recurring jobs', () => {
+test('installGrowthAutomation removes retired jobs and registers five recurring jobs', () => {
   const scheduleManager = require('../scripts/schedule-manager');
   const originalCreate = scheduleManager.createSchedule;
+  const originalDelete = scheduleManager.deleteSchedule;
   const originalList = scheduleManager.listSchedules;
   const calls = [];
+  const deleted = [];
 
   scheduleManager.createSchedule = (params) => {
     calls.push(params);
     return { success: true, schedule: params };
+  };
+  scheduleManager.deleteSchedule = (id) => {
+    deleted.push(id);
+    return { success: true, id };
   };
   scheduleManager.listSchedules = () => calls;
 
   const result = installGrowthAutomation();
 
   scheduleManager.createSchedule = originalCreate;
+  scheduleManager.deleteSchedule = originalDelete;
   scheduleManager.listSchedules = originalList;
 
-  assert.equal(result.installed.length, 8);
-  assert.equal(calls.length, 8);
-  assert.equal(calls[0].id, 'thumbgate-growth-schedule-campaign');
-  assert.equal(calls[1].id, 'thumbgate-growth-poll-zernio');
-  assert.equal(calls[2].id, 'thumbgate-growth-sync-launch-assets');
-  assert.equal(calls[3].id, 'thumbgate-growth-reply-monitor');
-  assert.equal(calls[4].id, 'thumbgate-growth-campaign-conversion');
-  assert.equal(calls[5].id, 'thumbgate-growth-money-watch');
-  assert.equal(calls[6].id, 'thumbgate-growth-revenue-loop');
-  assert.equal(calls[7].id, 'thumbgate-growth-social-digest');
+  assert.equal(result.retired.length, 3);
+  assert.equal(deleted.length, 3);
+  assert.equal(result.installed.length, 5);
+  assert.equal(calls.length, 5);
+  assert.equal(calls[0].id, 'thumbgate-growth-reply-monitor');
+  assert.equal(calls[1].id, 'thumbgate-growth-campaign-conversion');
+  assert.equal(calls[2].id, 'thumbgate-growth-money-watch');
+  assert.equal(calls[3].id, 'thumbgate-growth-revenue-loop');
+  assert.equal(calls[4].id, 'thumbgate-growth-social-digest');
 });

--- a/tests/install-growth-automation.test.js
+++ b/tests/install-growth-automation.test.js
@@ -49,6 +49,7 @@ test('buildGrowthSchedules includes revenue, reply, and money-watch automation',
     'thumbgate-growth-poll-zernio',
     'thumbgate-growth-sync-launch-assets',
     'thumbgate-growth-reply-monitor',
+    'thumbgate-growth-campaign-conversion',
     'thumbgate-growth-money-watch',
     'thumbgate-growth-revenue-loop',
     'thumbgate-growth-social-digest',
@@ -56,11 +57,16 @@ test('buildGrowthSchedules includes revenue, reply, and money-watch automation',
   const byId = Object.fromEntries(schedules.map((entry) => [entry.id, entry]));
   assert.match(byId['thumbgate-growth-revenue-loop'].command, /autonomous-sales-agent\.js/);
   assert.match(byId['thumbgate-growth-revenue-loop'].command, /gtm-revenue-loop/);
+  assert.match(
+    byId['thumbgate-growth-campaign-conversion'].command,
+    /verify-marketing-agent-campaign\.js/
+  );
+  assert.match(byId['thumbgate-growth-campaign-conversion'].command, /marketing-agent-campaign/);
   assert.match(byId['thumbgate-growth-money-watch'].command, /money-watcher\.js/);
   assert.match(byId['thumbgate-growth-sync-launch-assets'].command, /sync-launch-assets\.js/);
 });
 
-test('installGrowthAutomation registers seven recurring jobs', () => {
+test('installGrowthAutomation registers eight recurring jobs', () => {
   const scheduleManager = require('../scripts/schedule-manager');
   const originalCreate = scheduleManager.createSchedule;
   const originalList = scheduleManager.listSchedules;
@@ -77,13 +83,14 @@ test('installGrowthAutomation registers seven recurring jobs', () => {
   scheduleManager.createSchedule = originalCreate;
   scheduleManager.listSchedules = originalList;
 
-  assert.equal(result.installed.length, 7);
-  assert.equal(calls.length, 7);
+  assert.equal(result.installed.length, 8);
+  assert.equal(calls.length, 8);
   assert.equal(calls[0].id, 'thumbgate-growth-schedule-campaign');
   assert.equal(calls[1].id, 'thumbgate-growth-poll-zernio');
   assert.equal(calls[2].id, 'thumbgate-growth-sync-launch-assets');
   assert.equal(calls[3].id, 'thumbgate-growth-reply-monitor');
-  assert.equal(calls[4].id, 'thumbgate-growth-money-watch');
-  assert.equal(calls[5].id, 'thumbgate-growth-revenue-loop');
-  assert.equal(calls[6].id, 'thumbgate-growth-social-digest');
+  assert.equal(calls[4].id, 'thumbgate-growth-campaign-conversion');
+  assert.equal(calls[5].id, 'thumbgate-growth-money-watch');
+  assert.equal(calls[6].id, 'thumbgate-growth-revenue-loop');
+  assert.equal(calls[7].id, 'thumbgate-growth-social-digest');
 });


### PR DESCRIPTION
## What changed

- add a machine-readable seven-channel campaign registry with canonical tracked `/go/pro` buyer paths
- normalize the short campaign alias at redirect ingestion and billing attribution boundaries
- add a side-effect-free campaign verifier for publication reachability, buyer-route integrity, and hosted outcome truth
- schedule the campaign conversion monitor hourly alongside existing growth automation
- add regression coverage for route safety, attribution normalization, publication fallback behavior, outcome rollups, and scheduler wiring

## Why

The campaign was published across multiple channels, but attribution was fragmented and route availability was not the same as lead, buyer, or payment proof. This change makes those proof surfaces explicit and continuously verifiable without creating a payment-provider session.

## User impact

Operators get one command and one hourly report that distinguishes:

- publication availability
- tracked buyer-route health
- hosted acquisition and paid-order outcomes
- provider-verification boundaries

The existing Hashnode article was updated in place to use its canonical tracked `/go/pro` URL; no duplicate article was created.

## Validation

- `npm test` — PASS
- `npm run test:coverage` — PASS, 87.12% overall
- `npm run prove:adapters` — PASS, 48/48
- `npm run prove:automation` — PASS, 55/55
- `npm run self-heal:check` — HEALTHY, 6/6
- focused regression suite — PASS, 263/263 including package-boundary ratchets
- live campaign verifier — all seven buyer routes returned safe 302 redirects to `/checkout/pro`; no provider session created
- hosted campaign ledger — verified readback with 0 acquisitions, 0 paid orders, and $0 booked revenue; payment-provider verification remains separate