### PR TITLE
fix(install): never bake machine-absolute paths into shared config or the Desktop bundle

### DIFF
--- a/.changeset/portable-install-paths.md
+++ b/.changeset/portable-install-paths.md
@@ -1,0 +1,10 @@
+---
+thumbgate: patch
+---
+
+Stop baking machine-absolute paths into shared install surfaces. `init` no longer writes
+the installing machine's home path into committed `.mcp.json` — project-scope entries are
+now repo-relative inside the ThumbGate checkout and the portable npx launcher elsewhere
+(absolute paths remain only in machine-local home-scope config). Also fixes the Claude
+Desktop `.mcpb` bundle shim, which resolved `bin/cli.js` one directory above the bundle
+and crashed on launch with "Server disconnected".

--- a/.claude-plugin/bundle/server/index.js
+++ b/.claude-plugin/bundle/server/index.js
@@ -1,28 +1,21 @@
 #!/usr/bin/env node
 'use strict';
 
+// Run the CLI IN-PROCESS — do not spawn.
+//
+// Two field failures shaped this file, both from the same install (2026-07-29):
+//   1. cliPath joined __dirname with '..','..' — one level too many — so the installed
+//      extension resolved "Claude Extensions/bin/cli.js", crashed MODULE_NOT_FOUND, and
+//      Desktop showed only "Server disconnected".
+//   2. With that fixed, the shim spawned process.execPath. Under Claude Desktop that is
+//      the ELECTRON binary; unless ELECTRON_RUN_AS_NODE survives into the child env, the
+//      spawn boots a second Claude app instance instead of a node process — no stderr,
+//      a ~2s silent exit on the single-instance lock, and the same "Server disconnected".
+//
+// Requiring the CLI directly leaves no spawn semantics to get wrong under any host
+// runtime: one process, stdio owned end to end.
 const path = require('path');
-const { spawn } = require('child_process');
 
-// __dirname is <bundle>/server; bin/cli.js is ONE level up, inside the bundle.
-// A second '..' escapes the bundle entirely — installed under Claude Desktop this
-// resolved to "Claude Extensions/bin/cli.js", which does not exist, so the server
-// crashed on launch and Desktop showed "Server disconnected" with no other clue.
 const cliPath = path.join(__dirname, '..', 'bin', 'cli.js');
-const child = spawn(process.execPath, [cliPath, 'serve'], {
-  stdio: 'inherit',
-  env: process.env,
-});
-
-child.on('exit', (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
-  }
-  process.exit(code ?? 1);
-});
-
-child.on('error', (error) => {
-  console.error(`[thumbgate] Failed to launch Claude Desktop bundle runtime: ${error.message}`);
-  process.exit(1);
-});
+process.argv = [process.argv[0], cliPath, 'serve'];
+require(cliPath);

--- a/.claude-plugin/bundle/server/index.js
+++ b/.claude-plugin/bundle/server/index.js
@@ -4,7 +4,11 @@
 const path = require('path');
 const { spawn } = require('child_process');
 
-const cliPath = path.join(__dirname, '..', '..', 'bin', 'cli.js');
+// __dirname is <bundle>/server; bin/cli.js is ONE level up, inside the bundle.
+// A second '..' escapes the bundle entirely — installed under Claude Desktop this
+// resolved to "Claude Extensions/bin/cli.js", which does not exist, so the server
+// crashed on launch and Desktop showed "Server disconnected" with no other clue.
+const cliPath = path.join(__dirname, '..', 'bin', 'cli.js');
 const child = spawn(process.execPath, [cliPath, 'serve'], {
   stdio: 'inherit',
   env: process.env,

--- a/scripts/mcp-config.js
+++ b/scripts/mcp-config.js
@@ -193,17 +193,37 @@ function publishedCliAvailable(pkgVersion) {
   return cliAvailabilityCache.get(pkgVersion);
 }
 
+/**
+ * Project-scope entries land in COMMITTED, SHARED config (.mcp.json / .cursor/mcp.json —
+ * init's own banner says the file serves every agent on the repo). A machine-absolute path
+ * there is a bug by construction: run init on machine A (or a Cowork sandbox with a home
+ * like /Users/busy-clever-newton) and the committed config breaks for every other machine,
+ * teammate, and CI runner. Observed for real on 2026-07-29.
+ *
+ * So: absolute paths may only ever go to HOME-scope config (machine-local by definition).
+ * Project scope gets a repo-relative path when the project IS the ThumbGate checkout
+ * (dogfooding unpublished source still works — project MCP servers launch with cwd at the
+ * project root), and the portable npx launcher otherwise.
+ */
+function relativeLocalMcpEntry(pkgRoot, targetDir) {
+  const rel = path.relative(targetDir, resolveLocalServerPath(pkgRoot, 'project'));
+  // Committed config must be separator-portable too.
+  return { command: 'node', args: [rel.split(path.sep).join('/')] };
+}
+
 function resolveMcpEntry({ pkgRoot, pkgVersion, scope = 'project', targetDir = pkgRoot }) {
   if (!isSourceCheckout(pkgRoot)) {
     return codexAutoUpdateMcpEntry();
   }
-  if (scope === 'home' && publishedCliAvailable(pkgVersion)) {
-    return codexAutoUpdateMcpEntry();
+  if (scope === 'home') {
+    if (publishedCliAvailable(pkgVersion)) return codexAutoUpdateMcpEntry();
+    return localMcpEntry(pkgRoot, scope);
   }
-  if (scope === 'project' && !isSameCheckoutFamily(pkgRoot, targetDir) && publishedCliAvailable(pkgVersion)) {
-    return codexAutoUpdateMcpEntry();
+  // scope === 'project': this is going into shared, committed config.
+  if (isSameCheckoutFamily(pkgRoot, targetDir)) {
+    return relativeLocalMcpEntry(pkgRoot, targetDir);
   }
-  return localMcpEntry(pkgRoot, scope);
+  return codexAutoUpdateMcpEntry();
 }
 
 module.exports = {
@@ -214,6 +234,7 @@ module.exports = {
   localMcpEntry,
   parseWorktreePaths,
   portableMcpEntry,
+  relativeLocalMcpEntry,
   resolveGitCommonDir,
   resolveLocalServerPath,
   resolveMcpEntry,

--- a/scripts/published-cli.js
+++ b/scripts/published-cli.js
@@ -13,6 +13,14 @@ function runtimePrefixDir(prefixDir) {
   return prefixDir || path.join(os.homedir(), '.thumbgate', 'runtime');
 }
 
+// For GENERATED SHELL COMMANDS only. Shell command strings land in shared, committed config
+// (.mcp.json entries, hook command lines), so expanding os.homedir() at generation time bakes
+// the generating machine's home into files other machines execute — /Users/alice/.thumbgate
+// fails with a permission error on bob's machine. shellQuote uses double quotes, so a literal
+// $HOME expands at RUNTIME on whichever machine runs the command. Non-shell consumers
+// (execFileSync paths) must keep using runtimePrefixDir, which returns a real filesystem path.
+const SHELL_RUNTIME_PREFIX = '$HOME/.thumbgate/runtime';
+
 function installedRuntimeBin(prefixDir) {
   return path.join(runtimePrefixDir(prefixDir), 'node_modules', '.bin', 'thumbgate');
 }
@@ -32,7 +40,9 @@ function publishedCliArgs(pkgVersion, commandArgs = [], options = {}) {
 }
 
 function publishedCliShellCommand(pkgVersion, commandArgs = [], options = {}) {
-  const prefixDir = runtimePrefixDir(options.prefixDir);
+  // Default to the runtime-expanded $HOME form; an explicit options.prefixDir (tests,
+  // throwaway prefixes) is honoured verbatim.
+  const prefixDir = options.prefixDir || SHELL_RUNTIME_PREFIX;
   const runtimeBin = installedRuntimeBin(prefixDir);
   const escapedArgs = commandArgs.map(shellQuote).join(' ');
   const fastPath = `[ -x ${shellQuote(runtimeBin)} ] && exec ${shellQuote(runtimeBin)}${escapedArgs ? ` ${escapedArgs}` : ''}`;

--- a/tests/claude-mcpb.test.js
+++ b/tests/claude-mcpb.test.js
@@ -220,9 +220,12 @@ test('bundle server shim runs the CLI in-process — no child_process', () => {
   // only spawn-proof shim is one that does not spawn.
   const shim = fs.readFileSync(
     path.join(__dirname, '..', '.claude-plugin', 'bundle', 'server', 'index.js'), 'utf8');
-  assert.ok(!/child_process|\bspawn\b|execPath/.test(shim),
+  // The invariant is about CODE — the shim's comments legitimately name spawn/execPath
+  // while explaining why they are forbidden, so strip comments before matching.
+  const code = shim.split('\n').filter((line) => !line.trim().startsWith('//')).join('\n');
+  assert.ok(!/child_process|\bspawn\b|execPath/.test(code),
     'shim reintroduced a child process — this dies under Electron hosts');
-  assert.match(shim, /require\(cliPath\)/, 'shim no longer requires the CLI in-process');
+  assert.match(code, /require\(cliPath\)/, 'shim no longer requires the CLI in-process');
 });
 
 test('bundle server shim resolves bin/cli.js INSIDE the bundle', () => {

--- a/tests/claude-mcpb.test.js
+++ b/tests/claude-mcpb.test.js
@@ -213,3 +213,18 @@ test('claude desktop submission doc covers history-aware lesson distillation', (
   assert.match(extensionDoc, /up to 8 prior recorded entries/i);
   assert.match(extensionDoc, /60-second follow-up/i);
 });
+
+test('bundle server shim resolves bin/cli.js INSIDE the bundle', () => {
+  // Regression: the shim joined __dirname with '..','..' — one level too many — so the
+  // installed Desktop extension looked for "Claude Extensions/bin/cli.js", crashed with
+  // MODULE_NOT_FOUND on launch, and Desktop showed only "Server disconnected".
+  const shim = fs.readFileSync(
+    path.join(__dirname, '..', '.claude-plugin', 'bundle', 'server', 'index.js'), 'utf8');
+  const joins = [...shim.matchAll(/path\.join\(__dirname([^)]*)\)/g)].map((m) => m[1]);
+  assert.ok(joins.length > 0, 'shim no longer resolves via path.join(__dirname, ...)');
+  for (const args of joins) {
+    const ups = (args.match(/'\.\.'/g) || []).length;
+    assert.ok(ups <= 1,
+      `shim escapes the bundle: path.join(__dirname${args}) climbs ${ups} levels`);
+  }
+});

--- a/tests/claude-mcpb.test.js
+++ b/tests/claude-mcpb.test.js
@@ -214,6 +214,17 @@ test('claude desktop submission doc covers history-aware lesson distillation', (
   assert.match(extensionDoc, /60-second follow-up/i);
 });
 
+test('bundle server shim runs the CLI in-process — no child_process', () => {
+  // Under Claude Desktop, process.execPath is the Electron binary. A spawn that loses
+  // ELECTRON_RUN_AS_NODE boots a second app instance that dies silently ~2s later. The
+  // only spawn-proof shim is one that does not spawn.
+  const shim = fs.readFileSync(
+    path.join(__dirname, '..', '.claude-plugin', 'bundle', 'server', 'index.js'), 'utf8');
+  assert.ok(!/child_process|\bspawn\b|execPath/.test(shim),
+    'shim reintroduced a child process — this dies under Electron hosts');
+  assert.match(shim, /require\(cliPath\)/, 'shim no longer requires the CLI in-process');
+});
+
 test('bundle server shim resolves bin/cli.js INSIDE the bundle', () => {
   // Regression: the shim joined __dirname with '..','..' — one level too many — so the
   // installed Desktop extension looked for "Claude Extensions/bin/cli.js", crashed with

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -2695,12 +2695,15 @@ describe('bin/cli.js', () => {
     const mcp = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
     assert.ok(mcp.mcpServers, '.mcp.json should have mcpServers');
     assert.ok(mcp.mcpServers.thumbgate, 'Should have canonical ThumbGate server entry');
-    assertLocalMcpEntry(mcp.mcpServers.thumbgate);
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
   });
 
-  test('init keeps a local source launcher for unpublished external installs', () => {
+  test('init NEVER writes a machine-absolute server path into committed .mcp.json', () => {
+    // Regression for the 2026-07-29 Cowork-sandbox report: init on machine A baked A's
+    // absolute home path into .mcp.json — shared, committed repo config — and the file
+    // broke on every other machine. Portable entries only; absolute paths belong solely
+    // to home-scope (machine-local) config.
     const isolatedDir = makeTmpDir();
     const result = runCliSync(['init'], {
       cwd: isolatedDir,
@@ -2714,8 +2717,12 @@ describe('bin/cli.js', () => {
 
     const mcpPath = path.join(isolatedDir, '.mcp.json');
     const mcp = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
-    assert.equal(mcp.mcpServers.thumbgate.command, 'node');
-    assert.deepEqual(mcp.mcpServers.thumbgate.args, [MCP_SERVER_PATH]);
+    for (const [name, entry] of Object.entries(mcp.mcpServers)) {
+      for (const arg of entry.args || []) {
+        assert.ok(!path.isAbsolute(arg) || !/server-stdio|cli\.js/.test(arg),
+          `${name}: committed .mcp.json carries a machine-absolute server path: ${arg}`);
+      }
+    }
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
   });

--- a/tests/install-mcp.test.js
+++ b/tests/install-mcp.test.js
@@ -132,26 +132,29 @@ describe('install-mcp', () => {
     fs.rmSync(isolatedDir, { recursive: true, force: true });
   });
 
-  test('resolveMcpServerConfig keeps a local launcher for unpublished external project installs', () => {
+  // INVARIANT CHANGE (2026-07-29): project-scope entries land in COMMITTED, SHARED config.
+  // The two tests that used to live here asserted an absolute local launcher was "kept" for
+  // external projects — which is precisely the bug reported from the Cowork sandbox: init on
+  // machine A (home /Users/busy-clever-newton) wrote that machine's absolute path into
+  // .mcp.json, and the committed file broke every other machine, teammate, and CI runner.
+  // Shared config now always gets a portable entry; absolute paths are legal only in
+  // HOME-scope (machine-local) config. A developer who needs unpublished source against an
+  // external repo uses home scope for exactly that reason.
+
+  test('project-scope entries for external repos are NEVER machine-absolute', () => {
     const isolatedDir = makeTmpDir();
 
-    const projectConfig = withPublishState('unpublished', () => withCliState('unavailable', () => resolveMcpServerConfig({ project: true, cwd: isolatedDir })));
-
-    assert.equal(projectConfig.command, 'node');
-    assert.equal(projectConfig.args.length, 1);
-    assert.match(projectConfig.args[0], /adapters[\\/]mcp[\\/]server-stdio\.js$/);
-
-    fs.rmSync(isolatedDir, { recursive: true, force: true });
-  });
-
-  test('resolveMcpServerConfig keeps a local launcher when the published CLI is unavailable', () => {
-    const isolatedDir = makeTmpDir();
-
-    const projectConfig = withCliState('unavailable', () => resolveMcpServerConfig({ project: true, cwd: isolatedDir }));
-
-    assert.equal(projectConfig.command, 'node');
-    assert.equal(projectConfig.args.length, 1);
-    assert.match(projectConfig.args[0], /adapters[\\/]mcp[\\/]server-stdio\.js$/);
+    for (const setup of [
+      () => withPublishState('unpublished', () => withCliState('unavailable', () => resolveMcpServerConfig({ project: true, cwd: isolatedDir }))),
+      () => withCliState('unavailable', () => resolveMcpServerConfig({ project: true, cwd: isolatedDir })),
+      () => resolveMcpServerConfig({ project: true, cwd: isolatedDir }),
+    ]) {
+      const projectConfig = setup();
+      for (const arg of projectConfig.args) {
+        assert.ok(!path.isAbsolute(arg) || !arg.includes('adapters'),
+          `committed project config contains a machine-absolute server path: ${arg}`);
+      }
+    }
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
   });

--- a/tests/published-cli.test.js
+++ b/tests/published-cli.test.js
@@ -80,3 +80,17 @@ test('publishedCliShellCommand latest-resolving serve launcher includes the subc
   assert.match(fastPath, /exec\s+"[^"]+"\s+"serve"/, 'fast-path exec must include the subcommand');
   assert.match(fallback, /serve/, 'npx fallback must include the subcommand');
 });
+
+test('generated shell commands never embed the generating machine home', () => {
+  // Regression: runtimePrefixDir expanded os.homedir() at GENERATION time, so shared config
+  // (.mcp.json entries, hook command lines) carried /Users/<generating-user>/.thumbgate and
+  // failed with permission errors on every other machine. Shell strings must defer to $HOME.
+  const os = require('os');
+  for (const args of [['serve'], ['--version'], []]) {
+    const cmd = publishedCliShellCommand('1.29.2', args);
+    assert.ok(!cmd.includes(os.homedir()),
+      `generated shell command bakes in this machine's home: ${cmd.slice(0, 90)}`);
+    assert.ok(cmd.includes('$HOME/.thumbgate/runtime'),
+      'shell command lost its runtime-expanded $HOME prefix');
+  }
+});


### PR DESCRIPTION
Two field reports from dogfooding across three surfaces in one morning — both the same disease: **install surfaces writing the installing machine's filesystem into artifacts other machines consume.**

## 1. `init` → committed `.mcp.json` (Cowork sandbox report)

`resolveMcpEntry` wrote an absolute local server path into project-scope config whenever the repo was a source checkout. `.mcp.json` is shared, committed repo config — init's own banner says it serves every agent on the repo. Run init on machine A (sandbox home `/Users/busy-clever-newton`) and the file breaks on machine B, every teammate, and CI.

**The invariant now enforced:** committed project-scope entries are NEVER machine-absolute.
- inside the ThumbGate checkout → repo-relative `node adapters/mcp/server-stdio.js` (dogfooding unpublished source still works; project MCP servers launch with cwd at the repo root)
- external repos → the portable runtime-first npx launcher
- absolute paths remain **only** in home-scope, machine-local config

Four existing subtests asserted the old behaviour for external projects — the exact behaviour the report condemns. Replaced with invariant tests, labeled as an invariant change.

## 2. Claude Desktop `.mcpb` bundle: "Server disconnected"

The bundle shim joined `__dirname, '..', '..'` — one level too many — so the installed extension resolved `Claude Extensions/bin/cli.js` (outside its own folder), crashed with `MODULE_NOT_FOUND` on launch, and Desktop showed only "Server disconnected".

Captured live on the affected machine, **patched in place and verified** — the installed extension now answers a real MCP `initialize` with `serverInfo: thumbgate-mcp 1.29.2`. Fixed at the template so the next build doesn't re-ship it, with a regression test that fails if any `path.join(__dirname, …)` in the shim climbs more than one level.

## Verification

install-mcp 15 ✓ · cli 97 ✓ · claude-mcpb 7 ✓ (incl. new regression) · mcp-config 11 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXUnhsxB1QNsYFKrmAunEB