### PR TITLE
fix(dashboard): restore search and DPO export

### DIFF
--- a/.changeset/repair-dashboard-search-export.md
+++ b/.changeset/repair-dashboard-search-export.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Keep dashboard search responsive by bounding hidden chart work, and make DPO export download the actual preference-pair records through the authenticated POST API.

--- a/.changeset/repair-dashboard-search-export.md
+++ b/.changeset/repair-dashboard-search-export.md
@@ -2,4 +2,4 @@
 "thumbgate": patch
 ---
 
-Keep dashboard search responsive by bounding hidden chart work, and make DPO export download the actual preference-pair records through the authenticated POST API.
+Keep dashboard search responsive by bounding hidden chart work and preventing the paid-help overlay from covering dashboard controls. Make DPO export download the actual preference-pair records through the authenticated POST API.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -286,7 +286,7 @@
   }
 </style>
 </head>
-<body>
+<body data-revenue-assist="off">
 
 <nav>
   <div class="container">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1013,6 +1013,12 @@ async function checkLocalLlmReachable(url) {
 }
 
 function disconnectKey() {
+  pauseDashboardHydration();
+  dashboardDataPromise = null;
+  if (__liveEventsController) {
+    try { __liveEventsController.abort(); } catch (_) { /* already aborted */ }
+    __liveEventsController = null;
+  }
   API_KEY = '';
   isDemo = false;
   var input = document.getElementById('apiKey');

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1094,7 +1094,12 @@ async function connect(options) {
     }
     renderStats(data);
     setSelectedCard('all');
-    await loadDashboardData();
+    var deepLinkedTab = getDeepLinkTab();
+    if (deepLinkedTab && deepLinkedTab !== 'search') {
+      switchTab(deepLinkedTab);
+    } else {
+      scheduleDashboardHydration(10000);
+    }
     // Open a live-events stream so feedback/rule-regen events surface
     // without a manual refresh. Non-fatal: if the browser doesn't support
     // ReadableStream over fetch (very old), we simply stay on the polled path.
@@ -1175,6 +1180,7 @@ async function search() {
     return;
   }
 
+  pauseDashboardHydration();
   try {
     const res = await fetch('/v1/search', {
       method: 'POST',
@@ -1191,6 +1197,8 @@ async function search() {
     container.innerHTML = results.map(renderResult).join('');
   } catch (e) {
     setMessageState(container, 'empty', e && e.message ? e.message : 'Search failed');
+  } finally {
+    scheduleDashboardHydration(3000);
   }
 }
 
@@ -1376,6 +1384,20 @@ function switchTab(name) {
       history.replaceState(null, '', '#' + name);
     }
   } catch (e) { /* ignore: older browsers or sandboxed frames */ }
+  if (API_KEY && !isDemo) {
+    if (name === 'ai-inventory') {
+      loadAiInventory();
+    } else if (name === 'enterprise') {
+      loadEnterpriseDataChatStatus();
+    } else if (name !== 'search' && name !== 'export') {
+      ensureDashboardDataLoaded().then(function() {
+        if (name === 'generated') loadGeneratedView(currentGeneratedView);
+        if (name === 'insights') requestAnimationFrame(renderPendingInsightsCharts);
+      });
+    }
+  } else if (name === 'insights') {
+    requestAnimationFrame(renderPendingInsightsCharts);
+  }
 }
 
 /**
@@ -1433,15 +1455,36 @@ async function loadGates() {
 
 async function loadDashboardData() {
   await loadGates();
-  await loadGeneratedView(currentGeneratedView);
-  // Fetch full dashboard for insights charts
-  try {
-    var res = await fetch('/v1/dashboard', { headers: getHeaders() });
-    if (res.ok) {
-      var data = await res.json();
-      renderDashboardData(data);
-    }
-  } catch (e) { /* insights degrade gracefully */ }
+}
+
+var dashboardDataPromise = null;
+var dashboardHydrationTimer = null;
+
+function pauseDashboardHydration() {
+  if (dashboardHydrationTimer) {
+    clearTimeout(dashboardHydrationTimer);
+    dashboardHydrationTimer = null;
+  }
+}
+
+function ensureDashboardDataLoaded() {
+  pauseDashboardHydration();
+  if (!dashboardDataPromise) {
+    dashboardDataPromise = loadDashboardData().catch(function(error) {
+      dashboardDataPromise = null;
+      throw error;
+    });
+  }
+  return dashboardDataPromise;
+}
+
+function scheduleDashboardHydration(delayMs) {
+  if (!API_KEY || isDemo || dashboardDataPromise) return;
+  pauseDashboardHydration();
+  dashboardHydrationTimer = setTimeout(function() {
+    dashboardHydrationTimer = null;
+    ensureDashboardDataLoaded();
+  }, delayMs);
 }
 
 // Live-events SSE subscription. We use fetch() + ReadableStream instead of
@@ -1608,8 +1651,6 @@ function renderDashboardData(data) {
   renderRegulatedProof(data.regulatedProof || {});
   renderTemplates(data.templateLibrary || {});
   renderInsights(data);
-  loadAiInventory();
-  loadEnterpriseDataChatStatus();
 }
 
 async function loadAiInventory() {
@@ -2501,17 +2542,23 @@ async function exportDpo() {
   const status = document.getElementById('exportStatus');
   status.textContent = 'Exporting...';
   try {
-    const res = await fetch('/v1/dpo/export', { headers: getHeaders() });
-    if (!res.ok) throw new Error('Export failed');
+    const res = await fetch('/v1/dpo/export', {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify({ includePairs: true })
+    });
     const data = await res.json();
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    if (!res.ok) throw new Error(data.detail || data.error || 'Export failed');
+    if (!Array.isArray(data.records)) throw new Error('Export response did not include DPO pairs');
+    const records = data.records;
+    const blob = new Blob([JSON.stringify(records, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
     a.download = 'thumbgate-dpo-pairs-' + new Date().toISOString().slice(0,10) + '.json';
     a.click();
     URL.revokeObjectURL(url);
-    const count = data.pairs ? data.pairs.length : Array.isArray(data) ? data.length : 0;
+    const count = records.length;
     status.textContent = '✓ Exported ' + count + ' preference pairs';
     status.style.color = 'var(--green)';
   } catch (e) {
@@ -2526,14 +2573,24 @@ async function exportDpo() {
 var feedbackChart = null;
 var lessonChart = null;
 var gateAuditChart = null;
+var pendingInsightsData = null;
 
 function renderInsights(data) {
   renderTokenSavings(data.tokenSavings, data.gateStats || {});
   renderPipeline(data.lessonPipeline || {});
-  renderFeedbackTrendChart(data.feedbackTimeSeries || {});
-  renderLessonTrendChart(data.feedbackTimeSeries || {});
-  renderGateAuditChartFromData(data.gateAudit || {});
   renderActionableRemediations(data.actionableRemediations || []);
+  pendingInsightsData = data;
+  var insightsTab = document.getElementById('tab-insights');
+  if (insightsTab && insightsTab.classList.contains('active')) {
+    requestAnimationFrame(renderPendingInsightsCharts);
+  }
+}
+
+function renderPendingInsightsCharts() {
+  if (!pendingInsightsData) return;
+  renderFeedbackTrendChart(pendingInsightsData.feedbackTimeSeries || {});
+  renderLessonTrendChart(pendingInsightsData.feedbackTimeSeries || {});
+  renderGateAuditChartFromData(pendingInsightsData.gateAudit || {});
 }
 
 function renderActionableRemediations(remediations) {
@@ -2643,7 +2700,7 @@ function renderFeedbackTrendChart(ts) {
   var canvas = document.getElementById('feedbackTrendChart');
   if (!canvas) return;
   if (typeof Chart === 'undefined') return;
-  var days = ts.days || [];
+  var days = (ts.days || []).slice(-90);
   if (feedbackChart) feedbackChart.destroy();
 
   var labels = days.map(function(d) { return d.dayKey.slice(5); });
@@ -2684,7 +2741,7 @@ function renderFeedbackTrendChart(ts) {
       },
       scales: {
         x: { ticks: { color: '#8b8b96', font: { size: 10 }, maxRotation: 45 }, grid: { color: 'rgba(34,34,37,0.5)' } },
-        y: { beginAtZero: true, ticks: { color: '#8b8b96', stepSize: 1 }, grid: { color: 'rgba(34,34,37,0.5)' } },
+        y: { beginAtZero: true, ticks: { color: '#8b8b96', precision: 0, maxTicksLimit: 6 }, grid: { color: 'rgba(34,34,37,0.5)' } },
       },
     },
   });
@@ -2694,7 +2751,7 @@ function renderLessonTrendChart(ts) {
   var canvas = document.getElementById('lessonTrendChart');
   if (!canvas) return;
   if (typeof Chart === 'undefined') return;
-  var days = ts.days || [];
+  var days = (ts.days || []).slice(-90);
   if (lessonChart) lessonChart.destroy();
 
   var labels = days.map(function(d) { return d.dayKey.slice(5); });
@@ -2742,8 +2799,8 @@ function renderLessonTrendChart(ts) {
       },
       scales: {
         x: { ticks: { color: '#8b8b96', font: { size: 10 }, maxRotation: 45 }, grid: { color: 'rgba(34,34,37,0.5)' } },
-        y: { beginAtZero: true, position: 'left', ticks: { color: '#22d3ee', stepSize: 1 }, grid: { color: 'rgba(34,34,37,0.5)' } },
-        y1: { beginAtZero: true, position: 'right', ticks: { color: '#4ade80' }, grid: { drawOnChartArea: false } },
+        y: { beginAtZero: true, position: 'left', ticks: { color: '#22d3ee', precision: 0, maxTicksLimit: 6 }, grid: { color: 'rgba(34,34,37,0.5)' } },
+        y1: { beginAtZero: true, position: 'right', ticks: { color: '#4ade80', precision: 0, maxTicksLimit: 6 }, grid: { drawOnChartArea: false } },
       },
     },
   });
@@ -2753,7 +2810,7 @@ function renderGateAuditChartFromData(gateAudit) {
   var canvas = document.getElementById('gateAuditChart');
   if (!canvas) return;
   if (typeof Chart === 'undefined') return;
-  var days = gateAudit.days || [];
+  var days = (gateAudit.days || []).slice(-90);
   if (gateAuditChart) gateAuditChart.destroy();
 
   var labels = days.map(function(d) { return (d.dayKey || '').slice(5); });
@@ -2791,7 +2848,7 @@ function renderGateAuditChartFromData(gateAudit) {
       },
       scales: {
         x: { stacked: true, ticks: { color: '#8b8b96', font: { size: 10 } }, grid: { color: 'rgba(34,34,37,0.5)' } },
-        y: { stacked: true, beginAtZero: true, ticks: { color: '#8b8b96', stepSize: 1 }, grid: { color: 'rgba(34,34,37,0.5)' } },
+        y: { stacked: true, beginAtZero: true, ticks: { color: '#8b8b96', precision: 0, maxTicksLimit: 6 }, grid: { color: 'rgba(34,34,37,0.5)' } },
       },
     },
   });

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -9634,14 +9634,19 @@ a{color:#8b9}</style></head><body><form class="card" method="post" action="/oaut
           fs.writeFileSync(paths.outputPath, result.jsonl);
         }
 
-        sendJson(res, 200, {
+        const response = {
           pairs: result.pairs.length,
+          pairCount: result.pairs.length,
           errors: result.errors.length,
           learnings: result.learnings.length,
           unpairedErrors: result.unpairedErrors.length,
           unpairedLearnings: result.unpairedLearnings.length,
           outputPath: paths.outputPath,
-        });
+        };
+        if (body.includePairs === true) {
+          response.records = result.pairs;
+        }
+        sendJson(res, 200, response);
         return;
       }
 

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -2674,6 +2674,19 @@ test('dpo export endpoint works with local memory log', async () => {
   assert.equal(fs.existsSync(outputPath), true);
 });
 
+test('dpo export endpoint returns downloadable records when requested by the dashboard', async () => {
+  const res = await fetch(apiUrl('/v1/dpo/export'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...authHeader },
+    body: JSON.stringify({ includePairs: true }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.ok(Array.isArray(body.records));
+  assert.equal(body.pairCount, body.records.length);
+  assert.equal(body.pairs, body.records.length);
+});
+
 test('databricks export endpoint writes analytics bundle', async () => {
   const outputPath = path.join(tmpFeedbackDir, 'analytics', 'bundle-api');
   fs.mkdirSync(path.join(tmpProofDir, 'automation'), { recursive: true });

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -111,6 +111,7 @@ test('dashboard defaults to the Total Feedback card highlight on first render', 
   assert.match(dashboard, /function setSelectedCard\(action\)/);
   assert.match(dashboard, /card\.classList\.toggle\('selected', card\.dataset\.cardAction === action\)/);
   assert.match(dashboard, /<body data-revenue-assist="off">/);
+  assert.match(dashboard, /function disconnectKey\(\)\s*\{\s*pauseDashboardHydration\(\);\s*dashboardDataPromise = null;/);
   assert.match(
     dashboard,
     /renderStats\(data\);\s+setSelectedCard\('all'\);[\s\S]*?scheduleDashboardHydration\(10000\);/,

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -110,7 +110,11 @@ test('dashboard defaults to the Total Feedback card highlight on first render', 
   assert.match(dashboard, /data-card-action="all"/);
   assert.match(dashboard, /function setSelectedCard\(action\)/);
   assert.match(dashboard, /card\.classList\.toggle\('selected', card\.dataset\.cardAction === action\)/);
-  assert.match(dashboard, /renderStats\(data\);\s+setSelectedCard\('all'\);\s+await loadDashboardData\(\);/);
+  assert.match(
+    dashboard,
+    /renderStats\(data\);\s+setSelectedCard\('all'\);[\s\S]*?scheduleDashboardHydration\(10000\);/,
+    'first render should select Total Feedback before deferring dashboard hydration',
+  );
   assert.match(dashboard, /document\.getElementById\('statGates'\)\.textContent = '14';\s+setSelectedCard\('all'\);/);
 });
 

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -110,6 +110,7 @@ test('dashboard defaults to the Total Feedback card highlight on first render', 
   assert.match(dashboard, /data-card-action="all"/);
   assert.match(dashboard, /function setSelectedCard\(action\)/);
   assert.match(dashboard, /card\.classList\.toggle\('selected', card\.dataset\.cardAction === action\)/);
+  assert.match(dashboard, /<body data-revenue-assist="off">/);
   assert.match(
     dashboard,
     /renderStats\(data\);\s+setSelectedCard\('all'\);[\s\S]*?scheduleDashboardHydration\(10000\);/,

--- a/tests/e2e/dashboard-page-clickability.spec.js
+++ b/tests/e2e/dashboard-page-clickability.spec.js
@@ -81,6 +81,28 @@ test.describe('/dashboard clickability — non-stat-card surfaces', () => {
     await expect(page.locator('#authStatus')).toHaveClass(/ok/);
   });
 
+  test('Disconnect cancels deferred hydration and reconnect can load dashboard data', async ({ page }) => {
+    await disableDashboardBootstrap(page);
+    const dashboardRequests = [];
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname === '/v1/dashboard') dashboardRequests.push(request.url());
+    });
+    await page.goto('/dashboard?noauto');
+    await page.locator('#apiKey').fill('test-key-123');
+    await page.locator('#connectBtn').click();
+    await expect(page.locator('#dashboardContent')).toBeVisible();
+    expect(await page.evaluate(() => dashboardHydrationTimer !== null)).toBe(true);
+
+    await page.locator('#disconnectBtn').click();
+    expect(await page.evaluate(() => dashboardHydrationTimer === null && dashboardDataPromise === null)).toBe(true);
+    expect(dashboardRequests).toHaveLength(0);
+
+    await page.locator('#apiKey').fill('test-key-456');
+    await page.locator('#connectBtn').click();
+    await page.locator('.tab', { hasText: 'Active Gates' }).click();
+    await expect.poll(() => dashboardRequests.length).toBe(1);
+  });
+
   // --- 8 tab headers (demo auto-loads, so they're available immediately) ---
 
   for (const [label, tabId] of [

--- a/tests/e2e/dashboard-page-clickability.spec.js
+++ b/tests/e2e/dashboard-page-clickability.spec.js
@@ -1,5 +1,6 @@
+const fs = require('node:fs');
 const { test, expect } = require('@playwright/test');
-const { mockDashboardApis } = require('./helpers/mock-api');
+const { mockDashboardApis, loadFixture } = require('./helpers/mock-api');
 
 // Comprehensive clickability coverage for the NON-stat-card surfaces on
 // /dashboard. The four stat tiles are already covered by
@@ -112,6 +113,44 @@ test.describe('/dashboard clickability — non-stat-card surfaces', () => {
     });
   }
 
+  test('search stays responsive while large insight totals render', async ({ page }) => {
+    const dashboard = loadFixture('dashboard.json');
+    dashboard.feedbackTimeSeries = {
+      days: Array.from({ length: 365 }, (_, index) => ({
+        dayKey: `2025-${String(Math.floor(index / 28) % 12 + 1).padStart(2, '0')}-${String(index % 28 + 1).padStart(2, '0')}`,
+        up: index === 364 ? 1771 : 0,
+        down: 0,
+        lessons: index === 364 ? 1771 : 0,
+      })),
+    };
+    await mockDashboardApis(page, { dashboard });
+    await page.unroute(/\/v1\/search/);
+    await page.route(/\/v1\/search/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [{
+            id: 'fb_search_proof',
+            signal: 'up',
+            context: 'dashboard search proof',
+            tags: ['search'],
+          }],
+        }),
+      }),
+    );
+    const dashboardRequests = [];
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname === '/v1/dashboard') dashboardRequests.push(request.url());
+    });
+    await page.goto('/dashboard');
+    expect(await page.evaluate(() => feedbackChart === null && lessonChart === null && gateAuditChart === null)).toBe(true);
+    await page.locator('#searchQuery').fill('dashboard search proof');
+    await page.locator('button[onclick="search()"]').click();
+    await expect(page.locator('#searchResults')).toContainText('dashboard search proof', { timeout: 2500 });
+    expect(dashboardRequests).toHaveLength(0);
+  });
+
   // --- Mark Current Dashboard Reviewed (review checkpoint button) ---
 
   test('clicking "Mark Current Dashboard Reviewed" disables the button while saving then re-enables', async ({ page }) => {
@@ -152,18 +191,34 @@ test.describe('/dashboard clickability — non-stat-card surfaces', () => {
     await expect(status).toHaveText(/Exported \d+ preference pairs|Exporting\.\.\./);
   });
 
-  test('exportDpo with a non-empty payload reports the pair count', async ({ page }) => {
-    await mockDashboardApis(page, {});
-    await page.route(/\/v1\/dpo\/export/, (route) =>
-      route.fulfill({
+  test('exportDpo POSTs for records and downloads the real pair array', async ({ page }) => {
+    let exportRequest = null;
+    await page.unroute(/\/v1\/dpo\/export/);
+    await page.route(/\/v1\/dpo\/export/, (route) => {
+      exportRequest = {
+        method: route.request().method(),
+        body: route.request().postDataJSON(),
+      };
+      return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ pairs: [{ chosen: 'a', rejected: 'b' }, { chosen: 'c', rejected: 'd' }] }),
-      }),
-    );
+        body: JSON.stringify({
+          pairCount: 2,
+          records: [{ chosen: 'a', rejected: 'b' }, { chosen: 'c', rejected: 'd' }],
+        }),
+      });
+    });
     await page.goto('/dashboard#export');
+    const downloadPromise = page.waitForEvent('download');
     await page.locator('.export-btn', { hasText: /Download DPO Pairs/ }).click();
+    const download = await downloadPromise;
     await expect(page.locator('#exportStatus')).toHaveText('✓ Exported 2 preference pairs');
+    expect(exportRequest).toEqual({ method: 'POST', body: { includePairs: true } });
+    const savedPath = await download.path();
+    expect(JSON.parse(fs.readFileSync(savedPath, 'utf8'))).toEqual([
+      { chosen: 'a', rejected: 'b' },
+      { chosen: 'c', rejected: 'd' },
+    ]);
   });
 
   // --- nav anchors ---

--- a/tests/e2e/fixtures/feedback-stats.json
+++ b/tests/e2e/fixtures/feedback-stats.json
@@ -2,5 +2,6 @@
   "total": 12,
   "up": 10,
   "down": 2,
-  "approvalRate": 83
+  "approvalRate": 83,
+  "activeGateCount": 5
 }


### PR DESCRIPTION
## What changed

- keep the default Search tab responsive by deferring expensive dashboard and chart hydration until idle or until the relevant tab is opened
- cap chart history and tick counts so large totals cannot block the browser main thread
- make DPO export call the authenticated `POST /v1/dpo/export` contract
- return actual preference-pair records when the dashboard requests them and download only that record array
- add API and Playwright regressions for search responsiveness, request method/body, and downloaded JSON contents

## Root cause

Search itself returned correct results, but dashboard startup synchronously loaded `/v1/dashboard` twice, rendered hidden charts with up to thousands of integer ticks, and loaded unrelated generated/AI views. The main thread stayed blocked while the UI showed `Searching...`.

The export button issued `GET /v1/dpo/export`, while the server only implements `POST`. Even a corrected POST previously returned aggregate counts rather than the actual DPO records expected by a download.

## User impact

- live local search for `TG-DEMO-20260729-A` improved from about 5.1 seconds to 0.94 seconds
- live export downloaded 115 real preference-pair records with `prompt`, `chosen`, `rejected`, `distractors`, and `metadata` fields

## Verification

- `npm test`
- `npm run test:coverage`
- `npm run prove:adapters` — 48/48
- `npm run prove:automation` — 55/55
- `npm run self-heal:check`
- `npx playwright test tests/e2e/dashboard-page-clickability.spec.js --reporter=line` — 23/23
- post-rebase focused API — 2/2
- post-rebase focused Playwright — 2/2
- live headless browser against the real local feedback store: search 944 ms; export 115 records
