### PR TITLE
docs(evals): ML-evaluation mermaid diagrams + held-out risk-model report

### DIFF
--- a/.changeset/public-evaluations-page.md
+++ b/.changeset/public-evaluations-page.md
@@ -1,0 +1,9 @@
+---
+thumbgate: patch
+---
+
+Document the evaluation methodology. docs/ML-EVALUATION.md gains three mermaid diagrams
+(the model-eval pipeline, the enforcement-evaluation loop, and a lift chart),
+evals/risk-model-report.json publishes the held-out risk-model report backing the
+public /evaluations white paper, and /numbers now links to /evaluations. The
+/evaluations page and route themselves shipped separately in #3072.

--- a/docs/ML-EVALUATION.md
+++ b/docs/ML-EVALUATION.md
@@ -40,6 +40,30 @@ Each carries `accuracy`, `baselineAccuracy`, `lift`, `precision`, `recall`, `spe
 `lift` sits next to `accuracy` in every report so accuracy can never again be quoted without
 the baseline it must beat.
 
+### The pipeline, end to end
+
+```mermaid
+flowchart LR
+    subgraph corpus["feedback-sequences.jsonl — 1,791 rows"]
+        R[rows] --> F["extractFeatureMap()"]
+    end
+    F --> S{{"stratifiedSplit()<br/>group-aware, content-hashed,<br/>salted per resample"}}
+    S -->|train fold| REG["buildFeatureRegistry()<br/>train fold ONLY —<br/>no transductive vocabulary"]
+    REG --> FIT["fitBoostedModel()<br/>AdaBoost stumps"]
+    S -->|test fold| EV
+    FIT --> EV["evaluate()<br/>lift · MCC · AUC · Brier · ECE<br/>+ confusion matrix"]
+    EV --> IID["metrics.holdout<br/>IID: familiar kinds"]
+    EV --> NOV["metrics.holdoutNovelContext<br/>distribution shift:<br/>unseen action types"]
+    IID --> RS
+    NOV --> RS["eval-risk-model.js<br/>12 resamples, mean ± sd<br/>paired t for comparisons"]
+    RS --> GATE{{"CI quality gate<br/>risk-model-quality.test.js"}}
+```
+
+Two design rules are load-bearing in that picture: the registry is rebuilt **inside** each
+training fold (building it before the split let held-out rows choose the vocabulary), and the
+split key is the feature vector itself (the model sees nothing else, so rows sharing one are
+duplicate inputs and must share a fold).
+
 ## Current results
 
 Real corpus, 1,791 rows, 12 independent group-aware stratified splits
@@ -60,6 +84,20 @@ Novel-context held-out (unseen action types)
   MCC                                 0.244
   Brier / ECE                         0.300 / 0.310
 ```
+
+### The same result as a picture
+
+```mermaid
+xychart-beta
+    title "Accuracy lift over the majority-class baseline (points)"
+    x-axis ["in-sample (old headline)", "held-out IID", "held-out novel-context"]
+    y-axis "lift (accuracy points)" -12 --> 12
+    bar [10.9, 9.9, -10.5]
+```
+
+The first bar is why in-sample accuracy was retired as a quality number: measured properly,
+the model keeps most of that lift on familiar traffic and **inverts** on unfamiliar action
+types — the case a firewall exists for.
 
 **Evidence.** These figures are reproducible from the harness rather than asserted:
 `npm run eval:risk -- --corpus <path> --json` emits the same report machine-readably, and the
@@ -122,6 +160,27 @@ adversarial code review of the evaluator itself.
 
 The lesson is uncomfortable and worth stating plainly: **the evaluator is as capable of being
 wrong as the model it measures**, and its errors are harder to notice because they flatter you.
+
+## The enforcement evaluation loop
+
+The model harness above is one half. The other half evaluates the **gates themselves**, from
+production traces to the published npm artifact:
+
+```mermaid
+flowchart TD
+    A["audit-trail.jsonl<br/>real production decisions"] -->|"mine-eval-set.js<br/>redact + dedupe by shape"| G["gate-decisions.golden.jsonl<br/>60 cases · 12 gates"]
+    G -->|eval-baseline.js| B["gate-decisions.baseline.json<br/>recorded verdicts"]
+    G --> D
+    B --> D{{"gate-golden-set.test.js<br/>fails when any real command's<br/>verdict MOVES"}}
+    E["gate-evasion-matrix<br/>14 commands × 9 transforms"] --> CI[("CI")]
+    D --> CI
+    P["npm tarball — what users get"] -->|"verify-published-enforcement.mjs<br/>fresh HOME, public hook contract"| W{{"launchd drift-watch<br/>2× daily"}}
+    L["live decision stream"] --> C{{"gate-decision-canary<br/>silent · spike · novelty"}}
+```
+
+Drift, not correctness-vs-production, is what the golden set asserts: most gates are
+state-conditional, so a fresh sandbox cannot reproduce the verdict — but a verdict that
+*changes* for a real command is exactly the signature of every bypass found in this codebase.
 
 ## The CI gate
 

--- a/evals/risk-model-report.json
+++ b/evals/risk-model-report.json
@@ -1,0 +1,60 @@
+{
+  "_provenance": {
+    "generatedAt": "2026-07-29",
+    "generator": "node scripts/eval-risk-model.js --resamples 12 --json",
+    "corpus": "operator feedback telemetry \u2014 PRIVATE, not distributable; row count and metrics only",
+    "note": "Backs thumbgate.ai/evaluations and docs/ML-EVALUATION.md. Regenerate on any corpus with the same command; the CI quality gate (npm run test:risk-quality) is runnable from a clean clone with no private data."
+  },
+  "source": "private feedback telemetry (redacted path); 1,791 rows as of 2026-07-29",
+  "rows": 1791,
+  "resamples": 12,
+  "inSample": 0.820212171970966,
+  "iid": {
+    "available": true,
+    "resamples": 12,
+    "meanTestCount": 447,
+    "lift": {
+      "mean": 0.09898333333333333,
+      "sd": 0.017157886103933536,
+      "foldsBeatingBaseline": 12
+    },
+    "rocAuc": {
+      "mean": 0.8864583333333332,
+      "sd": 0.011073049740498565
+    },
+    "mcc": {
+      "mean": 0.5418499999999999,
+      "sd": 0.04016780427158048
+    },
+    "brierScore": {
+      "mean": 0.12461666666666665
+    },
+    "expectedCalibrationError": {
+      "mean": 0.05855
+    }
+  },
+  "novel": {
+    "available": true,
+    "resamples": 12,
+    "meanTestCount": 444,
+    "lift": {
+      "mean": -0.10450833333333333,
+      "sd": 0.09044392791792175,
+      "foldsBeatingBaseline": 1
+    },
+    "rocAuc": {
+      "mean": 0.7182833333333334,
+      "sd": 0.05803586295463254
+    },
+    "mcc": {
+      "mean": 0.24397500000000003,
+      "sd": 0.13112322528192072
+    },
+    "brierScore": {
+      "mean": 0.29959166666666665
+    },
+    "expectedCalibrationError": {
+      "mean": 0.30955000000000005
+    }
+  }
+}

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -195,6 +195,7 @@
   <a href="/learn">Learn</a>
   <a href="/compare">Compare</a>
   <a href="/numbers">Numbers</a>
+  <a href="/evaluations">Evaluations</a>
   <a href="/dashboard">Dashboard</a>
   <a href="/pro">Pro</a>
 </nav>


### PR DESCRIPTION
Docs-only successor to #3071, which was closed as superseded by #3072. The supersession was correct for the /evaluations page and server route, but file-level verification against `origin/main` shows three additive pieces #3072 did not carry:

- `docs/ML-EVALUATION.md` — three mermaid diagrams: model-eval pipeline, enforcement-evaluation loop, lift chart
- `evals/risk-model-report.json` — held-out risk-model report backing the public white paper (`evals/` is not in the npm `files` list; bundle ratchet unaffected)
- `public/numbers.html` — adds the missing link to `/evaluations`

Dropped relative to #3071: the page, the route, and `tests/evaluations-page.test.js` (main's `tests/eval-proof-pack-pages.test.js` already covers the route; that redundant test was also the source of #3071's red SonarCloud job — parent-timeout under coverage instrumentation).

Targeted suites pass locally: eval-proof-pack-pages, public-bundle-ratchet, package-boundary, public-core-boundary, numbers-page — 37/37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157MF8QJHAtyjDQp1tghnhj