### PR TITLE
fix(dashboard): Active Gates no longer stuck on blank dash

### DIFF
--- a/.changeset/fix-dashboard-active-gates.md
+++ b/.changeset/fix-dashboard-active-gates.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix dashboard Active Gates stuck on "—" by returning gate counts from /v1/feedback/stats and painting them in renderStats on connect/live refresh.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1115,6 +1115,22 @@ async function connect(options) {
   }
 }
 
+function resolveActiveGateCount(data) {
+  if (!data || typeof data !== 'object') return null;
+  if (data.activeGateCount != null && data.activeGateCount !== '') {
+    var fromCount = Number(data.activeGateCount);
+    if (Number.isFinite(fromCount)) return fromCount;
+  }
+  var gateStats = data.gateStats || {};
+  if (gateStats.totalGates != null && gateStats.totalGates !== '') {
+    var fromStats = Number(gateStats.totalGates);
+    if (Number.isFinite(fromStats)) return fromStats;
+  }
+  if (Array.isArray(data.gates)) return data.gates.length;
+  if (Array.isArray(data.activeGates)) return data.activeGates.length;
+  return null;
+}
+
 function renderStats(data) {
   const total = (data.totalFeedback || data.total || 0);
   const pos = (data.totalPositive || data.positive || data.thumbsUp || 0);
@@ -1122,6 +1138,14 @@ function renderStats(data) {
   document.getElementById('statTotal').textContent = total;
   document.getElementById('statPositive').textContent = pos;
   document.getElementById('statNegative').textContent = neg;
+  // Active Gates used to stay on the HTML placeholder "—" because only
+  // renderDashboardData(/v1/dashboard) set it. Connect + live refresh only call
+  // /v1/feedback/stats → renderStats. Prefer activeGateCount from stats; fall
+  // back to gateStats/gates when present.
+  var gateCount = resolveActiveGateCount(data);
+  if (gateCount != null) {
+    document.getElementById('statGates').textContent = gateCount;
+  }
 }
 
 function setSelectedCard(action) {
@@ -1390,6 +1414,13 @@ async function loadGates() {
     const data = await res.json();
     renderDashboardData(data);
   } catch (e) {
+    // Do not leave Active Gates stuck on the HTML placeholder "—" when the
+    // full dashboard payload fails — feedback stats may already have painted a
+    // real count; only fall back to 0 if still unset.
+    var gatesEl = document.getElementById('statGates');
+    if (gatesEl && (gatesEl.textContent === '—' || gatesEl.textContent === '' || gatesEl.textContent == null)) {
+      gatesEl.textContent = '0';
+    }
     setMessageState(document.getElementById('gatesList'), 'empty', e && e.message ? e.message : 'Failed to load gates');
     setMessageState(document.getElementById('teamSummaryCards'), 'empty', e && e.message ? e.message : 'Failed to load team metrics');
     setMessageState(document.getElementById('predictiveSummaryCards'), 'empty', e && e.message ? e.message : 'Failed to load predictive insights');
@@ -1552,7 +1583,11 @@ function renderDashboardData(data) {
   if (reviewButton) reviewButton.disabled = false;
   const gates = data.gates || data.activeGates || [];
   const gateStats = data.gateStats || {};
-  document.getElementById('statGates').textContent = gates.length || gateStats.totalGates || 0;
+  // Prefer explicit count; never leave the hero card on the "—" placeholder.
+  // Note: `gates.length || totalGates` is wrong when length is 0 but totalGates
+  // is also 0 — use resolveActiveGateCount so 0 still renders as "0".
+  var gateCount = resolveActiveGateCount(data);
+  document.getElementById('statGates').textContent = gateCount != null ? gateCount : 0;
   if (!gates.length) {
     document.getElementById('gatesList').innerHTML = '<div class="empty">No active checks</div>';
   } else {

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -8665,6 +8665,33 @@ a{color:#8b9}</style></head><body><form class="card" method="post" action="/oaut
           stats.tier = 'Pro';
         }
 
+        // Active gates for the dashboard hero cards. Connect only fetches
+        // /v1/feedback/stats first; without these fields Active Gates stays
+        // stuck on the HTML placeholder "—" until a later /v1/dashboard call
+        // succeeds (and never updates if that call fails).
+        try {
+          const { computeGateStats } = require('../../scripts/dashboard');
+          const gateStats = computeGateStats();
+          stats.activeGateCount = Number(gateStats.totalGates) || 0;
+          stats.gateStats = {
+            totalGates: Number(gateStats.totalGates) || 0,
+            manualCount: Number(gateStats.manualCount) || 0,
+            autoCount: Number(gateStats.autoCount) || 0,
+            blocked: Number(gateStats.blocked) || 0,
+            warned: Number(gateStats.warned) || 0,
+          };
+        } catch (error) {
+          debugApiFallback('gate stats unavailable for feedback/stats', error);
+          stats.activeGateCount = 0;
+          stats.gateStats = {
+            totalGates: 0,
+            manualCount: 0,
+            autoCount: 0,
+            blocked: 0,
+            warned: 0,
+          };
+        }
+
         const projectChatSettings = readProjectChatSettings(req, parsed);
 
         stats.geminiConfigured = Boolean(

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -2488,6 +2488,27 @@ test('default feedback stats stay on THUMBGATE_FEEDBACK_DIR even when INIT_CWD i
   }
 });
 
+test('feedback stats includes activeGateCount for the dashboard hero card', async () => {
+  // The dashboard connect path paints Total/Positive/Negative from this
+  // endpoint and used to leave Active Gates stuck on "—" because gate counts
+  // only arrived later (and only if /v1/dashboard succeeded).
+  const res = await fetch(apiUrl('/v1/feedback/stats'), { headers: authHeader });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.ok(Number.isFinite(Number(body.activeGateCount)), 'activeGateCount must be a finite number');
+  assert.ok(Number(body.activeGateCount) >= 0);
+  assert.ok(body.gateStats && typeof body.gateStats === 'object');
+  assert.equal(Number(body.gateStats.totalGates), Number(body.activeGateCount));
+  assert.ok(Number.isFinite(Number(body.gateStats.manualCount)));
+  assert.ok(Number.isFinite(Number(body.gateStats.autoCount)));
+  // Default shipped gates exist in config/gates/default.json — count must be > 0
+  // on a normal package checkout so the dashboard never looks "empty of gates".
+  assert.ok(
+    Number(body.activeGateCount) > 0,
+    `expected default gates to be counted, got ${body.activeGateCount}`,
+  );
+});
+
 test('project-scoped endpoints honor explicit project selection for stats, lessons, and dashboard', async () => {
   const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-project-scope-api-'));
   const feedbackDir = path.join(projectDir, '.thumbgate');

--- a/tests/dashboard-html.test.js
+++ b/tests/dashboard-html.test.js
@@ -114,6 +114,31 @@ test('dashboard defaults to the Total Feedback card highlight on first render', 
   assert.match(dashboard, /document\.getElementById\('statGates'\)\.textContent = '14';\s+setSelectedCard\('all'\);/);
 });
 
+test('dashboard paints Active Gates from feedback/stats so the hero card is never stuck on —', () => {
+  // Match against full HTML (dashboard may have multiple <script> tags; the
+  // first is not always the main app script).
+  const dashboard = readDashboard();
+
+  // Connect path only calls /v1/feedback/stats → renderStats first. That path
+  // must set #statGates from activeGateCount/gateStats, not leave the HTML "—".
+  assert.match(dashboard, /function resolveActiveGateCount\(data\)/);
+  assert.match(dashboard, /function renderStats\(data\)/);
+  assert.match(dashboard, /activeGateCount/);
+  assert.match(dashboard, /document\.getElementById\('statGates'\)\.textContent = gateCount/);
+  // On /v1/dashboard failure, never leave the placeholder dash if still blank.
+  assert.match(dashboard, /gatesEl\.textContent === '—'/);
+  assert.match(dashboard, /gatesEl\.textContent = '0'/);
+  // Dashboard payload path uses resolveActiveGateCount (not `length || totalGates`
+  // which mis-handles zeros).
+  assert.match(dashboard, /function renderDashboardData\(data\)/);
+  assert.match(dashboard, /resolveActiveGateCount\(data\)/);
+  assert.doesNotMatch(
+    dashboard,
+    /statGates'\)\.textContent = gates\.length \|\| gateStats\.totalGates \|\| 0/,
+  );
+  assert.match(dashboard, /id="statGates"/);
+});
+
 test('dashboard has noindex and meta description for SEO safety', () => {
   const dashboard = readDashboard();
   assert.match(dashboard, /noindex/, 'dashboard must have noindex to prevent Google indexing a Pro-only page');


### PR DESCRIPTION
## Summary

Local Enterprise dashboard showed **Total Feedback / Positive / Negative** correctly but **Active Gates** stayed on the HTML placeholder `—`.

### Root cause

Connect only calls `GET /v1/feedback/stats` → `renderStats()`, which painted feedback counts and **never touched `#statGates`**. Gate counts only arrived via `GET /v1/dashboard` → `renderDashboardData()`. If that call failed/hung, or simply hadn't completed, the card stayed blank. Live SSE refresh (`refreshStatsOnly`) had the same gap.

### Fix

1. **`/v1/feedback/stats`** now includes `activeGateCount` + compact `gateStats` from `computeGateStats()`.
2. **`renderStats()`** sets `#statGates` from that payload on connect + live refresh.
3. **`renderDashboardData()`** uses `resolveActiveGateCount()` so `0` still renders as `0` (no more `length || total` pitfall).
4. **`loadGates()` error path** falls back to `0` if still on `—`.

## Tests

```text
node --test tests/dashboard-html.test.js  → 9/9 pass
node --test --test-name-pattern "feedback stats includes activeGateCount" tests/api-server.test.js → pass
```

## How to verify after deploy

1. Hard-refresh `localhost:3456/dashboard` (or production dashboard).
2. Connect Local Enterprise.
3. **Active Gates** should show a number (defaults + auto-promoted), not `—`.