### PR TITLE
Add MCP Toplist rank badge (community: @chrstphe)

### DIFF
--- a/.changeset/mcp-toplist-badge.md
+++ b/.changeset/mcp-toplist-badge.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+README: add the MCP Toplist rank badge (community contribution by @chrstphe).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ThumbGate
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2FIgorGanapolsky%2Fmcp-memory-gateway.svg)](https://mcptoplist.com/server/glama%2FIgorGanapolsky%2Fmcp-memory-gateway)
+
 <p align="center">
   <a href="https://thumbgate.ai">
     <img src="public/assets/brand/thumbgate-icon-512.png" alt="ThumbGate" width="128" height="128" />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThumbGate
 
-[![MCP Toplist](https://mcptoplist.com/badge/glama%2FIgorGanapolsky%2Fmcp-memory-gateway.svg)](https://mcptoplist.com/server/glama%2FIgorGanapolsky%2Fmcp-memory-gateway)
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2FIgorGanapolsky%2FThumbGate.svg)](https://mcptoplist.com/server/glama%2FIgorGanapolsky%2FThumbGate)
 
 <p align="center">
   <a href="https://thumbgate.ai">


### PR DESCRIPTION
Same-repo re-home of #3069 by @chrstphe — their commit and authorship are preserved (02ea25e2). Re-homed because the fork PR hit limitations our pipeline can't work around: fork workflow runs need per-push approval, Vercel refuses fork deploys without authorization, and the Trunk queue rejected the fork submission in 51s twice.

On top of the original commit:
- changeset (README ships in the npm package, so changeset:check requires a release note)
- badge repointed from the retired `mcp-memory-gateway` slug to the live **ThumbGate** listing (rank #1,021, top 5% of 94,094) — the canonical-scope test rightly blocked the legacy identity

Closes #3069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157MF8QJHAtyjDQp1tghnhj