### PR TITLE
fix(ingestion): isolate bench feedback writes + alarm on embedding-index drift

### DIFF
--- a/.changeset/ingestion-isolation-drift-alarm.md
+++ b/.changeset/ingestion-isolation-drift-alarm.md
@@ -1,0 +1,5 @@
+---
+thumbgate: patch
+---
+
+Bench runs no longer write feedback into the operator's production store: `scripts/thumbgate-bench.js` now defaults all feedback capture (including `--use-runtime-state` runs and agent-session project-scoped environments) to an isolated temp directory, with `--feedback-dir` / `THUMBGATE_BENCH_FEEDBACK_DIR` as the explicit opt-out. `npm run self-heal:check` gains an `embedding_index_drift` check that reports UNHEALTHY when `feedback-log.jsonl` is more than 24h newer than `lesson-embeddings.json` (or the index is missing while lessons exist), naming both paths, the lag in hours, and the remediation `run: node scripts/backfill-lesson-embeddings.js`.

--- a/scripts/self-healing-check.js
+++ b/scripts/self-healing-check.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { diagnoseFailure } = require('./failure-diagnostics');
 const { appendDiagnosticRecord } = require('./feedback-loop');
+const { resolveFeedbackDir } = require('./feedback-paths');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 const DEFAULT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
@@ -12,6 +13,63 @@ const DEFAULT_TESTS_TIMEOUT_MS = Number.parseInt(
   process.env.THUMBGATE_SELF_HEAL_TEST_TIMEOUT_MS || '',
   10,
 ) || 60 * 60_000;
+const EMBEDDING_DRIFT_MAX_LAG_HOURS = 24;
+const EMBEDDING_DRIFT_REMEDIATION = 'run: node scripts/backfill-lesson-embeddings.js';
+
+function safeStat(filePath) {
+  try {
+    return fs.statSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detects lesson-embedding index drift: the feedback log kept growing while
+ * <feedbackDir>/lesson-embeddings.json stopped updating (an audit found the
+ * embedding store frozen for 11 days with no alarm). Returns a run-shaped
+ * result so it plugs into collectHealthReport like any other check.
+ */
+function evaluateEmbeddingIndexDrift({ feedbackDir } = {}) {
+  const started = Date.now();
+  const resolvedDir = feedbackDir || resolveFeedbackDir();
+  const feedbackLogPath = path.join(resolvedDir, 'feedback-log.jsonl');
+  const embeddingsPath = path.join(resolvedDir, 'lesson-embeddings.json');
+  const finish = (exitCode, message) => ({
+    exitCode,
+    durationMs: Date.now() - started,
+    stdout: message,
+    stderr: '',
+    error: null,
+  });
+
+  const feedbackLogStat = safeStat(feedbackLogPath);
+  if (!feedbackLogStat) {
+    return finish(0, `No feedback log at ${feedbackLogPath}; embedding-index drift check skipped.`);
+  }
+
+  const embeddingsStat = safeStat(embeddingsPath);
+  if (!embeddingsStat) {
+    if (feedbackLogStat.size === 0) {
+      return finish(0, `Feedback log ${feedbackLogPath} is empty and no embedding index exists at ${embeddingsPath}; nothing to index yet.`);
+    }
+    return finish(1, [
+      `Lesson embedding index missing: ${embeddingsPath} does not exist while lessons exist in ${feedbackLogPath}.`,
+      `Remediation: ${EMBEDDING_DRIFT_REMEDIATION}`,
+    ].join('\n'));
+  }
+
+  const lagHours = (feedbackLogStat.mtimeMs - embeddingsStat.mtimeMs) / 3_600_000;
+  const roundedLagHours = Math.round(lagHours * 10) / 10;
+  if (lagHours > EMBEDDING_DRIFT_MAX_LAG_HOURS) {
+    return finish(1, [
+      `Lesson embedding index is stale: ${feedbackLogPath} is ${roundedLagHours}h newer than ${embeddingsPath} (max ${EMBEDDING_DRIFT_MAX_LAG_HOURS}h).`,
+      `Remediation: ${EMBEDDING_DRIFT_REMEDIATION}`,
+    ].join('\n'));
+  }
+
+  return finish(0, `Lesson embedding index fresh: ${embeddingsPath} lags ${feedbackLogPath} by ${Math.max(0, roundedLagHours)}h (max ${EMBEDDING_DRIFT_MAX_LAG_HOURS}h).`);
+}
 
 const DEFAULT_CHECKS = [
   { name: 'budget_status', command: ['npm', 'run', 'budget:status'], timeoutMs: 60_000 },
@@ -20,6 +78,12 @@ const DEFAULT_CHECKS = [
   { name: 'prove_automation', command: ['npm', 'run', 'prove:automation'], timeoutMs: 10 * 60_000, useTempProofDir: true },
   { name: 'prove_data_pipeline', command: ['npm', 'run', 'prove:data-pipeline'], timeoutMs: 10 * 60_000, useTempProofDir: true },
   { name: 'prove_tessl', command: ['npm', 'run', 'prove:tessl'], timeoutMs: 10 * 60_000, useTempProofDir: true },
+  {
+    name: 'embedding_index_drift',
+    command: ['internal', 'embedding-index-drift'],
+    timeoutMs: 60_000,
+    evaluate: (options = {}) => evaluateEmbeddingIndexDrift(options),
+  },
 ];
 
 function runCommand(command, {
@@ -79,7 +143,9 @@ function collectHealthReport({
     const { env, cleanup } = createCheckEnvironment(check);
     let run;
     try {
-      run = runner(check.command, { cwd, timeoutMs: check.timeoutMs, env });
+      run = typeof check.evaluate === 'function'
+        ? check.evaluate({ cwd })
+        : runner(check.command, { cwd, timeoutMs: check.timeoutMs, env });
     } finally {
       if (cleanup) {
         cleanup();
@@ -183,11 +249,14 @@ module.exports = {
   DEFAULT_CHECKS,
   DEFAULT_TESTS_TIMEOUT_MS,
   DEFAULT_MAX_BUFFER_BYTES,
+  EMBEDDING_DRIFT_MAX_LAG_HOURS,
+  evaluateEmbeddingIndexDrift,
   runCommand,
   collectHealthReport,
   reportToText,
 };
 
-if (require.main === module) {
+// Path-based direct-execution check (SonarCloud S3403 flags `require.main === module`).
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
   runCli();
 }

--- a/scripts/self-healing-check.js
+++ b/scripts/self-healing-check.js
@@ -33,6 +33,11 @@ function safeStat(filePath) {
 function evaluateEmbeddingIndexDrift({ feedbackDir } = {}) {
   const started = Date.now();
   const resolvedDir = feedbackDir || resolveFeedbackDir();
+  // Drift is measured against the PROMOTED corpus (lessons-index.jsonl), not the raw
+  // feedback log: vague/schema-rejected entries grow the log without creating anything
+  // embeddable, and keying on the log pages operators for corpus movement that has no
+  // retrieval consequence. Fall back to the log only on stores without an index.
+  const lessonsIndexPath = path.join(resolvedDir, 'lessons-index.jsonl');
   const feedbackLogPath = path.join(resolvedDir, 'feedback-log.jsonl');
   const embeddingsPath = path.join(resolvedDir, 'lesson-embeddings.json');
   const finish = (exitCode, message) => ({
@@ -43,32 +48,35 @@ function evaluateEmbeddingIndexDrift({ feedbackDir } = {}) {
     error: null,
   });
 
-  const feedbackLogStat = safeStat(feedbackLogPath);
-  if (!feedbackLogStat) {
-    return finish(0, `No feedback log at ${feedbackLogPath}; embedding-index drift check skipped.`);
+  const lessonsIndexStat = safeStat(lessonsIndexPath);
+  const feedbackLogStat = lessonsIndexStat ? null : safeStat(feedbackLogPath);
+  const sourceStat = lessonsIndexStat || feedbackLogStat;
+  const sourcePath = lessonsIndexStat ? lessonsIndexPath : feedbackLogPath;
+  if (!sourceStat) {
+    return finish(0, `No lesson corpus at ${lessonsIndexPath} or ${feedbackLogPath}; embedding-index drift check skipped.`);
   }
 
   const embeddingsStat = safeStat(embeddingsPath);
   if (!embeddingsStat) {
-    if (feedbackLogStat.size === 0) {
-      return finish(0, `Feedback log ${feedbackLogPath} is empty and no embedding index exists at ${embeddingsPath}; nothing to index yet.`);
+    if (sourceStat.size === 0) {
+      return finish(0, `Lesson corpus ${sourcePath} is empty and no embedding index exists at ${embeddingsPath}; nothing to index yet.`);
     }
     return finish(1, [
-      `Lesson embedding index missing: ${embeddingsPath} does not exist while lessons exist in ${feedbackLogPath}.`,
+      `Lesson embedding index missing: ${embeddingsPath} does not exist while lessons exist in ${sourcePath}.`,
       `Remediation: ${EMBEDDING_DRIFT_REMEDIATION}`,
     ].join('\n'));
   }
 
-  const lagHours = (feedbackLogStat.mtimeMs - embeddingsStat.mtimeMs) / 3_600_000;
+  const lagHours = (sourceStat.mtimeMs - embeddingsStat.mtimeMs) / 3_600_000;
   const roundedLagHours = Math.round(lagHours * 10) / 10;
   if (lagHours > EMBEDDING_DRIFT_MAX_LAG_HOURS) {
     return finish(1, [
-      `Lesson embedding index is stale: ${feedbackLogPath} is ${roundedLagHours}h newer than ${embeddingsPath} (max ${EMBEDDING_DRIFT_MAX_LAG_HOURS}h).`,
+      `Lesson embedding index is stale: ${sourcePath} is ${roundedLagHours}h newer than ${embeddingsPath} (max ${EMBEDDING_DRIFT_MAX_LAG_HOURS}h).`,
       `Remediation: ${EMBEDDING_DRIFT_REMEDIATION}`,
     ].join('\n'));
   }
 
-  return finish(0, `Lesson embedding index fresh: ${embeddingsPath} lags ${feedbackLogPath} by ${Math.max(0, roundedLagHours)}h (max ${EMBEDDING_DRIFT_MAX_LAG_HOURS}h).`);
+  return finish(0, `Lesson embedding index fresh: ${embeddingsPath} lags ${sourcePath} by ${Math.max(0, roundedLagHours)}h (max ${EMBEDDING_DRIFT_MAX_LAG_HOURS}h).`);
 }
 
 const DEFAULT_CHECKS = [

--- a/scripts/thumbgate-bench.js
+++ b/scripts/thumbgate-bench.js
@@ -75,6 +75,7 @@ function parseValueOption(args, arg) {
   return parsePathOption(args, arg, '--scenarios', 'suitePath')
     || parsePathOption(args, arg, '--programbench-scenarios', 'programbenchSuitePath')
     || parsePathOption(args, arg, '--out-dir', 'outDir')
+    || parsePathOption(args, arg, '--feedback-dir', 'feedbackDir')
     || parseMinScoreOption(args, arg);
 }
 
@@ -82,6 +83,7 @@ function parseArgs(argv = process.argv.slice(2)) {
   const args = {
     suitePath: DEFAULT_SUITE_PATH,
     outDir: null,
+    feedbackDir: null,
     json: false,
     useRuntimeState: false,
     programbenchSmoke: false,
@@ -107,6 +109,10 @@ function usage() {
     '  --programbench          Alias for --programbench-smoke.',
     `  --programbench-scenarios=<path> ProgramBench-style smoke suite JSON. Default: ${path.relative(ROOT, DEFAULT_PROGRAMBENCH_SUITE_PATH)}`,
     '  --out-dir=<path>        Report directory. Default: .thumbgate/bench/<timestamp>',
+    '  --feedback-dir=<path>   Feedback capture directory for the bench run. Default: an',
+    '                          isolated temp dir (also THUMBGATE_BENCH_FEEDBACK_DIR). Bench',
+    '                          runs never write to the operator feedback store unless this',
+    '                          is set explicitly.',
     '  --min-score=<0-100>     Required score before exit code 1. Default: 90',
     '  --json                  Print the JSON report to stdout.',
     '  --use-runtime-state     Evaluate against current runtime state instead of an isolated temp state.',
@@ -250,6 +256,17 @@ function restoreEnv(snapshot) {
   }
 }
 
+function resolveBenchFeedbackDir(options = {}) {
+  const explicit = options.feedbackDir || process.env.THUMBGATE_BENCH_FEEDBACK_DIR || null;
+  if (explicit) {
+    return { dir: path.resolve(String(explicit)), isTemporary: false };
+  }
+  return {
+    dir: fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-bench-feedback-')),
+    isTemporary: true,
+  };
+}
+
 function withGateRuntime(options, callback) {
   const gatesEngine = require('./gates-engine');
   const originalPaths = {
@@ -264,6 +281,10 @@ function withGateRuntime(options, callback) {
     'THUMBGATE_FEEDBACK_DIR',
     'THUMBGATE_FEEDBACK_LOG',
     'THUMBGATE_ATTRIBUTED_FEEDBACK',
+    // Project-scope env suppresses THUMBGATE_FEEDBACK_DIR (feedback-paths.js), so
+    // an agent-session bench run would silently write into <project>/.thumbgate.
+    'THUMBGATE_PROJECT_DIR',
+    'CLAUDE_PROJECT_DIR',
     'THUMBGATE_GUARDS_PATH',
     'THUMBGATE_SECRET_SCAN_PROVIDER',
     'THUMBGATE_HARNESS',
@@ -279,10 +300,27 @@ function withGateRuntime(options, callback) {
   const runtimeDir = options.useRuntimeState
     ? null
     : fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-bench-runtime-'));
+  // Bench replays scenario documents through the live capture path. Those writes
+  // must never land in the operator's production feedback store (an audit found
+  // one bench document replayed 210x into .thumbgate/feedback-log.jsonl). Every
+  // bench run, including --use-runtime-state, defaults feedback writes to an
+  // isolated temp dir; only --feedback-dir / THUMBGATE_BENCH_FEEDBACK_DIR opt out.
+  const benchFeedback = resolveBenchFeedbackDir(options);
 
   try {
     delete process.env.THUMBGATE_HARNESS;
     delete process.env.THUMBGATE_HARNESS_CONFIG;
+
+    delete process.env.THUMBGATE_PROJECT_DIR;
+    delete process.env.CLAUDE_PROJECT_DIR;
+    process.env.THUMBGATE_FEEDBACK_DIR = benchFeedback.dir;
+    process.env.THUMBGATE_FEEDBACK_LOG = path.join(benchFeedback.dir, 'feedback-log.jsonl');
+    process.env.THUMBGATE_ATTRIBUTED_FEEDBACK = path.join(benchFeedback.dir, 'attributed-feedback.jsonl');
+    fs.mkdirSync(benchFeedback.dir, { recursive: true });
+    if (benchFeedback.isTemporary) {
+      fs.writeFileSync(process.env.THUMBGATE_FEEDBACK_LOG, '');
+      fs.writeFileSync(process.env.THUMBGATE_ATTRIBUTED_FEEDBACK, '');
+    }
 
     if (!options.useRuntimeState) {
       gatesEngine.STATE_PATH = path.join(runtimeDir, 'gate-state.json');
@@ -291,9 +329,6 @@ function withGateRuntime(options, callback) {
       gatesEngine.SESSION_ACTIONS_PATH = path.join(runtimeDir, 'session-actions.json');
       gatesEngine.CUSTOM_CLAIM_GATES_PATH = path.join(runtimeDir, 'claim-verification.json');
       gatesEngine.GOVERNANCE_STATE_PATH = path.join(runtimeDir, 'governance-state.json');
-      process.env.THUMBGATE_FEEDBACK_DIR = path.join(runtimeDir, 'feedback');
-      process.env.THUMBGATE_FEEDBACK_LOG = path.join(runtimeDir, 'feedback-log.jsonl');
-      process.env.THUMBGATE_ATTRIBUTED_FEEDBACK = path.join(runtimeDir, 'attributed-feedback.jsonl');
       process.env.THUMBGATE_GUARDS_PATH = path.join(runtimeDir, 'pretool-guards.json');
       process.env.THUMBGATE_SECRET_SCAN_PROVIDER = 'heuristic';
       // Pin enforcement posture for golden deny expectations (scorecard reproducibility).
@@ -302,9 +337,6 @@ function withGateRuntime(options, callback) {
       delete process.env.THUMBGATE_ENFORCE_ENTITLEMENTS;
       delete process.env.THUMBGATE_PRO_LICENSE_KEY;
       delete process.env.THUMBGATE_LICENSE_KEY;
-      fs.mkdirSync(process.env.THUMBGATE_FEEDBACK_DIR, { recursive: true });
-      fs.writeFileSync(process.env.THUMBGATE_FEEDBACK_LOG, '');
-      fs.writeFileSync(process.env.THUMBGATE_ATTRIBUTED_FEEDBACK, '');
     }
 
     return callback(gatesEngine);
@@ -313,6 +345,9 @@ function withGateRuntime(options, callback) {
     restoreEnv(envSnapshot);
     if (runtimeDir) {
       fs.rmSync(runtimeDir, { recursive: true, force: true });
+    }
+    if (benchFeedback.isTemporary) {
+      fs.rmSync(benchFeedback.dir, { recursive: true, force: true });
     }
   }
 }
@@ -719,6 +754,8 @@ module.exports = {
   loadProgramBenchSmokeSuite,
   normalizeDecision,
   expectedMatches,
+  resolveBenchFeedbackDir,
+  withGateRuntime,
   runScenario,
   runSuitePass,
   runProgramBenchSmokeScenario,

--- a/tests/self-healing-check.test.js
+++ b/tests/self-healing-check.test.js
@@ -7,10 +7,27 @@ const path = require('node:path');
 const {
   DEFAULT_CHECKS,
   DEFAULT_TESTS_TIMEOUT_MS,
+  EMBEDDING_DRIFT_MAX_LAG_HOURS,
+  evaluateEmbeddingIndexDrift,
   collectHealthReport,
   runCommand,
   reportToText,
 } = require('../scripts/self-healing-check');
+
+function makeDriftFixture({ feedbackLogContent, feedbackLogMtime, embeddingsMtime } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-embedding-drift-'));
+  const feedbackLogPath = path.join(dir, 'feedback-log.jsonl');
+  const embeddingsPath = path.join(dir, 'lesson-embeddings.json');
+  if (feedbackLogContent !== undefined) {
+    fs.writeFileSync(feedbackLogPath, feedbackLogContent);
+    if (feedbackLogMtime) fs.utimesSync(feedbackLogPath, feedbackLogMtime, feedbackLogMtime);
+  }
+  if (embeddingsMtime) {
+    fs.writeFileSync(embeddingsPath, '{}');
+    fs.utimesSync(embeddingsPath, embeddingsMtime, embeddingsMtime);
+  }
+  return { dir, feedbackLogPath, embeddingsPath };
+}
 
 test('DEFAULT_CHECKS delegates verification through npm test', () => {
   const testsCheck = DEFAULT_CHECKS.find((check) => check.name === 'tests');
@@ -29,6 +46,125 @@ test('DEFAULT_CHECKS isolates proof artifacts for prove checks', () => {
   assert.equal(proveAutomation.useTempProofDir, true);
   assert.equal(proveDataPipeline.useTempProofDir, true);
   assert.equal(proveTessl.useTempProofDir, true);
+});
+
+test('DEFAULT_CHECKS includes the embedding index drift check', () => {
+  const drift = DEFAULT_CHECKS.find((check) => check.name === 'embedding_index_drift');
+  assert.ok(drift, 'embedding_index_drift check must be part of the self-heal surface');
+  assert.equal(typeof drift.evaluate, 'function');
+  assert.equal(EMBEDDING_DRIFT_MAX_LAG_HOURS, 24);
+});
+
+test('evaluateEmbeddingIndexDrift is healthy when the index is fresh', () => {
+  const now = new Date();
+  const fixture = makeDriftFixture({
+    feedbackLogContent: '{"id":"lesson-1"}\n',
+    feedbackLogMtime: now,
+    embeddingsMtime: now,
+  });
+  try {
+    const result = evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir });
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /fresh/);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('evaluateEmbeddingIndexDrift tolerates lag under 24h', () => {
+  const now = new Date();
+  const fixture = makeDriftFixture({
+    feedbackLogContent: '{"id":"lesson-1"}\n',
+    feedbackLogMtime: now,
+    embeddingsMtime: new Date(now.getTime() - (23 * 3_600_000)),
+  });
+  try {
+    const result = evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir });
+    assert.equal(result.exitCode, 0);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('evaluateEmbeddingIndexDrift flags a stale index with both paths, lag hours, and remediation', () => {
+  const now = new Date();
+  const fixture = makeDriftFixture({
+    feedbackLogContent: '{"id":"lesson-1"}\n',
+    feedbackLogMtime: now,
+    embeddingsMtime: new Date(now.getTime() - (30 * 3_600_000)),
+  });
+  try {
+    const result = evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir });
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.stdout.includes(fixture.feedbackLogPath), 'names the feedback log path');
+    assert.ok(result.stdout.includes(fixture.embeddingsPath), 'names the embeddings path');
+    assert.match(result.stdout, /30h newer/);
+    assert.match(result.stdout, /run: node scripts\/backfill-lesson-embeddings\.js/);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('evaluateEmbeddingIndexDrift flags a missing index while lessons exist', () => {
+  const fixture = makeDriftFixture({ feedbackLogContent: '{"id":"lesson-1"}\n' });
+  try {
+    const result = evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir });
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.stdout.includes(fixture.feedbackLogPath));
+    assert.ok(result.stdout.includes(fixture.embeddingsPath));
+    assert.match(result.stdout, /run: node scripts\/backfill-lesson-embeddings\.js/);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('evaluateEmbeddingIndexDrift skips when there is no feedback log', () => {
+  const fixture = makeDriftFixture({});
+  try {
+    const result = evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir });
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /skipped/);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('evaluateEmbeddingIndexDrift stays healthy for an empty log with no index', () => {
+  const fixture = makeDriftFixture({ feedbackLogContent: '' });
+  try {
+    const result = evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir });
+    assert.equal(result.exitCode, 0);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('collectHealthReport surfaces embedding drift as an unhealthy check', () => {
+  const now = new Date();
+  const fixture = makeDriftFixture({
+    feedbackLogContent: '{"id":"lesson-1"}\n',
+    feedbackLogMtime: now,
+    embeddingsMtime: new Date(now.getTime() - (48 * 3_600_000)),
+  });
+  try {
+    const report = collectHealthReport({
+      checks: [{
+        name: 'embedding_index_drift',
+        command: ['internal', 'embedding-index-drift'],
+        evaluate: () => evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir }),
+      }],
+      runner: () => {
+        throw new Error('runner must not be invoked for evaluate-based checks');
+      },
+    });
+
+    assert.equal(report.overall_status, 'unhealthy');
+    assert.equal(report.checks[0].status, 'unhealthy');
+    assert.match(report.checks[0].outputTail, /48h newer/);
+    assert.match(report.checks[0].outputTail, /run: node scripts\/backfill-lesson-embeddings\.js/);
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
 });
 
 test('collectHealthReport marks overall healthy when all checks pass', () => {

--- a/tests/self-healing-check.test.js
+++ b/tests/self-healing-check.test.js
@@ -370,3 +370,25 @@ test('reportToText includes multiple checks', () => {
   assert.match(text, /budget/);
   assert.match(text, /tests/);
 });
+
+test('evaluateEmbeddingIndexDrift stays healthy when promoted index is fresh though raw log is newer', () => {
+  // P1 review case: vague/schema-rejected entries grow feedback-log.jsonl without
+  // promoting anything embeddable; the check must key on lessons-index.jsonl.
+  const now = new Date();
+  const fixture = makeDriftFixture({
+    feedbackLogContent: '{"id":"vague-signal"}\n',
+    feedbackLogMtime: now,
+    embeddingsMtime: new Date(now.getTime() - (30 * 3_600_000)),
+  });
+  try {
+    const lessonsIndexPath = path.join(fixture.dir, 'lessons-index.jsonl');
+    fs.writeFileSync(lessonsIndexPath, '{"id":"lesson-1"}\n');
+    const indexMtime = new Date(now.getTime() - (31 * 3_600_000));
+    fs.utimesSync(lessonsIndexPath, indexMtime, indexMtime);
+    const result = evaluateEmbeddingIndexDrift({ feedbackDir: fixture.dir });
+    assert.equal(result.exitCode, 0, 'fresh promoted corpus must not alarm on raw-log churn');
+    assert.ok(result.stdout.includes(lessonsIndexPath), 'drift is keyed on the lessons index');
+  } finally {
+    fs.rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});

--- a/tests/thumbgate-bench.test.js
+++ b/tests/thumbgate-bench.test.js
@@ -14,6 +14,8 @@ const {
   DEFAULT_PROGRAMBENCH_SUITE_PATH,
   loadScenarioSuite,
   loadProgramBenchSmokeSuite,
+  resolveBenchFeedbackDir,
+  withGateRuntime,
   runSuitePass,
   runProgramBenchSmokeSuite,
   scoreResults,
@@ -177,6 +179,117 @@ test('ThumbGate Bench CLI emits JSON report when requested', () => {
     assert.ok(report.reportPaths.json.endsWith('thumbgate-bench-report.json'));
   } finally {
     fs.rmSync(outDir, { recursive: true, force: true });
+  }
+});
+
+test('resolveBenchFeedbackDir defaults to an isolated temp dir', () => {
+  const resolved = resolveBenchFeedbackDir({});
+  try {
+    assert.equal(resolved.isTemporary, true);
+    assert.ok(path.basename(resolved.dir).startsWith('thumbgate-bench-feedback-'));
+    assert.ok(fs.existsSync(resolved.dir));
+  } finally {
+    fs.rmSync(resolved.dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveBenchFeedbackDir honors an explicit --feedback-dir option', () => {
+  const explicitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-bench-explicit-'));
+  try {
+    const resolved = resolveBenchFeedbackDir({ feedbackDir: explicitDir });
+    assert.equal(resolved.isTemporary, false);
+    assert.equal(resolved.dir, path.resolve(explicitDir));
+  } finally {
+    fs.rmSync(explicitDir, { recursive: true, force: true });
+  }
+});
+
+test('resolveBenchFeedbackDir honors THUMBGATE_BENCH_FEEDBACK_DIR', () => {
+  const explicitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-bench-envdir-'));
+  const previous = process.env.THUMBGATE_BENCH_FEEDBACK_DIR;
+  process.env.THUMBGATE_BENCH_FEEDBACK_DIR = explicitDir;
+  try {
+    const resolved = resolveBenchFeedbackDir({});
+    assert.equal(resolved.isTemporary, false);
+    assert.equal(resolved.dir, path.resolve(explicitDir));
+  } finally {
+    if (previous === undefined) delete process.env.THUMBGATE_BENCH_FEEDBACK_DIR;
+    else process.env.THUMBGATE_BENCH_FEEDBACK_DIR = previous;
+    fs.rmSync(explicitDir, { recursive: true, force: true });
+  }
+});
+
+test('withGateRuntime isolates feedback env even with --use-runtime-state', () => {
+  const previousProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = path.join(__dirname, '..');
+  const previousFeedbackDir = process.env.THUMBGATE_FEEDBACK_DIR;
+  try {
+    const observed = withGateRuntime({ useRuntimeState: true }, () => ({
+      feedbackDir: process.env.THUMBGATE_FEEDBACK_DIR,
+      feedbackLog: process.env.THUMBGATE_FEEDBACK_LOG,
+      projectDir: process.env.CLAUDE_PROJECT_DIR,
+    }));
+
+    assert.ok(path.basename(observed.feedbackDir).startsWith('thumbgate-bench-feedback-'));
+    assert.equal(observed.feedbackLog, path.join(observed.feedbackDir, 'feedback-log.jsonl'));
+    assert.equal(observed.projectDir, undefined, 'project scope must not suppress the feedback override');
+    assert.equal(fs.existsSync(observed.feedbackDir), false, 'temp feedback dir is cleaned up');
+    assert.equal(process.env.THUMBGATE_FEEDBACK_DIR, previousFeedbackDir);
+    assert.equal(process.env.CLAUDE_PROJECT_DIR, path.join(__dirname, '..'));
+  } finally {
+    if (previousProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = previousProjectDir;
+  }
+});
+
+test('withGateRuntime keeps an explicit feedback dir in place', () => {
+  const explicitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-bench-keep-'));
+  try {
+    const observed = withGateRuntime({ useRuntimeState: true, feedbackDir: explicitDir }, () => ({
+      feedbackDir: process.env.THUMBGATE_FEEDBACK_DIR,
+    }));
+
+    assert.equal(observed.feedbackDir, path.resolve(explicitDir));
+    assert.equal(fs.existsSync(explicitDir), true, 'explicit feedback dir must not be deleted');
+  } finally {
+    fs.rmSync(explicitDir, { recursive: true, force: true });
+  }
+});
+
+test('ThumbGate Bench CLI leaves the operator feedback store untouched', () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-bench-repo-'));
+  try {
+    const storeDir = path.join(fixtureRoot, '.thumbgate');
+    fs.mkdirSync(storeDir, { recursive: true });
+    const storePath = path.join(storeDir, 'feedback-log.jsonl');
+    const sentinel = `${JSON.stringify({ id: 'operator-entry', feedback: 'up' })}\n`;
+    fs.writeFileSync(storePath, sentinel);
+    const outDir = path.join(fixtureRoot, 'bench-out');
+
+    // Simulate the leak vector: an agent-session env whose project scope made
+    // resolveFeedbackDir() prefer <project>/.thumbgate over any override.
+    const env = {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: fixtureRoot,
+      THUMBGATE_PROJECT_DIR: fixtureRoot,
+    };
+    delete env.THUMBGATE_FEEDBACK_DIR;
+    delete env.THUMBGATE_FEEDBACK_LOG;
+    delete env.THUMBGATE_BENCH_FEEDBACK_DIR;
+
+    const stdout = execFileSync(
+      process.execPath,
+      [path.join(__dirname, '..', 'scripts', 'thumbgate-bench.js'), '--json', `--out-dir=${outDir}`],
+      { cwd: fixtureRoot, encoding: 'utf8', env },
+    );
+    const report = JSON.parse(stdout);
+
+    assert.equal(report.passed, true);
+    assert.equal(fs.readFileSync(storePath, 'utf8'), sentinel, 'operator feedback log must be byte-identical');
+    assert.deepEqual(fs.readdirSync(storeDir).sort(), ['feedback-log.jsonl'], 'no bench artifacts may appear in the operator store');
+    assert.ok(fs.existsSync(path.join(outDir, 'thumbgate-bench-report.json')), 'report output location unchanged');
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Two ingestion fixes from today's RAG audit (86.4% duplicate corpus incl. a 210× bench-replay doc; embedding index frozen 11 days with no alarm):

**Bench isolation** — root cause found and proven: the bench already set THUMBGATE_FEEDBACK_DIR, but (a) `--use-runtime-state` skipped the override and (b) `feedback-paths.js` ignores THUMBGATE_FEEDBACK_DIR whenever CLAUDE_PROJECT_DIR/THUMBGATE_PROJECT_DIR is set — so every agent-session bench run wrote into the project's `.thumbgate/`. Empirically: origin/main bench in a project-scoped fixture writes 5 ingestion artifacts into the store; fixed bench writes none (test's readdirSync assertion fails on old code, passes on new). Bench feedback now defaults to a cleaned-up mkdtemp dir, overridable via `--feedback-dir` / `THUMBGATE_BENCH_FEEDBACK_DIR`; report output location unchanged.

**Drift alarm** — `self-heal:check` gains `embedding_index_drift`: UNHEALTHY when feedback-log.jsonl is >24h newer than lesson-embeddings.json (or the index is missing while lessons exist), naming both paths, the lag in hours, and the remediation (`node scripts/backfill-lesson-embeddings.js`, shipping in #3094). The 11-day silent freeze this alarm exists to catch was found only by manual audit.

Verified: thumbgate-bench 16/16, self-healing-check 23/23, self-heal 18/18 (57/57 agent-side; 39/39 re-run firsthand). Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157MF8QJHAtyjDQp1tghnhj