### PR TITLE
feat: prove and route local inference backends

### DIFF
--- a/.changeset/local-inference-proof-routing.md
+++ b/.changeset/local-inference-proof-routing.md
@@ -1,0 +1,8 @@
+---
+"thumbgate": patch
+---
+
+Add a local-inference proof command that verifies model discovery and real
+OpenAI-compatible chat completions, records latency and throughput evidence,
+and deterministically routes the backend to interactive local, private batch,
+evaluation-only, or managed fallback use.

--- a/README.md
+++ b/README.md
@@ -648,6 +648,16 @@ Pro operators can invoke `search_lessons` through MCP and use `npx thumbgate les
 
 The package includes a local data-chat path over ThumbGate data using lesson retrieval, LanceDB-backed vectors, and an operator-configured LLM. Set `THUMBGATE_LOCAL_LLM_ENDPOINT` to an OpenAI-compatible local endpoint (Ollama, llama.cpp, vLLM, LM Studio, etc.) when you want generated answers without sending dashboard data to Google. This is a local package capability, not a hosted org-dashboard claim.
 
+Prove the endpoint before routing work to it:
+
+```bash
+THUMBGATE_LOCAL_LLM_ENDPOINT=http://127.0.0.1:8000/v1 \
+THUMBGATE_LOCAL_MODEL=qwen3-0.6b-4bit \
+npm run local-inference:prove
+```
+
+The proof checks model discovery and three real chat completions, then returns one of four deterministic routes: `interactive_local`, `private_batch_local`, `evaluation_only_local`, or `managed_fallback`. A slow but contract-compliant local model stays eligible for private batch work without being misrepresented as interactive-ready; contract failures exit nonzero and remain evaluation-only.
+
 Google Cloud is an optional adapter, not a dashboard requirement. The package provides setup and guard-adapter code for operators who already use Vertex AI or Dialogflow CX; each deployment and data boundary must be configured and verified in that tenancy.
 
 ### Optional Vertex Setup

--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
     "stripe:webhook:audit": "node scripts/rotate-stripe-webhook-secret.js --audit",
     "stripe:webhook:disable-legacy": "node scripts/rotate-stripe-webhook-secret.js --disable-legacy",
     "zai:smoke": "node scripts/zai-smoke.js",
+    "local-inference:prove": "node scripts/local-model-profile.js --probe --samples=3",
     "gtm:revenue-loop": "node scripts/autonomous-sales-agent.js",
     "gtm:aiventyx": "node scripts/aiventyx-marketplace-plan.js",
     "gtm:chatgpt": "node scripts/chatgpt-gpt-revenue-pack.js",

--- a/scripts/local-model-profile.js
+++ b/scripts/local-model-profile.js
@@ -9,6 +9,10 @@ const { resolveFeedbackDir: resolveSharedFeedbackDir } = require('./feedback-pat
 const PROJECT_ROOT = path.join(__dirname, '..');
 const DEFAULT_FEEDBACK_DIR = resolveSharedFeedbackDir();
 const DEFAULT_EMBED_MODEL = 'Xenova/all-MiniLM-L6-v2';
+const DEFAULT_LOCAL_LLM_ENDPOINT = 'http://127.0.0.1:8000/v1';
+const DEFAULT_LOCAL_INFERENCE_SAMPLES = 3;
+const DEFAULT_LOCAL_INFERENCE_TIMEOUT_MS = 30000;
+const DEFAULT_INTERACTIVE_LATENCY_MS = 8000;
 
 // ---------------------------------------------------------------------------
 // Model Role Router (OpenDev workload-specialized model routing)
@@ -103,6 +107,326 @@ function normalizeSlug(value, fallback = '') {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
   return normalized || fallback;
+}
+
+function normalizeEndpoint(value) {
+  const endpoint = String(value || DEFAULT_LOCAL_LLM_ENDPOINT).trim();
+  return endpoint.replace(/\/+$/, '');
+}
+
+function clampInteger(value, fallback, min, max) {
+  const parsed = Math.floor(parseNumber(value, fallback));
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function resolveLocalInferenceConfig(env = process.env, overrides = {}) {
+  const endpoint = normalizeEndpoint(
+    overrides.endpoint
+      || env.THUMBGATE_LOCAL_LLM_ENDPOINT
+      || env.THUMBGATE_OMLX_BASE_URL
+      || env.THUMBGATE_LOCAL_MODEL_ENDPOINT,
+  );
+  const model = String(
+    overrides.model
+      || env.THUMBGATE_OMLX_MODEL
+      || env.THUMBGATE_LOCAL_MODEL
+      || env.THUMBGATE_MODEL_ID
+      || '',
+  ).trim();
+  const samples = clampInteger(
+    overrides.samples ?? env.THUMBGATE_LOCAL_INFERENCE_SAMPLES,
+    DEFAULT_LOCAL_INFERENCE_SAMPLES,
+    1,
+    10,
+  );
+  const timeoutMs = clampInteger(
+    overrides.timeoutMs ?? env.THUMBGATE_LOCAL_INFERENCE_TIMEOUT_MS,
+    DEFAULT_LOCAL_INFERENCE_TIMEOUT_MS,
+    1000,
+    120000,
+  );
+  const maxInteractiveLatencyMs = clampInteger(
+    overrides.maxInteractiveLatencyMs ?? env.THUMBGATE_LOCAL_INTERACTIVE_LATENCY_MS,
+    DEFAULT_INTERACTIVE_LATENCY_MS,
+    250,
+    120000,
+  );
+  const apiKey = String(
+    overrides.apiKey
+      || env.THUMBGATE_OMLX_API_KEY
+      || env.THUMBGATE_LOCAL_LLM_API_KEY
+      || '',
+  ).trim();
+
+  return {
+    endpoint,
+    model,
+    samples,
+    timeoutMs,
+    maxInteractiveLatencyMs,
+    authorizationConfigured: Boolean(apiKey),
+  };
+}
+
+function resolveLocalAuthorization(env = process.env, overrides = {}) {
+  const apiKey = String(
+    overrides.apiKey
+      || env.THUMBGATE_OMLX_API_KEY
+      || env.THUMBGATE_LOCAL_LLM_API_KEY
+      || '',
+  ).trim();
+  return apiKey ? `Bearer ${apiKey}` : '';
+}
+
+async function fetchJson(fetchImpl, url, init, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { ...init, signal: controller.signal });
+    const body = await response.text();
+    let payload = {};
+    if (body) {
+      try {
+        payload = JSON.parse(body);
+      } catch {
+        throw new Error(`non_json_response:${response.status}`);
+      }
+    }
+    if (!response.ok) {
+      throw new Error(`http_${response.status}`);
+    }
+    return { status: response.status, payload };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function percentile(values, pct) {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.max(
+    0,
+    Math.min(sorted.length - 1, Math.ceil((pct / 100) * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+function extractAssistantText(payload) {
+  const content = payload?.choices?.[0]?.message?.content;
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+    .join(' ')
+    .trim();
+}
+
+function evaluateLocalInferenceBenchmark(samples, options = {}) {
+  const maxInteractiveLatencyMs = clampInteger(
+    options.maxInteractiveLatencyMs,
+    DEFAULT_INTERACTIVE_LATENCY_MS,
+    250,
+    120000,
+  );
+  const successful = samples.filter((sample) => sample.ok);
+  const contractPassing = successful.filter((sample) => sample.contractOk);
+  const latencies = successful.map((sample) => sample.latencyMs);
+  const totalOutputTokens = successful.reduce(
+    (sum, sample) => sum + Number(sample.outputTokens || 0),
+    0,
+  );
+  const totalLatencyMs = latencies.reduce((sum, value) => sum + value, 0);
+  const successRate = samples.length > 0 ? successful.length / samples.length : 0;
+  const contractPassRate = samples.length > 0
+    ? contractPassing.length / samples.length
+    : 0;
+  const p50LatencyMs = percentile(latencies, 50);
+  const p95LatencyMs = percentile(latencies, 95);
+  const tokensPerSecond = totalLatencyMs > 0
+    ? totalOutputTokens / (totalLatencyMs / 1000)
+    : null;
+
+  let status = 'unavailable';
+  let route = 'managed_fallback';
+  let reason = 'local inference did not return a non-empty assistant response for every sample.';
+  if (
+    successRate === 1
+    && contractPassRate === 1
+    && p95LatencyMs !== null
+    && p95LatencyMs <= maxInteractiveLatencyMs
+  ) {
+    status = 'interactive_ready';
+    route = 'interactive_local';
+    reason = `local inference passed every response contract within the ${maxInteractiveLatencyMs}ms interactive latency budget.`;
+  } else if (successRate === 1 && contractPassRate === 1) {
+    status = 'batch_ready';
+    route = 'private_batch_local';
+    reason = `local inference passed every response contract, but p95 latency exceeded the ${maxInteractiveLatencyMs}ms interactive budget.`;
+  } else if (successRate === 1) {
+    status = 'evaluation_only';
+    route = 'evaluation_only_local';
+    reason = 'local inference returned non-empty responses, but at least one deterministic response contract failed.';
+  }
+
+  return {
+    status,
+    route,
+    reason,
+    successRate: Number(successRate.toFixed(4)),
+    contractPassRate: Number(contractPassRate.toFixed(4)),
+    contractPassingSamples: contractPassing.length,
+    successfulSamples: successful.length,
+    totalSamples: samples.length,
+    p50LatencyMs,
+    p95LatencyMs,
+    maxInteractiveLatencyMs,
+    totalOutputTokens,
+    tokensPerSecond: tokensPerSecond === null
+      ? null
+      : Number(tokensPerSecond.toFixed(3)),
+    recommendedUses: status === 'interactive_ready'
+      ? ['private retrieval', 'classification', 'policy support', 'interactive local chat']
+      : status === 'batch_ready'
+        ? ['private retrieval', 'offline classification', 'batch policy analysis']
+        : status === 'evaluation_only'
+          ? ['private experimentation', 'model evaluation']
+        : [],
+    blockedUses: status === 'interactive_ready'
+      ? []
+      : status === 'batch_ready'
+        ? ['latency-sensitive interactive routing']
+        : status === 'evaluation_only'
+          ? ['production routing', 'policy decisions', 'autonomous actions']
+        : ['production routing'],
+  };
+}
+
+function localInferenceProofExitCode(result) {
+  return String(result?.evaluation?.status || '').endsWith('_ready') ? 0 : 1;
+}
+
+async function probeLocalInference(options = {}) {
+  const env = options.env || process.env;
+  const config = resolveLocalInferenceConfig(env, options);
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('fetch_unavailable');
+  }
+  const now = options.now || (() => Date.now());
+  const headers = { 'content-type': 'application/json' };
+  const authorization = resolveLocalAuthorization(env, options);
+  if (authorization) headers.authorization = authorization;
+
+  let model = config.model;
+  let models = [];
+  try {
+    const response = await fetchJson(
+      fetchImpl,
+      `${config.endpoint}/models`,
+      { method: 'GET', headers },
+      config.timeoutMs,
+    );
+    models = Array.isArray(response.payload?.data)
+      ? response.payload.data.map((item) => String(item?.id || '')).filter(Boolean)
+      : [];
+    model = model || models[0] || '';
+  } catch (error) {
+    return {
+      generatedAt: new Date().toISOString(),
+      provider: 'openai-compatible-local',
+      endpoint: config.endpoint,
+      model,
+      models,
+      authorizationConfigured: config.authorizationConfigured,
+      endpointReady: false,
+      samples: [],
+      evaluation: evaluateLocalInferenceBenchmark([], config),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (!model) {
+    return {
+      generatedAt: new Date().toISOString(),
+      provider: 'openai-compatible-local',
+      endpoint: config.endpoint,
+      model: '',
+      models,
+      authorizationConfigured: config.authorizationConfigured,
+      endpointReady: true,
+      samples: [],
+      evaluation: evaluateLocalInferenceBenchmark([], config),
+      error: 'models_empty',
+    };
+  }
+
+  const samples = [];
+  for (let index = 0; index < config.samples; index += 1) {
+    const startedAt = now();
+    try {
+      const response = await fetchJson(
+        fetchImpl,
+        `${config.endpoint}/chat/completions`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            model,
+            messages: [
+              {
+                role: 'system',
+                content: 'You are a deterministic health probe. Output exactly READY and nothing else.',
+              },
+              {
+                role: 'user',
+                content: '/no_think\nOutput exactly READY.',
+              },
+            ],
+            temperature: 0,
+            max_tokens: 16,
+          }),
+        },
+        config.timeoutMs,
+      );
+      const text = extractAssistantText(response.payload);
+      const latencyMs = Math.max(0, Math.round(now() - startedAt));
+      samples.push({
+        index: index + 1,
+        ok: Boolean(text),
+        contractOk: text === 'READY',
+        latencyMs,
+        outputTokens: Number(
+          response.payload?.usage?.completion_tokens
+            ?? response.payload?.usage?.output_tokens
+            ?? 0,
+        ),
+        textPreview: text.slice(0, 80),
+        error: text ? null : 'empty_assistant_response',
+      });
+    } catch (error) {
+      samples.push({
+        index: index + 1,
+        ok: false,
+        contractOk: false,
+        latencyMs: Math.max(0, Math.round(now() - startedAt)),
+        outputTokens: 0,
+        textPreview: '',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    provider: 'openai-compatible-local',
+    endpoint: config.endpoint,
+    model,
+    models,
+    authorizationConfigured: config.authorizationConfigured,
+    endpointReady: true,
+    samples,
+    evaluation: evaluateLocalInferenceBenchmark(samples, config),
+  };
 }
 
 function isSparseAttentionFamily(modelFamily) {
@@ -382,6 +706,10 @@ function writeModelFitReport(feedbackDir, options = {}) {
 module.exports = {
   DEFAULT_EMBED_MODEL,
   DEFAULT_FEEDBACK_DIR,
+  DEFAULT_INTERACTIVE_LATENCY_MS,
+  DEFAULT_LOCAL_INFERENCE_SAMPLES,
+  DEFAULT_LOCAL_INFERENCE_TIMEOUT_MS,
+  DEFAULT_LOCAL_LLM_ENDPOINT,
   EMBEDDING_PROFILES,
   GLM_MODEL_ROLES,
   INDEXCACHE_SERVER_ENGINES,
@@ -397,11 +725,44 @@ module.exports = {
   writeModelFitReport,
   getModelFitReportPath,
   isLongContextTask,
+  evaluateLocalInferenceBenchmark,
+  localInferenceProofExitCode,
+  probeLocalInference,
   recommendInferenceBackend,
   resolveFeedbackDir,
+  resolveLocalInferenceConfig,
 };
 
-if (require.main === module) {
-  const report = buildModelFitReport();
-  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+async function main(argv = process.argv.slice(2)) {
+  const probe = argv.includes('--probe');
+  const samplesArg = argv.find((arg) => arg.startsWith('--samples='));
+  const maxLatencyArg = argv.find((arg) => arg.startsWith('--max-interactive-latency-ms='));
+  if (!probe) {
+    const report = buildModelFitReport();
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return 0;
+  }
+
+  const result = await probeLocalInference({
+    samples: samplesArg ? samplesArg.split('=', 2)[1] : undefined,
+    maxInteractiveLatencyMs: maxLatencyArg
+      ? maxLatencyArg.split('=', 2)[1]
+      : undefined,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  return localInferenceProofExitCode(result);
+}
+
+module.exports.main = main;
+
+if (
+  process.argv[1]
+  && path.resolve(process.argv[1]) === path.resolve(__filename)
+) {
+  main().then((exitCode) => {
+    process.exitCode = exitCode;
+  }).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
 }

--- a/scripts/local-model-profile.js
+++ b/scripts/local-model-profile.js
@@ -85,6 +85,34 @@ const LONG_CONTEXT_TAGS = new Set([
   'xmemory',
 ]);
 
+const LOCAL_INFERENCE_USE_POLICY = Object.freeze({
+  interactive_ready: Object.freeze({
+    recommended: Object.freeze([
+      'private retrieval',
+      'classification',
+      'policy support',
+      'interactive local chat',
+    ]),
+    blocked: Object.freeze([]),
+  }),
+  batch_ready: Object.freeze({
+    recommended: Object.freeze([
+      'private retrieval',
+      'offline classification',
+      'batch policy analysis',
+    ]),
+    blocked: Object.freeze(['latency-sensitive interactive routing']),
+  }),
+  evaluation_only: Object.freeze({
+    recommended: Object.freeze(['private experimentation', 'model evaluation']),
+    blocked: Object.freeze(['production routing', 'policy decisions', 'autonomous actions']),
+  }),
+  unavailable: Object.freeze({
+    recommended: Object.freeze([]),
+    blocked: Object.freeze(['production routing']),
+  }),
+});
+
 function parseNumber(value, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
@@ -101,17 +129,23 @@ function parseBoolean(value, fallback) {
 
 function normalizeSlug(value, fallback = '') {
   if (value === undefined || value === null || value === '') return fallback;
-  const normalized = String(value)
+  const sanitized = String(value)
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^a-z0-9]+/g, '-');
+  let start = 0;
+  let end = sanitized.length;
+  while (sanitized[start] === '-') start += 1;
+  while (sanitized[end - 1] === '-') end -= 1;
+  const normalized = sanitized.slice(start, end);
   return normalized || fallback;
 }
 
 function normalizeEndpoint(value) {
   const endpoint = String(value || DEFAULT_LOCAL_LLM_ENDPOINT).trim();
-  return endpoint.replace(/\/+$/, '');
+  let end = endpoint.length;
+  while (endpoint[end - 1] === '/') end -= 1;
+  return endpoint.slice(0, end);
 }
 
 function clampInteger(value, fallback, min, max) {
@@ -221,6 +255,45 @@ function extractAssistantText(payload) {
     .trim();
 }
 
+function classifyLocalInference({
+  successRate,
+  contractPassRate,
+  p95LatencyMs,
+  maxInteractiveLatencyMs,
+}) {
+  const passedAllContracts = successRate === 1 && contractPassRate === 1;
+  const metInteractiveBudget = (
+    p95LatencyMs !== null
+    && p95LatencyMs <= maxInteractiveLatencyMs
+  );
+  if (passedAllContracts && metInteractiveBudget) {
+    return {
+      status: 'interactive_ready',
+      route: 'interactive_local',
+      reason: `local inference passed every response contract within the ${maxInteractiveLatencyMs}ms interactive latency budget.`,
+    };
+  }
+  if (passedAllContracts) {
+    return {
+      status: 'batch_ready',
+      route: 'private_batch_local',
+      reason: `local inference passed every response contract, but p95 latency exceeded the ${maxInteractiveLatencyMs}ms interactive budget.`,
+    };
+  }
+  if (successRate === 1) {
+    return {
+      status: 'evaluation_only',
+      route: 'evaluation_only_local',
+      reason: 'local inference returned non-empty responses, but at least one deterministic response contract failed.',
+    };
+  }
+  return {
+    status: 'unavailable',
+    route: 'managed_fallback',
+    reason: 'local inference did not return a non-empty assistant response for every sample.',
+  };
+}
+
 function evaluateLocalInferenceBenchmark(samples, options = {}) {
   const maxInteractiveLatencyMs = clampInteger(
     options.maxInteractiveLatencyMs,
@@ -245,33 +318,16 @@ function evaluateLocalInferenceBenchmark(samples, options = {}) {
   const tokensPerSecond = totalLatencyMs > 0
     ? totalOutputTokens / (totalLatencyMs / 1000)
     : null;
-
-  let status = 'unavailable';
-  let route = 'managed_fallback';
-  let reason = 'local inference did not return a non-empty assistant response for every sample.';
-  if (
-    successRate === 1
-    && contractPassRate === 1
-    && p95LatencyMs !== null
-    && p95LatencyMs <= maxInteractiveLatencyMs
-  ) {
-    status = 'interactive_ready';
-    route = 'interactive_local';
-    reason = `local inference passed every response contract within the ${maxInteractiveLatencyMs}ms interactive latency budget.`;
-  } else if (successRate === 1 && contractPassRate === 1) {
-    status = 'batch_ready';
-    route = 'private_batch_local';
-    reason = `local inference passed every response contract, but p95 latency exceeded the ${maxInteractiveLatencyMs}ms interactive budget.`;
-  } else if (successRate === 1) {
-    status = 'evaluation_only';
-    route = 'evaluation_only_local';
-    reason = 'local inference returned non-empty responses, but at least one deterministic response contract failed.';
-  }
+  const classification = classifyLocalInference({
+    successRate,
+    contractPassRate,
+    p95LatencyMs,
+    maxInteractiveLatencyMs,
+  });
+  const usePolicy = LOCAL_INFERENCE_USE_POLICY[classification.status];
 
   return {
-    status,
-    route,
-    reason,
+    ...classification,
     successRate: Number(successRate.toFixed(4)),
     contractPassRate: Number(contractPassRate.toFixed(4)),
     contractPassingSamples: contractPassing.length,
@@ -284,20 +340,8 @@ function evaluateLocalInferenceBenchmark(samples, options = {}) {
     tokensPerSecond: tokensPerSecond === null
       ? null
       : Number(tokensPerSecond.toFixed(3)),
-    recommendedUses: status === 'interactive_ready'
-      ? ['private retrieval', 'classification', 'policy support', 'interactive local chat']
-      : status === 'batch_ready'
-        ? ['private retrieval', 'offline classification', 'batch policy analysis']
-        : status === 'evaluation_only'
-          ? ['private experimentation', 'model evaluation']
-        : [],
-    blockedUses: status === 'interactive_ready'
-      ? []
-      : status === 'batch_ready'
-        ? ['latency-sensitive interactive routing']
-        : status === 'evaluation_only'
-          ? ['production routing', 'policy decisions', 'autonomous actions']
-        : ['production routing'],
+    recommendedUses: [...usePolicy.recommended],
+    blockedUses: [...usePolicy.blocked],
   };
 }
 
@@ -310,7 +354,7 @@ async function probeLocalInference(options = {}) {
   const config = resolveLocalInferenceConfig(env, options);
   const fetchImpl = options.fetchImpl || globalThis.fetch;
   if (typeof fetchImpl !== 'function') {
-    throw new Error('fetch_unavailable');
+    throw new TypeError('fetch_unavailable');
   }
   const now = options.now || (() => Date.now());
   const headers = { 'content-type': 'application/json' };

--- a/tests/local-model-profile.test.js
+++ b/tests/local-model-profile.test.js
@@ -235,8 +235,12 @@ test('resolveModelRole throws on unknown role', () => {
 
 test('GLM_MODEL_ROLES covers all valid roles and uses lite variant for compaction', () => {
   for (const role of VALID_MODEL_ROLES) {
-    assert.ok(typeof GLM_MODEL_ROLES[role] === 'string' && GLM_MODEL_ROLES[role].length > 0,
-      `GLM_MODEL_ROLES missing role: ${role}`);
+    assert.equal(
+      typeof GLM_MODEL_ROLES[role],
+      'string',
+      `GLM_MODEL_ROLES must contain a string for role: ${role}`,
+    );
+    assert.ok(GLM_MODEL_ROLES[role].length > 0, `GLM_MODEL_ROLES missing role: ${role}`);
   }
   assert.ok(GLM_MODEL_ROLES.compaction.includes('4-9b') || GLM_MODEL_ROLES.compaction.includes('lite'),
     'compaction should use a lighter GLM model');

--- a/tests/local-model-profile.test.js
+++ b/tests/local-model-profile.test.js
@@ -9,14 +9,28 @@ const path = require('node:path');
 const {
   detectHardware,
   detectInferenceBackend,
+  evaluateLocalInferenceBenchmark,
+  localInferenceProofExitCode,
+  probeLocalInference,
   recommendInferenceBackend,
   resolveEmbeddingProfile,
+  resolveLocalInferenceConfig,
   writeModelFitReport,
   resolveModelRole,
   GLM_MODEL_ROLES,
   MODEL_ROLES,
   VALID_MODEL_ROLES,
 } = require('../scripts/local-model-profile');
+
+function jsonResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return JSON.stringify(payload);
+    },
+  };
+}
 
 test('detectHardware respects env overrides', () => {
   const hardware = detectHardware({
@@ -59,6 +73,118 @@ test('resolveEmbeddingProfile honors explicit env overrides', () => {
   assert.equal(resolved.selectedProfile.model, 'custom/model');
   assert.equal(resolved.selectedProfile.quantized, false);
   assert.equal(resolved.selectedProfile.maxChars, 1234);
+});
+
+test('resolveLocalInferenceConfig supports oMLX aliases without exposing the API key', () => {
+  const config = resolveLocalInferenceConfig({
+    THUMBGATE_OMLX_BASE_URL: 'http://127.0.0.1:8000/v1/',
+    THUMBGATE_OMLX_MODEL: 'qwen3-0.6b-4bit',
+    THUMBGATE_OMLX_API_KEY: 'runtime-only-secret',
+    THUMBGATE_LOCAL_INFERENCE_SAMPLES: '4',
+  });
+
+  assert.equal(config.endpoint, 'http://127.0.0.1:8000/v1');
+  assert.equal(config.model, 'qwen3-0.6b-4bit');
+  assert.equal(config.samples, 4);
+  assert.equal(config.authorizationConfigured, true);
+  assert.equal('apiKey' in config, false);
+  assert.equal(JSON.stringify(config).includes('runtime-only-secret'), false);
+});
+
+test('evaluateLocalInferenceBenchmark separates interactive and private batch routes', () => {
+  const interactive = evaluateLocalInferenceBenchmark(
+    [
+      { ok: true, contractOk: true, latencyMs: 900, outputTokens: 9 },
+      { ok: true, contractOk: true, latencyMs: 1100, outputTokens: 11 },
+    ],
+    { maxInteractiveLatencyMs: 1500 },
+  );
+  assert.equal(interactive.status, 'interactive_ready');
+  assert.equal(interactive.route, 'interactive_local');
+  assert.equal(interactive.successRate, 1);
+
+  const batch = evaluateLocalInferenceBenchmark(
+    [
+      { ok: true, contractOk: true, latencyMs: 9000, outputTokens: 9 },
+      { ok: true, contractOk: true, latencyMs: 12000, outputTokens: 11 },
+    ],
+    { maxInteractiveLatencyMs: 1500 },
+  );
+  assert.equal(batch.status, 'batch_ready');
+  assert.equal(batch.route, 'private_batch_local');
+  assert.ok(batch.blockedUses.includes('latency-sensitive interactive routing'));
+});
+
+test('evaluateLocalInferenceBenchmark does not route contract failures to production', () => {
+  const evaluation = evaluateLocalInferenceBenchmark(
+    [
+      { ok: true, contractOk: false, latencyMs: 400, outputTokens: 8 },
+    ],
+    { maxInteractiveLatencyMs: 1500 },
+  );
+
+  assert.equal(evaluation.status, 'evaluation_only');
+  assert.equal(evaluation.route, 'evaluation_only_local');
+  assert.equal(evaluation.successRate, 1);
+  assert.equal(evaluation.contractPassRate, 0);
+  assert.ok(evaluation.blockedUses.includes('autonomous actions'));
+  assert.equal(localInferenceProofExitCode({ evaluation }), 1);
+  assert.equal(
+    localInferenceProofExitCode({
+      evaluation: { status: 'interactive_ready' },
+    }),
+    0,
+  );
+});
+
+test('probeLocalInference verifies models and non-empty chat responses', async () => {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    if (url.endsWith('/models')) {
+      return jsonResponse({
+        data: [{ id: 'qwen3-0.6b-4bit' }],
+      });
+    }
+    return jsonResponse({
+      choices: [{ message: { content: 'READY' } }],
+      usage: { completion_tokens: 1 },
+    });
+  };
+  const ticks = [1000, 1800, 2000, 2900];
+  const proof = await probeLocalInference({
+    env: {
+      THUMBGATE_OMLX_BASE_URL: 'http://127.0.0.1:8000/v1',
+      THUMBGATE_OMLX_MODEL: 'qwen3-0.6b-4bit',
+    },
+    fetchImpl,
+    now: () => ticks.shift(),
+    samples: 2,
+    maxInteractiveLatencyMs: 1000,
+  });
+
+  assert.equal(proof.endpointReady, true);
+  assert.equal(proof.model, 'qwen3-0.6b-4bit');
+  assert.equal(proof.samples.length, 2);
+  assert.equal(proof.samples.every((sample) => sample.contractOk), true);
+  assert.equal(proof.evaluation.status, 'interactive_ready');
+  assert.equal(proof.evaluation.contractPassRate, 1);
+  assert.equal(proof.evaluation.p95LatencyMs, 900);
+  assert.equal(calls.length, 3);
+  assert.equal(calls.some((call) => call.init.headers.authorization), false);
+});
+
+test('probeLocalInference fails closed when the models endpoint is unavailable', async () => {
+  const proof = await probeLocalInference({
+    env: {},
+    fetchImpl: async () => jsonResponse({ error: 'offline' }, 503),
+    samples: 1,
+  });
+
+  assert.equal(proof.endpointReady, false);
+  assert.equal(proof.evaluation.status, 'unavailable');
+  assert.equal(proof.evaluation.route, 'managed_fallback');
+  assert.equal(proof.error, 'http_503');
 });
 
 test('writeModelFitReport persists machine-readable evidence', () => {


### PR DESCRIPTION
## Summary

- add a real OpenAI-compatible local inference proof command
- verify model discovery plus three deterministic chat completions
- measure contract pass rate, latency, token throughput, and routing readiness
- route to interactive, private batch, evaluation-only, or managed fallback lanes
- fail the proof command when the model is unavailable or violates the response contract
- support oMLX environment aliases without serializing API keys

## Verification

- `npm test` — passed
- `npm run test:api` — 969 passed
- `npm run test:high-roi` — 195 passed
- `node --test tests/local-model-profile.test.js` — 22 passed
- `npm run test:coverage` — 87.12% lines, 74.73% branches, 88.56% functions
- adapter proof, automation proof, self-healing check, version sync, and pre-push guards — passed
- `npm audit` — 0 vulnerabilities

## Live oMLX proof

`qwen3-0.6b-4bit` returned exact `READY` on 3/3 samples. p50 was 1,584 ms and p95 was 1,629 ms, producing `interactive_ready` / `interactive_local` with no blocked uses.

A patch changeset is included.