### PR TITLE
docs(agents): permanent completion-claim contract after CEO thumbs-down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,23 @@ On explicit user preference signals (`up/down`, `correct/wrong`, or subjective "
 - Never claim completion before verification.
 - Report failures immediately and factually.
 
+## Completion Claim Contract (CEO thumbs-down 2026-07-30)
+
+Permanent (not auto-generated; do not dilute into generic "investigate"). Applies to **done / fixed / shipped / live / crisis over / kill-switch complete**.
+
+| Claim type | Required evidence before the word |
+|------------|-----------------------------------|
+| Code on `main` | Merge commit SHA is tip (or ancestor) of `origin/main` |
+| Production live | `GET /health` `buildSha` **equals** that SHA (and version when versioned) |
+| CI green | Terminal required checks on **that exact SHA** (not an older branch run) |
+| Actions / minutes "fixed" | Raw billing or usage readout after the change — not "workflows disabled" alone |
+| Private workflow burn stopped | Full inventory including **active push CI** and `dynamic/dependabot/*`, not only `disabled_manually` schedules |
+
+**Rules:**
+- **Partial = partial.** Mid-flight deploy, pending CI, or remaining active burners are not "complete."
+- **TRUE/FALSE ledger first** when the CEO asks "are you sure?" or after any overclaim correction.
+- **NEVER** dress partial progress as a closed crisis. Feedback: `fb_1785435078277_umex12`.
+
 ## Operational Standards
 
 - Adhere to two-space indentation and single-quote strings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,12 @@ Adopted 2026-05-12 after a full PR/branch sweep. Persisted here so every future 
 - Never say "done", "deployed", "shipped", "live", or "merged" without first running the relevant verification:
   - PRs: `gh pr view --json reviewDecision,mergeStateStatus,statusCheckRollup` showing CLEAN + SUCCESS + merged=true.
   - Deploys: the full Deployment Verification Gate (`/health` version grep + `/dashboard` grep + a route-specific 302/200 grep for the change shipped).
+- **Completion Claim Contract (2026-07-30 CEO thumbs-down):** also never say "fixed", "crisis over", or "kill-switch complete" without the matching evidence class:
+  - prod `/health.buildSha` equals claimed main tip when production is in scope;
+  - terminal required CI on that exact SHA;
+  - for Actions-minutes claims, raw billing/usage after the change (workflow disable alone is not proof);
+  - full private workflow inventory including push CI and `dynamic/dependabot/*`, not only `disabled_manually` schedules.
+  - Partial progress stays labeled partial. TRUE/FALSE ledger first after any "are you sure?".
 
 ### No Manual Handoffs
 - Never instruct the CEO to run a command, click a dashboard, or paste a value if the CTO can do it.
@@ -359,6 +365,7 @@ Adopted 2026-05-12 after a full PR/branch sweep. Persisted here so every future 
 - Lying is not allowed. "Code shipped ≠ outcome achieved." Verify against production data before framing as solved.
 - Failures must be surfaced as they happen, not buried under retries.
 - Mistakes get logged to the local lesson DB via `.claude/scripts/feedback/capture-feedback.js`.
+- Manual appends to `.thumbgate/prevention-rules.md` are **not durable** (meta-agent regen wipes them). Permanent behavioral contracts belong in tracked `AGENTS.md` / `CLAUDE.md` (this file), not only local runtime rules.
 
 ### Continuous Learning
 - Record every trade and lesson in RAG.


### PR DESCRIPTION
## Summary
- Pins a **permanent Completion Claim Contract** in tracked `AGENTS.md` + `CLAUDE.md` after CEO thumbs-down on overclaiming "kill switch complete" / crisis closed while prod, CI, and Actions evidence were incomplete.
- Documents that `.thumbgate/prevention-rules.md` is **not durable** (meta-agent regen wipes manual appends); permanent contracts live in tracked directives.

## Evidence requirement
| Claim | Required |
|-------|----------|
| main | merge SHA on tip |
| prod live | `/health` buildSha equals that SHA |
| CI | terminal required checks on that SHA |
| Actions minutes fixed | raw billing/usage after change |
| private burn stopped | full inventory incl. push CI + dynamic Dependabot |

## Test plan
- [x] Diff review of AGENTS.md / CLAUDE.md only
- [ ] Agents read contract on next session load