### PR TITLE
fix(checkout): direct Stripe skip on Pro interstitial

### DIFF
--- a/.changeset/pro-checkout-direct-stripe-skip.md
+++ b/.changeset/pro-checkout-direct-stripe-skip.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Pro checkout interstitial adds a nofollow direct Stripe Payment Link CTA so buyers who bounce on the email form can still open live checkout without a second server round-trip.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -480,6 +480,25 @@ const TRACKED_LINK_TARGETS = Object.freeze({
     },
     allowCustomerEmail: true,
   },
+  // Human skip from Pro interstitial: same-origin hop so crawlers never see buy.stripe.com
+  // in the interstitial HTML (bot-guard contract). Bots are deflected to /checkout/pro.
+  'pro-direct': {
+    fallbackHref: PRO_CHECKOUT_URL,
+    external: true,
+    botDeflectPath: '/checkout/pro',
+    ctaId: 'pro_checkout_direct_stripe',
+    ctaPlacement: 'checkout_interstitial',
+    eventType: 'pro_checkout_direct_stripe',
+    defaults: {
+      utm_source: 'website',
+      utm_medium: 'checkout_interstitial',
+      utm_campaign: 'pro_upgrade',
+      plan_id: 'pro',
+      billing_cycle: 'monthly',
+    },
+    allowCustomerEmail: true,
+    prefillStripeEmail: true,
+  },
   // 2026-06-02: Teams/Aiventyx deprecated. Redirect legacy links to Pro.
   teams: {
     path: '/go/pro?utm_source=legacy_teams&utm_medium=redirect',
@@ -2501,9 +2520,9 @@ ${hiddenInputs}
 <p class="email-note">Required so the checkout has attributable buyer intent and your receipt can be recovered.</p>
 <button type="submit" class="primary">Pay $19/mo with Stripe →</button>
 </form>
-<a class="secondary" data-i="pro_checkout_direct_stripe" rel="nofollow noopener noreferrer" target="_blank" href="${PRO_CHECKOUT_URL}">Skip form — open Stripe checkout directly →</a>
+<a class="secondary" data-i="pro_checkout_direct_stripe" rel="nofollow" href="/go/pro-direct?utm_source=website&amp;utm_medium=checkout_interstitial&amp;utm_campaign=pro_upgrade&amp;utm_content=skip_form&amp;cta_id=pro_checkout_direct_stripe&amp;cta_placement=checkout_interstitial">Skip form — open Stripe checkout directly →</a>
 <a class="secondary" data-i="workflow_sprint_intake" href="/#workflow-sprint-intake">Not sure yet? Send the workflow first</a>
-<p class="choice-note">Cancel anytime. 7-day refund, no questions. Diagnostics and sprints have their own pages. Email path keeps receipts attributable; the direct Stripe link is for buyers who bounce on the form.</p>
+<p class="choice-note">Cancel anytime. 7-day refund, no questions. Diagnostics and sprints have their own pages. Email path keeps receipts attributable; skip uses a same-origin hop that bot-deflects crawlers.</p>
 <div class="objection-box" aria-label="Checkout feedback">
 <strong>Not buying today?</strong>
 <p class="objection-note">Tap one reason so we know what to fix. This does not sign you up.</p>
@@ -2826,6 +2845,37 @@ function serveTrackedLinkRedirect({ req, res, parsed, hostedConfig, isHeadReques
 
   const { FEEDBACK_DIR } = getFeedbackPaths();
   const journeyState = resolveJourneyState(req, parsed);
+  const botClassification = classifyRequester(req.headers);
+  if (target.botDeflectPath && botClassification.isBot) {
+    const deflectUrl = new URL(target.botDeflectPath, hostedConfig.appOrigin);
+    appendTrackedLinkQueryParams(deflectUrl, parsed, target);
+    if (!isHeadRequest) {
+      appendBestEffortTelemetry(
+        FEEDBACK_DIR,
+        {
+          eventType: 'checkout_bot_deflected',
+          clientType: 'web',
+          page: `/go/${target.slug}`,
+          reason: botClassification.reason || 'bot',
+          destinationSlug: target.slug,
+          acquisitionId: journeyState.acquisitionId,
+          visitorId: journeyState.visitorId,
+          sessionId: journeyState.sessionId,
+        },
+        req.headers,
+        `tracked_link_bot_deflect:${target.slug}`
+      );
+    }
+    res.writeHead(302, {
+      ...(journeyState.setCookieHeaders.length ? { 'Set-Cookie': journeyState.setCookieHeaders } : {}),
+      'Cache-Control': 'no-store',
+      'X-Robots-Tag': 'noindex,nofollow',
+      'X-ThumbGate-Link-Slug': target.slug,
+      Location: deflectUrl.toString(),
+    });
+    res.end();
+    return;
+  }
   const destinationUrl = buildTrackedLinkDestination(target, hostedConfig, parsed);
   const attribution = buildTrackedLinkAttribution(target, parsed, req, journeyState, destinationUrl);
   if (target.external) {

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2501,8 +2501,9 @@ ${hiddenInputs}
 <p class="email-note">Required so the checkout has attributable buyer intent and your receipt can be recovered.</p>
 <button type="submit" class="primary">Pay $19/mo with Stripe →</button>
 </form>
+<a class="secondary" data-i="pro_checkout_direct_stripe" rel="nofollow noopener noreferrer" target="_blank" href="${PRO_CHECKOUT_URL}">Skip form — open Stripe checkout directly →</a>
 <a class="secondary" data-i="workflow_sprint_intake" href="/#workflow-sprint-intake">Not sure yet? Send the workflow first</a>
-<p class="choice-note">Cancel anytime. 7-day refund, no questions. Diagnostics and sprints have their own pages.</p>
+<p class="choice-note">Cancel anytime. 7-day refund, no questions. Diagnostics and sprints have their own pages. Email path keeps receipts attributable; the direct Stripe link is for buyers who bounce on the form.</p>
 <div class="objection-box" aria-label="Checkout feedback">
 <strong>Not buying today?</strong>
 <p class="objection-note">Tap one reason so we know what to fix. This does not sign you up.</p>

--- a/tests/checkout-bot-guard.test.js
+++ b/tests/checkout-bot-guard.test.js
@@ -563,4 +563,37 @@ describe('/checkout/pro bot guard', () => {
       'deflection reason should be populated',
     );
   });
+
+  it('bot deflects /go/pro-direct to /checkout/pro without Stripe URL', async () => {
+    try { fs.unlinkSync(path.join(ENV.THUMBGATE_FEEDBACK_DIR, 'telemetry-pings.jsonl')); } catch {}
+    const res = await fetch(`${origin}/go/pro-direct`, {
+      redirect: 'manual',
+      headers: {
+        'user-agent': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+        accept: 'text/html,*/*',
+      },
+    });
+    assert.equal(res.status, 302);
+    const loc = res.headers.get('location') || '';
+    assert.match(loc, /\/checkout\/pro/);
+    assert.doesNotMatch(loc, /buy\.stripe\.com/);
+    const events = readFunnelEvents();
+    assert.ok(
+      events.some((e) => e.eventType === 'checkout_bot_deflected'),
+      'bot pro-direct should log checkout_bot_deflected',
+    );
+  });
+
+  it('human /go/pro-direct redirects to live Stripe Payment Link', async () => {
+    const res = await fetch(`${origin}/go/pro-direct?utm_content=skip_form`, {
+      redirect: 'manual',
+      headers: {
+        'user-agent': BROWSER_UA,
+        accept: BROWSER_ACCEPT,
+      },
+    });
+    assert.equal(res.status, 302);
+    const loc = res.headers.get('location') || '';
+    assert.match(loc, /buy\.stripe\.com\//);
+  });
 });

--- a/tests/checkout-pro-confirmation-gate.test.js
+++ b/tests/checkout-pro-confirmation-gate.test.js
@@ -88,7 +88,8 @@ describe('/checkout/pro confirmation gate (closes 0/50 conversion leak)', () => 
     assert.match(body, /name="confirm" value="1"/);
     assert.match(body, /name="customer_email"[^>]*required/);
     assert.match(body, /pro_checkout_direct_stripe/);
-    assert.match(body, /buy\.stripe\.com/);
+    assert.match(body, /\/go\/pro-direct/);
+    assert.doesNotMatch(body, /buy\.stripe\.com\//);
     assert.match(body, /hosted team sync and a hosted org dashboard are not generally available/i);
     assert.doesNotMatch(body, /Shared hosted lessons and org dashboards are Enterprise/i);
     assert.doesNotMatch(body, /<form action="https:\/\/buy\.stripe\.com\//);

--- a/tests/checkout-pro-confirmation-gate.test.js
+++ b/tests/checkout-pro-confirmation-gate.test.js
@@ -87,6 +87,8 @@ describe('/checkout/pro confirmation gate (closes 0/50 conversion leak)', () => 
     assert.match(body, /action="\/checkout\/pro" method="POST"/);
     assert.match(body, /name="confirm" value="1"/);
     assert.match(body, /name="customer_email"[^>]*required/);
+    assert.match(body, /pro_checkout_direct_stripe/);
+    assert.match(body, /buy\.stripe\.com/);
     assert.match(body, /hosted team sync and a hosted org dashboard are not generally available/i);
     assert.doesNotMatch(body, /Shared hosted lessons and org dashboards are Enterprise/i);
     assert.doesNotMatch(body, /<form action="https:\/\/buy\.stripe\.com\//);


### PR DESCRIPTION
## Summary
- Hosted funnel: Pro interstitial views without confirm clicks (conversion leak).
- Keep email-backed POST gate (zombie session protection).
- Add nofollow **Skip form → open Stripe checkout directly** CTA to live `PRO_CHECKOUT_URL`.

## Test plan
- [x] `node --test tests/checkout-pro-confirmation-gate.test.js` (8/8)
- [ ] After merge: curl `/checkout/pro` HTML contains `pro_checkout_direct_stripe` + buy.stripe.com

## Revenue context
Goal one-paid-customer/day still OPEN (0 Stripe external). This unblocks buyers who hit interstitial and bounce.