### PR TITLE
feat(landing): thumbs visuals + self-improving loop diagrams

### DIFF
--- a/.changeset/landing-visual-thumbs-self-improve.md
+++ b/.changeset/landing-visual-thumbs-self-improve.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Visual homepage overhaul: giant thumbs branding, before/after + self-improving loop diagrams, and a plain-English answer to “is it really self-improving?” (control layer, not model retrain).

--- a/public/assets/diagrams/before-after.svg
+++ b/public/assets/diagrams/before-after.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 300" role="img" aria-labelledby="t d">
   <title id="t">Before and after ThumbGate</title>
-  <desc id="d">Without ThumbGate the same mistake repeats. With ThumbGate one thumbs-down becomes a permanent pre-action gate.</desc>
+  <desc id="d">Without ThumbGate the same mistake repeats. With ThumbGate one thumbs-down becomes a local pre-action gate that can refresh or expire.</desc>
   <rect width="960" height="300" rx="24" fill="#0a0a0b"/>
   <g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif">
     <!-- WITHOUT -->
@@ -17,6 +17,6 @@
     <text x="714" y="130" text-anchor="middle" fill="#f5f5f7" font-size="32" font-weight="900">👎 once</text>
     <text x="714" y="172" text-anchor="middle" fill="#e5e7eb" font-size="18">Rule saved locally</text>
     <text x="714" y="204" text-anchor="middle" fill="#e5e7eb" font-size="18">Next attempt is gated</text>
-    <text x="714" y="240" text-anchor="middle" fill="#9ca3af" font-size="14">one correction → permanent pre-action gate</text>
+    <text x="714" y="240" text-anchor="middle" fill="#9ca3af" font-size="14">one correction → local gate (auto-promoted gates expire)</text>
   </g>
 </svg>

--- a/public/assets/diagrams/before-after.svg
+++ b/public/assets/diagrams/before-after.svg
@@ -1,21 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 280" role="img" aria-labelledby="t d">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 300" role="img" aria-labelledby="t d">
   <title id="t">Before and after ThumbGate</title>
-  <desc id="d">Without ThumbGate the same mistake repeats. With ThumbGate the second attempt is caught.</desc>
-  <rect width="960" height="280" fill="#0a0a0b"/>
-  <g font-family="system-ui,sans-serif">
+  <desc id="d">Without ThumbGate the same mistake repeats. With ThumbGate one thumbs-down becomes a permanent pre-action gate.</desc>
+  <rect width="960" height="300" rx="24" fill="#0a0a0b"/>
+  <g font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif">
     <!-- WITHOUT -->
-    <rect x="40" y="36" width="400" height="208" rx="20" fill="#1a1012" stroke="#f87171" stroke-width="2"/>
-    <text x="240" y="72" text-anchor="middle" fill="#f87171" font-size="18" font-weight="900">WITHOUT</text>
-    <text x="240" y="118" text-anchor="middle" fill="#f5f5f7" font-size="20" font-weight="700">🔥 force-push / bad shell</text>
-    <text x="240" y="152" text-anchor="middle" fill="#e5e7eb" font-size="16">You clean it up…</text>
-    <text x="240" y="182" text-anchor="middle" fill="#e5e7eb" font-size="16">…and it happens again.</text>
-    <text x="240" y="218" text-anchor="middle" fill="#9ca3af" font-size="14">time × trust × risk</text>
+    <rect x="36" y="36" width="420" height="228" rx="22" fill="#1a1012" stroke="#f87171" stroke-width="2.5"/>
+    <text x="246" y="78" text-anchor="middle" fill="#f87171" font-size="16" font-weight="900" letter-spacing="1.5">WITHOUT THUMBGATE</text>
+    <text x="246" y="130" text-anchor="middle" fill="#f5f5f7" font-size="28" font-weight="800">🔥 force-push · bad shell</text>
+    <text x="246" y="172" text-anchor="middle" fill="#e5e7eb" font-size="18">You clean it up…</text>
+    <text x="246" y="204" text-anchor="middle" fill="#e5e7eb" font-size="18">…and the agent does it again.</text>
+    <text x="246" y="240" text-anchor="middle" fill="#9ca3af" font-size="14">time × trust × risk × token burn</text>
+
     <!-- WITH -->
-    <rect x="520" y="36" width="400" height="208" rx="20" fill="#0c1a14" stroke="#4ade80" stroke-width="2"/>
-    <text x="720" y="72" text-anchor="middle" fill="#4ade80" font-size="18" font-weight="900">WITH THUMBGATE</text>
-    <text x="720" y="118" text-anchor="middle" fill="#f5f5f7" font-size="20" font-weight="700">👎 once</text>
-    <text x="720" y="152" text-anchor="middle" fill="#e5e7eb" font-size="16">Rule saved locally</text>
-    <text x="720" y="182" text-anchor="middle" fill="#e5e7eb" font-size="16">Next attempt is checked</text>
-    <text x="720" y="218" text-anchor="middle" fill="#9ca3af" font-size="14">one correction → permanent gate</text>
+    <rect x="504" y="36" width="420" height="228" rx="22" fill="#0c1a14" stroke="#4ade80" stroke-width="2.5"/>
+    <text x="714" y="78" text-anchor="middle" fill="#4ade80" font-size="16" font-weight="900" letter-spacing="1.5">WITH THUMBGATE</text>
+    <text x="714" y="130" text-anchor="middle" fill="#f5f5f7" font-size="32" font-weight="900">👎 once</text>
+    <text x="714" y="172" text-anchor="middle" fill="#e5e7eb" font-size="18">Rule saved locally</text>
+    <text x="714" y="204" text-anchor="middle" fill="#e5e7eb" font-size="18">Next attempt is gated</text>
+    <text x="714" y="240" text-anchor="middle" fill="#9ca3af" font-size="14">one correction → permanent pre-action gate</text>
   </g>
 </svg>

--- a/public/assets/diagrams/hero-thumbs.svg
+++ b/public/assets/diagrams/hero-thumbs.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">ThumbGate: thumbs up and thumbs down become pre-action gates</title>
+  <desc id="desc">Two large thumbs icons feeding a gate that decides ALLOW, WARN, or DENY before an AI agent tool call runs.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a1018"/>
+      <stop offset="100%" stop-color="#111a28"/>
+    </linearGradient>
+    <linearGradient id="gate" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#4ade80"/>
+    </linearGradient>
+    <filter id="glow">
+      <feDropShadow dx="0" dy="0" stdDeviation="12" flood-color="#22d3ee" flood-opacity="0.35"/>
+    </filter>
+    <filter id="soft">
+      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+  </defs>
+  <rect width="640" height="360" rx="24" fill="url(#bg)"/>
+
+  <!-- Brand line -->
+  <text x="32" y="42" fill="#22d3ee" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="800" letter-spacing="2">THUMBGATE</text>
+  <text x="32" y="68" fill="#f5f7fb" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="22" font-weight="800">Named for the signal. Built for the gate.</text>
+
+  <!-- Big thumbs up -->
+  <g filter="url(#soft)" transform="translate(48, 100)">
+    <rect width="150" height="190" rx="24" fill="#0d1f18" stroke="#4ade80" stroke-width="2.5"/>
+    <circle cx="75" cy="78" r="54" fill="#4ade80" opacity="0.12"/>
+    <g transform="translate(35, 35) scale(2.1)" fill="none" stroke="#4ade80" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M7 22V13a2 2 0 0 1 2-2h2.5l3.2-7.2A2.5 2.5 0 0 1 17 2.5 3.5 3.5 0 0 1 20.5 6v5H28a3 3 0 0 1 3 3.4l-1.6 9A3 3 0 0 1 26.5 26H9a2 2 0 0 1-2-2z"/>
+      <path d="M7 13H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3"/>
+    </g>
+    <text x="75" y="158" text-anchor="middle" fill="#4ade80" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="28" font-weight="900">👍</text>
+    <text x="75" y="182" text-anchor="middle" fill="#9db8ad" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13" font-weight="700">good pattern</text>
+  </g>
+
+  <!-- Big thumbs down -->
+  <g filter="url(#soft)" transform="translate(220, 100)">
+    <rect width="150" height="190" rx="24" fill="#1f1014" stroke="#ff6480" stroke-width="2.5"/>
+    <circle cx="75" cy="78" r="54" fill="#ff6480" opacity="0.12"/>
+    <g transform="translate(35, 40) scale(2.1)" fill="none" stroke="#ff6480" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M7 2v9a2 2 0 0 0 2 2h2.5l3.2 7.2A2.5 2.5 0 0 0 17 21.5 3.5 3.5 0 0 0 20.5 18v-5H28a3 3 0 0 0 3-3.4l-1.6-9A3 3 0 0 0 26.5-2H9a2 2 0 0 0-2 2z" transform="translate(0 6)"/>
+      <path d="M7 11H4a2 2 0 0 1-2-2V0a2 2 0 0 1 2-2h3" transform="translate(0 6)"/>
+    </g>
+    <text x="75" y="158" text-anchor="middle" fill="#ff8a9a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="28" font-weight="900">👎</text>
+    <text x="75" y="182" text-anchor="middle" fill="#b899a0" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13" font-weight="700">never again</text>
+  </g>
+
+  <!-- Arrow into gate -->
+  <path d="M385 195 H420" stroke="#22d3ee" stroke-width="4" stroke-linecap="round"/>
+  <path d="M410 185 L425 195 L410 205" fill="none" stroke="#22d3ee" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Gate panel -->
+  <g filter="url(#glow)" transform="translate(440, 90)">
+    <rect width="168" height="210" rx="24" fill="#0c1622" stroke="url(#gate)" stroke-width="3"/>
+    <text x="84" y="42" text-anchor="middle" fill="#22d3ee" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="800" letter-spacing="1.5">PRE-ACTION GATE</text>
+    <!-- mini shield / gate -->
+    <path d="M84 68 C64 76 56 88 56 108 C56 128 72 142 84 148 C96 142 112 128 112 108 C112 88 104 76 84 68 Z" fill="none" stroke="#8cf5d1" stroke-width="4"/>
+    <text x="84" y="118" text-anchor="middle" fill="#e7fbff" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="18" font-weight="900">TG</text>
+    <rect x="22" y="168" width="46" height="24" rx="12" fill="rgba(86,227,159,0.12)" stroke="#56e39f"/>
+    <text x="45" y="184" text-anchor="middle" fill="#56e39f" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10" font-weight="800">ALLOW</text>
+    <rect x="74" y="168" width="42" height="24" rx="12" fill="rgba(255,209,102,0.12)" stroke="#ffd166"/>
+    <text x="95" y="184" text-anchor="middle" fill="#ffd166" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10" font-weight="800">WARN</text>
+    <rect x="122" y="168" width="42" height="24" rx="12" fill="rgba(255,100,124,0.12)" stroke="#ff647c"/>
+    <text x="143" y="184" text-anchor="middle" fill="#ff647c" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="10" font-weight="800">DENY</text>
+  </g>
+</svg>

--- a/public/assets/diagrams/loop.svg
+++ b/public/assets/diagrams/loop.svg
@@ -1,34 +1,40 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 280" role="img" aria-labelledby="t d">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 300" role="img" aria-labelledby="t d">
   <title id="t">ThumbGate feedback loop</title>
-  <desc id="d">Agent proposes a tool call, ThumbGate decides allow warn or deny, feedback becomes a rule.</desc>
-  <rect width="960" height="280" fill="#0a0a0b"/>
+  <desc id="d">Agent proposes a tool call, ThumbGate decides allow warn or deny, thumbs feedback becomes a rule that closes the loop.</desc>
+  <rect width="960" height="300" rx="24" fill="#0a0a0b"/>
   <defs>
     <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#22d3ee"/></marker>
+    <marker id="arrG" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#4ade80"/></marker>
     <linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#22d3ee"/><stop offset="1" stop-color="#4ade80"/></linearGradient>
   </defs>
+
   <!-- Step 1 -->
-  <rect x="40" y="70" width="180" height="110" rx="18" fill="#161618" stroke="#333"/>
+  <rect x="40" y="70" width="180" height="120" rx="18" fill="#161618" stroke="#333"/>
   <circle cx="70" cy="100" r="16" fill="#222" stroke="#22d3ee" stroke-width="2"/>
   <text x="70" y="105" text-anchor="middle" fill="#22d3ee" font-family="system-ui,sans-serif" font-size="14" font-weight="800">1</text>
-  <text x="130" y="120" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="18" font-weight="800">Agent</text>
+  <text x="130" y="118" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="18" font-weight="800">Agent</text>
   <text x="130" y="146" text-anchor="middle" fill="#9ca3af" font-family="system-ui,sans-serif" font-size="13">proposes a tool</text>
-  <line x1="230" y1="125" x2="290" y2="125" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+  <line x1="230" y1="130" x2="290" y2="130" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+
   <!-- Step 2 -->
-  <rect x="300" y="50" width="240" height="150" rx="18" fill="#07151a" stroke="url(#g)" stroke-width="2.5"/>
+  <rect x="300" y="50" width="240" height="160" rx="18" fill="#07151a" stroke="url(#g)" stroke-width="2.5"/>
   <circle cx="340" cy="90" r="16" fill="#0d2530" stroke="#22d3ee" stroke-width="2"/>
   <text x="340" y="95" text-anchor="middle" fill="#22d3ee" font-family="system-ui,sans-serif" font-size="14" font-weight="800">2</text>
   <text x="420" y="95" text-anchor="middle" fill="#22d3ee" font-family="system-ui,sans-serif" font-size="20" font-weight="900">ThumbGate</text>
   <text x="420" y="130" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="16" font-weight="700">ALLOW · WARN · DENY</text>
   <text x="420" y="158" text-anchor="middle" fill="#9ca3af" font-family="system-ui,sans-serif" font-size="13">before the tool runs</text>
-  <line x1="550" y1="125" x2="610" y2="125" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+  <text x="420" y="184" text-anchor="middle" fill="#4ade80" font-family="system-ui,sans-serif" font-size="18" font-weight="800">👍  👎</text>
+  <line x1="550" y1="130" x2="610" y2="130" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+
   <!-- Step 3 -->
-  <rect x="620" y="70" width="180" height="110" rx="18" fill="#161618" stroke="#333"/>
+  <rect x="620" y="70" width="180" height="120" rx="18" fill="#161618" stroke="#333"/>
   <circle cx="650" cy="100" r="16" fill="#222" stroke="#4ade80" stroke-width="2"/>
   <text x="650" y="105" text-anchor="middle" fill="#4ade80" font-family="system-ui,sans-serif" font-size="14" font-weight="800">3</text>
-  <text x="710" y="120" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="18" font-weight="800">Action</text>
+  <text x="710" y="118" text-anchor="middle" fill="#f5f5f7" font-family="system-ui,sans-serif" font-size="18" font-weight="800">Action</text>
   <text x="710" y="146" text-anchor="middle" fill="#9ca3af" font-family="system-ui,sans-serif" font-size="13">shell · git · db</text>
+
   <!-- Feedback loop -->
-  <path d="M710 185 C710 240 130 240 130 185" fill="none" stroke="#4ade80" stroke-width="3" stroke-dasharray="6 4" marker-end="url(#arr)"/>
-  <rect x="280" y="218" width="280" height="36" rx="18" fill="#0d1b14" stroke="#4ade80"/>
-  <text x="420" y="241" text-anchor="middle" fill="#4ade80" font-family="system-ui,sans-serif" font-size="14" font-weight="700">👍 👎 feedback → lesson → rule</text>
+  <path d="M710 200 C710 250 130 250 130 200" fill="none" stroke="#4ade80" stroke-width="3" stroke-dasharray="6 4" marker-end="url(#arrG)"/>
+  <rect x="260" y="232" width="320" height="40" rx="20" fill="#0d1b14" stroke="#4ade80"/>
+  <text x="420" y="258" text-anchor="middle" fill="#4ade80" font-family="system-ui,sans-serif" font-size="15" font-weight="800">👍 👎 feedback → lesson → rule → gate</text>
 </svg>

--- a/public/assets/diagrams/self-improving-thumbs-loop.svg
+++ b/public/assets/diagrams/self-improving-thumbs-loop.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 420" role="img" aria-labelledby="title desc">
+  <title id="title">How ThumbGate self-improves from thumbs up and thumbs down</title>
+  <desc id="desc">Closed loop: you give thumbs up or thumbs down, ThumbGate stores a local lesson, promotes a prevention rule, and gates the next tool call before it runs.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#081018"/>
+      <stop offset="100%" stop-color="#0d121c"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#4ade80"/>
+    </linearGradient>
+    <linearGradient id="upGlow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#56e39f"/>
+      <stop offset="100%" stop-color="#1f9d62"/>
+    </linearGradient>
+    <linearGradient id="downGlow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ff8a9a"/>
+      <stop offset="100%" stop-color="#e11d48"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="16" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+    <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#22d3ee"/>
+    </marker>
+    <marker id="arrG" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#4ade80"/>
+    </marker>
+  </defs>
+
+  <rect width="1100" height="420" rx="28" fill="url(#bg)"/>
+
+  <!-- Header -->
+  <text x="48" y="48" fill="#e8eef7" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="28" font-weight="800">Yes — self-improving. Not the model. The gate.</text>
+  <text x="48" y="78" fill="#9ca8ba" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="15">Your 👍 / 👎 teach local rules. Next matching tool call is checked before it runs.</text>
+
+  <!-- Giant thumbs pair -->
+  <g filter="url(#soft)" transform="translate(48, 110)">
+    <!-- Thumbs up card -->
+    <rect x="0" y="0" width="150" height="180" rx="22" fill="#0d1f18" stroke="#4ade80" stroke-width="2"/>
+    <circle cx="75" cy="72" r="42" fill="url(#upGlow)" opacity="0.18"/>
+    <!-- thumbs-up hand icon -->
+    <g transform="translate(42, 38) scale(1.45)" fill="none" stroke="#4ade80" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M7 22V13a2 2 0 0 1 2-2h2.5l3.2-7.2A2.5 2.5 0 0 1 17 2.5 3.5 3.5 0 0 1 20.5 6v5H28a3 3 0 0 1 3 3.4l-1.6 9A3 3 0 0 1 26.5 26H9a2 2 0 0 1-2-2z"/>
+      <path d="M7 13H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3"/>
+    </g>
+    <text x="75" y="148" text-anchor="middle" fill="#4ade80" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="18" font-weight="800">👍 Keep</text>
+    <text x="75" y="170" text-anchor="middle" fill="#8fa09a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="12">reinforce good pattern</text>
+
+    <!-- Thumbs down card -->
+    <rect x="170" y="0" width="150" height="180" rx="22" fill="#1f1014" stroke="#ff6480" stroke-width="2"/>
+    <circle cx="245" cy="72" r="42" fill="url(#downGlow)" opacity="0.18"/>
+    <!-- thumbs-down hand icon -->
+    <g transform="translate(212, 38) scale(1.45)" fill="none" stroke="#ff6480" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M7 2v9a2 2 0 0 0 2 2h2.5l3.2 7.2A2.5 2.5 0 0 0 17 21.5 3.5 3.5 0 0 0 20.5 18v-5H28a3 3 0 0 0 3-3.4l-1.6-9A3 3 0 0 0 26.5-2H9a2 2 0 0 0-2 2z" transform="translate(0 8)"/>
+      <path d="M7 11H4a2 2 0 0 1-2-2V0a2 2 0 0 1 2-2h3" transform="translate(0 8)"/>
+    </g>
+    <text x="245" y="148" text-anchor="middle" fill="#ff8a9a" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="18" font-weight="800">👎 Fix</text>
+    <text x="245" y="170" text-anchor="middle" fill="#b08a93" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="12">never repeat this</text>
+  </g>
+
+  <!-- Arrow to lesson -->
+  <path d="M340 200 H390" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+
+  <!-- Step 2: Local lesson -->
+  <g filter="url(#soft)">
+    <rect x="400" y="130" width="180" height="140" rx="20" fill="#111722" stroke="#273246" stroke-width="2"/>
+    <text x="490" y="168" text-anchor="middle" fill="#22d3ee" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="800" letter-spacing="1.2">LOCAL LESSON</text>
+    <text x="490" y="202" text-anchor="middle" fill="#f5f7fb" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="18" font-weight="800">SQLite memory</text>
+    <text x="490" y="228" text-anchor="middle" fill="#9ca8ba" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">survives sessions</text>
+    <text x="490" y="248" text-anchor="middle" fill="#9ca8ba" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">not model weights</text>
+  </g>
+
+  <path d="M590 200 H640" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+
+  <!-- Step 3: Rule / gate -->
+  <g filter="url(#soft)">
+    <rect x="650" y="130" width="180" height="140" rx="20" fill="#0c1820" stroke="url(#ring)" stroke-width="2.5"/>
+    <text x="740" y="168" text-anchor="middle" fill="#22d3ee" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="800" letter-spacing="1.2">PREVENTION RULE</text>
+    <text x="740" y="202" text-anchor="middle" fill="#f5f7fb" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="18" font-weight="800">Auto-promoted</text>
+    <text x="740" y="228" text-anchor="middle" fill="#9ca8ba" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">from repeats</text>
+    <text x="740" y="248" text-anchor="middle" fill="#9ca8ba" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">stale rules expire</text>
+  </g>
+
+  <path d="M840 200 H890" stroke="#22d3ee" stroke-width="3" marker-end="url(#arr)"/>
+
+  <!-- Step 4: Gate next action -->
+  <g filter="url(#soft)">
+    <rect x="900" y="118" width="168" height="164" rx="20" fill="#111722" stroke="#273246" stroke-width="2"/>
+    <text x="984" y="152" text-anchor="middle" fill="#22d3ee" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="12" font-weight="800" letter-spacing="1.2">NEXT TOOL CALL</text>
+    <rect x="922" y="168" width="52" height="26" rx="13" fill="rgba(86,227,159,0.12)" stroke="#56e39f"/>
+    <text x="948" y="186" text-anchor="middle" fill="#56e39f" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="800">ALLOW</text>
+    <rect x="982" y="168" width="48" height="26" rx="13" fill="rgba(255,209,102,0.12)" stroke="#ffd166"/>
+    <text x="1006" y="186" text-anchor="middle" fill="#ffd166" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="800">WARN</text>
+    <rect x="948" y="206" width="52" height="26" rx="13" fill="rgba(255,100,124,0.12)" stroke="#ff647c"/>
+    <text x="974" y="224" text-anchor="middle" fill="#ff647c" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="11" font-weight="800">DENY</text>
+    <text x="984" y="258" text-anchor="middle" fill="#f5f7fb" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="15" font-weight="700">before it runs</text>
+  </g>
+
+  <!-- Closing the loop dashed arrow back -->
+  <path d="M984 300 C984 360 120 360 120 300" fill="none" stroke="#4ade80" stroke-width="3" stroke-dasharray="8 6" marker-end="url(#arrG)"/>
+  <rect x="360" y="332" width="380" height="40" rx="20" fill="#0d1b14" stroke="#4ade80"/>
+  <text x="550" y="358" text-anchor="middle" fill="#4ade80" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="15" font-weight="800">Loop closes · under your control · no model retrain</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -559,6 +559,87 @@
       h1 { font-size: 46px; }
       .checkout-card, .pro-card { padding: 22px 18px; }
     }
+
+    /* Visual-first conversion: thumbs + diagrams */
+    .hero-thumbs {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 14px;
+      margin: 0 0 18px;
+      font-size: clamp(42px, 6vw, 64px);
+      line-height: 1;
+      filter: drop-shadow(0 0 28px rgba(34, 211, 238, 0.28));
+    }
+    .hero-thumbs span {
+      display: inline-flex;
+      width: 1.15em;
+      height: 1.15em;
+      align-items: center;
+      justify-content: center;
+      border-radius: 22%;
+      background: rgba(17, 23, 34, 0.9);
+      border: 1px solid rgba(39, 50, 70, 0.9);
+    }
+    .hero-thumbs .up { border-color: rgba(86, 227, 159, 0.55); box-shadow: 0 0 0 1px rgba(86, 227, 159, 0.12); }
+    .hero-thumbs .down { border-color: rgba(255, 100, 124, 0.55); box-shadow: 0 0 0 1px rgba(255, 100, 124, 0.12); }
+    .hero-visual {
+      margin: 22px 0 0;
+      border: 1px solid rgba(56, 215, 255, 0.22);
+      border-radius: 18px;
+      overflow: hidden;
+      background: #0a1018;
+      box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+    }
+    .hero-visual img, .diagram-frame img {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+    .diagram-strip { padding: 56px 0 12px; }
+    .diagram-frame {
+      margin-top: 28px;
+      border: 1px solid rgba(56, 215, 255, 0.2);
+      border-radius: 20px;
+      overflow: hidden;
+      background: #0a0a0b;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+    .diagram-caption {
+      margin: 14px 0 0;
+      color: var(--muted);
+      font-size: 14px;
+      text-align: center;
+    }
+    .self-improve-callout {
+      margin: 28px 0 0;
+      padding: 20px 22px;
+      border: 1px solid rgba(86, 227, 159, 0.3);
+      border-radius: 14px;
+      background: rgba(86, 227, 159, 0.06);
+      color: #c5ceda;
+      font-size: 16px;
+      line-height: 1.55;
+      max-width: 820px;
+    }
+    .self-improve-callout strong { color: var(--green); }
+    .loop-step .thumb-icon {
+      display: inline-flex;
+      font-size: 28px;
+      line-height: 1;
+      margin-bottom: 4px;
+    }
+    .visual-pair {
+      display: grid;
+      grid-template-columns: 1.1fr 0.9fr;
+      gap: 18px;
+      margin-top: 28px;
+      align-items: stretch;
+    }
+    @media (max-width: 900px) {
+      .visual-pair { grid-template-columns: 1fr; }
+      .hero-thumbs { justify-content: center; }
+    }
   </style>
 </head>
 <body data-revenue-assist="off">
@@ -584,16 +665,21 @@
       <div class="shell hero-grid">
         <div class="hero-copy">
           <div class="eyebrow">Now live · Pre-action gates · Not a prompt · Not a postmortem</div>
+          <div class="hero-thumbs" aria-hidden="true"><span class="up">👍</span><span class="down">👎</span></div>
           <h1>Stop AI agent mistakes before they cost you.</h1>
           <p class="hero-lede">Hard allow/deny at the <strong>tool-call boundary</strong>. Audit entry written at decision time. Every approval teaches the next gate.</p>
-          <p class="fit-line"><strong>Dual path (buy + book):</strong> <strong>$499 Diagnostic</strong> maps one expensive failure on Claude Code, Cursor, Codex, or similar agents and installs a hard gate with proof — or self-serve <strong>Pro at $19/mo</strong> if you already know the loop. Free local evaluate stays free.</p>
+          <p class="fit-line"><strong>Dual path:</strong> <strong>$499 Diagnostic</strong> maps one expensive failure and installs a hard gate with proof — or self-serve <strong>Pro at $19/mo</strong>. Free local evaluate stays free.</p>
           <div class="spec-chips" aria-label="What ThumbGate does">
             <span class="spec-chip"><strong>Capture</strong> feedback</span>
             <span class="spec-chip"><strong>Rank</strong> lessons</span>
             <span class="spec-chip"><strong>Promote</strong> gates</span>
             <span class="spec-chip"><strong>Block</strong> next action</span>
           </div>
-          <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
+          <figure class="hero-visual">
+            <img src="/assets/diagrams/hero-thumbs.svg" width="640" height="360" alt="ThumbGate: thumbs up and thumbs down become a pre-action gate that can ALLOW, WARN, or DENY before the tool call runs" loading="eager" decoding="async">
+          </figure>
+          <a class="proof-link" href="#how-it-works">See how the self-improving loop works ↓</a>
+          <a class="proof-link" href="#proof" style="margin-left:14px">See a strict-mode deny example ↓</a>
           <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually minutes after install · <a href="/pricing">how we stack up</a></p>
           <p class="install-hint" id="thumbgate-dashboard-command" style="margin-top:10px;">Dashboard: <code>npx thumbgate dashboard --open</code> · <code>/thumbgate-dashboard</code> · bin <code>thumbgate-dashboard</code> if global · <a href="/dashboard#insights">demo</a></p>
         </div>
@@ -638,36 +724,62 @@
       </div>
     </section>
 
+    <section class="diagram-strip" id="before-after" aria-label="Before and after ThumbGate">
+      <div class="shell">
+        <div class="section-kicker">Why it’s called ThumbGate</div>
+        <h2 class="section-title">Thumbs teach. The gate enforces.</h2>
+        <div class="visual-pair">
+          <figure class="diagram-frame">
+            <img src="/assets/diagrams/before-after.svg" width="960" height="300" alt="Without ThumbGate the same AI agent mistake repeats. With ThumbGate one thumbs-down becomes a permanent pre-action gate." loading="lazy" decoding="async">
+          </figure>
+          <figure class="diagram-frame">
+            <img src="/assets/diagrams/loop.svg" width="960" height="300" alt="Agent proposes a tool, ThumbGate decides ALLOW WARN or DENY, thumbs feedback becomes a rule that closes the loop." loading="lazy" decoding="async">
+          </figure>
+        </div>
+      </div>
+    </section>
+
     <section id="how-it-works">
       <div class="shell">
         <div class="section-kicker">Self-improving product loop</div>
         <h2 class="section-title">Pre-action checks—and the systems that refine them.</h2>
-        <p class="section-lede">No governance novel. Corrections become reviewable local lessons; relevant lessons are re-ranked; repeated negative patterns can become explicit gates; and the next action is checked before execution. <strong style="color:var(--text)">Click a step</strong> to see what happens under the hood.</p>
+        <p class="section-lede">Corrections become local lessons; repeated negatives become gates; the next action is checked before execution. <strong style="color:var(--text)">Click a step</strong> for the under-the-hood demo.</p>
+        <figure class="diagram-frame" style="margin-top:28px">
+          <img src="/assets/diagrams/self-improving-thumbs-loop.svg" width="1100" height="420" alt="Self-improving ThumbGate loop: thumbs up or thumbs down become a local lesson, then a prevention rule, then ALLOW WARN or DENY on the next tool call. The loop closes under your control without retraining the model." loading="lazy" decoding="async">
+        </figure>
+        <div class="self-improve-callout">
+          <strong>Is it really self-improving?</strong>
+          Yes — the control layer, not the LLM. 👍/👎 → local lesson → ranked rule → next tool call gated. No model retrain.
+        </div>
         <div class="loop" role="tablist" aria-label="Self-improving product loop — click a step for under-the-hood demo">
           <!-- Cards are divs (not <button>) so headings/chips stay valid HTML; browsers
                auto-close <button> around <h3>/<div>, which broke click targets. -->
           <div class="loop-step" role="tab" tabindex="0" id="loop-tab-1" data-loop-step="1" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">1</span>
+            <div class="thumb-icon" aria-hidden="true">👍👎</div>
             <h3>Capture feedback</h3>
-            <p>Record explicit 👍 or 👎 feedback with the action and outcome context that made it useful or wrong.</p>
+            <p>Record explicit 👍 or 👎 with the action and outcome context.</p>
             <span class="loop-hint">Under the hood ↓</span>
           </div>
           <div class="loop-step" role="tab" tabindex="0" id="loop-tab-2" data-loop-step="2" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">2</span>
+            <div class="thumb-icon" aria-hidden="true">🧠</div>
             <h3>Remember locally</h3>
-            <p>Store a reviewable lesson that survives sessions and model changes without sending the control history into model weights.</p>
+            <p>Store a reviewable lesson that survives sessions without writing into model weights.</p>
             <span class="loop-hint">Under the hood ↓</span>
           </div>
           <div class="loop-step" role="tab" tabindex="0" id="loop-tab-3" data-loop-step="3" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">3</span>
+            <div class="thumb-icon" aria-hidden="true">📈</div>
             <h3>Rank and refine</h3>
-            <p>Re-rank relevant lessons for the action. Repeated negative patterns can promote from warnings to blocking gates; stale gates expire.</p>
+            <p>Re-rank lessons for the action. Repeated negatives can promote to blocking gates; stale gates expire.</p>
             <span class="loop-hint">Under the hood ↓</span>
           </div>
           <div class="loop-step" role="tab" tabindex="0" id="loop-tab-4" data-loop-step="4" aria-selected="false" aria-controls="loop-panel" aria-expanded="false">
             <span class="loop-number">4</span>
+            <div class="thumb-icon" aria-hidden="true">🛡️</div>
             <h3>Gate the next action</h3>
-            <p>The action is allowed, warned, or denied before the tool proceeds.</p>
+            <p>ALLOW, WARN, or DENY before the tool proceeds.</p>
             <div class="decisions" aria-label="Possible decisions">
               <span class="decision allow">ALLOW</span>
               <span class="decision warn">WARN</span>
@@ -717,7 +829,7 @@
       <div class="shell">
         <div class="section-kicker">What the $499 enterprise gate buys</div>
         <h2 class="section-title">A managed gate for one painful workflow.</h2>
-        <p class="section-lede">This is the enterprise entry offer for one workflow, not an org-wide hosted platform license.</p>
+        <p class="section-lede">Enterprise entry for one workflow—not an org-wide platform license.</p>
         <div class="deliverables">
           <article class="deliverable">
             <h3>Failure map</h3>
@@ -760,8 +872,8 @@ next      decision recorded before execution</pre>
             </div>
           </div>
           <div class="proof-copy">
-            <p>Detected secret exfiltration and attempts to kill or bypass the gate process are denied by default. Matching destructive actions warn by default and deny in strict mode.</p>
-            <p>Managed strict-mode example. It is not a claim that every free install blocks every risky command automatically.</p>
+            <p>Detected secret exfiltration and gate-bypass attempts are denied by default. Matching destructive actions warn by default and deny in strict mode.</p>
+            <p>Managed strict-mode example—not a claim that every free install blocks every risky command automatically.</p>
             <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Read the test-backed verification evidence →</a>
             <p style="margin-top:12px;"><a href="/whitepaper">White paper</a> · <a href="/eval-scorecard">Scorecard</a> · <a href="/architecture">Architecture</a> · <a href="/case-studies">Cases</a></p>
           </div>
@@ -802,7 +914,7 @@ next      decision recorded before execution</pre>
       <div class="shell">
         <div class="section-kicker">Two cash paths</div>
         <h2 class="section-title">Start self-serve, or bring the failure that already cost you time.</h2>
-        <p class="section-lede">Pro is the self-serve subscription for operators. The $499 enterprise gate is a managed install for one painful workflow—not another policy deck.</p>
+        <p class="section-lede">Pro is self-serve for operators. The $499 gate is a managed install for one painful workflow—not a policy deck.</p>
         <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;margin-top:22px">
           <a class="nav-buy" href="/checkout/pro?utm_source=website&amp;utm_medium=homepage_final&amp;utm_campaign=pro_self_serve&amp;cta_id=final_pro_buy&amp;cta_placement=final&amp;plan_id=pro" data-offer-link data-cta-id="final_pro_buy">Start Pro — $19/mo</a>
           <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="final_diagnostic_buy">Buy the $499 enterprise gate</a>

--- a/public/index.html
+++ b/public/index.html
@@ -678,8 +678,8 @@
           <figure class="hero-visual">
             <img src="/assets/diagrams/hero-thumbs.svg" width="640" height="360" alt="ThumbGate: thumbs up and thumbs down become a pre-action gate that can ALLOW, WARN, or DENY before the tool call runs" loading="eager" decoding="async">
           </figure>
-          <a class="proof-link" href="#how-it-works">See how the self-improving loop works ↓</a>
-          <a class="proof-link" href="#proof" style="margin-left:14px">See a strict-mode deny example ↓</a>
+          <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
+          <a class="proof-link-secondary" href="#how-it-works" style="margin-left:14px;color:var(--cyan);font-weight:750;text-decoration:none">See how the self-improving loop works ↓</a>
           <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually minutes after install · <a href="/pricing">how we stack up</a></p>
           <p class="install-hint" id="thumbgate-dashboard-command" style="margin-top:10px;">Dashboard: <code>npx thumbgate dashboard --open</code> · <code>/thumbgate-dashboard</code> · bin <code>thumbgate-dashboard</code> if global · <a href="/dashboard#insights">demo</a></p>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -598,12 +598,29 @@
     }
     .diagram-strip { padding: 56px 0 12px; }
     .diagram-frame {
-      margin-top: 28px;
+      margin: 28px 0 0;
       border: 1px solid rgba(56, 215, 255, 0.2);
       border-radius: 20px;
-      overflow: hidden;
+      overflow-x: auto;
+      overflow-y: hidden;
+      -webkit-overflow-scrolling: touch;
       background: #0a0a0b;
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    }
+    .diagram-frame img {
+      min-width: 640px;
+    }
+    .hero-visual img {
+      min-width: 0;
+    }
+    @media (max-width: 720px) {
+      .diagram-frame img {
+        min-width: 720px;
+      }
+      .hero-visual {
+        margin-left: -4px;
+        margin-right: -4px;
+      }
     }
     .diagram-caption {
       margin: 14px 0 0;
@@ -730,7 +747,7 @@
         <h2 class="section-title">Thumbs teach. The gate enforces.</h2>
         <div class="visual-pair">
           <figure class="diagram-frame">
-            <img src="/assets/diagrams/before-after.svg" width="960" height="300" alt="Without ThumbGate the same AI agent mistake repeats. With ThumbGate one thumbs-down becomes a permanent pre-action gate." loading="lazy" decoding="async">
+            <img src="/assets/diagrams/before-after.svg" width="960" height="300" alt="Without ThumbGate the same AI agent mistake repeats. With ThumbGate one thumbs-down becomes a local pre-action gate that can refresh or expire." loading="lazy" decoding="async">
           </figure>
           <figure class="diagram-frame">
             <img src="/assets/diagrams/loop.svg" width="960" height="300" alt="Agent proposes a tool, ThumbGate decides ALLOW WARN or DENY, thumbs feedback becomes a rule that closes the loop." loading="lazy" decoding="async">

--- a/tests/e2e/index-page-clickability.spec.js
+++ b/tests/e2e/index-page-clickability.spec.js
@@ -103,7 +103,7 @@ test.describe('/ dual-offer conversion path', () => {
 
   test('proof link lands on the honest strict-mode boundary', async ({ page }) => {
     await page.goto('/');
-    await page.locator('.proof-link').click();
+    await page.locator('.proof-link[href="#proof"]').click();
 
     await expect(page).toHaveURL(/#proof$/);
     await expect(page.locator('#proof .terminal')).toBeVisible();

--- a/tests/public-landing.test.js
+++ b/tests/public-landing.test.js
@@ -212,3 +212,21 @@ test('homepage preserves brand, version, repository, and deployment placeholders
   assert.match(landingPage, /__GA_BOOTSTRAP__/);
   assert.doesNotMatch(landingPage, /Math\.random\(/);
 });
+
+test('homepage features thumbs branding and self-improving diagrams above the fold story', () => {
+  assert.match(landingPage, /class="hero-thumbs"/);
+  assert.match(landingPage, /class="hero-thumbs"[\s\S]{0,120}👍[\s\S]{0,80}👎/);
+  assert.match(landingPage, /\/assets\/diagrams\/hero-thumbs\.svg/);
+  assert.match(landingPage, /\/assets\/diagrams\/before-after\.svg/);
+  assert.match(landingPage, /\/assets\/diagrams\/loop\.svg/);
+  assert.match(landingPage, /\/assets\/diagrams\/self-improving-thumbs-loop\.svg/);
+  assert.match(landingPage, /Is it really self-improving\?/);
+  assert.match(landingPage, /Thumbs teach\. The gate enforces\./);
+  assert.match(landingPage, /control layer, not the LLM/i);
+
+  const heroStart = landingPage.indexOf('<!-- HERO -->');
+  const howStart = landingPage.indexOf('id="how-it-works"');
+  const heroBlock = landingPage.slice(heroStart, howStart);
+  assert.ok(heroBlock.includes('hero-thumbs.svg'), 'hero diagram must appear before how-it-works');
+  assert.ok(heroBlock.includes('class="hero-thumbs"'), 'big thumbs must appear in hero');
+});


### PR DESCRIPTION
## Summary
- Make thumbgate.ai **visual-first**: giant 👍/👎 in the hero, before/after diagram, feedback-loop diagram, and a full self-improving thumbs→lesson→rule→gate SVG.
- Answer **“is it really self-improving?”** on the page: yes for the **control layer** (lessons re-ranked, gates promoted, stale gates expire), **not** model retrain.
- Trim prose so the homepage stays under the 1100-word scannability ratchet; add regression coverage for thumbs branding + diagrams.

## Why
Conversion: the product is named ThumbGate but the live page barely showed thumbs. Self-improving was mostly FAQ JSON-LD, not a scannable story.

## Test plan
- [x] `node --test tests/public-landing.test.js` (13/13)
- [x] `node --test tests/brand-assets.test.js`
- [x] `node --test tests/public-static-assets.test.js`
- [ ] After merge: curl production for hero-thumbs.svg + “Is it really self-improving?”