### PR TITLE
fix(gates): make auto-promoted gates actually enforce

### DIFF
--- a/.changeset/auto-promoted-gates-enforce.md
+++ b/.changeset/auto-promoted-gates-enforce.md
@@ -1,0 +1,13 @@
+---
+"thumbgate": patch
+---
+
+Make auto-promoted gates actually enforce.
+
+The thumbs-down → block loop was inert. Three repeated 👎 on a command produced a gate that rendered as `action: "block"`, `severity: "critical"`, `occurrences: 3` — while a pre-action check on that exact command still returned **allow**. The dashboard showed a learned blocking rule; nothing was enforced.
+
+**The gate's match pattern was the group key.** `buildGateRule` reused `group.key` as the gate's `pattern`. Keys are usually tag-derived — a `kubectl delete deploy` capture was tagged `entity:Customer` / `entity:Funnel` by the auto-tagger. The gates engine compiles `pattern` with `new RegExp()` and tests it against command text, so `entity:Customer+entity:Funnel` could never match a command, and its `+` silently parsed as a regex quantifier. Grouping by tag is correct; reusing that key as the match pattern is not. Patterns now derive from the captured command, with regex metacharacters escaped.
+
+**The regression guard counted the incident itself as a false positive.** The command you are learning to block was, by definition, allowed before you learned it — that prior allow *is* the failure that got thumbs-downed. With a false-block limit of zero, every gate learned from a real failure was quarantined to `warn` and never enforced. Originating contexts are now excluded from the false-block count by normalized command equality, so genuine collateral damage (a different command that merely quotes the incident text) still quarantines as intended. Applied to both the new-gate and the `warn` → `block` upgrade path.
+
+`promote()` also now refuses to persist any gate whose pattern cannot match its own originating context, rather than writing an inert rule that reads as though the agent learned something.

--- a/demo/scale-the-vibe-demo.sh
+++ b/demo/scale-the-vibe-demo.sh
@@ -10,8 +10,9 @@
 #
 # Honesty:
 #   - Default product is warn-by-default; demo pins STRICT so blocks show.
-#   - Learning uses force-promote (operator permanent gate). Auto multi-thumbs
-#     promotion is being hardened (PR #3119) so tag patterns are not inert.
+#   - Learning uses force-promote (operator permanent gate) as the demo path.
+#     Auto multi-thumbs promotion also enforces as of PR #3119; before that fix,
+#     promoted gates carried tag-derived patterns and sat inert.
 #
 # Usage:
 #   bash demo/scale-the-vibe-demo.sh
@@ -202,8 +203,8 @@ else
   printf '  %s\n' "${RED}✖ Still allowed after promote — do not claim learning in the room${OFF}"
   printf '  %s\n' "${DIM}BEFORE=$BEFORE AFTER=$AFTER FEEDBACK_DIR=$THUMBGATE_FEEDBACK_DIR${OFF}"
 fi
-printf '\n  %s\n' "${DIM}Honest boundary: force-promote is the proven permanent path. Auto multi-👎${OFF}"
-printf '  %s\n' "${DIM}promotion is being hardened so tag-derived patterns cannot sit inert (PR #3119).${OFF}"
+printf '\n  %s\n' "${DIM}Honest boundary: force-promote is the operator-confirmed permanent path shown${OFF}"
+printf '  %s\n' "${DIM}here. Auto promotion (3x 👎 → block) also enforces as of PR #3119.${OFF}"
 
 if [ "$FAST" -eq 0 ] && [ "$LEARN_ONLY" -eq 0 ]; then
 section "6. No PreToolUse hook? Still get a verdict over MCP"

--- a/public/index.html
+++ b/public/index.html
@@ -698,7 +698,6 @@
           <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
           <a class="proof-link-secondary" href="#how-it-works" style="margin-left:14px;color:var(--cyan);font-weight:750;text-decoration:none">See how the self-improving loop works ↓</a>
           <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually minutes after install · <a href="/pricing">how we stack up</a></p>
-          <p class="install-hint">Works with <strong>Claude Code</strong>, <strong>Cursor</strong>, <strong>Codex</strong>, Gemini CLI, Amp, Cline, OpenCode, or similar agents.</p>
           <p class="install-hint" id="thumbgate-dashboard-command" style="margin-top:10px;">Dashboard: <code>npx thumbgate dashboard --open</code> · <code>/thumbgate-dashboard</code> · bin <code>thumbgate-dashboard</code> if global · <a href="/dashboard#insights">demo</a></p>
         </div>
         <div id="offers" class="offer-stack">

--- a/public/index.html
+++ b/public/index.html
@@ -698,6 +698,7 @@
           <a class="proof-link" href="#proof">See a strict-mode deny example ↓</a>
           <a class="proof-link-secondary" href="#how-it-works" style="margin-left:14px;color:var(--cyan);font-weight:750;text-decoration:none">See how the self-improving loop works ↓</a>
           <p class="install-hint"><code>npx thumbgate init</code> free local evaluate · first hard gate usually minutes after install · <a href="/pricing">how we stack up</a></p>
+          <p class="install-hint">Works with <strong>Claude Code</strong>, <strong>Cursor</strong>, <strong>Codex</strong>, Gemini CLI, Amp, Cline, OpenCode, or similar agents.</p>
           <p class="install-hint" id="thumbgate-dashboard-command" style="margin-top:10px;">Dashboard: <code>npx thumbgate dashboard --open</code> · <code>/thumbgate-dashboard</code> · bin <code>thumbgate-dashboard</code> if global · <a href="/dashboard#insights">demo</a></p>
         </div>
         <div id="offers" class="offer-stack">

--- a/public/index.html
+++ b/public/index.html
@@ -681,7 +681,7 @@
     <section class="hero">
       <div class="shell hero-grid">
         <div class="hero-copy">
-          <div class="eyebrow">Now live · Pre-action gates · Not a prompt · Not a postmortem</div>
+          <div class="eyebrow">The Self-Improving Firewall for AI Agents · Not a prompt · Not a postmortem</div>
           <div class="hero-thumbs" aria-hidden="true"><span class="up">👍</span><span class="down">👎</span></div>
           <h1>Stop AI agent mistakes before they cost you.</h1>
           <p class="hero-lede">Hard allow/deny at the <strong>tool-call boundary</strong>. Audit entry written at decision time. Every approval teaches the next gate.</p>

--- a/scripts/auto-promote-gates.js
+++ b/scripts/auto-promote-gates.js
@@ -84,8 +84,32 @@ function regressionCheck(gate, options = {}) {
   let matchesGate;
   try { ({ matchesGate } = require('./gates-engine')); } catch { return null; }
   if (typeof matchesGate !== 'function') return null;
-  const allowed = entries.filter((e) => e && e.decision === 'allow' && e.toolName);
+  let allowed = entries.filter((e) => e && e.decision === 'allow' && e.toolName);
   if (!allowed.length) return null;
+
+  // The command we just learned to block was, by definition, ALLOWED before we
+  // learned it — that prior allow IS the incident the operator thumbs-downed.
+  // Counting it as a false block quarantines every gate learned from a real
+  // failure, which is the normal path (run it, get burned, 👎 it). Exclude the
+  // originating contexts so the check only measures collateral damage to
+  // genuinely unrelated actions.
+  // Match on normalized command EQUALITY, not substring containment: a longer,
+  // genuinely different command that merely quotes the incident text (e.g.
+  // `notify-team --dry-run "<incident>"`) is real collateral damage and must
+  // still count toward quarantine.
+  const incidentSignatures = new Set(
+    (options.incidentContexts || [])
+      .map((c) => normalizeCommandSignature(String(c || '')))
+      .filter(Boolean),
+  );
+  if (incidentSignatures.size > 0) {
+    allowed = allowed.filter((e) => {
+      const cmd = (e.toolInput && (e.toolInput.command || e.toolInput.pattern)) || '';
+      return !incidentSignatures.has(normalizeCommandSignature(String(cmd)));
+    });
+    if (!allowed.length) return { falseBlocks: 0, allowSampleSize: 0 };
+  }
+
   let falseBlocks = 0;
   for (const e of allowed) {
     try {
@@ -234,6 +258,38 @@ function patternToGateId(key) {
   return 'auto-' + key.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').slice(0, 50).toLowerCase();
 }
 
+/**
+ * Turn a captured context string into a pattern the gates engine can actually
+ * match. `gates-engine.js` compiles `gate.pattern` with `new RegExp(...)` and
+ * tests it against the tool-call text, so the pattern MUST be regex-safe text
+ * drawn from the command itself.
+ *
+ * It must NOT be the group key: keys are frequently tag-derived
+ * ("entity:Customer+entity:Funnel"), which is both meaningless against a command
+ * string and actively hazardous as a regex ('+' is a quantifier). Grouping by tag
+ * is correct — reusing that key as the match pattern is not.
+ */
+function contextToPattern(context) {
+  const raw = String(context || '').trim();
+  if (raw.length < 4) return null;
+  // Escape every regex metacharacter: the captured command is literal text.
+  return raw.slice(0, 120).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * A gate that cannot match the very context that produced it is inert — it
+ * shows up in the dashboard as an active blocking rule while enforcing nothing.
+ * That failure mode is worse than no gate at all, so callers drop these.
+ */
+function gateMatchesOwnContext(gate, context) {
+  if (!gate || !gate.pattern) return false;
+  try {
+    return new RegExp(gate.pattern).test(String(context || ''));
+  } catch {
+    return false;
+  }
+}
+
 function buildGateRule(group, actionOverride) {
   const action = actionOverride || (group.count === 'MANUAL' ? group.manualAction || 'block' : (group.count >= BLOCK_THRESHOLD ? 'block' : 'warn'));
   const severity = action === 'block' ? 'critical' : action === 'approve' ? 'high' : 'medium';
@@ -257,7 +313,8 @@ function buildGateRule(group, actionOverride) {
   return {
     id: patternToGateId(group.key),
     trigger: `auto:${group.key}`,
-    pattern: group.key.replace(/^diagnosis:|constraint:/, ''),
+    // Derived from the captured command, NOT from group.key — see contextToPattern.
+    pattern: contextToPattern(group.latestContext),
     action,
     message: suggestedMessage,
     severity,
@@ -393,6 +450,16 @@ function promote(feedbackLogPath, options) {
 
     const gateId = patternToGateId(group.key);
 
+    // Contexts that produced this gate. Their prior "allow" decisions are the
+    // incident the operator thumbs-downed, not false positives — both the
+    // new-gate and the warn->block upgrade path must exclude them from the
+    // regression check, or every gate learned from a real failure is held at warn.
+    const incidentContexts = [
+      group.latestContext,
+      ...(group.entries || []).map((e) => e && (e.context || e.whatWentWrong)),
+    ].filter(Boolean);
+    const regressionOpts = { ...opts, incidentContexts };
+
     // Check for existing gate — possibly upgrade
     const existingIdx = data.gates.findIndex((g) => g.id === gateId);
     if (existingIdx !== -1) {
@@ -400,7 +467,7 @@ function promote(feedbackLogPath, options) {
       const newAction = group.count >= BLOCK_THRESHOLD ? 'block' : 'warn';
       if (existing.action !== newAction && newAction === 'block') {
         // Self-Harness stage 3: regression-test before upgrading warn -> block.
-        const regression = opts.skipRegression ? null : safeRegressionCheck(buildGateRule(group, 'block'), opts);
+        const regression = opts.skipRegression ? null : safeRegressionCheck(buildGateRule(group, 'block'), regressionOpts);
         if (regression && regression.falseBlocks > REGRESSION_FALSE_BLOCK_LIMIT) {
           // Would block prior safe actions — hold at warn instead of upgrading.
           promotions.push({ type: 'upgrade-quarantined', gateId, from: existing.action, occurrences: group.count, falseBlocks: regression.falseBlocks });
@@ -418,12 +485,25 @@ function promote(feedbackLogPath, options) {
     // New gate — respect explicit gateAction override (e.g. 'approve' for human-approval rules)
     const gate = buildGateRule(group, opts.gateAction);
 
+    // Never persist a gate that cannot match the context that produced it. Such a
+    // gate renders in the dashboard as an active blocking rule while enforcing
+    // nothing, which reads as "the agent learned" when it did not.
+    if (!gateMatchesOwnContext(gate, group.latestContext)) {
+      promotions.push({
+        type: 'skipped-unmatchable',
+        gateId: gate.id,
+        reason: 'derived pattern does not match originating context',
+        occurrences: group.count,
+      });
+      continue;
+    }
+
     // Self-Harness stage 3: before a feedback rule goes live as a hard block,
     // regression-test it against prior allowed actions. If it would have blocked
     // safe actions, quarantine it to `warn` instead of `block`.
     let regression = null;
     if (gate.action === 'block' && !opts.gateAction && !opts.skipRegression) {
-      regression = safeRegressionCheck(gate, opts);
+      regression = safeRegressionCheck(gate, regressionOpts);
       if (regression && regression.falseBlocks > REGRESSION_FALSE_BLOCK_LIMIT) {
         gate.action = 'warn';
         gate.severity = 'medium';
@@ -506,6 +586,8 @@ module.exports = {
   groupNegativeFeedback,
   patternToGateId,
   buildGateRule,
+  contextToPattern,
+  gateMatchesOwnContext,
   regressionCheck,
   getAuditTrailPath,
   REGRESSION_FALSE_BLOCK_LIMIT,

--- a/tests/auto-promote-gates.test.js
+++ b/tests/auto-promote-gates.test.js
@@ -220,7 +220,7 @@ test('promote: block threshold upgrades gate from warn to block', (t) => {
   assert.strictEqual(upgrade.to, 'block');
 
   const data = loadAutoGates();
-  const gate = data.gates.find((g) => g.pattern === 'execution-gap');
+  const gate = data.gates.find((g) => g.id === 'auto-execution-gap');
   assert.strictEqual(gate.action, 'block');
 });
 
@@ -241,12 +241,12 @@ test('promote: does not create duplicate gates', (t) => {
 
   promote(logPath);
   const first = loadAutoGates();
-  const countBefore = first.gates.filter((g) => g.pattern === 'dedup-test').length;
+  const countBefore = first.gates.filter((g) => g.id === 'auto-dedup-test').length;
 
   // Run again — should not create duplicate
   promote(logPath);
   const second = loadAutoGates();
-  const countAfter = second.gates.filter((g) => g.pattern === 'dedup-test').length;
+  const countAfter = second.gates.filter((g) => g.id === 'auto-dedup-test').length;
 
   assert.strictEqual(countBefore, 1);
   assert.strictEqual(countAfter, 1);
@@ -336,7 +336,7 @@ test('promote: called from feedback-loop on negative capture', (t) => {
 
   // The auto-promote should create a warn gate before the hard block threshold.
   const data = loadAutoGates();
-  const gate = data.gates.find((g) => g.pattern === 'pipeline-integration-test');
+  const gate = data.gates.find((g) => g.id === 'auto-pipeline-integration-test');
   assert.ok(gate, 'auto-promoted gate should exist before the block threshold is reached');
   assert.strictEqual(gate.action, 'warn');
 });
@@ -389,7 +389,7 @@ test('runCli: supports force-block without falling through to a second entrypoin
   assert.ok(lines.some((line) => line.includes('Forced block gate created')));
 
   const data = loadAutoGates();
-  const gate = data.gates.find((entry) => entry.pattern === 'pipeline-regression');
+  const gate = data.gates.find((entry) => entry.id === 'auto-pipeline-regression');
   assert.ok(gate);
   assert.strictEqual(gate.action, 'block');
 });
@@ -404,6 +404,8 @@ const {
   getRuleTtlDays,
   getRuleTtlMs,
   DEFAULT_RULE_TTL_DAYS,
+  contextToPattern,
+  gateMatchesOwnContext,
 } = require('../scripts/auto-promote-gates');
 
 test('buildGateRule sets expiresAt for auto-promoted gates (default 90 day TTL)', () => {
@@ -630,4 +632,77 @@ test('extractPatternKey: still prefers tags when present', () => {
   });
   // Tag-based key wins over command normalization.
   assert.strictEqual(k, 'destructive-fs');
+});
+
+// --- Regression: promoted gates must actually enforce -------------------------
+// 2026-07-31. `buildGateRule` used `group.key` as the gate's match `pattern`.
+// Keys are usually tag-derived ("entity:Customer+entity:Funnel"), which the gates
+// engine compiles via `new RegExp(...)` and tests against command text — so it
+// could never match. Result: a gate rendering as action:"block", severity:
+// "critical", occurrences:3 that enforced nothing. The suite passed because it
+// only asserted that promotion HAPPENED, never that the gate MATCHED.
+
+test('buildGateRule: pattern matches the originating command, not the group key', () => {
+  const command = 'kubectl delete deploy checkout-api -n prod';
+  const gate = buildGateRule({
+    key: 'entity:Customer+entity:Funnel', // tag-derived key, as the auto-tagger emits
+    count: 3,
+    latestContext: command,
+    entries: [],
+  });
+
+  assert.strictEqual(gate.action, 'block');
+  assert.ok(
+    new RegExp(gate.pattern).test(command),
+    `promoted gate must match its own command. pattern=${JSON.stringify(gate.pattern)}`,
+  );
+  assert.ok(
+    !new RegExp(gate.pattern).test('git status'),
+    'promoted gate must not match unrelated commands',
+  );
+});
+
+test('contextToPattern: escapes regex metacharacters in captured commands', () => {
+  const command = 'rm -rf build/ && echo "done" (cleanup)';
+  const pattern = contextToPattern(command);
+  assert.ok(new RegExp(pattern).test(command), 'escaped pattern must match the literal command');
+});
+
+test('contextToPattern: returns null for unusably short context', () => {
+  assert.strictEqual(contextToPattern(''), null);
+  assert.strictEqual(contextToPattern('ls'), null);
+});
+
+test('gateMatchesOwnContext: rejects a tag-string pattern against a command', () => {
+  const inert = { pattern: 'entity:Customer\\+entity:Funnel' };
+  assert.strictEqual(gateMatchesOwnContext(inert, 'kubectl delete deploy checkout-api -n prod'), false);
+});
+
+test('promote: skips gates whose pattern cannot match, rather than persisting them inert', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-unmatchable-'));
+  const logPath = path.join(dir, 'feedback-log.jsonl');
+  process.env.THUMBGATE_FEEDBACK_DIR = dir;
+
+  // Context too short to yield a usable pattern -> must not become a live gate.
+  const rows = [1, 2, 3].map(() => JSON.stringify({
+    signal: 'negative',
+    tags: ['entity:Customer', 'entity:Funnel'],
+    context: 'x',
+    timestamp: new Date().toISOString(),
+  }));
+  fs.writeFileSync(logPath, rows.join('\n') + '\n');
+
+  const result = promote(logPath);
+  const live = result.data.gates.filter((g) => g.pattern);
+  for (const g of live) {
+    assert.ok(
+      typeof g.pattern === 'string' && g.pattern.length > 0,
+      'no gate may be persisted without a usable pattern',
+    );
+  }
+  assert.strictEqual(
+    result.data.gates.some((g) => !g.pattern),
+    false,
+    'a gate with a null pattern must never be persisted',
+  );
 });

--- a/tests/auto-promote-regression-gate.test.js
+++ b/tests/auto-promote-regression-gate.test.js
@@ -92,7 +92,15 @@ test('promote: quarantines a would-be BLOCK to warn when it would block prior sa
     const grp = Object.values(groupNegativeFeedback(entries, 30)).find((g) => g.count >= 3);
     assert.ok(grp, 'expected a group with >=3 occurrences');
     const pattern = buildGateRule(grp, 'block').pattern;
-    writeAudit(dir, [{ decision: 'allow', toolName: 'Bash', toolInput: { command: pattern } }]);
+    // Collateral damage must be a DIFFERENT, genuinely safe action that the pattern
+    // happens to match — not a replay of the incident itself. A prior allow of the
+    // incident command is the failure the operator thumbs-downed, and counting it
+    // would quarantine every gate learned from a real failure (2026-07-31).
+    writeAudit(dir, [{
+      decision: 'allow',
+      toolName: 'Bash',
+      toolInput: { command: `notify-team --dry-run "agent ran echomarker and it failed"` },
+    }]);
 
     const result = promote(logPath);
     const gate = result.data.gates.find((g) => g.pattern === pattern);

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -403,7 +403,14 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     // 395 -> 400 (2026-07-30): embedding maintenance + hybrid ablation runtime/fixture
     // plus document chunker + skill-pack dependencies required by packed search
     // 400 -> 401 (2026-07-30): scripts/harness-tool-names.js. adapters/mcp/server-stdio.js require()s it during gate_check, so the published package throws without it. Pure lookup table mapping harness tool vocabularies to canonical gate names; no I/O, no Core imports.
-    // 401 -> 405 (2026-07-31): headroom for security/runtime scripts already on the enforcement path; CI pack observed 403 during secret-exfil coverage PR without intentional new package entries. Cap raised with deliberate note so the ratchet stays honest.
+    // 401 -> 405 (2026-07-31). Two separate causes, recorded accurately:
+    //   401 -> 403: #3116 added public/assets/diagrams/hero-thumbs.svg and
+    //     self-improving-thumbs-loop.svg. public/index.html ships (server.js reads it
+    //     at runtime) and <img>-references both, so they must ship too. #3116 added
+    //     them without moving the ceiling, which left main red.
+    //   403 -> 405: #3117 raised the cap to 405 for headroom on enforcement-path
+    //     security scripts. Its note attributed the observed 403 to "no intentional
+    //     new package entries" — that was a misread of #3116's SVGs, corrected here.
     manifest.fileCount <= 405,
     `npm package should stay <= 405 files, got ${manifest.fileCount}`
   );


### PR DESCRIPTION
## Problem

The thumbs-down → block loop was inert. 3× 👎 on a command produced a gate that rendered as `action:"block"`, `severity:"critical"`, `occurrences:3` — while `gate-check` on that exact command still returned **allow**.

This fails in the worst direction: the dashboard shows a critical blocking rule, so it reads as "the agent learned," while the next identical command runs.

This is the mechanism behind the **"Self-Improving Firewall"** positioning. Verified inert on `v1.30.0` / `origin/main`.

## Two defects

**1. The gate's match pattern was the group key.** `buildGateRule` used `group.key` as `pattern`. Keys are usually tag-derived (a `kubectl` capture got `["entity:Customer","entity:Funnel"]` from the auto-tagger). `gates-engine.js:1741` compiles `gate.pattern` with `new RegExp()` against command text, so `entity:Customer+entity:Funnel` could never match — and `+` silently parsed as a quantifier.

Grouping by tag is legitimate. Reusing that key as the *match pattern* is not. Pattern now derives from the captured command via `contextToPattern()`, regex-escaped.

**2. The regression guard counted the incident as a false positive.** The command being learned was, by definition, **allowed before it was learned** — that prior allow is the failure the operator thumbs-downed. With `REGRESSION_FALSE_BLOCK_LIMIT = 0`, *every* gate learned from a real failure was quarantined to `warn`.

Incident contexts are now excluded from the false-block count by **normalized command equality**, not substring containment — so a different command that merely quotes the incident text still counts as genuine collateral damage. Wired through both the new-gate and the `warn`→`block` upgrade path; the upgrade path is the one the real flow takes.

Also: `promote()` now refuses to persist any gate whose pattern cannot match its own originating context.

## Evidence — clean sandbox, realistic path

```
STEP 1 — agent runs it, allowed (the incident):
    allow
STEP 2 — 3x 👎 -> promoted:
    action: block | occ: 3
STEP 3 — SAME command again:
    deny | [GATE:auto-entity-customer-entity-funnel]
STEP 4 — unrelated must still pass:
    allow   (git status)
    allow   (a dev-dependency install)
```

## Tests

`tests/auto-promote-gates.test.js` + `tests/auto-promote-regression-gate.test.js`: **51 pass / 0 fail**.

Five new regression tests, including one asserting a promoted gate denies the command that created it — the assertion whose absence let this ship.

Three existing tests keyed off `gate.pattern === '<tag>'`, which *encoded* defect 1; they now key off the stable `gate.id`. The quarantine test used the incident text itself as the "prior safe action," conflating incident replay with collateral damage; it now uses a genuinely different command that the pattern matches, preserving the real safety property.

**Pre-existing failure, not from this PR:** `run allows writes into private resume secrets vault` fails identically on clean `origin/main` when the 5 gate suites run together (cross-file env leakage). Baseline `origin/main` 296 pass/1 fail; this branch 301 pass/1 fail.

## Follow-up (not in this PR)

`public/index.html:1342` says "every 👎 compiles into a rule, and each rule…". That was not true before this change. Landing-page proof copy should be revisited once this lands.

Side note: creating this PR was initially blocked by our own `slopsquat-guard`, which read `(npm` in the body text as a typosquat of `pnpm`. Prose in a PR body is not a package install — worth a separate look at that gate's context sensitivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
