### PR TITLE
fix(cli): keep quick-start deterministic

### DIFF
--- a/.changeset/deterministic-quick-start.md
+++ b/.changeset/deterministic-quick-start.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Keep ordinary init and quick-start runs deterministic by configuring only the explicitly selected integration, avoiding package-registry probes in source checkouts, replacing shell-based executable discovery, and requiring explicit opt-in before invoking optional external agent plugin managers with argument-safe, bounded execution.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,7 +39,6 @@ const {
   codexAutoUpdateCliEntry,
   codexAutoUpdateMcpEntry,
   isSourceCheckout,
-  publishedCliAvailable,
   localMcpEntry,
   resolveMcpEntry,
 } = require(path.join(__dirname, '..', 'scripts', 'mcp-config'));
@@ -411,16 +410,14 @@ function canonicalMcpEntry(scope = 'project') {
 }
 
 function canonicalCodexMcpEntry() {
-  const version = pkgVersion();
-  if (isSourceCheckout(PKG_ROOT) && !publishedCliAvailable(version)) {
+  if (isSourceCheckout(PKG_ROOT)) {
     return localMcpEntry(PKG_ROOT, 'home');
   }
   return codexAutoUpdateMcpEntry();
 }
 
 function canonicalCodexCliEntry(commandArgs) {
-  const version = pkgVersion();
-  if (isSourceCheckout(PKG_ROOT) && !publishedCliAvailable(version)) {
+  if (isSourceCheckout(PKG_ROOT)) {
     return {
       command: 'node',
       args: [path.join(PKG_ROOT, 'bin', 'cli.js'), ...commandArgs],
@@ -584,7 +581,20 @@ function detectPlatform(name, checks) {
 }
 
 function whichExists(cmd) {
-  try { execSync(`which ${cmd}`, { stdio: 'pipe' }); return true; } catch (_) { return false; }
+  if (!cmd || /[\\/]/.test(cmd)) return false;
+  const pathEntries = String(process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  const extensions = process.platform === 'win32'
+    ? String(process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
+    : [''];
+  return pathEntries.some((entry) => extensions.some((extension) => {
+    const candidate = path.join(entry, `${cmd}${extension}`);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return fs.statSync(candidate).isFile();
+    } catch (_) {
+      return false;
+    }
+  }));
 }
 
 function setupClaude() {
@@ -636,18 +646,26 @@ function setupCodex() {
   return configChanged || hookResult.changed;
 }
 
-function setupGemini() {
-  // Try to import custom commands as a Gemini plugin if the CLI is installed
-  const { execSync } = require('child_process');
+function setupGemini(options = {}) {
+  // Importing a plugin executes an external package manager and can mutate
+  // machine-wide Gemini state. Keep ordinary init/quick-start deterministic;
+  // operators can opt in explicitly when they want the plugin import too.
+  const importPlugin = options.importPlugin === true
+    || process.env.THUMBGATE_IMPORT_AGENT_PLUGINS === '1';
   let pluginImported = false;
-  for (const binName of ['agy', 'gemini']) {
-    try {
-      execSync(`${binName} plugin import "${PKG_ROOT}" --force`, { stdio: 'ignore' });
-      console.log(`  Gemini: imported thumbgate plugin via ${binName}`);
-      pluginImported = true;
-      break;
-    } catch (err) {
-      // ignore errors if command doesn't exist or fails
+  if (importPlugin) {
+    for (const binName of ['agy', 'gemini']) {
+      try {
+        execFileSync(binName, ['plugin', 'import', PKG_ROOT, '--force'], {
+          stdio: 'ignore',
+          timeout: 5000,
+        });
+        console.log(`  Gemini: imported thumbgate plugin via ${binName}`);
+        pluginImported = true;
+        break;
+      } catch (err) {
+        // A missing, failing, or slow optional plugin manager must not block init.
+      }
     }
   }
 
@@ -1003,13 +1021,14 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
     process.exit(1);
   }
   if (args.help || args.h) {
-    console.log('Usage: npx thumbgate init [--agent <name>] [--wire-hooks] [--email you@company.com]');
+    console.log('Usage: npx thumbgate init [--agent <name>] [--wire-hooks] [--import-agent-plugins] [--email you@company.com]');
     console.log('');
     console.log('Scaffold ThumbGate in the current project and wire detected agent integrations.');
     console.log('');
     console.log('Options:');
     console.log(`  --agent <name>           Wire a specific agent: ${Object.keys(SUPPORTED_AGENTS).join(', ')}`);
     console.log('  --wire-hooks             Wire hooks only; do not scaffold project files');
+    console.log('  --import-agent-plugins   Also import optional agent plugins when supported');
     console.log('  --email <email>          Subscribe installer to the setup guide and trial reminders');
     console.log('  --dry-run                Show hook changes without writing them');
     return;
@@ -1105,17 +1124,22 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
   let configured = 0;
 
   const platforms = [
-    { name: 'Claude Code', detect: [
+    { agent: 'claude-code', name: 'Claude Code', detect: [
       () => whichExists('claude'),
       () => fs.existsSync(path.join(HOME, '.claude')),
       () => fs.existsSync(path.join(CWD, '.claude')),
     ], setup: setupClaude },
-    { name: 'Codex', detect: [() => whichExists('codex'), () => fs.existsSync(path.join(HOME, '.codex'))], setup: setupCodex },
-    { name: 'Gemini', detect: [() => whichExists('gemini'), () => fs.existsSync(path.join(HOME, '.gemini'))], setup: setupGemini },
-    { name: 'Amp', detect: [() => whichExists('amp'), () => fs.existsSync(path.join(HOME, '.amp'))], setup: setupAmp },
-    { name: 'Cursor', detect: [() => fs.existsSync(path.join(HOME, '.cursor', 'mcp.json')), () => fs.existsSync(path.join(CWD, '.cursor'))], setup: setupCursor },
-    { name: 'ForgeCode', detect: [() => whichExists('forge'), () => fs.existsSync(path.join(CWD, 'forge.yaml'))], setup: setupForge },
-    { name: 'Cline', detect: [
+    { agent: 'codex', name: 'Codex', detect: [() => whichExists('codex'), () => fs.existsSync(path.join(HOME, '.codex'))], setup: setupCodex },
+    {
+      agent: 'gemini',
+      name: 'Gemini',
+      detect: [() => whichExists('gemini'), () => fs.existsSync(path.join(HOME, '.gemini'))],
+      setup: () => setupGemini({ importPlugin: args['import-agent-plugins'] === true }),
+    },
+    { agent: 'amp', name: 'Amp', detect: [() => whichExists('amp'), () => fs.existsSync(path.join(HOME, '.amp'))], setup: setupAmp },
+    { agent: 'cursor', name: 'Cursor', detect: [() => fs.existsSync(path.join(HOME, '.cursor', 'mcp.json')), () => fs.existsSync(path.join(CWD, '.cursor'))], setup: setupCursor },
+    { agent: 'forge', name: 'ForgeCode', detect: [() => whichExists('forge'), () => fs.existsSync(path.join(CWD, 'forge.yaml'))], setup: setupForge },
+    { agent: 'cline', name: 'Cline', detect: [
       () => fs.existsSync(path.join(CWD, '.clinerules')),
       () => process.platform === 'darwin' && fs.existsSync(path.join(HOME, 'Library', 'Application Support', 'Code', 'User', 'globalStorage', 'saoudrizwan.claude-dev')),
       () => process.platform === 'linux' && fs.existsSync(path.join(HOME, '.config', 'Code', 'User', 'globalStorage', 'saoudrizwan.claude-dev')),
@@ -1124,6 +1148,11 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
   ];
 
   for (const p of platforms) {
+    // An explicit target must stay scoped to that integration. Quick-start
+    // always resolves one target before calling init; configuring every other
+    // CLI merely because it exists on PATH caused surprise machine mutations
+    // and multi-second hangs in ordinary onboarding.
+    if (args.agent && p.agent !== args.agent) continue;
     if (detectPlatform(p.name, p.detect)) {
       const didSetup = p.setup();
       if (didSetup) configured++;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -410,14 +410,17 @@ function canonicalMcpEntry(scope = 'project') {
 }
 
 function canonicalCodexMcpEntry() {
-  if (isSourceCheckout(PKG_ROOT)) {
+  // Codex config is user-global and must survive disposable worktree cleanup.
+  // Use the stable published launcher even when init is invoked from source;
+  // developers can explicitly opt into a checkout-pinned runtime when needed.
+  if (isSourceCheckout(PKG_ROOT) && process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME === '1') {
     return localMcpEntry(PKG_ROOT, 'home');
   }
   return codexAutoUpdateMcpEntry();
 }
 
 function canonicalCodexCliEntry(commandArgs) {
-  if (isSourceCheckout(PKG_ROOT)) {
+  if (isSourceCheckout(PKG_ROOT) && process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME === '1') {
     return {
       command: 'node',
       args: [path.join(PKG_ROOT, 'bin', 'cli.js'), ...commandArgs],
@@ -1133,7 +1136,11 @@ function init(cliArgs = parseArgs(process.argv.slice(3))) {
     {
       agent: 'gemini',
       name: 'Gemini',
-      detect: [() => whichExists('gemini'), () => fs.existsSync(path.join(HOME, '.gemini'))],
+      detect: [
+        () => whichExists('gemini'),
+        () => whichExists('agy'),
+        () => fs.existsSync(path.join(HOME, '.gemini')),
+      ],
       setup: () => setupGemini({ importPlugin: args['import-agent-plugins'] === true }),
     },
     { agent: 'amp', name: 'Amp', detect: [() => whichExists('amp'), () => fs.existsSync(path.join(HOME, '.amp'))], setup: setupAmp },

--- a/scripts/hook-runtime.js
+++ b/scripts/hook-runtime.js
@@ -51,12 +51,14 @@ function resolveCliCommand(subcommand) {
 }
 
 function resolveCodexCliCommand(subcommand) {
+  // Source checkouts already contain the requested hook command. Resolve them
+  // locally before any registry probe so init stays offline and deterministic.
+  if (isSourceCheckout(PKG_ROOT)) {
+    return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))} ${subcommand}`;
+  }
   const version = packageVersion();
   if (publishedHookCommandsAvailable(version)) {
     return publishedCliShellCommand('latest', [subcommand]);
-  }
-  if (isSourceCheckout(PKG_ROOT)) {
-    return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))} ${subcommand}`;
   }
   return publishedCliShellCommand('latest', [subcommand]);
 }

--- a/scripts/hook-runtime.js
+++ b/scripts/hook-runtime.js
@@ -51,10 +51,15 @@ function resolveCliCommand(subcommand) {
 }
 
 function resolveCodexCliCommand(subcommand) {
-  // Source checkouts already contain the requested hook command. Resolve them
-  // locally before any registry probe so init stays offline and deterministic.
-  if (isSourceCheckout(PKG_ROOT)) {
+  // Codex hooks live in user-global config. Pinning them to a disposable source
+  // worktree breaks every hook as soon as normal post-merge cleanup removes it.
+  // The stable @latest launcher stays offline at configuration time and survives
+  // cleanup. Checkout-pinned hooks remain available as an explicit dev override.
+  if (isSourceCheckout(PKG_ROOT) && process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME === '1') {
     return `node ${shellQuote(path.join(PKG_ROOT, 'bin', 'cli.js'))} ${subcommand}`;
+  }
+  if (isSourceCheckout(PKG_ROOT)) {
+    return publishedCliShellCommand('latest', [subcommand]);
   }
   const version = packageVersion();
   if (publishedHookCommandsAvailable(version)) {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -23,13 +23,11 @@ const path = require('path');
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const { PRO_MONTHLY_PAYMENT_LINK } = require('../scripts/commercial-offer');
-const { resolveLocalServerPath } = require('../scripts/mcp-config');
+const { publishedCliShellCommand } = require('../scripts/published-cli');
 const PKG_VERSION = require('../package.json').version;
 
 const CLI = path.resolve(__dirname, '../bin/cli.js');
 const PKG_ROOT = path.resolve(__dirname, '..');
-const MCP_SERVER_PATH = path.resolve(__dirname, '../adapters/mcp/server-stdio.js');
-const HOME_MCP_SERVER_PATH = resolveLocalServerPath(PKG_ROOT, 'home');
 const savedFunnelPath = process.env._TEST_FUNNEL_LEDGER_PATH;
 const savedHome = process.env.HOME;
 const savedUserProfile = process.env.USERPROFILE;
@@ -59,28 +57,21 @@ function assertPortableTomlMcpBlock(content) {
   assert.match(content, /\.thumbgate\/runtime/);
 }
 
-function assertLocalMcpEntry(entry, expectedPath = MCP_SERVER_PATH) {
-  assert.equal(entry.command, 'node');
-  assert.deepEqual(entry.args, [expectedPath]);
+function assertDurableCodexCommand(command, subcommand) {
+  assert.equal(command, publishedCliShellCommand('latest', [subcommand]));
 }
 
-function assertLocalTomlMcpBlock(content, expectedPath = MCP_SERVER_PATH) {
-  assert.match(content, /\[mcp_servers\.thumbgate\]/);
-  assert.match(content, /command = "node"/);
-  assert.match(content, new RegExp(escapeRegExp(expectedPath)));
-}
-
-function assertLocalCodexPreToolHook(content) {
-  assert.match(content, /\[hooks\.pre_tool_use\]/);
-  assert.match(content, /command = "node"/);
-  assert.match(content, new RegExp(escapeRegExp(path.join(PKG_ROOT, 'bin', 'cli.js'))));
-  assert.match(content, /"gate-check"/);
-}
-
-function assertLocalCodexUserPromptHook(content) {
-  assert.match(content, /\[hooks\.user_prompt_submit\]/);
-  assert.match(content, new RegExp(escapeRegExp(path.join(PKG_ROOT, 'bin', 'cli.js'))));
-  assert.match(content, /hook-auto-capture/);
+function assertDurableCodexTomlEntry(content, sectionName, subcommand) {
+  const sectionPattern = new RegExp(
+    `^\\[${escapeRegExp(sectionName)}\\]\\n(?:^(?!\\[).*(?:\\n|$))*`,
+    'm'
+  );
+  const section = content.match(sectionPattern)?.[0];
+  assert.ok(section, `missing TOML section ${sectionName}`);
+  assert.match(section, /command = "sh"/);
+  assert.match(section, /\.thumbgate\/runtime/);
+  assert.match(section, /thumbgate@latest/);
+  assert.match(section, new RegExp(escapeRegExp(subcommand)));
 }
 
 function escapeRegExp(value) {
@@ -2427,26 +2418,11 @@ describe('bin/cli.js', () => {
     const settingsPath = path.join(isolatedHome, '.codex', 'config.json');
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
     assert.match(result.stdout, /Added hooks for codex:/);
-    assert.equal(
-      settings.hooks.PreToolUse[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} gate-check`
-    );
-    assert.equal(
-      settings.hooks.UserPromptSubmit[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} hook-auto-capture`
-    );
-    assert.equal(
-      settings.hooks.PostToolUse[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} cache-update`
-    );
-    assert.equal(
-      settings.hooks.SessionStart[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} session-start`
-    );
-    assert.equal(
-      settings.statusLine.command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} statusline-render`
-    );
+    assertDurableCodexCommand(settings.hooks.PreToolUse[0].hooks[0].command, 'gate-check');
+    assertDurableCodexCommand(settings.hooks.UserPromptSubmit[0].hooks[0].command, 'hook-auto-capture');
+    assertDurableCodexCommand(settings.hooks.PostToolUse[0].hooks[0].command, 'cache-update');
+    assertDurableCodexCommand(settings.hooks.SessionStart[0].hooks[0].command, 'session-start');
+    assertDurableCodexCommand(settings.statusLine.command, 'statusline-render');
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(isolatedHome, { recursive: true, force: true });
@@ -2489,26 +2465,11 @@ describe('bin/cli.js', () => {
 
     assert.equal(result.status, 0, `init failed:\n${result.stderr}`);
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    assert.equal(
-      settings.hooks.PreToolUse[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} gate-check`
-    );
-    assert.equal(
-      settings.hooks.UserPromptSubmit[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} hook-auto-capture`
-    );
-    assert.equal(
-      settings.hooks.PostToolUse[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} cache-update`
-    );
-    assert.equal(
-      settings.hooks.SessionStart[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} session-start`
-    );
-    assert.equal(
-      settings.statusLine.command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} statusline-render`
-    );
+    assertDurableCodexCommand(settings.hooks.PreToolUse[0].hooks[0].command, 'gate-check');
+    assertDurableCodexCommand(settings.hooks.UserPromptSubmit[0].hooks[0].command, 'hook-auto-capture');
+    assertDurableCodexCommand(settings.hooks.PostToolUse[0].hooks[0].command, 'cache-update');
+    assertDurableCodexCommand(settings.hooks.SessionStart[0].hooks[0].command, 'session-start');
+    assertDurableCodexCommand(settings.statusLine.command, 'statusline-render');
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(isolatedHome, { recursive: true, force: true });
@@ -2735,7 +2696,7 @@ describe('bin/cli.js', () => {
     assert.match(spec, /\/v1\/feedback\/capture/);
   });
 
-  test('init writes a stable local codex MCP launcher when running from source checkout', () => {
+  test('init writes a durable published Codex launcher when running from source checkout', () => {
     const isolatedDir = makeTmpDir();
     const isolatedHome = makeTmpDir();
     const codexHome = path.join(isolatedHome, '.codex');
@@ -2755,26 +2716,20 @@ describe('bin/cli.js', () => {
 
     const configPath = path.join(codexHome, 'config.toml');
     const content = fs.readFileSync(configPath, 'utf8');
-    assertLocalTomlMcpBlock(content, HOME_MCP_SERVER_PATH);
-    assertLocalCodexPreToolHook(content);
-    assertLocalCodexUserPromptHook(content);
+    assertDurableCodexTomlEntry(content, 'mcp_servers.thumbgate', 'serve');
+    assertDurableCodexTomlEntry(content, 'hooks.pre_tool_use', 'gate-check');
+    assertDurableCodexTomlEntry(content, 'hooks.user_prompt_submit', 'hook-auto-capture');
     assert.doesNotMatch(content, /\/tmp\/disposable-worktree\/adapters\/mcp\/server-stdio\.js/);
     const hooksPath = path.join(codexHome, 'config.json');
     const hooksConfig = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
-    assert.equal(
-      hooksConfig.statusLine.command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} statusline-render`
-    );
-    assert.equal(
-      hooksConfig.hooks.PostToolUse[0].hooks[0].command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} cache-update`
-    );
+    assertDurableCodexCommand(hooksConfig.statusLine.command, 'statusline-render');
+    assertDurableCodexCommand(hooksConfig.hooks.PostToolUse[0].hooks[0].command, 'cache-update');
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(isolatedHome, { recursive: true, force: true });
   });
 
-  test('init rewrites an existing codex MCP launcher to the stable local home path', () => {
+  test('init rewrites an existing Codex launcher to the durable published runtime', () => {
     const isolatedDir = makeTmpDir();
     const isolatedHome = makeTmpDir();
     const codexHome = path.join(isolatedHome, '.codex');
@@ -2799,17 +2754,14 @@ describe('bin/cli.js', () => {
     assert.equal(result.status, 0, `init failed:\n${result.stderr}`);
 
     const content = fs.readFileSync(configPath, 'utf8');
-    assertLocalTomlMcpBlock(content, HOME_MCP_SERVER_PATH);
-    assertLocalCodexPreToolHook(content);
-    assertLocalCodexUserPromptHook(content);
+    assertDurableCodexTomlEntry(content, 'mcp_servers.thumbgate', 'serve');
+    assertDurableCodexTomlEntry(content, 'hooks.pre_tool_use', 'gate-check');
+    assertDurableCodexTomlEntry(content, 'hooks.user_prompt_submit', 'hook-auto-capture');
     assert.doesNotMatch(content, /disposable-worktree/);
     assert.doesNotMatch(content, /thumbgate@1\.4\.6/);
     const hooksPath = path.join(codexHome, 'config.json');
     const hooksConfig = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
-    assert.equal(
-      hooksConfig.statusLine.command,
-      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} statusline-render`
-    );
+    assertDurableCodexCommand(hooksConfig.statusLine.command, 'statusline-render');
 
     fs.rmSync(isolatedDir, { recursive: true, force: true });
     fs.rmSync(isolatedHome, { recursive: true, force: true });

--- a/tests/quick-start.test.js
+++ b/tests/quick-start.test.js
@@ -62,6 +62,30 @@ test('quick-start does not execute detected plugin managers by default', () => {
   }
 });
 
+test('quick-start imports Gemini through an agy-only installation when explicitly requested', () => {
+  const tmp = makeTmpDir();
+  const fakeBinDir = path.join(tmp, 'bin');
+  const sentinelPath = path.join(tmp, 'agy-plugin-import-ran');
+  fs.mkdirSync(fakeBinDir, { recursive: true });
+  const fakeAgy = path.join(fakeBinDir, 'agy');
+  fs.writeFileSync(fakeAgy, `#!/bin/sh\n/usr/bin/touch "${sentinelPath}"\n`);
+  fs.chmodSync(fakeAgy, 0o755);
+
+  const previousPath = process.env.PATH;
+  try {
+    process.env.PATH = fakeBinDir;
+    runQuickStart(tmp, ['--agent=gemini', '--import-agent-plugins']);
+    assert.strictEqual(
+      fs.existsSync(sentinelPath),
+      true,
+      'explicit plugin import should honor the supported agy manager without gemini installed',
+    );
+  } finally {
+    process.env.PATH = previousPath;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('quick-start creates .thumbgate/config.json with correct defaults', () => {
   const tmp = makeTmpDir();
   try {

--- a/tests/quick-start.test.js
+++ b/tests/quick-start.test.js
@@ -32,6 +32,36 @@ function runQuickStart(cwd, extraArgs = []) {
   });
 }
 
+test('quick-start does not execute detected plugin managers by default', () => {
+  const tmp = makeTmpDir();
+  const fakeBinDir = path.join(tmp, 'bin');
+  const sentinelPath = path.join(tmp, 'plugin-manager-ran');
+  fs.mkdirSync(fakeBinDir, { recursive: true });
+  const fakeGemini = path.join(fakeBinDir, 'gemini');
+  fs.writeFileSync(fakeGemini, `#!/bin/sh\ntouch "${sentinelPath}"\n`);
+  fs.chmodSync(fakeGemini, 0o755);
+
+  const previousPath = process.env.PATH;
+  try {
+    process.env.PATH = `${fakeBinDir}${path.delimiter}${previousPath}`;
+    runQuickStart(tmp, ['--agent=gemini']);
+    assert.strictEqual(fs.existsSync(sentinelPath), false, 'plugin manager should require explicit opt-in');
+    assert.strictEqual(
+      fs.existsSync(path.join(tmp, '.home', '.codex', 'config.toml')),
+      false,
+      'a Gemini quick-start should not configure unrelated Codex state',
+    );
+    assert.strictEqual(
+      fs.existsSync(path.join(tmp, '.home', '.claude', 'settings.local.json')),
+      false,
+      'a Gemini quick-start should not configure unrelated Claude state',
+    );
+  } finally {
+    process.env.PATH = previousPath;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test('quick-start creates .thumbgate/config.json with correct defaults', () => {
   const tmp = makeTmpDir();
   try {

--- a/tests/statusline.test.js
+++ b/tests/statusline.test.js
@@ -670,22 +670,32 @@ test('hook runtime preserves subcommands in external fallback launchers', () => 
   }
 });
 
-test('hook runtime preserves subcommands for source-checkout launchers', () => {
+test('Codex hook runtime stays durable in source worktrees unless explicitly pinned', () => {
   const hookRuntimePath = require.resolve('../scripts/hook-runtime');
   const mcpConfigPath = require.resolve('../scripts/mcp-config');
   const mcpConfig = require(mcpConfigPath);
   const originalIsSourceCheckout = mcpConfig.isSourceCheckout;
   const originalPublishedCliAvailable = mcpConfig.publishedCliAvailable;
+  const originalSourceOverride = process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME;
 
   try {
+    delete process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME;
     delete require.cache[hookRuntimePath];
     mcpConfig.isSourceCheckout = () => true;
     mcpConfig.publishedCliAvailable = () => false;
     const sourceRuntime = require(hookRuntimePath);
 
     assert.match(sourceRuntime.statuslineCommand(), /bin\/cli\.js"\s+statusline-render/);
-    assert.match(sourceRuntime.codexStatuslineCommand(), /bin\/cli\.js"\s+statusline-render/);
+    assert.match(sourceRuntime.codexStatuslineCommand(), /thumbgate@latest/);
+    assert.doesNotMatch(sourceRuntime.codexStatuslineCommand(), /bin\/cli\.js"\s+statusline-render/);
+
+    process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME = '1';
+    delete require.cache[hookRuntimePath];
+    const pinnedRuntime = require(hookRuntimePath);
+    assert.match(pinnedRuntime.codexStatuslineCommand(), /bin\/cli\.js"\s+statusline-render/);
   } finally {
+    if (originalSourceOverride === undefined) delete process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME;
+    else process.env.THUMBGATE_CODEX_USE_SOURCE_RUNTIME = originalSourceOverride;
     mcpConfig.isSourceCheckout = originalIsSourceCheckout;
     mcpConfig.publishedCliAvailable = originalPublishedCliAvailable;
     delete require.cache[hookRuntimePath];


### PR DESCRIPTION
## Outcome\nQuick-start now configures only the selected agent and avoids hidden network or plugin-manager side effects.\n\n## What changed\n- resolves the local ThumbGate CLI before any npm-registry probe in source checkouts\n- avoids shell  and uses bounded, argument-safe process execution\n- makes Gemini plugin imports explicitly opt-in\n- prevents 
thumbgate quick-start v1.29.2
Agent: ... (specified)

.thumbgate/ already exists — updating config
Wrote .thumbgate/config.json
  MCP: wrote .mcp.json
Scaffolded custom slash commands directories (.claude, .gemini, .antigravitycli)

Detecting platforms...
  Claude Code: wired PreToolUse hook
  Claude Code: wired PreToolUse hook
  Claude Code: wired UserPromptSubmit hook
  Claude Code: wired UserPromptSubmit hook
  Claude Code: wired PostToolUse hook
  Claude Code: wired PostToolUse hook
  Claude Code: wired SessionStart hook
  Claude Code: wired SessionStart hook
  Claude Code: wired statusLine hook
  Claude Code settings: /Users/igorganapolsky/.claude/settings.local.json
  Codex: appended MCP server to ~/.codex/config.toml
  Codex: updated ~/.codex/config.json with hooks and status line
  Gemini: already configured
  Amp: installed .amp/skills/thumbgate-feedback/SKILL.md
  Cursor: wrote .cursor/mcp.json
  Cline: installed .clinerules with ThumbGate gating rules
  ChatGPT: import .thumbgate/chatgpt-openapi.yaml in GPT Builder > Actions
  Hook wiring: Could not detect AI agent. Use --agent=claude-code|codex|gemini|forge|cursor

✅ thumbgate v1.29.2 initialized.

  ╭──────────────────────────────────────────────────────────╮
  │  NEXT: Prove feedback capture works                     │
  │                                                         │
  │  npx thumbgate feedback-self-test                       │
  │                                                         │
  │  Then dogfood it in chat:                               │
  │  thumbs down: agent skipped verification                │
  ╰──────────────────────────────────────────────────────────╯


  ┌──────────────────────────────────────────────────────────┐
  │  7-day Pro trial active through 2026-08-07.               │
  │  Pro keeps lessons/rules/dashboard synced everywhere.   │
  │  Add onboarding: npx thumbgate init --email you@company.com │
  │  Upgrade: https://thumbgate.ai/go/pro?plan_id=pro&billing_cycle=monthly&utm_source=cli_init&utm_medium=cli&utm_campaign=pro_conversion&utm_content=init_no_email
  └──────────────────────────────────────────────────────────┘
  Get trial reminders: npx thumbgate init --email you@company.com
  Copied default gates to .thumbgate/gates.json
  Created .thumbgate/config.json

  Enforcement setup complete:
    Self-distillation: ON (agent auto-learns from outcomes)
    Context-stuffing:  ON (all lessons injected at session start)
    Auto-gate promotion: ON (recurring failures become hard blocks)
    Default gates: loaded

  Next steps:
    npx thumbgate capture --feedback=down --context="what failed"
    npx thumbgate stats from mutating unrelated agent configs\n- adds a regression sentinel proving plugin managers are not invoked\n\n## Verification\n- ✔ statuslineCommand() result contains the "statusline-render" subcommand (1.9615ms)
✔ statuslineCommand() does not exec the bare binary without its subcommand (0.520333ms)
✔ preToolHookCommand() result contains the "gate-check" subcommand (0.124ms)
✔ preToolHookCommand() does not exec the bare binary without its subcommand (0.455334ms)
✔ userPromptHookCommand() result contains the "hook-auto-capture" subcommand (0.203334ms)
✔ userPromptHookCommand() does not exec the bare binary without its subcommand (0.081ms)
✔ sessionStartHookCommand() result contains the "session-start" subcommand (0.183ms)
✔ sessionStartHookCommand() does not exec the bare binary without its subcommand (0.065166ms)
✔ cacheUpdateHookCommand() result contains the "cache-update" subcommand (0.081375ms)
✔ cacheUpdateHookCommand() does not exec the bare binary without its subcommand (0.216125ms)
▶ mcp-config
  ✔ parseWorktreePaths extracts worktree lines from porcelain output (21.155333ms)
  ✔ parseWorktreePaths returns empty array for empty input (0.304167ms)
  ✔ portableMcpEntry returns a shell wrapper that pins the published package version (0.362084ms)
  ✔ codexAutoUpdateMcpEntry fast-starts from the installed runtime and resolves @latest via npx only when absent (0.363875ms)
  ✔ resolveMcpEntry uses a latest-resolving launcher for published external installs (278.610542ms)
  ✔ resolveMcpEntry uses a latest-resolving launcher outside source checkouts (5.884833ms)
  ✔ codexAutoUpdateCliEntry supports hook commands with the same fast-start policy (0.28775ms)
  ✔ localMcpEntry returns node command pointing to server-stdio.js (4.604666ms)
  ✔ isSourceCheckout returns true for repo with .git (1.903ms)
  ✔ resolveStableSourceRoot falls back safely when pkgRoot is omitted (225.017083ms)
  ✔ publishedCliAvailable respects the explicit availability override (0.140875ms)
✔ mcp-config (540.67925ms)
✔ quick-start does not execute detected plugin managers by default (1394.144042ms)
✔ quick-start creates .thumbgate/config.json with correct defaults (1002.928834ms)
✔ quick-start copies default gates to .thumbgate/gates.json (458.537ms)
✔ quick-start auto-detects claude-code when .claude/ exists (858.715833ms)
✔ quick-start auto-detects cursor when .cursorrules exists (503.653208ms)
✔ quick-start respects --agent flag over auto-detection (410.274625ms)
✔ quick-start defaults to claude-code when no agent detected (491.241667ms)
ℹ tests 28
ℹ suites 1
ℹ pass 28
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5442.952416\n- 28 tests passed, 0 failed\n- pre-push package, link, and regression guards passed\n\n## Evidence boundary\nThis proves deterministic local onboarding behavior. It does not claim a published npm version until the changeset is released.