### PR TITLE
feat(routing): execute risk-aware model plans

### DIFF
--- a/.changeset/risk-aware-generation-router.md
+++ b/.changeset/risk-aware-generation-router.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Make risk-aware model routing executable with provider dispatch, prompt-free outcome telemetry, and fixed-model holdout evaluation while explicitly separating generation routing from LLM-as-a-Judge scoring and deprecating misleading MoE-style expert terminology.

--- a/config/model-tiers.json
+++ b/config/model-tiers.json
@@ -4,6 +4,7 @@
     "nano": {
       "label": "GPT-5.4 nano",
       "modelId": "gpt-5.4-nano",
+      "provider": "openai",
       "taskTypes": ["classification", "extraction", "ranking", "labeling", "summarization"],
       "maxContextTokens": 32000,
       "costMultiplier": 0.1
@@ -11,6 +12,7 @@
     "mini": {
       "label": "GPT-5.4 mini",
       "modelId": "gpt-5.4-mini",
+      "provider": "openai",
       "taskTypes": ["code-edit", "test-generation", "review", "tool-use", "debugging"],
       "maxContextTokens": 200000,
       "costMultiplier": 0.4
@@ -18,6 +20,7 @@
     "frontier": {
       "label": "GPT-5.5",
       "modelId": "gpt-5.5",
+      "provider": "openai",
       "taskTypes": ["architecture", "cross-file", "complex-debugging", "large-context"],
       "maxContextTokens": 1000000,
       "costMultiplier": 1.0,
@@ -28,6 +31,8 @@
     },
     "localFrontier": {
       "label": "GLM 5.1",
+      "modelId": "glm-5.1",
+      "provider": "openai-compatible",
       "taskTypes": [],
       "maxContextTokens": 1000000,
       "costMultiplier": 0.0,

--- a/config/model-tiers.json
+++ b/config/model-tiers.json
@@ -30,8 +30,8 @@
       }
     },
     "localFrontier": {
-      "label": "GLM 5.1",
-      "modelId": "glm-5.1",
+      "label": "Configured local frontier",
+      "modelId": null,
       "provider": "openai-compatible",
       "taskTypes": [],
       "maxContextTokens": 1000000,
@@ -40,7 +40,7 @@
         "tokenCap": 2000000,
         "requireReason": false
       },
-      "notes": "Self-hosted open-source tier. Activate via THUMBGATE_LOCAL_MODEL_FAMILY=glm-*. Zero marginal cost; no token budget enforcement needed."
+      "notes": "Self-hosted open-source tier. The runtime derives the served model from THUMBGATE_MODEL_ROLE_NORMAL, THUMBGATE_LOCAL_MODEL, THUMBGATE_MODEL_ID, or THUMBGATE_LOCAL_MODEL_FAMILY. Zero marginal API cost; no token budget enforcement needed."
     }
   },
   "escalationRules": {

--- a/docs/RISK_AWARE_MODEL_ROUTING.md
+++ b/docs/RISK_AWARE_MODEL_ROUTING.md
@@ -10,6 +10,8 @@ ThumbGate routes complete generation requests between external model tiers. It d
 
 The default runtime supports OpenAI and OpenAI-compatible local endpoints. Other providers register an adapter under their provider or tier name. Cost remains `null` unless the provider or adapter returns a verified cost; ThumbGate does not invent price data.
 
+`privacyRoute: 'local'` is fail closed: execution requires an active local backend, forces the OpenAI-compatible local adapter, and rejects cloud provider overrides. The served model is resolved from the active local model family or role override rather than a hard-coded model ID.
+
 ```js
 const {
   executeRoutedGeneration,
@@ -24,3 +26,11 @@ const result = await executeRoutedGeneration(
 ```
 
 Treat a routing policy as production-ready only after a held-out workload shows acceptable quality regret against a fixed frontier baseline and the recorded cost/latency tradeoff justifies the route.
+
+## Verification evidence
+
+- [Human-readable verification log](./VERIFICATION_EVIDENCE.md)
+- [Machine-readable risk-model report](../evals/risk-model-report.json), which validates the risk signal available to the policy but does not prove routed output quality
+- `node --test tests/model-tier-router.test.js tests/local-model-profile.test.js` for deterministic routing, privacy, provider, telemetry, and holdout contracts
+
+The holdout evaluator deliberately requires an external scorer. A deployment must persist its own machine-readable holdout report before claiming a quality or cost improvement; the checked-in risk report alone is not such proof.

--- a/docs/RISK_AWARE_MODEL_ROUTING.md
+++ b/docs/RISK_AWARE_MODEL_ROUTING.md
@@ -1,0 +1,26 @@
+# Risk-aware model routing
+
+ThumbGate routes complete generation requests between external model tiers. It does not implement a neural Mixture of Experts (MoE): there is no token-level gate, sparse expert layer, capacity factor, expert-weight training, or load-balancing loss.
+
+`scripts/model-tier-router.js` now provides three distinct stages:
+
+1. `recommendExecutionPlan` selects an external tier from task type, context, risk, retries, and local-provider policy.
+2. `executeRoutedGeneration` dispatches the request through the selected provider adapter and emits prompt-free route, token, latency, cost, and outcome telemetry.
+3. `evaluateRoutingHoldout` compares routed generation against a fixed-model baseline. A caller-supplied deterministic scorer or separately calibrated LLM judge evaluates both outputs; the generation router never judges its own output.
+
+The default runtime supports OpenAI and OpenAI-compatible local endpoints. Other providers register an adapter under their provider or tier name. Cost remains `null` unless the provider or adapter returns a verified cost; ThumbGate does not invent price data.
+
+```js
+const {
+  executeRoutedGeneration,
+  createJsonlTelemetrySink,
+} = require('thumbgate/scripts/model-tier-router');
+
+const result = await executeRoutedGeneration(
+  { type: 'code-edit', riskLevel: 'medium', contextTokens: 18000 },
+  { userPrompt: 'Add validation to this function.' },
+  { telemetrySink: createJsonlTelemetrySink('.thumbgate/generation-routes.jsonl') }
+);
+```
+
+Treat a routing policy as production-ready only after a held-out workload shows acceptable quality regret against a fixed frontier baseline and the recorded cost/latency tradeoff justifies the route.

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "scripts/meta-agent-loop.js",
     "scripts/model-access-eligibility.js",
     "scripts/model-migration-readiness.js",
+    "scripts/model-tier-router.js",
     "scripts/multimodal-retrieval-plan.js",
     "scripts/native-messaging-audit.js",
     "scripts/natural-language-harness.js",

--- a/scripts/inference-economics.js
+++ b/scripts/inference-economics.js
@@ -17,18 +17,18 @@ function planInferenceBudget(input = {}) {
   const maxCostCents = Number.isFinite(Number(input.maxCostCents)) ? Number(input.maxCostCents) : 50;
   let depth = 'shallow';
   let reasoningEffort = 'low';
-  let expertCount = 1;
+  let parallelCandidates = 1;
   let humanHandoff = false;
 
   if (difficulty >= 70) {
     depth = 'deep';
     reasoningEffort = 'high';
-    expertCount = 4;
+    parallelCandidates = 4;
     humanHandoff = true;
   } else if (difficulty >= 35) {
     depth = 'standard';
     reasoningEffort = 'medium';
-    expertCount = 2;
+    parallelCandidates = 2;
   }
 
   if (maxCostCents < 20 && depth === 'deep') {
@@ -41,9 +41,13 @@ function planInferenceBudget(input = {}) {
     maxCostCents,
     depth,
     reasoningEffort,
-    activeExperts: expertCount,
+    parallelCandidates,
+    // Backward-compatible alias. This is candidate-level application routing,
+    // not internal MoE expert activation; remove after downstream migration.
+    activeExperts: parallelCandidates,
+    activeExpertsDeprecated: true,
     humanHandoff,
-    telemetry: ['difficulty', 'depth', 'reasoningEffort', 'activeExperts', 'latencyMs', 'costCents', 'outcome'],
+    telemetry: ['difficulty', 'depth', 'reasoningEffort', 'parallelCandidates', 'latencyMs', 'costCents', 'outcome'],
   };
 }
 

--- a/scripts/model-tier-router.js
+++ b/scripts/model-tier-router.js
@@ -2,13 +2,16 @@
 'use strict';
 
 /**
- * GPT tier router — routes tasks to nano/mini/frontier based on
- * task complexity, context size, risk level, and retry count.
- * Includes frontier budget control.
+ * Risk-aware model router — routes whole generation requests to an external
+ * provider/model tier based on task complexity, context size, risk level, and
+ * retry count. This is application-level routing, not a neural Mixture of
+ * Experts (MoE): it never routes tokens through internal expert subnetworks.
  */
 
+const fs = require('fs');
 const path = require('path');
 const { recommendInferenceBackend } = require('./local-model-profile');
+const { redactSecrets } = require('./secret-redaction');
 
 const CONFIG_PATH = path.join(__dirname, '..', 'config', 'model-tiers.json');
 
@@ -278,6 +281,8 @@ function recommendExecutionPlan(task = {}, env = process.env) {
     : classification.tier;
 
   return {
+    architecture: 'risk-aware-model-routing',
+    mixtureOfExperts: false,
     tier: effectiveTier,
     escalated: classification.escalated,
     tierReason: classification.reason,
@@ -292,10 +297,245 @@ function recommendExecutionPlan(task = {}, env = process.env) {
 }
 
 // ---------------------------------------------------------------------------
+// Executable generation routing
+// ---------------------------------------------------------------------------
+
+function inferProvider(modelId, tier) {
+  if (tier === 'localFrontier') return 'openai-compatible';
+  if (/^(gpt-|o\d)/i.test(modelId || '')) return 'openai';
+  if (/^claude-/i.test(modelId || '')) return 'anthropic';
+  if (/^(gemini|vertex)/i.test(modelId || '')) return 'gemini';
+  return 'custom';
+}
+
+function normalizeGenerationResult(result, fallback = {}) {
+  if (typeof result === 'string') {
+    return {
+      text: result,
+      model: fallback.model,
+      provider: fallback.provider,
+      usage: null,
+      costCents: null,
+    };
+  }
+  if (!result || typeof result !== 'object') {
+    throw new Error('generation adapter returned no result');
+  }
+  return {
+    ...result,
+    text: String(result.text || ''),
+    model: result.model || fallback.model,
+    provider: result.provider || fallback.provider,
+    usage: result.usage || null,
+    costCents: Number.isFinite(Number(result.costCents)) ? Number(result.costCents) : null,
+  };
+}
+
+function createOpenAiCompatibleAdapter(options = {}) {
+  const env = options.env || process.env;
+  const fetchImpl = options.fetchImpl || global.fetch;
+
+  return async function openAiCompatibleAdapter({ request, model, provider }) {
+    if (typeof fetchImpl !== 'function') throw new Error('fetch is unavailable');
+    const local = provider === 'openai-compatible';
+    const baseUrl = local
+      ? env.THUMBGATE_LOCAL_MODEL_BASE_URL
+      : (env.OPENAI_BASE_URL || 'https://api.openai.com/v1');
+    const apiKey = local ? env.THUMBGATE_LOCAL_MODEL_API_KEY : env.OPENAI_API_KEY;
+    if (!baseUrl) throw new Error('THUMBGATE_LOCAL_MODEL_BASE_URL is required for local routing');
+    if (!local && !apiKey) throw new Error('OPENAI_API_KEY is required for OpenAI routing');
+
+    const messages = Array.isArray(request.messages) && request.messages.length > 0
+      ? request.messages
+      : [
+        ...(request.systemPrompt ? [{ role: 'system', content: request.systemPrompt }] : []),
+        { role: 'user', content: request.userPrompt || request.prompt || '' },
+      ];
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+    const response = await fetchImpl(`${String(baseUrl).replace(/\/$/, '')}/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model,
+        messages,
+        max_tokens: request.maxTokens || 1024,
+        temperature: Number.isFinite(request.temperature) ? request.temperature : 0,
+      }),
+    });
+    if (!response.ok) throw new Error(`${provider} generation failed with HTTP ${response.status}`);
+    const payload = await response.json();
+    return {
+      text: payload?.choices?.[0]?.message?.content || '',
+      model: payload?.model || model,
+      provider,
+      usage: payload?.usage || null,
+      costCents: null,
+    };
+  };
+}
+
+function createDefaultGenerationAdapters(options = {}) {
+  const openAiCompatible = createOpenAiCompatibleAdapter(options);
+  return {
+    openai: openAiCompatible,
+    'openai-compatible': openAiCompatible,
+  };
+}
+
+function createJsonlTelemetrySink(filePath) {
+  if (!filePath) throw new Error('telemetry file path is required');
+  return (event) => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.appendFileSync(filePath, `${JSON.stringify(event)}\n`, 'utf8');
+  };
+}
+
+async function executeRoutedGeneration(task = {}, request = {}, options = {}) {
+  const env = options.env || process.env;
+  const config = options.config || loadConfig();
+  const plan = recommendExecutionPlan(task, env);
+  const tierConfig = config.tiers[plan.tier];
+  if (!tierConfig) throw new Error(`missing configuration for tier "${plan.tier}"`);
+  const model = options.modelOverrides?.[plan.tier] || tierConfig.modelId;
+  if (!model) throw new Error(`missing modelId for tier "${plan.tier}"`);
+  const provider = options.providerOverrides?.[plan.tier]
+    || tierConfig.provider
+    || inferProvider(model, plan.tier);
+  const adapters = options.adapters || createDefaultGenerationAdapters({ env, fetchImpl: options.fetchImpl });
+  const adapter = adapters[plan.tier] || adapters[provider];
+  if (typeof adapter !== 'function') throw new Error(`no generation adapter registered for provider "${provider}"`);
+
+  const now = options.now || (() => Date.now());
+  const startedAt = now();
+  const baseEvent = {
+    timestamp: new Date().toISOString(),
+    architecture: plan.architecture,
+    taskType: task.type || 'unknown',
+    riskLevel: task.riskLevel || 'unspecified',
+    tier: plan.tier,
+    provider,
+    model,
+    escalated: plan.escalated,
+    routeReason: plan.reason,
+  };
+
+  try {
+    const raw = await adapter({ task, request, plan, model, provider });
+    const result = normalizeGenerationResult(raw, { model, provider });
+    const event = {
+      ...baseEvent,
+      latencyMs: Math.max(0, now() - startedAt),
+      inputTokens: Number(result.usage?.input_tokens || result.usage?.prompt_tokens || 0) || null,
+      outputTokens: Number(result.usage?.output_tokens || result.usage?.completion_tokens || 0) || null,
+      costCents: result.costCents,
+      outcome: 'success',
+    };
+    if (options.telemetrySink) await options.telemetrySink(event);
+    return { ...result, route: plan, telemetry: event };
+  } catch (error) {
+    const event = {
+      ...baseEvent,
+      latencyMs: Math.max(0, now() - startedAt),
+      inputTokens: null,
+      outputTokens: null,
+      costCents: null,
+      outcome: 'error',
+      error: redactSecrets(String(error?.message || error)).split('\n')[0].slice(0, 300),
+    };
+    if (options.telemetrySink) await options.telemetrySink(event);
+    throw error;
+  }
+}
+
+function average(values) {
+  const finite = values.filter((value) => Number.isFinite(value));
+  return finite.length ? finite.reduce((sum, value) => sum + value, 0) / finite.length : null;
+}
+
+async function evaluateRoutingHoldout(cases, options = {}) {
+  if (!Array.isArray(cases) || cases.length === 0) throw new Error('holdout cases are required');
+  if (typeof options.fixedGenerate !== 'function') throw new Error('fixedGenerate baseline is required');
+  if (typeof options.scoreOutput !== 'function') {
+    throw new Error('scoreOutput is required; model routing and output judging must remain separate');
+  }
+  const routedGenerate = options.routedGenerate
+    || ((testCase) => executeRoutedGeneration(testCase.task, testCase.request, options.routerOptions));
+  const results = [];
+
+  for (const testCase of cases) {
+    const routed = await routedGenerate(testCase);
+    const fixed = await options.fixedGenerate(testCase);
+    const routedScore = Number(await options.scoreOutput(routed, testCase, 'routed'));
+    const fixedScore = Number(await options.scoreOutput(fixed, testCase, 'fixed'));
+    if (!Number.isFinite(routedScore) || !Number.isFinite(fixedScore)) {
+      throw new Error(`non-numeric holdout score for case "${testCase.id || 'unknown'}"`);
+    }
+    results.push({
+      id: testCase.id || `case-${results.length + 1}`,
+      routed: {
+        tier: routed.route?.tier || null,
+        model: routed.model || null,
+        score: routedScore,
+        costCents: Number.isFinite(routed.costCents) ? routed.costCents : null,
+        latencyMs: Number.isFinite(routed.telemetry?.latencyMs) ? routed.telemetry.latencyMs : null,
+      },
+      fixed: {
+        model: fixed.model || options.fixedModel || null,
+        score: fixedScore,
+        costCents: Number.isFinite(fixed.costCents) ? fixed.costCents : null,
+        latencyMs: Number.isFinite(fixed.telemetry?.latencyMs) ? fixed.telemetry.latencyMs : null,
+      },
+      qualityRegret: fixedScore - routedScore,
+    });
+  }
+
+  const costPairs = results.filter((result) => (
+    Number.isFinite(result.routed.costCents) && Number.isFinite(result.fixed.costCents)
+  ));
+  const routedCost = average(costPairs.map((result) => result.routed.costCents));
+  const fixedCost = average(costPairs.map((result) => result.fixed.costCents));
+  const averageQualityRegret = average(results.map((result) => result.qualityRegret));
+  const worstCaseQualityRegret = Math.max(...results.map((result) => result.qualityRegret));
+  const maxQualityRegret = Number.isFinite(options.maxQualityRegret) ? options.maxQualityRegret : 0;
+  return {
+    architecture: 'risk-aware-model-routing',
+    judgeStage: 'external-scorer',
+    caseCount: results.length,
+    metrics: {
+      routedQuality: average(results.map((result) => result.routed.score)),
+      fixedQuality: average(results.map((result) => result.fixed.score)),
+      averageQualityRegret,
+      worstCaseQualityRegret,
+      routedCostCents: routedCost,
+      fixedCostCents: fixedCost,
+      costSavingsCents: routedCost === null || fixedCost === null ? null : fixedCost - routedCost,
+      costCoverage: { measuredCases: costPairs.length, totalCases: results.length },
+    },
+    thresholds: { maxQualityRegret },
+    passed: worstCaseQualityRegret <= maxQualityRegret,
+    results,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
-module.exports = { TIERS, classifyTask, shouldEscalate, FrontierBudget, recommendExecutionPlan };
+module.exports = {
+  TIERS,
+  classifyTask,
+  shouldEscalate,
+  FrontierBudget,
+  recommendExecutionPlan,
+  inferProvider,
+  normalizeGenerationResult,
+  createOpenAiCompatibleAdapter,
+  createDefaultGenerationAdapters,
+  createJsonlTelemetrySink,
+  executeRoutedGeneration,
+  evaluateRoutingHoldout,
+};
 
 // ---------------------------------------------------------------------------
 // CLI

--- a/scripts/model-tier-router.js
+++ b/scripts/model-tier-router.js
@@ -10,7 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { recommendInferenceBackend } = require('./local-model-profile');
+const { recommendInferenceBackend, resolveModelRole } = require('./local-model-profile');
 const { redactSecrets } = require('./secret-redaction');
 
 const CONFIG_PATH = path.join(__dirname, '..', 'config', 'model-tiers.json');
@@ -288,6 +288,7 @@ function recommendExecutionPlan(task = {}, env = process.env) {
     tierReason: classification.reason,
     backendId: inference.backend.id,
     providerMode: inference.backend.providerMode,
+    modelFamily: inference.backend.modelFamily,
     workloadClass: inference.workloadClass,
     recommendationClass: inference.recommendationClass,
     indexCacheEligible: inference.backend.indexCacheEligible,
@@ -321,13 +322,58 @@ function normalizeGenerationResult(result, fallback = {}) {
   if (!result || typeof result !== 'object') {
     throw new Error('generation adapter returned no result');
   }
+  const rawCostCents = result.costCents;
   return {
     ...result,
     text: String(result.text || ''),
     model: result.model || fallback.model,
     provider: result.provider || fallback.provider,
     usage: result.usage || null,
-    costCents: Number.isFinite(Number(result.costCents)) ? Number(result.costCents) : null,
+    costCents: rawCostCents === null || rawCostCents === undefined || rawCostCents === ''
+      ? null
+      : (Number.isFinite(Number(rawCostCents)) ? Number(rawCostCents) : null),
+  };
+}
+
+function resolveLocalGenerationModel(env, plan) {
+  const role = resolveModelRole('normal', env);
+  if (role.provider === 'local') return role.model;
+
+  const configuredModel = [
+    env.THUMBGATE_MODEL_ROLE_NORMAL,
+    env.THUMBGATE_LOCAL_MODEL,
+    env.THUMBGATE_MODEL_ID,
+    env.THUMBGATE_LOCAL_MODEL_FAMILY,
+    plan.modelFamily,
+  ].find((value) => value && String(value).trim() && String(value).trim() !== 'unknown');
+  if (configuredModel) return String(configuredModel).trim();
+  throw new Error('a local model ID or family is required for local routing');
+}
+
+function resolveGenerationTarget(plan, task, tierConfig, options, env) {
+  const modelOverride = options.modelOverrides?.[plan.tier];
+  const providerOverride = options.providerOverrides?.[plan.tier];
+  const localOnly = task.privacyRoute === 'local';
+
+  if (localOnly && plan.providerMode !== 'local') {
+    throw new Error('privacyRoute "local" requires a configured local inference backend');
+  }
+
+  if (plan.providerMode === 'local') {
+    if (providerOverride && providerOverride !== 'openai-compatible') {
+      throw new Error('local inference cannot use a cloud provider override');
+    }
+    return {
+      model: modelOverride || resolveLocalGenerationModel(env, plan),
+      provider: 'openai-compatible',
+    };
+  }
+
+  const model = modelOverride || tierConfig.modelId;
+  if (!model) throw new Error(`missing modelId for tier "${plan.tier}"`);
+  return {
+    model,
+    provider: providerOverride || tierConfig.provider || inferProvider(model, plan.tier),
   };
 }
 
@@ -397,11 +443,7 @@ async function executeRoutedGeneration(task = {}, request = {}, options = {}) {
   const plan = recommendExecutionPlan(task, env);
   const tierConfig = config.tiers[plan.tier];
   if (!tierConfig) throw new Error(`missing configuration for tier "${plan.tier}"`);
-  const model = options.modelOverrides?.[plan.tier] || tierConfig.modelId;
-  if (!model) throw new Error(`missing modelId for tier "${plan.tier}"`);
-  const provider = options.providerOverrides?.[plan.tier]
-    || tierConfig.provider
-    || inferProvider(model, plan.tier);
+  const { model, provider } = resolveGenerationTarget(plan, task, tierConfig, options, env);
   const adapters = options.adapters || createDefaultGenerationAdapters({ env, fetchImpl: options.fetchImpl });
   const adapter = adapters[plan.tier] || adapters[provider];
   if (typeof adapter !== 'function') throw new Error(`no generation adapter registered for provider "${provider}"`);
@@ -530,6 +572,7 @@ module.exports = {
   recommendExecutionPlan,
   inferProvider,
   normalizeGenerationResult,
+  resolveGenerationTarget,
   createOpenAiCompatibleAdapter,
   createDefaultGenerationAdapters,
   createJsonlTelemetrySink,

--- a/tests/high-roi-agent-workflows.test.js
+++ b/tests/high-roi-agent-workflows.test.js
@@ -782,6 +782,11 @@ test('inference economics planner scales reasoning depth by difficulty and budge
   });
   assert.equal(hard.depth, 'deep');
   assert.equal(hard.humanHandoff, true);
+  assert.equal(hard.parallelCandidates, 4);
+  assert.equal(hard.activeExperts, 4);
+  assert.equal(hard.activeExpertsDeprecated, true);
+  assert.ok(hard.telemetry.includes('parallelCandidates'));
+  assert.equal(hard.telemetry.includes('activeExperts'), false);
 
   const constrained = planInferenceBudget({
     difficulty: 90,

--- a/tests/model-tier-router.test.js
+++ b/tests/model-tier-router.test.js
@@ -14,6 +14,7 @@ const {
   recommendExecutionPlan,
   inferProvider,
   normalizeGenerationResult,
+  resolveGenerationTarget,
   createOpenAiCompatibleAdapter,
   createDefaultGenerationAdapters,
   createJsonlTelemetrySink,
@@ -380,6 +381,27 @@ test('generation result normalization supports text adapters and rejects empty r
     usage: null,
     costCents: null,
   });
+  assert.equal(normalizeGenerationResult({ text: 'unknown', costCents: null }).costCents, null);
+  assert.equal(normalizeGenerationResult({ text: 'unknown' }).costCents, null);
+  assert.equal(normalizeGenerationResult({ text: 'known', costCents: '0.25' }).costCents, 0.25);
+});
+
+test('local execution target uses the activated model family instead of a hard-coded model', () => {
+  const env = {
+    THUMBGATE_PROVIDER_MODE: 'local',
+    THUMBGATE_LOCAL_MODEL_FAMILY: 'glm-z1',
+  };
+  const plan = recommendExecutionPlan({ type: 'architecture' }, env);
+  const target = resolveGenerationTarget(
+    plan,
+    { type: 'architecture' },
+    config.tiers[plan.tier],
+    {},
+    env,
+  );
+  assert.equal(target.provider, 'openai-compatible');
+  assert.equal(target.model, 'glm-z1-9b');
+  assert.notEqual(target.model, 'glm-5.1');
 });
 
 test('default adapters share the OpenAI-compatible contract and JSONL telemetry is durable', async (t) => {
@@ -463,6 +485,56 @@ test('executeRoutedGeneration dispatches the selected adapter and emits prompt-f
   assert.equal(result.telemetry.latencyMs, 25);
   assert.equal(events.length, 1);
   assert.equal(JSON.stringify(events).includes('secret prompt body'), false);
+});
+
+test('privacy-local execution cannot fall through to a configured cloud provider', async () => {
+  let fetchedUrl = null;
+  const result = await executeRoutedGeneration({
+    type: 'classification',
+    privacyRoute: 'local',
+  }, {
+    userPrompt: 'private prompt',
+  }, {
+    env: {
+      THUMBGATE_PROVIDER_MODE: 'local',
+      THUMBGATE_LOCAL_MODEL_FAMILY: 'glm-z1',
+      THUMBGATE_LOCAL_MODEL_BASE_URL: 'http://127.0.0.1:9000/v1',
+      OPENAI_API_KEY: 'cloud-key-must-not-be-used',
+    },
+    fetchImpl: async (url, options) => {
+      fetchedUrl = url;
+      assert.equal(options.headers.Authorization, undefined);
+      assert.equal(JSON.parse(options.body).model, 'glm-z1-9b');
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'local-only' } }] }),
+      };
+    },
+  });
+  assert.equal(fetchedUrl, 'http://127.0.0.1:9000/v1/chat/completions');
+  assert.equal(result.provider, 'openai-compatible');
+  assert.equal(result.model, 'glm-z1-9b');
+});
+
+test('privacy-local execution fails closed without a local backend or with a cloud override', async () => {
+  await assert.rejects(
+    executeRoutedGeneration({ type: 'classification', privacyRoute: 'local' }, {}, {
+      env: { OPENAI_API_KEY: 'cloud-key-must-not-be-used' },
+    }),
+    /requires a configured local inference backend/,
+  );
+
+  await assert.rejects(
+    executeRoutedGeneration({ type: 'classification', privacyRoute: 'local' }, {}, {
+      env: {
+        THUMBGATE_PROVIDER_MODE: 'local',
+        THUMBGATE_LOCAL_MODEL_FAMILY: 'deepseek-v3',
+        THUMBGATE_LOCAL_MODEL_BASE_URL: 'http://127.0.0.1:9000/v1',
+      },
+      providerOverrides: { nano: 'openai' },
+    }),
+    /cannot use a cloud provider override/,
+  );
 });
 
 test('OpenAI-compatible adapter uses the selected model and standard endpoint contract', async () => {

--- a/tests/model-tier-router.test.js
+++ b/tests/model-tier-router.test.js
@@ -2,6 +2,9 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   TIERS,
@@ -9,7 +12,11 @@ const {
   shouldEscalate,
   FrontierBudget,
   recommendExecutionPlan,
+  inferProvider,
+  normalizeGenerationResult,
   createOpenAiCompatibleAdapter,
+  createDefaultGenerationAdapters,
+  createJsonlTelemetrySink,
   executeRoutedGeneration,
   evaluateRoutingHoldout,
 } = require('../scripts/model-tier-router');
@@ -339,6 +346,89 @@ test('execution plan calls the architecture risk-aware routing, not MoE', () => 
   const plan = recommendExecutionPlan({ type: 'review' }, {});
   assert.equal(plan.architecture, 'risk-aware-model-routing');
   assert.equal(plan.mixtureOfExperts, false);
+});
+
+test('provider inference distinguishes local, OpenAI, Anthropic, Gemini, and custom models', () => {
+  assert.equal(inferProvider('local-model', 'localFrontier'), 'openai-compatible');
+  assert.equal(inferProvider('gpt-5.5', 'frontier'), 'openai');
+  assert.equal(inferProvider('o3', 'frontier'), 'openai');
+  assert.equal(inferProvider('claude-opus-4', 'frontier'), 'anthropic');
+  assert.equal(inferProvider('gemini-3-pro', 'frontier'), 'gemini');
+  assert.equal(inferProvider('vertex-gemini', 'frontier'), 'gemini');
+  assert.equal(inferProvider('private-router-v1', 'mini'), 'custom');
+});
+
+test('generation result normalization supports text adapters and rejects empty results', () => {
+  assert.deepEqual(normalizeGenerationResult('ok', {
+    model: 'gpt-test',
+    provider: 'openai',
+  }), {
+    text: 'ok',
+    model: 'gpt-test',
+    provider: 'openai',
+    usage: null,
+    costCents: null,
+  });
+  assert.throws(() => normalizeGenerationResult(null), /returned no result/);
+  assert.deepEqual(normalizeGenerationResult({ text: 42 }, {
+    model: 'fallback-model',
+    provider: 'custom',
+  }), {
+    text: '42',
+    model: 'fallback-model',
+    provider: 'custom',
+    usage: null,
+    costCents: null,
+  });
+});
+
+test('default adapters share the OpenAI-compatible contract and JSONL telemetry is durable', async (t) => {
+  const adapters = createDefaultGenerationAdapters({
+    env: { THUMBGATE_LOCAL_MODEL_BASE_URL: 'http://127.0.0.1:9000/v1' },
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'local-ok' } }] }),
+    }),
+  });
+  assert.equal(adapters.openai, adapters['openai-compatible']);
+  const local = await adapters['openai-compatible']({
+    request: { messages: [{ role: 'user', content: 'hello' }] },
+    model: 'local-model',
+    provider: 'openai-compatible',
+  });
+  assert.equal(local.text, 'local-ok');
+  assert.equal(local.model, 'local-model');
+
+  assert.throws(() => createJsonlTelemetrySink(), /file path is required/);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-route-telemetry-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, 'nested', 'routes.jsonl');
+  const sink = createJsonlTelemetrySink(file);
+  sink({ tier: 'nano', outcome: 'success' });
+  assert.deepEqual(
+    fs.readFileSync(file, 'utf8').trim().split('\n').map((line) => JSON.parse(line)),
+    [{ tier: 'nano', outcome: 'success' }],
+  );
+});
+
+test('OpenAI-compatible adapter enforces credentials and reports upstream HTTP failures', async () => {
+  const noKey = createOpenAiCompatibleAdapter({
+    env: {},
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+  });
+  await assert.rejects(
+    noKey({ request: {}, model: 'gpt-test', provider: 'openai' }),
+    /OPENAI_API_KEY is required/,
+  );
+
+  const upstreamFailure = createOpenAiCompatibleAdapter({
+    env: { OPENAI_API_KEY: 'test-key' },
+    fetchImpl: async () => ({ ok: false, status: 429 }),
+  });
+  await assert.rejects(
+    upstreamFailure({ request: { prompt: 'hello' }, model: 'gpt-test', provider: 'openai' }),
+    /HTTP 429/,
+  );
 });
 
 test('executeRoutedGeneration dispatches the selected adapter and emits prompt-free telemetry', async () => {

--- a/tests/model-tier-router.test.js
+++ b/tests/model-tier-router.test.js
@@ -9,6 +9,9 @@ const {
   shouldEscalate,
   FrontierBudget,
   recommendExecutionPlan,
+  createOpenAiCompatibleAdapter,
+  executeRoutedGeneration,
+  evaluateRoutingHoldout,
 } = require('../scripts/model-tier-router');
 
 const config = require('../config/model-tiers.json');
@@ -330,4 +333,147 @@ test('recommendExecutionPlan keeps frontier tier when no local GLM backend', () 
   }, {});
 
   assert.equal(plan.tier, 'frontier');
+});
+
+test('execution plan calls the architecture risk-aware routing, not MoE', () => {
+  const plan = recommendExecutionPlan({ type: 'review' }, {});
+  assert.equal(plan.architecture, 'risk-aware-model-routing');
+  assert.equal(plan.mixtureOfExperts, false);
+});
+
+test('executeRoutedGeneration dispatches the selected adapter and emits prompt-free telemetry', async () => {
+  const events = [];
+  const result = await executeRoutedGeneration({
+    type: 'classification',
+    riskLevel: 'low',
+  }, {
+    userPrompt: 'secret prompt body must not enter telemetry',
+  }, {
+    adapters: {
+      openai: async ({ model, provider }) => ({
+        text: 'classified',
+        model,
+        provider,
+        usage: { prompt_tokens: 11, completion_tokens: 3 },
+        costCents: 0.2,
+      }),
+    },
+    telemetrySink: (event) => events.push(event),
+    now: (() => {
+      const times = [1000, 1025];
+      return () => times.shift();
+    })(),
+  });
+
+  assert.equal(result.text, 'classified');
+  assert.equal(result.route.tier, 'nano');
+  assert.equal(result.telemetry.outcome, 'success');
+  assert.equal(result.telemetry.inputTokens, 11);
+  assert.equal(result.telemetry.outputTokens, 3);
+  assert.equal(result.telemetry.latencyMs, 25);
+  assert.equal(events.length, 1);
+  assert.equal(JSON.stringify(events).includes('secret prompt body'), false);
+});
+
+test('OpenAI-compatible adapter uses the selected model and standard endpoint contract', async () => {
+  let observed;
+  const adapter = createOpenAiCompatibleAdapter({
+    env: { OPENAI_API_KEY: 'test-key', OPENAI_BASE_URL: 'https://models.example/v1/' },
+    fetchImpl: async (url, options) => {
+      observed = { url, options };
+      return {
+        ok: true,
+        json: async () => ({
+          model: 'gpt-test',
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 2, completion_tokens: 1 },
+        }),
+      };
+    },
+  });
+  const result = await adapter({
+    request: { userPrompt: 'hello' },
+    model: 'gpt-test',
+    provider: 'openai',
+  });
+
+  assert.equal(observed.url, 'https://models.example/v1/chat/completions');
+  assert.equal(JSON.parse(observed.options.body).model, 'gpt-test');
+  assert.equal(result.text, 'ok');
+  assert.equal(result.costCents, null);
+});
+
+test('failed routed generation emits a redacted error outcome', async () => {
+  const events = [];
+  await assert.rejects(
+    executeRoutedGeneration({ type: 'review' }, { userPrompt: 'private' }, {
+      adapters: {
+        openai: async () => {
+          throw new Error('request failed with sk-testsecretvalue1234567890');
+        },
+      },
+      telemetrySink: (event) => events.push(event),
+    }),
+    /request failed/,
+  );
+  assert.equal(events[0].outcome, 'error');
+  assert.equal(events[0].error.includes('sk-testsecretvalue'), false);
+  assert.match(events[0].error, /REDACTED/);
+});
+
+test('routing holdout reports quality regret and cost against a fixed baseline', async () => {
+  const cases = [
+    { id: 'simple', expected: 'safe', task: { type: 'classification' } },
+    { id: 'complex', expected: 'correct', task: { type: 'architecture' } },
+  ];
+  const report = await evaluateRoutingHoldout(cases, {
+    routedGenerate: async (testCase) => ({
+      text: testCase.expected,
+      model: testCase.id === 'simple' ? 'nano' : 'frontier',
+      route: { tier: testCase.task.type === 'classification' ? 'nano' : 'frontier' },
+      costCents: testCase.id === 'simple' ? 0.1 : 0.8,
+      telemetry: { latencyMs: 10 },
+    }),
+    fixedGenerate: async (testCase) => ({
+      text: testCase.expected,
+      model: 'fixed-frontier',
+      costCents: 1,
+      telemetry: { latencyMs: 25 },
+    }),
+    scoreOutput: (output, testCase) => output.text === testCase.expected ? 1 : 0,
+    maxQualityRegret: 0,
+  });
+
+  assert.equal(report.caseCount, 2);
+  assert.equal(report.judgeStage, 'external-scorer');
+  assert.equal(report.metrics.averageQualityRegret, 0);
+  assert.equal(report.metrics.worstCaseQualityRegret, 0);
+  assert.equal(report.metrics.routedCostCents, 0.45);
+  assert.equal(report.metrics.fixedCostCents, 1);
+  assert.equal(report.metrics.costSavingsCents, 0.55);
+  assert.deepEqual(report.metrics.costCoverage, { measuredCases: 2, totalCases: 2 });
+  assert.equal(report.passed, true);
+});
+
+test('routing holdout refuses to self-judge without an external scorer', async () => {
+  await assert.rejects(
+    evaluateRoutingHoldout([{ id: 'one' }], { fixedGenerate: async () => ({ text: 'x' }) }),
+    /scoreOutput is required/,
+  );
+});
+
+test('routing holdout fails on one regressed case even when averages cancel out', async () => {
+  const cases = [{ id: 'regression' }, { id: 'improvement' }];
+  const routedScores = { regression: 0, improvement: 1 };
+  const fixedScores = { regression: 1, improvement: 0 };
+  const report = await evaluateRoutingHoldout(cases, {
+    routedGenerate: async (testCase) => ({ text: String(routedScores[testCase.id]) }),
+    fixedGenerate: async (testCase) => ({ text: String(fixedScores[testCase.id]) }),
+    scoreOutput: (output) => Number(output.text),
+    maxQualityRegret: 0,
+  });
+
+  assert.equal(report.metrics.averageQualityRegret, 0);
+  assert.equal(report.metrics.worstCaseQualityRegret, 1);
+  assert.equal(report.passed, false);
 });


### PR DESCRIPTION
## Outcome\nTurns the existing model-tier recommendation into an executable, measurable risk-aware generation router without mislabeling it as neural Mixture of Experts.\n\n## What changed\n- dispatches selected tiers through explicit provider adapters\n- supports OpenAI-compatible and local endpoints with dependency-injected transport\n- emits prompt-free JSONL telemetry for model, tier, latency, tokens, verified cost, and outcome\n- adds an external-scorer holdout that compares routed execution with a fixed-model baseline\n- fails on per-case quality regret rather than allowing averages to hide regressions\n- removes misleading “expert” terminology from inference economics\n- documents that this is application-level whole-request routing, not token-level neural MoE\n\n## Verification\n- ✔ workspace routines encode approval, evidence, and connector limits (15.378583ms)
✔ data table agent schema planner creates governed rows and QA reports (14.990958ms)
✔ CRE prompt programs require context role expectations and paste-ready outputs (0.396125ms)
✔ Task Context Result queries flag expensive vague dispatches (0.206916ms)
✔ artifact agent plans isolate tasks into forked review lanes (0.186209ms)
✔ MCP transport strategy pilots gRPC only for hot path or existing gRPC services (0.283667ms)
✔ code mode MCP collapses large API surfaces into search and execute with sandbox gates (3.438292ms)
✔ agent audit traces capture prompt, data, tools, cost, and decision path (0.309584ms)
✔ knowledge layer plan makes recommendations explainable and reusable (0.455ms)
✔ hybrid supervisor decomposes structured plus unstructured questions into native source calls (1.027292ms)
✔ memory store governance blocks secrets and requires redaction for sensitive context (1.587833ms)
✔ scaling claim evaluator separates pretraining from feedback-policy claims (1.861375ms)
✔ creator growth campaign packages webinar, paywall, and posts (0.290167ms)
✔ marketing-agent campaign registry pins seven live tracked buyer paths (9.181ms)
✔ marketing-agent buyer-path probe is side-effect free and requires canonical attribution (0.441ms)
✔ marketing-agent buyer-path probe rejects a matching checkout path on another origin (0.252459ms)
✔ publication probe retries with a bounded GET before treating a HEAD-only 404 as missing (0.6655ms)
✔ publication probe treats an unverified redirect as partial (0.066583ms)
✔ marketing-agent outcome summary combines campaign aliases but keeps channel truth separate (0.16725ms)
✔ marketing-agent report separates verified routes from hosted and provider outcome proof (0.471917ms)
✔ marketing-agent report status and CLI formatter preserve proof boundaries (0.093375ms)
✔ AI org governance plans persistent agent teams with budget and approval gates (0.2875ms)
✔ agent memory lifecycle policy gates promotion by type, source, outcome, and privacy (1.583667ms)
✔ agent memory lifecycle classifies scoped sticky memories and entity-linked recall (4.245459ms)
✔ agent memory lifecycle marks old low-risk lessons for consolidation instead of prompt bloat (0.438083ms)
✔ model access eligibility blocks platform setup claims before gated approval (0.231667ms)
✔ model migration readiness requires proof suites before routing high-risk GPT-5.5 work (0.1655ms)
✔ AI search distribution plan turns claims into citeable entity fragments (1.386584ms)
✔ agent readiness plan maps public promotion into discoverable agent standards (0.529208ms)
✔ production agent readiness requires decomposition, schemas, RAG, traces, and circuit breakers (0.34225ms)
✔ inference economics planner scales reasoning depth by difficulty and budget (0.288ms)
✔ inference cache policy prioritizes stable prefixes before semantic cache overhead (0.153375ms)
✔ depth-wise KV cache sharing requires training-adapted model before rollout (0.1135ms)
✔ post-training governance requires dataset, checkpoint, redaction, evals, reward spec, and spend cap (0.067458ms)
✔ experience replay governance reuses feedback trajectories only when fresh enough and evidenced (0.103333ms)
✔ student-consistent training prevents teacher synthetic data from drifting off policy (0.185417ms)
✔ synthetic data provenance blocks subliminal-learning-sensitive promotion without behavioral probes (0.809834ms)
✔ Agents SDK sandbox plan enforces manifest boundaries and durable state (0.481334ms)
✔ enterprise agent rollout encodes FDE, human oversight, sovereign option, and measurable outcomes (2.322958ms)
✔ document workflow governance requires zero-trust scopes, sandbox manifest, and audit event ids (2.458125ms)
✔ OpenTelemetry declarative config centralizes traces metrics and logs with redaction policy (0.2485ms)
✔ granular verifier scoring requires multiple criteria, repeats, and calibration (0.255583ms)
✔ token TCO evaluates cost per useful blocked failure instead of raw GPU price (0.246667ms)
✔ Skill-RAG router skips wasteful retrieval and routes failure states to typed skills (0.498083ms)
✔ classifyTask routes classification → nano (1.889125ms)
✔ classifyTask routes extraction → nano (0.11125ms)
✔ classifyTask routes labeling → nano (0.047375ms)
✔ classifyTask routes summarization → nano (0.049292ms)
✔ classifyTask routes ranking → nano (0.0395ms)
✔ classifyTask routes code-edit → mini (0.034083ms)
✔ classifyTask routes test-generation → mini (0.039375ms)
✔ classifyTask routes review → mini (0.032209ms)
✔ classifyTask routes architecture → frontier (0.044625ms)
✔ classifyTask routes cross-file → frontier (0.069417ms)
✔ classifyTask escalates to frontier when context > 200k (0.081084ms)
✔ classifyTask escalates high risk + 2 retries to frontier (0.051583ms)
✔ classifyTask escalates architecture tag to frontier (0.039708ms)
✔ classifyTask does NOT escalate high risk with only 1 retry (0.027625ms)
✔ classifyTask defaults unknown type to mini (0.026375ms)
✔ FrontierBudget.canSpend returns true when under cap (0.064166ms)
✔ FrontierBudget.canSpend returns false when over cap (0.030459ms)
✔ FrontierBudget.canSpend rejects missing reason when requireReason=true (0.023209ms)
✔ FrontierBudget.spend deducts correctly and logs reason (8.326541ms)
✔ FrontierBudget.spend refuses when over budget (0.078375ms)
✔ FrontierBudget.spend tracks multiple invocations (0.059333ms)
✔ FrontierBudget.status returns correct remaining (0.035833ms)
✔ FrontierBudget.reset clears spent (0.036208ms)
✔ shouldEscalate returns escalation for two consecutive mini failures (0.089458ms)
✔ shouldEscalate returns no escalation for single failure (0.02875ms)
✔ shouldEscalate returns no escalation when last attempt succeeded (0.023583ms)
✔ shouldEscalate detects context-based escalation (0.026625ms)
✔ TIERS constants match config/model-tiers.json (0.029542ms)
✔ config version is 1 (0.019458ms)
✔ frontier tier is pinned to GPT-5.5 while cheaper tiers stay explicit (0.021125ms)
✔ config escalation threshold matches TIERS.mini.maxContext (0.017542ms)
✔ recommendExecutionPlan combines tier escalation with IndexCache-aware backend recommendation (0.3245ms)
✔ TIERS includes localFrontier with zero cost multiplier (0.02325ms)
✔ recommendExecutionPlan routes frontier tasks to localFrontier when local GLM is active (0.04175ms)
✔ recommendExecutionPlan does NOT use localFrontier for non-frontier tasks with GLM (0.041125ms)
✔ recommendExecutionPlan keeps frontier tier when no local GLM backend (0.030959ms)
✔ execution plan calls the architecture risk-aware routing, not MoE (0.026083ms)
✔ executeRoutedGeneration dispatches the selected adapter and emits prompt-free telemetry (0.218208ms)
✔ OpenAI-compatible adapter uses the selected model and standard endpoint contract (0.139625ms)
✔ failed routed generation emits a redacted error outcome (3.815416ms)
✔ routing holdout reports quality regret and cost against a fixed baseline (0.551167ms)
✔ routing holdout refuses to self-judge without an external scorer (0.063375ms)
✔ routing holdout fails on one regressed case even when averages cancel out (0.34925ms)
ℹ tests 87
ℹ suites 0
ℹ pass 87
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 338.745375\n- 87 passed, 0 failed\n- [
  {
    "id": "thumbgate@1.30.0",
    "name": "thumbgate",
    "version": "1.30.0",
    "size": 2371896,
    "unpackedSize": 6668915,
    "shasum": "fbe64b6568c25b62a3f767051b34410a60ca9dfa",
    "integrity": "sha512-XhOoO9sjKAP1k0em69oou/F1R2XL66tNIe+jAzSvXp+nFCg5OuencrqZoW8Xb/C5QHvnjkDmPG1mzCa/LFZbeg==",
    "filename": "thumbgate-1.30.0.tgz",
    "files": [
      {
        "path": ".claude-plugin/plugin.json",
        "size": 1086,
        "mode": 420
      },
      {
        "path": ".claude/commands/dashboard.md",
        "size": 561,
        "mode": 420
      },
      {
        "path": ".claude/commands/thumbgate-blocked.md",
        "size": 1404,
        "mode": 420
      },
      {
        "path": ".claude/commands/thumbgate-dashboard.md",
        "size": 1059,
        "mode": 420
      },
      {
        "path": ".claude/commands/thumbgate-doctor.md",
        "size": 1415,
        "mode": 420
      },
      {
        "path": ".claude/commands/thumbgate-guard.md",
        "size": 2016,
        "mode": 420
      },
      {
        "path": ".claude/commands/thumbgate-protect.md",
        "size": 1746,
        "mode": 420
      },
      {
        "path": ".claude/commands/thumbgate-rules.md",
        "size": 1363,
        "mode": 420
      },
      {
        "path": ".well-known/agentic-verify.txt",
        "size": 65,
        "mode": 420
      },
      {
        "path": ".well-known/llms.txt",
        "size": 5152,
        "mode": 420
      },
      {
        "path": ".well-known/mcp/server-card.json",
        "size": 706,
        "mode": 420
      },
      {
        "path": "LICENSE",
        "size": 1072,
        "mode": 420
      },
      {
        "path": "README.md",
        "size": 55289,
        "mode": 420
      },
      {
        "path": "adapters/amp/skills/thumbgate-feedback/SKILL.md",
        "size": 569,
        "mode": 420
      },
      {
        "path": "adapters/claude/.mcp.json",
        "size": 306,
        "mode": 420
      },
      {
        "path": "adapters/codex/config.toml",
        "size": 993,
        "mode": 420
      },
      {
        "path": "adapters/forge/forge.yaml",
        "size": 814,
        "mode": 420
      },
      {
        "path": "adapters/gcp/dfcx-webhook-gate.js",
        "size": 12014,
        "mode": 420
      },
      {
        "path": "adapters/gemini/function-declarations.json",
        "size": 7937,
        "mode": 420
      },
      {
        "path": "adapters/letta/README.md",
        "size": 1747,
        "mode": 420
      },
      {
        "path": "adapters/letta/thumbgate-letta-adapter.js",
        "size": 4128,
        "mode": 420
      },
      {
        "path": "adapters/mcp/server-stdio.js",
        "size": 70335,
        "mode": 420
      },
      {
        "path": "adapters/opencode/opencode.json",
        "size": 283,
        "mode": 420
      },
      {
        "path": "adapters/policy-engine/ethicore-guardian-client.js",
        "size": 1802,
        "mode": 420
      },
      {
        "path": "adapters/policy-engine/thumbgate-policy-engine-adapter.js",
        "size": 7397,
        "mode": 420
      },
      {
        "path": "bench/observability-eval-suite.json",
        "size": 1174,
        "mode": 420
      },
      {
        "path": "bench/programbench-smoke.json",
        "size": 2849,
        "mode": 420
      },
      {
        "path": "bench/prompt-eval-suite.json",
        "size": 3700,
        "mode": 420
      },
      {
        "path": "bench/thumbgate-bench.json",
        "size": 3920,
        "mode": 420
      },
      {
        "path": "bin/cli.js",
        "size": 173334,
        "mode": 493
      },
      {
        "path": "bin/dashboard-cli.js",
        "size": 171,
        "mode": 493
      },
      {
        "path": "bin/postinstall.js",
        "size": 1833,
        "mode": 493
      },
      {
        "path": "commands/dashboard.md",
        "size": 590,
        "mode": 420
      },
      {
        "path": "commands/thumbgate-dashboard.md",
        "size": 1059,
        "mode": 420
      },
      {
        "path": "config/agent-outcome-monitor-thresholds.json",
        "size": 1191,
        "mode": 420
      },
      {
        "path": "config/budget.json",
        "size": 317,
        "mode": 420
      },
      {
        "path": "config/build-metadata.json",
        "size": 46,
        "mode": 420
      },
      {
        "path": "config/e2e-critical-flows.json",
        "size": 1729,
        "mode": 420
      },
      {
        "path": "config/enforcement.json",
        "size": 2456,
        "mode": 420
      },
      {
        "path": "config/entitlement-public-keys.json",
        "size": 198,
        "mode": 420
      },
      {
        "path": "config/evals/agent-outcomes-baseline.json",
        "size": 712,
        "mode": 420
      },
      {
        "path": "config/evals/agent-outcomes-golden.json",
        "size": 10703,
        "mode": 420
      },
      {
        "path": "config/evals/agent-safety-eval.json",
        "size": 16921,
        "mode": 420
      },
      {
        "path": "config/evals/prompt-eval-baseline.json",
        "size": 1171,
        "mode": 420
      },
      {
        "path": "config/evals/retrieval-hybrid-ablation.json",
        "size": 2066,
        "mode": 420
      },
      {
        "path": "config/evals/retrieval-ranking-golden.json",
        "size": 7829,
        "mode": 420
      },
      {
        "path": "config/gate-classifier-routing.json",
        "size": 3073,
        "mode": 420
      },
      {
        "path": "config/gate-templates.json",
        "size": 41009,
        "mode": 420
      },
      {
        "path": "config/gates/claim-verification.json",
        "size": 2676,
        "mode": 420
      },
      {
        "path": "config/gates/code-edit.json",
        "size": 2374,
        "mode": 420
      },
      {
        "path": "config/gates/computer-use.json",
        "size": 1620,
        "mode": 420
      },
      {
        "path": "config/gates/db-write.json",
        "size": 2350,
        "mode": 420
      },
      {
        "path": "config/gates/default.json",
        "size": 19135,
        "mode": 420
      },
      {
        "path": "config/gates/deploy.json",
        "size": 2477,
        "mode": 420
      },
      {
        "path": "config/gates/routine.json",
        "size": 1824,
        "mode": 420
      },
      {
        "path": "config/github-about.json",
        "size": 887,
        "mode": 420
      },
      {
        "path": "config/mcp-allowlists.json",
        "size": 7710,
        "mode": 420
      },
      {
        "path": "config/merge-quality-checks.json",
        "size": 472,
        "mode": 420
      },
      {
        "path": "config/model-candidates.json",
        "size": 15896,
        "mode": 420
      },
      {
        "path": "config/model-tiers.json",
        "size": 1587,
        "mode": 420
      },
      {
        "path": "config/partner-routing.json",
        "size": 3909,
        "mode": 420
      },
      {
        "path": "config/policy-bundles/constrained-v1.json",
        "size": 1659,
        "mode": 420
      },
      {
        "path": "config/policy-bundles/default-v1.json",
        "size": 2277,
        "mode": 420
      },
      {
        "path": "config/post-deploy-marketing-pages.json",
        "size": 3843,
        "mode": 420
      },
      {
        "path": "config/pro/constraints-pro.json",
        "size": 2431,
        "mode": 420
      },
      {
        "path": "config/pro/prevention-rules-pro.md",
        "size": 1278,
        "mode": 420
      },
      {
        "path": "config/pro/reminders-pro.json",
        "size": 1098,
        "mode": 420
      },
      {
        "path": "config/pro/thompson-presets.json",
        "size": 1030,
        "mode": 420
      },
      {
        "path": "config/rubrics/default-v1.json",
        "size": 1140,
        "mode": 420
      },
      {
        "path": "config/schemas/task-outcome-receipt.schema.json",
        "size": 6082,
        "mode": 420
      },
      {
        "path": "config/skill-packs/react-testing.json",
        "size": 485,
        "mode": 420
      },
      {
        "path": "config/skill-packs/stripe-integration/references/api-spec.json",
        "size": 17,
        "mode": 420
      },
      {
        "path": "config/skill-packs/stripe-integration/references/webhook-guide.md",
        "size": 42,
        "mode": 420
      },
      {
        "path": "config/skill-specs/pr-reviewer.json",
        "size": 382,
        "mode": 420
      },
      {
        "path": "config/skill-specs/release-status.json",
        "size": 291,
        "mode": 420
      },
      {
        "path": "config/skill-specs/ticket-triage.json",
        "size": 335,
        "mode": 420
      },
      {
        "path": "config/specs/agent-safety.json",
        "size": 2582,
        "mode": 420
      },
      {
        "path": "config/subagent-profiles.json",
        "size": 845,
        "mode": 420
      },
      {
        "path": "config/tessl-tiles.json",
        "size": 773,
        "mode": 420
      },
      {
        "path": "config/thumbgate-settings.managed.json",
        "size": 200,
        "mode": 420
      },
      {
        "path": "docs/integrations/grafana/README.md",
        "size": 7550,
        "mode": 420
      },
      {
        "path": "docs/integrations/grafana/thumbgate-revenue-evidence-dashboard.json",
        "size": 45357,
        "mode": 420
      },
      {
        "path": "glama.json",
        "size": 105,
        "mode": 420
      },
      {
        "path": "hooks/hooks.json",
        "size": 767,
        "mode": 420
      },
      {
        "path": "openapi/openapi.yaml",
        "size": 60281,
        "mode": 420
      },
      {
        "path": "package.json",
        "size": 75961,
        "mode": 420
      },
      {
        "path": "public/about.html",
        "size": 7130,
        "mode": 420
      },
      {
        "path": "public/agent-manager.html",
        "size": 13115,
        "mode": 420
      },
      {
        "path": "public/agents-cost-savings.html",
        "size": 12997,
        "mode": 420
      },
      {
        "path": "public/ai-malpractice-prevention.html",
        "size": 51797,
        "mode": 420
      },
      {
        "path": "public/architecture.html",
        "size": 7281,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-icon-512.png",
        "size": 24887,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-icon-pro-512.png",
        "size": 26585,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-icon-team-512.png",
        "size": 26359,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-logo-1200x360.png",
        "size": 32033,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-logo-transparent.svg",
        "size": 1970,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-mark-inline-v3.svg",
        "size": 1492,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-mark-pro.svg",
        "size": 1684,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-mark-team.svg",
        "size": 1832,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-mark.svg",
        "size": 1421,
        "mode": 420
      },
      {
        "path": "public/assets/brand/thumbgate-wordmark.svg",
        "size": 1594,
        "mode": 420
      },
      {
        "path": "public/assets/claude-thumbgate-statusbar.svg",
        "size": 978,
        "mode": 420
      },
      {
        "path": "public/assets/codex-thumbgate-statusbar-test.svg",
        "size": 1308,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/agent-integration.png",
        "size": 344837,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/before-after.svg",
        "size": 1921,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/decision.svg",
        "size": 3142,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/feedback-pipeline.png",
        "size": 194669,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/hero-thumbs.svg",
        "size": 5203,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/loop.svg",
        "size": 3584,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/plugin-topology.png",
        "size": 67384,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/pre-action-gate-loop.svg",
        "size": 5538,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/self-improving-thumbs-loop.svg",
        "size": 8096,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/stack.svg",
        "size": 1539,
        "mode": 420
      },
      {
        "path": "public/assets/diagrams/thumbgate-architecture.png",
        "size": 332710,
        "mode": 420
      },
      {
        "path": "public/assets/legal-intake-control-flow.svg",
        "size": 5050,
        "mode": 420
      },
      {
        "path": "public/blog.html",
        "size": 15906,
        "mode": 420
      },
      {
        "path": "public/blog/inside-your-boundary.html",
        "size": 7158,
        "mode": 420
      },
      {
        "path": "public/blog/process-over-outcome-gates.html",
        "size": 7519,
        "mode": 420
      },
      {
        "path": "public/brand/thumbgate-mark.svg",
        "size": 1010,
        "mode": 420
      },
      {
        "path": "public/brand/thumbgate-og.svg",
        "size": 1066,
        "mode": 420
      },
      {
        "path": "public/case-studies.html",
        "size": 9355,
        "mode": 420
      },
      {
        "path": "public/chatgpt-app.html",
        "size": 15903,
        "mode": 420
      },
      {
        "path": "public/codex-enterprise.html",
        "size": 10081,
        "mode": 420
      },
      {
        "path": "public/codex-plugin.html",
        "size": 19626,
        "mode": 420
      },
      {
        "path": "public/compare.html",
        "size": 22073,
        "mode": 420
      },
      {
        "path": "public/dashboard.html",
        "size": 157934,
        "mode": 420
      },
      {
        "path": "public/diagnostic.html",
        "size": 16422,
        "mode": 420
      },
      {
        "path": "public/eval-scorecard.html",
        "size": 9646,
        "mode": 420
      },
      {
        "path": "public/eval-scorecard.json",
        "size": 432,
        "mode": 420
      },
      {
        "path": "public/evaluations.html",
        "size": 13640,
        "mode": 420
      },
      {
        "path": "public/federal.html",
        "size": 23524,
        "mode": 420
      },
      {
        "path": "public/guide.html",
        "size": 22353,
        "mode": 420
      },
      {
        "path": "public/index.html",
        "size": 62784,
        "mode": 420
      },
      {
        "path": "public/install.html",
        "size": 13553,
        "mode": 420
      },
      {
        "path": "public/js/buyer-intent.js",
        "size": 25845,
        "mode": 420
      },
      {
        "path": "public/learn.html",
        "size": 27440,
        "mode": 420
      },
      {
        "path": "public/lessons.html",
        "size": 64084,
        "mode": 420
      },
      {
        "path": "public/numbers.html",
        "size": 12389,
        "mode": 420
      },
      {
        "path": "public/partner-intake.html",
        "size": 7374,
        "mode": 420
      },
      {
        "path": "public/pricing.html",
        "size": 19071,
        "mode": 420
      },
      {
        "path": "public/pro.html",
        "size": 39054,
        "mode": 420
      },
      {
        "path": "public/whitepaper.html",
        "size": 10768,
        "mode": 420
      },
      {
        "path": "scripts/access-anomaly-detector.js",
        "size": 3630,
        "mode": 420
      },
      {
        "path": "scripts/action-receipts.js",
        "size": 10490,
        "mode": 420
      },
      {
        "path": "scripts/activation-quickstart.js",
        "size": 7463,
        "mode": 420
      },
      {
        "path": "scripts/activation-tracker.js",
        "size": 4273,
        "mode": 420
      },
      {
        "path": "scripts/agent-audit-trace.js",
        "size": 2215,
        "mode": 420
      },
      {
        "path": "scripts/agent-design-governance.js",
        "size": 8848,
        "mode": 420
      },
      {
        "path": "scripts/agent-memory-lifecycle.js",
        "size": 10167,
        "mode": 420
      },
      {
        "path": "scripts/agent-operations-planner.js",
        "size": 33806,
        "mode": 420
      },
      {
        "path": "scripts/agent-outcome-eval.js",
        "size": 4903,
        "mode": 420
      },
      {
        "path": "scripts/agent-outcome-monitor.js",
        "size": 11035,
        "mode": 420
      },
      {
        "path": "scripts/agent-readiness-plan.js",
        "size": 3595,
        "mode": 420
      },
      {
        "path": "scripts/agent-readiness.js",
        "size": 7685,
        "mode": 420
      },
      {
        "path": "scripts/agent-reasoning-traces.js",
        "size": 26206,
        "mode": 420
      },
      {
        "path": "scripts/agent-reward-model.js",
        "size": 18261,
        "mode": 420
      },
      {
        "path": "scripts/agent-stack-survival-audit.js",
        "size": 7306,
        "mode": 420
      },
      {
        "path": "scripts/agentic-data-pipeline.js",
        "size": 29066,
        "mode": 420
      },
      {
        "path": "scripts/ai-component-inventory.js",
        "size": 13030,
        "mode": 420
      },
      {
        "path": "scripts/ai-engineering-stack-guardrails.js",
        "size": 10444,
        "mode": 420
      },
      {
        "path": "scripts/ai-search-distribution.js",
        "size": 1417,
        "mode": 420
      },
      {
        "path": "scripts/analytics-window.js",
        "size": 4258,
        "mode": 420
      },
      {
        "path": "scripts/async-eval-observability.js",
        "size": 8029,
        "mode": 420
      },
      {
        "path": "scripts/async-job-runner.js",
        "size": 37375,
        "mode": 420
      },
      {
        "path": "scripts/audit-trail.js",
        "size": 15997,
        "mode": 420
      },
      {
        "path": "scripts/audit.js",
        "size": 1614,
        "mode": 420
      },
      {
        "path": "scripts/auto-promote-gates.js",
        "size": 19590,
        "mode": 420
      },
      {
        "path": "scripts/auto-wire-hooks.js",
        "size": 26781,
        "mode": 420
      },
      {
        "path": "scripts/autoresearch-runner.js",
        "size": 8833,
        "mode": 420
      },
      {
        "path": "scripts/aws-blocks-guardrails.js",
        "size": 10925,
        "mode": 420
      },
      {
        "path": "scripts/background-agent-governance.js",
        "size": 9489,
        "mode": 420
      },
      {
        "path": "scripts/bayes-optimal-gate.js",
        "size": 9947,
        "mode": 420
      },
      {
        "path": "scripts/belief-update.js",
        "size": 2616,
        "mode": 420
      },
      {
        "path": "scripts/billing.js",
        "size": 159228,
        "mode": 493
      },
      {
        "path": "scripts/bot-detection.js",
        "size": 6687,
        "mode": 420
      },
      {
        "path": "scripts/build-metadata.js",
        "size": 5128,
        "mode": 420
      },
      {
        "path": "scripts/buyer-paths.js",
        "size": 2682,
        "mode": 420
      },
      {
        "path": "scripts/chatgpt-ads-readiness-pack.js",
        "size": 7982,
        "mode": 420
      },
      {
        "path": "scripts/checkout-attribution-reference.js",
        "size": 3514,
        "mode": 420
      },
      {
        "path": "scripts/classifier-routing.js",
        "size": 5942,
        "mode": 420
      },
      {
        "path": "scripts/claude-feedback-sync.js",
        "size": 10581,
        "mode": 420
      },
      {
        "path": "scripts/cli-demo.js",
        "size": 4281,
        "mode": 420
      },
      {
        "path": "scripts/cli-feedback.js",
        "size": 7392,
        "mode": 420
      },
      {
        "path": "scripts/cli-schema.js",
        "size": 38236,
        "mode": 420
      },
      {
        "path": "scripts/cli-status.js",
        "size": 5541,
        "mode": 420
      },
      {
        "path": "scripts/cli-telemetry.js",
        "size": 3262,
        "mode": 420
      },
      {
        "path": "scripts/cloudflare-dynamic-sandbox.js",
        "size": 9718,
        "mode": 420
      },
      {
        "path": "scripts/code-graph-guardrails.js",
        "size": 6210,
        "mode": 420
      },
      {
        "path": "scripts/code-mode-mcp-plan.js",
        "size": 2594,
        "mode": 420
      },
      {
        "path": "scripts/code-reasoning.js",
        "size": 12815,
        "mode": 420
      },
      {
        "path": "scripts/codegraph-context.js",
        "size": 12732,
        "mode": 420
      },
      {
        "path": "scripts/codex-self-heal.js",
        "size": 1240,
        "mode": 420
      },
      {
        "path": "scripts/commercial-offer.js",
        "size": 5124,
        "mode": 420
      },
      {
        "path": "scripts/context-engine.js",
        "size": 22841,
        "mode": 420
      },
      {
        "path": "scripts/context-footprint.js",
        "size": 6628,
        "mode": 420
      },
      {
        "path": "scripts/context-manager.js",
        "size": 12748,
        "mode": 420
      },
      {
        "path": "scripts/contextfs.js",
        "size": 44230,
        "mode": 420
      },
      {
        "path": "scripts/conversation-context.js",
        "size": 3266,
        "mode": 420
      },
      {
        "path": "scripts/cross-encoder-reranker.js",
        "size": 8559,
        "mode": 420
      },
      {
        "path": "scripts/dashboard-chat.js",
        "size": 15461,
        "mode": 420
      },
      {
        "path": "scripts/dashboard-render-spec.js",
        "size": 13830,
        "mode": 420
      },
      {
        "path": "scripts/dashboard.js",
        "size": 86310,
        "mode": 420
      },
      {
        "path": "scripts/decision-journal.js",
        "size": 13352,
        "mode": 420
      },
      {
        "path": "scripts/deepseek-v4-runtime-guardrails.js",
        "size": 11452,
        "mode": 420
      },
      {
        "path": "scripts/docker-sandbox-planner.js",
        "size": 6843,
        "mode": 420
      },
      {
        "path": "scripts/document-intake.js",
        "size": 33026,
        "mode": 420
      },
      {
        "path": "scripts/document-workflow-governance.js",
        "size": 2110,
        "mode": 420
      },
      {
        "path": "scripts/durability/step.js",
        "size": 8408,
        "mode": 420
      },
      {
        "path": "scripts/entitlement.js",
        "size": 9663,
        "mode": 420
      },
      {
        "path": "scripts/evolution-state.js",
        "size": 6369,
        "mode": 420
      },
      {
        "path": "scripts/experiment-tracker.js",
        "size": 8715,
        "mode": 420
      },
      {
        "path": "scripts/explore-subcommands.js",
        "size": 8754,
        "mode": 420
      },
      {
        "path": "scripts/explore.js",
        "size": 17412,
        "mode": 420
      },
      {
        "path": "scripts/export-databricks-bundle.js",
        "size": 7743,
        "mode": 420
      },
      {
        "path": "scripts/export-dpo-pairs.js",
        "size": 11066,
        "mode": 420
      },
      {
        "path": "scripts/export-hf-dataset.js",
        "size": 10267,
        "mode": 420
      },
      {
        "path": "scripts/external-customer-audit.js",
        "size": 35989,
        "mode": 420
      },
      {
        "path": "scripts/failure-diagnostics.js",
        "size": 16320,
        "mode": 420
      },
      {
        "path": "scripts/feedback_quality_eval.py",
        "size": 26751,
        "mode": 420
      },
      {
        "path": "scripts/feedback-aggregate.js",
        "size": 9259,
        "mode": 420
      },
      {
        "path": "scripts/feedback-attribution.js",
        "size": 10340,
        "mode": 420
      },
      {
        "path": "scripts/feedback-history-distiller.js",
        "size": 12189,
        "mode": 420
      },
      {
        "path": "scripts/feedback-loop.js",
        "size": 98419,
        "mode": 420
      },
      {
        "path": "scripts/feedback-paths.js",
        "size": 8648,
        "mode": 420
      },
      {
        "path": "scripts/feedback-quality.js",
        "size": 6244,
        "mode": 420
      },
      {
        "path": "scripts/feedback-sanitizer.js",
        "size": 8512,
        "mode": 420
      },
      {
        "path": "scripts/feedback-schema.js",
        "size": 15442,
        "mode": 420
      },
      {
        "path": "scripts/feedback-session.js",
        "size": 10105,
        "mode": 420
      },
      {
        "path": "scripts/feedback-to-rules.js",
        "size": 12842,
        "mode": 420
      },
      {
        "path": "scripts/filesystem-search.js",
        "size": 15466,
        "mode": 420
      },
      {
        "path": "scripts/fs-utils.js",
        "size": 2795,
        "mode": 420
      },
      {
        "path": "scripts/gate-stats.js",
        "size": 9938,
        "mode": 420
      },
      {
        "path": "scripts/gate-templates.js",
        "size": 2022,
        "mode": 420
      },
      {
        "path": "scripts/gates-engine.js",
        "size": 167585,
        "mode": 420
      },
      {
        "path": "scripts/gemini-embedding-policy.js",
        "size": 7516,
        "mode": 420
      },
      {
        "path": "scripts/generate-case-study-outreach.js",
        "size": 7815,
        "mode": 420
      },
      {
        "path": "scripts/generate-eval-scorecard.js",
        "size": 12161,
        "mode": 420
      },
      {
        "path": "scripts/grafana-revenue-evidence.js",
        "size": 36678,
        "mode": 420
      },
      {
        "path": "scripts/growth-campaigns.js",
        "size": 7233,
        "mode": 420
      },
      {
        "path": "scripts/harness-selector.js",
        "size": 18363,
        "mode": 420
      },
      {
        "path": "scripts/harness-tool-names.js",
        "size": 2235,
        "mode": 420
      },
      {
        "path": "scripts/hf-papers.js",
        "size": 8073,
        "mode": 420
      },
      {
        "path": "scripts/hook-runtime.js",
        "size": 3460,
        "mode": 420
      },
      {
        "path": "scripts/hook-stop-anti-claim.js",
        "size": 9841,
        "mode": 420
      },
      {
        "path": "scripts/hook-thumbgate-cache-updater.js",
        "size": 3750,
        "mode": 420
      },
      {
        "path": "scripts/hosted-config.js",
        "size": 5924,
        "mode": 420
      },
      {
        "path": "scripts/human-escalation.js",
        "size": 9638,
        "mode": 420
      },
      {
        "path": "scripts/hybrid-feedback-context.js",
        "size": 32297,
        "mode": 420
      },
      {
        "path": "scripts/hybrid-supervisor-agent.js",
        "size": 2834,
        "mode": 420
      },
      {
        "path": "scripts/imperative-detector.js",
        "size": 3488,
        "mode": 420
      },
      {
        "path": "scripts/inference-cache-policy.js",
        "size": 4238,
        "mode": 420
      },
      {
        "path": "scripts/install-mcp.js",
        "size": 4736,
        "mode": 420
      },
      {
        "path": "scripts/install-shim.js",
        "size": 2793,
        "mode": 420
      },
      {
        "path": "scripts/internal-agent-bootstrap.js",
        "size": 14270,
        "mode": 420
      },
      {
        "path": "scripts/intervention-policy.js",
        "size": 27972,
        "mode": 420
      },
      {
        "path": "scripts/jsonl-watcher.js",
        "size": 5022,
        "mode": 420
      },
      {
        "path": "scripts/jsonl-window.js",
        "size": 2411,
        "mode": 420
      },
      {
        "path": "scripts/judge-reward-function.js",
        "size": 13761,
        "mode": 420
      },
      {
        "path": "scripts/lesson-canonical.js",
        "size": 7335,
        "mode": 420
      },
      {
        "path": "scripts/lesson-db.js",
        "size": 21870,
        "mode": 420
      },
      {
        "path": "scripts/lesson-embedding-index.js",
        "size": 7871,
        "mode": 420
      },
      {
        "path": "scripts/lesson-embedding-maintenance.js",
        "size": 4858,
        "mode": 420
      },
      {
        "path": "scripts/lesson-inference.js",
        "size": 27288,
        "mode": 420
      },
      {
        "path": "scripts/lesson-reranker.js",
        "size": 9898,
        "mode": 420
      },
      {
        "path": "scripts/lesson-retrieval.js",
        "size": 28274,
        "mode": 420
      },
      {
        "path": "scripts/lesson-rotation.js",
        "size": 4109,
        "mode": 420
      },
      {
        "path": "scripts/lesson-search.js",
        "size": 26771,
        "mode": 420
      },
      {
        "path": "scripts/lesson-synthesis.js",
        "size": 7061,
        "mode": 420
      },
      {
        "path": "scripts/license.js",
        "size": 2625,
        "mode": 420
      },
      {
        "path": "scripts/llm-behavior-monitor.js",
        "size": 8998,
        "mode": 420
      },
      {
        "path": "scripts/llm-client.js",
        "size": 11027,
        "mode": 420
      },
      {
        "path": "scripts/local-model-profile.js",
        "size": 13724,
        "mode": 420
      },
      {
        "path": "scripts/long-running-agent-context-guardrails.js",
        "size": 6760,
        "mode": 420
      },
      {
        "path": "scripts/mailer/index.js",
        "size": 285,
        "mode": 420
      },
      {
        "path": "scripts/mailer/resend-mailer.js",
        "size": 27551,
        "mode": 420
      },
      {
        "path": "scripts/mcp-config.js",
        "size": 7494,
        "mode": 420
      },
      {
        "path": "scripts/mcp-oauth.js",
        "size": 12479,
        "mode": 420
      },
      {
        "path": "scripts/mcp-policy.js",
        "size": 3482,
        "mode": 420
      },
      {
        "path": "scripts/mcp-transport-strategy.js",
        "size": 2440,
        "mode": 420
      },
      {
        "path": "scripts/memory-firewall.js",
        "size": 6112,
        "mode": 420
      },
      {
        "path": "scripts/memory-scope-readiness.js",
        "size": 14531,
        "mode": 420
      },
      {
        "path": "scripts/meta-agent-loop.js",
        "size": 24860,
        "mode": 420
      },
      {
        "path": "scripts/model-access-eligibility.js",
        "size": 1257,
        "mode": 420
      },
      {
        "path": "scripts/model-eval.js",
        "size": 13305,
        "mode": 420
      },
      {
        "path": "scripts/model-migration-readiness.js",
        "size": 1954,
        "mode": 420
      },
      {
        "path": "scripts/model-tier-router.js",
        "size": 19742,
        "mode": 420
      },
      {
        "path": "scripts/multimodal-retrieval-plan.js",
        "size": 5492,
        "mode": 420
      },
      {
        "path": "scripts/native-messaging-audit.js",
        "size": 16101,
        "mode": 420
      },
      {
        "path": "scripts/natural-language-harness.js",
        "size": 9180,
        "mode": 420
      },
      {
        "path": "scripts/noop-detect.js",
        "size": 10992,
        "mode": 420
      },
      {
        "path": "scripts/observability-env.js",
        "size": 4776,
        "mode": 420
      },
      {
        "path": "scripts/observability-setup.js",
        "size": 1751,
        "mode": 420
      },
      {
        "path": "scripts/obsidian-export.js",
        "size": 22082,
        "mode": 420
      },
      {
        "path": "scripts/operational-integrity.js",
        "size": 32121,
        "mode": 420
      },
      {
        "path": "scripts/oss-pr-opportunity-scout.js",
        "size": 10756,
        "mode": 420
      },
      {
        "path": "scripts/otel-declarative-config.js",
        "size": 1801,
        "mode": 420
      },
      {
        "path": "scripts/parallel-workflow-orchestrator.js",
        "size": 11146,
        "mode": 420
      },
      {
        "path": "scripts/perplexity-client.js",
        "size": 5905,
        "mode": 420
      },
      {
        "path": "scripts/plan-gate.js",
        "size": 7365,
        "mode": 420
      },
      {
        "path": "scripts/plausible-domain-config.js",
        "size": 3554,
        "mode": 420
      },
      {
        "path": "scripts/plausible-server-events.js",
        "size": 5574,
        "mode": 420
      },
      {
        "path": "scripts/pr-manager.js",
        "size": 13688,
        "mode": 420
      },
      {
        "path": "scripts/pragmatic-hybrid-search.js",
        "size": 12975,
        "mode": 420
      },
      {
        "path": "scripts/private-core-boundary.js",
        "size": 1891,
        "mode": 420
      },
      {
        "path": "scripts/pro-local-dashboard.js",
        "size": 12327,
        "mode": 420
      },
      {
        "path": "scripts/proactive-agent-eval-guardrails.js",
        "size": 9852,
        "mode": 420
      },
      {
        "path": "scripts/problem-detail.js",
        "size": 1885,
        "mode": 420
      },
      {
        "path": "scripts/product-feedback.js",
        "size": 3635,
        "mode": 420
      },
      {
        "path": "scripts/profile-router.js",
        "size": 8492,
        "mode": 420
      },
      {
        "path": "scripts/prompt-eval.js",
        "size": 33392,
        "mode": 420
      },
      {
        "path": "scripts/prompt-guard.js",
        "size": 2227,
        "mode": 420
      },
      {
        "path": "scripts/prompt-programs.js",
        "size": 3439,
        "mode": 420
      },
      {
        "path": "scripts/prompting-operating-system.js",
        "size": 9805,
        "mode": 420
      },
      {
        "path": "scripts/provider-action-normalizer.js",
        "size": 20117,
        "mode": 420
      },
      {
        "path": "scripts/provider-live-evidence.js",
        "size": 59704,
        "mode": 420
      },
      {
        "path": "scripts/provider-payment-reconciler.js",
        "size": 17682,
        "mode": 420
      },
      {
        "path": "scripts/provider-revenue-evidence.js",
        "size": 12580,
        "mode": 420
      },
      {
        "path": "scripts/proxy-pointer-rag-guardrails.js",
        "size": 9118,
        "mode": 420
      },
      {
        "path": "scripts/published-cli.js",
        "size": 2913,
        "mode": 420
      },
      {
        "path": "scripts/qa-scenario-planner.js",
        "size": 6130,
        "mode": 420
      },
      {
        "path": "scripts/rag-document-pipeline.js",
        "size": 16072,
        "mode": 420
      },
      {
        "path": "scripts/rag-precision-guardrails.js",
        "size": 11614,
        "mode": 420
      },
      {
        "path": "scripts/rag-structured-output.js",
        "size": 6811,
        "mode": 420
      },
      {
        "path": "scripts/rate-limiter.js",
        "size": 9093,
        "mode": 420
      },
      {
        "path": "scripts/reasoning-efficiency-guardrails.js",
        "size": 11359,
        "mode": 420
      },
      {
        "path": "scripts/refresh-proof-pack.js",
        "size": 8211,
        "mode": 420
      },
      {
        "path": "scripts/repeat-metric.js",
        "size": 5136,
        "mode": 420
      },
      {
        "path": "scripts/retrieval-hybrid-ablation.js",
        "size": 3961,
        "mode": 420
      },
      {
        "path": "scripts/revenue-action-eligibility.js",
        "size": 15911,
        "mode": 420
      },
      {
        "path": "scripts/revenue-evidence-remediation.js",
        "size": 27267,
        "mode": 420
      },
      {
        "path": "scripts/revenue-offer-system.js",
        "size": 31692,
        "mode": 420
      },
      {
        "path": "scripts/reward-hacking-guardrails.js",
        "size": 11601,
        "mode": 420
      },
      {
        "path": "scripts/risk-scorer.js",
        "size": 22640,
        "mode": 420
      },
      {
        "path": "scripts/rlaif-self-audit.js",
        "size": 4130,
        "mode": 420
      },
      {
        "path": "scripts/rubric-engine.js",
        "size": 7584,
        "mode": 420
      },
      {
        "path": "scripts/rule-validator.js",
        "size": 10555,
        "mode": 420
      },
      {
        "path": "scripts/sales-pipeline.js",
        "size": 39749,
        "mode": 420
      },
      {
        "path": "scripts/schedule-manager.js",
        "size": 8239,
        "mode": 420
      },
      {
        "path": "scripts/secret-fixture-tokens.js",
        "size": 1807,
        "mode": 420
      },
      {
        "path": "scripts/secret-redaction.js",
        "size": 7246,
        "mode": 420
      },
      {
        "path": "scripts/secret-scanner.js",
        "size": 38834,
        "mode": 420
      },
      {
        "path": "scripts/security-scanner.js",
        "size": 25671,
        "mode": 420
      },
      {
        "path": "scripts/self-distill-agent.js",
        "size": 17942,
        "mode": 420
      },
      {
        "path": "scripts/self-harness-optimizer.js",
        "size": 4779,
        "mode": 493
      },
      {
        "path": "scripts/self-heal.js",
        "size": 4460,
        "mode": 420
      },
      {
        "path": "scripts/self-healing-check.js",
        "size": 6847,
        "mode": 420
      },
      {
        "path": "scripts/self-protection.js",
        "size": 3061,
        "mode": 420
      },
      {
        "path": "scripts/semantic-dedup.js",
        "size": 3462,
        "mode": 420
      },
      {
        "path": "scripts/semantic-layer.js",
        "size": 3141,
        "mode": 420
      },
      {
        "path": "scripts/seo-gsd.js",
        "size": 241010,
        "mode": 420
      },
      {
        "path": "scripts/settings-hierarchy.js",
        "size": 5596,
        "mode": 420
      },
      {
        "path": "scripts/silent-failure-cluster.js",
        "size": 19325,
        "mode": 420
      },
      {
        "path": "scripts/single-use-credential-gate.js",
        "size": 6436,
        "mode": 420
      },
      {
        "path": "scripts/skill-generator.js",
        "size": 13397,
        "mode": 420
      },
      {
        "path": "scripts/skill-packs.js",
        "size": 11386,
        "mode": 420
      },
      {
        "path": "scripts/skill-rag-router.js",
        "size": 1839,
        "mode": 420
      },
      {
        "path": "scripts/slo-alert-engine.js",
        "size": 2313,
        "mode": 420
      },
      {
        "path": "scripts/spec-gate.js",
        "size": 11364,
        "mode": 420
      },
      {
        "path": "scripts/statusline-cache-path.js",
        "size": 1424,
        "mode": 420
      },
      {
        "path": "scripts/statusline-cache-read.js",
        "size": 2017,
        "mode": 420
      },
      {
        "path": "scripts/statusline-context.js",
        "size": 5125,
        "mode": 420
      },
      {
        "path": "scripts/statusline-lesson.js",
        "size": 443,
        "mode": 420
      },
      {
        "path": "scripts/statusline-links.js",
        "size": 6789,
        "mode": 420
      },
      {
        "path": "scripts/statusline-local-stats.js",
        "size": 1094,
        "mode": 420
      },
      {
        "path": "scripts/statusline-meta.js",
        "size": 1435,
        "mode": 420
      },
      {
        "path": "scripts/statusline-tower.js",
        "size": 1239,
        "mode": 420
      },
      {
        "path": "scripts/statusline.sh",
        "size": 9792,
        "mode": 493
      },
      {
        "path": "scripts/stripe-credentials.js",
        "size": 1044,
        "mode": 420
      },
      {
        "path": "scripts/stripe-revenue-catalog-audit.js",
        "size": 12732,
        "mode": 420
      },
      {
        "path": "scripts/stripe-revenue-catalog.js",
        "size": 6050,
        "mode": 420
      },
      {
        "path": "scripts/structured-prompt-driven.js",
        "size": 8534,
        "mode": 420
      },
      {
        "path": "scripts/sync-telemetry-from-prod.js",
        "size": 13832,
        "mode": 420
      },
      {
        "path": "scripts/synthetic-data-provenance.js",
        "size": 3473,
        "mode": 420
      },
      {
        "path": "scripts/task-context-result.js",
        "size": 3026,
        "mode": 420
      },
      {
        "path": "scripts/task-outcomes.js",
        "size": 15579,
        "mode": 420
      },
      {
        "path": "scripts/telemetry-analytics.js",
        "size": 57417,
        "mode": 420
      },
      {
        "path": "scripts/thompson-sampling.js",
        "size": 16615,
        "mode": 420
      },
      {
        "path": "scripts/thumbgate-bench.js",
        "size": 26544,
        "mode": 420
      },
      {
        "path": "scripts/thumbgate-search.js",
        "size": 11695,
        "mode": 420
      },
      {
        "path": "scripts/token-savings.js",
        "size": 6011,
        "mode": 420
      },
      {
        "path": "scripts/token-tco.js",
        "size": 1835,
        "mode": 420
      },
      {
        "path": "scripts/tool-contract-validator.js",
        "size": 10870,
        "mode": 420
      },
      {
        "path": "scripts/tool-kpi-tracker.js",
        "size": 3693,
        "mode": 420
      },
      {
        "path": "scripts/tool-registry.js",
        "size": 80483,
        "mode": 420
      },
      {
        "path": "scripts/trajectory-scorer.js",
        "size": 2003,
        "mode": 420
      },
      {
        "path": "scripts/upstream-contribution-engine.js",
        "size": 15016,
        "mode": 420
      },
      {
        "path": "scripts/user-profile.js",
        "size": 3214,
        "mode": 420
      },
      {
        "path": "scripts/validate-workflow-contract.js",
        "size": 8474,
        "mode": 420
      },
      {
        "path": "scripts/vector-store.js",
        "size": 17288,
        "mode": 420
      },
      {
        "path": "scripts/verification-loop.js",
        "size": 9616,
        "mode": 420
      },
      {
        "path": "scripts/verifier-scoring.js",
        "size": 2428,
        "mode": 420
      },
      {
        "path": "scripts/verify-marketing-pages-deployed.js",
        "size": 7929,
        "mode": 420
      },
      {
        "path": "scripts/visitor-journey.js",
        "size": 5704,
        "mode": 420
      },
      {
        "path": "scripts/workflow-intake-queue.js",
        "size": 17993,
        "mode": 420
      },
      {
        "path": "scripts/workflow-runs.js",
        "size": 5152,
        "mode": 420
      },
      {
        "path": "scripts/workflow-sentinel.js",
        "size": 61816,
        "mode": 420
      },
      {
        "path": "scripts/workspace-agent-routines.js",
        "size": 4144,
        "mode": 420
      },
      {
        "path": "scripts/workspace-evolver.js",
        "size": 12654,
        "mode": 420
      },
      {
        "path": "scripts/xmemory-lite.js",
        "size": 12213,
        "mode": 420
      },
      {
        "path": "server.json",
        "size": 1419,
        "mode": 420
      },
      {
        "path": "skills/thumbgate/SKILL.md",
        "size": 3595,
        "mode": 420
      },
      {
        "path": "smithery.yaml",
        "size": 658,
        "mode": 420
      },
      {
        "path": "src/api/server.js",
        "size": 444994,
        "mode": 420
      },
      {
        "path": "src/index.js",
        "size": 69,
        "mode": 420
      }
    ],
    "entryCount": 404,
    "bundled": []
  }
]: 404 files on this head\n- pre-push package, link, and regression guards passed\n\n## Evidence boundary\nThe execution path and holdout harness are tested with deterministic adapters. This PR does not claim a live-provider quality win or a trained neural MoE.