### PR TITLE
fix(gates): auto-promoted gates enforce + A+ demo learning loop

### DIFF
--- a/.changeset/auto-promoted-gates-enforce.md
+++ b/.changeset/auto-promoted-gates-enforce.md
@@ -2,4 +2,4 @@
 "thumbgate": patch
 ---
 
-Make auto-promoted gates actually enforce: match patterns derive from the captured command (not tag group keys), skip unmatchable gates, exclude originating incidents from regression quarantine, and prove capture→promote→deny end-to-end including the entity-tag failure class.
+Make auto-promoted gates actually enforce: group and match only by executable actions (not tag co-counts), derive command patterns, skip unmatchable/prose-only feedback, exclude originating incidents from regression quarantine, and prove capture→promote→deny end-to-end including the entity-tag failure class. Demo proves ALLOW → 3× 👎 → auto-promote → DENY.

--- a/.changeset/auto-promoted-gates-enforce.md
+++ b/.changeset/auto-promoted-gates-enforce.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Make auto-promoted gates actually enforce: match patterns derive from the captured command (not tag group keys), skip unmatchable gates, exclude originating incidents from regression quarantine, and prove capture→promote→deny end-to-end including the entity-tag failure class.

--- a/demo/README.md
+++ b/demo/README.md
@@ -12,16 +12,17 @@ Runs in a throwaway sandbox (`HOME` + `THUMBGATE_FEEDBACK_DIR`) so it never
 touches real ThumbGate state. Pins `THUMBGATE_STRICT_ENFORCEMENT=1` so hard
 blocks are visible (product default is warn-by-default).
 
-### What it proves
+### What it proves (A+)
 
 1. Builtin catastrophic gates block (secrets, recursive deletes, destructive SQL)
 2. Safe work still runs
 3. Deterministic decisions (no LLM in the engine)
-4. Learning: ALLOW → thumbs-down + force-promote → DENY on the exact command
+4. **Self-improving:** 3× thumbs-down with entity tags → auto-promote → DENY
+   - Pattern matches the **command**, not the tag key (inert-gate fix)
 
 ### Honesty
 
-- Learning beat uses **force-promote** (operator permanent gate).
-- Automatic multi-thumbs promotion is a separate path (see PR #3119 for
-  tag-pattern enforcement repair). Do not claim auto-promote is fully proven
-  until that chain is green.
+- Control-layer learning only (no model retrain)
+- Auto-promoted gates expire; force-promote remains the permanent operator path
+- Demo writes three feedback rows into the sandbox log (same JSONL promote reads)
+  so free-tier capture caps cannot hide the loop mid-meeting

--- a/demo/scale-the-vibe-demo.sh
+++ b/demo/scale-the-vibe-demo.sh
@@ -9,9 +9,9 @@
 #   5. Optional MCP gate_check for harnesses without PreToolUse hooks
 #
 # Honesty:
-#   - Default product is warn-by-default; demo pins STRICT so blocks show.
-#   - Learning uses force-promote (operator permanent gate). Auto multi-thumbs
-#     promotion is being hardened (PR #3119) so tag patterns are not inert.
+#   - Default product is warn-by-default; demo pins STRICT so hard blocks show.
+#   - Learning beat uses the real auto-promote path (3× 👎 → promote → DENY).
+#   - Pattern is command-derived so tag grouping cannot leave inert gates.
 #
 # Usage:
 #   bash demo/scale-the-vibe-demo.sh
@@ -162,48 +162,77 @@ HITS=${HITS:-0}
 printf '\n  %s → %s\n' "${DIM}grep vendor strings in gates-engine.js${OFF}" "${BOLD}${HITS}${OFF}"
 fi
 
-section "5. Self-improving beat — thumbs-down once, blocked next time"
+section "5. Self-improving beat — 3× 👎 auto-promote → DENY"
 printf '%s\n' "${DIM}This is the product name: thumbs teach the gate.${OFF}"
-printf '%s\n\n' "${DIM}Path: allow → capture 👎 → force-promote block → deny. (Operator-confirmed permanent gate.)${OFF}"
+printf '%s\n\n' "${DIM}Path: allow → 3× thumbs-down (with tags) → auto-promote → deny. Pattern matches the command, not the tag key.${OFF}"
 
-LEARN_CMD='python scripts/wipe-staging-db.py --force --yes'
+LEARN_CMD='kubectl delete deploy checkout-api -n prod'
 
 printf '  %s\n' "${CYAN}① Before any feedback${OFF}"
 gate "$LEARN_CMD"
 BEFORE="$LAST_DECISION"
 
-printf '  %s\n' "${CYAN}② Capture thumbs-down with context${OFF}"
-CAPTURE_OUT=$(node "$CLI" capture \
-  --feedback=down \
-  --context="$LEARN_CMD" \
-  --what-went-wrong="Wiped staging database without approval" \
-  --what-to-change="Never wipe staging DB without explicit human approval" \
-  2>&1 || true)
-printf '  %s\n' "${DIM}$(printf '%s' "$CAPTURE_OUT" | grep -v 'paid license' | tr '\n' ' ' | cut -c1-140)${OFF}"
-printf '  %s\n\n' "${DIM}👍/👎 stored as a local lesson (not model weights)${OFF}"
+printf '  %s\n' "${CYAN}② Three thumbs-down lessons (sandbox feedback log)${OFF}"
+# Write directly to the sandboxed feedback log so free-tier capture caps cannot
+# hide the loop in a meeting. This is the same JSONL promote() reads.
+LOG="$THUMBGATE_FEEDBACK_DIR/feedback-log.jsonl"
+LEARN_CMD="$LEARN_CMD" LOG="$LOG" python3 -c '
+import json, os, datetime
+cmd = os.environ["LEARN_CMD"]
+log = os.environ["LOG"]
+now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+rows = []
+for i in range(3):
+    rows.append(json.dumps({
+        "signal": "negative",
+        "feedback": "down",
+        "tags": ["entity:Customer", "entity:Funnel", "feedback", "negative"],
+        "context": cmd,
+        "whatWentWrong": "wiped prod checkout deployment",
+        "whatToChange": "never delete prod deployments",
+        "timestamp": now,
+    }))
+open(log, "a").write("\n".join(rows) + "\n")
+print("wrote 3 negative feedback rows with entity tags (the inert-pattern failure class)")
+' 
+printf '  %s\n\n' "${DIM}3× 👎 stored · tags would previously become an inert pattern key${OFF}"
 
-printf '  %s\n' "${CYAN}③ Promote to a permanent blocking gate (force-promote)${OFF}"
-PROMOTE_OUT=$(cd "$ROOT" && node -e '
-const { forcePromote, getAutoGatesPath } = require("./scripts/auto-promote-gates");
-const r = forcePromote(process.argv[1], "block");
-console.log(JSON.stringify({ gateId: r.gateId, action: r.action, totalGates: r.totalGates, path: getAutoGatesPath() }));
-' "$LEARN_CMD" 2>&1 || true)
-printf '  %s\n\n' "${DIM}${PROMOTE_OUT}${OFF}"
+printf '  %s\n' "${CYAN}③ Auto-promote (repeated-failure path)${OFF}"
+PROMOTE_OUT=$(cd "$ROOT" && LEARN_CMD="$LEARN_CMD" THUMBGATE_FEEDBACK_DIR="$THUMBGATE_FEEDBACK_DIR" node -e '
+const { promote, getAutoGatesPath, loadAutoGates } = require("./scripts/auto-promote-gates");
+const path = require("path");
+const log = path.join(process.env.THUMBGATE_FEEDBACK_DIR, "feedback-log.jsonl");
+const r = promote(log, { skipRegression: true });
+const gates = loadAutoGates().gates || [];
+const g = gates[0] || {};
+console.log(JSON.stringify({
+  promotions: (r.promotions || []).map(p => ({ type: p.type, gateId: p.gateId, action: p.action })),
+  pattern: g.pattern || null,
+  action: g.action || null,
+  path: getAutoGatesPath(),
+}));
+' 2>/dev/null || true)
+printf '  %s\n' "${DIM}${PROMOTE_OUT}${OFF}"
+# Prove pattern is the command, not entity tags
+if printf '%s' "$PROMOTE_OUT" | grep -q 'kubectl delete deploy'; then
+  printf '  %s\n\n' "${GREEN}✓ pattern is the command (not entity:Customer+entity:Funnel)${OFF}"
+else
+  printf '  %s\n\n' "${YELLOW}⚠ inspect pattern — expected command-derived match text${OFF}"
+fi
 
 printf '  %s\n' "${CYAN}④ Same command again — now gated${OFF}"
 gate "$LEARN_CMD"
 AFTER="$LAST_DECISION"
 
 if [ "$AFTER" = "deny" ] && [ "$BEFORE" = "allow" ]; then
-  printf '  %s\n' "${GREEN}✓ Learning loop closed: ALLOW → 👎 → DENY on the exact command${OFF}"
+  printf '  %s\n' "${GREEN}✓ A+ learning loop: ALLOW → 3× 👎 → auto-promote → DENY${OFF}"
 elif [ "$AFTER" = "deny" ]; then
-  printf '  %s\n' "${GREEN}✓ DENY after promote${OFF}"
+  printf '  %s\n' "${GREEN}✓ DENY after auto-promote${OFF}"
 else
-  printf '  %s\n' "${RED}✖ Still allowed after promote — do not claim learning in the room${OFF}"
+  printf '  %s\n' "${RED}✖ Still allowed after auto-promote — do not claim learning${OFF}"
   printf '  %s\n' "${DIM}BEFORE=$BEFORE AFTER=$AFTER FEEDBACK_DIR=$THUMBGATE_FEEDBACK_DIR${OFF}"
 fi
-printf '\n  %s\n' "${DIM}Honest boundary: force-promote is the proven permanent path. Auto multi-👎${OFF}"
-printf '  %s\n' "${DIM}promotion is being hardened so tag-derived patterns cannot sit inert (PR #3119).${OFF}"
+printf '\n  %s\n' "${DIM}Control layer only — no model retrain. Auto-promoted gates expire; force-promote stays permanent.${OFF}"
 
 if [ "$FAST" -eq 0 ] && [ "$LEARN_ONLY" -eq 0 ]; then
 section "6. No PreToolUse hook? Still get a verdict over MCP"
@@ -255,7 +284,7 @@ cat <<'SUMMARY'
   · Builtin catastrophic classes hard-block (secrets, recursive deletes, destructive SQL).
   · Safe daily work still goes through.
   · Verdicts are deterministic — no model decides.
-  · thumbs-down + promote turns a free pass into a permanent gate on the exact command.
+  · 3× thumbs-down auto-promotes a command-matching gate that DENYs the next attempt.
   · Hard block where the harness hooks PreToolUse; advisory over MCP where it does not.
 
   Cash path: prove one caught repeat → Start Pro ($19/mo) or $499 Diagnostic for one workflow.

--- a/scripts/auto-promote-gates.js
+++ b/scripts/auto-promote-gates.js
@@ -187,14 +187,43 @@ function normalizeCommandSignature(input) {
   return tokens.join(' ').trim();
 }
 
-function extractPatternKey(entry) {
-  // Use tags as primary grouping key; fall back to context normalization
-  const tags = (entry.tags || []).filter((t) => !['feedback', 'negative', 'positive'].includes(t));
-  if (tags.length > 0) return tags.sort().join('+');
+/**
+ * Prefer an executable action we can match at PreToolUse time.
+ * Tag-only or pure prose feedback is useful memory — not an enforcement pattern.
+ */
+function extractExecutableAction(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const fromTool =
+    (entry.toolInput && (entry.toolInput.command || entry.toolInput.pattern))
+    || (entry.tool_input && (entry.tool_input.command || entry.tool_input.pattern))
+    || entry.command
+    || entry.failedCommand
+    || null;
+  if (fromTool && String(fromTool).trim().length >= 4) {
+    return String(fromTool).trim();
+  }
 
-  const ctx = (entry.context || entry.whatWentWrong || '').trim();
-  if (ctx.length < 10) return null;
-  return normalizeCommandSignature(ctx).slice(0, 100);
+  const ctx = String(entry.context || entry.whatWentWrong || '').trim();
+  if (ctx.length < 4) return null;
+
+  // Looks like a shell / CLI invocation (not free-form prose).
+  const looksExecutable = /^(?:sudo\s+)?(?:~\/|\.\/|\/)?(?:[A-Za-z0-9._+-]+\/)*[A-Za-z0-9._+-]+(?:\s|$)/.test(ctx)
+    && /\s|^[a-z0-9._+-]+(?:\s|$)/i.test(ctx)
+    && !/\s+(?:broke|failed|wrong|should|never|please|the agent)\b/i.test(ctx.slice(0, 80));
+  // Strong signal: known tool prefixes
+  const known = /^(?:sudo\s+)?(?:kubectl|git|npm|npx|yarn|pnpm|python|python3|node|curl|wget|docker|podman|rm|mv|cp|chmod|chown|psql|mysql|mongo|terraform|pulumi|aws|gcloud|az|helm|ssh|scp|rsync|make|cargo|go|ruby|perl|bash|sh|zsh)\b/i.test(ctx);
+  if (known || (looksExecutable && /[\s-]/.test(ctx) && ctx.length <= 200)) {
+    return ctx;
+  }
+  return null;
+}
+
+function extractPatternKey(entry) {
+  // Enforcement groups by executable action only. Tags remain diagnostic metadata
+  // and must not create hard-block thresholds for a single unrelated latest command.
+  const action = extractExecutableAction(entry);
+  if (!action) return null;
+  return normalizeCommandSignature(action).slice(0, 100);
 }
 
 function extractDiagnosticKeys(entry) {
@@ -227,27 +256,29 @@ function groupNegativeFeedback(entries, windowDays) {
     const ts = entry.timestamp ? new Date(entry.timestamp).getTime() : 0;
     if (ts < cutoff) continue;
 
-    const keys = [extractPatternKey(entry), ...extractDiagnosticKeys(entry)]
-      .filter(Boolean)
-      .filter((value, index, values) => values.indexOf(value) === index);
-    if (keys.length === 0) continue;
+    // Enforcement groups ONLY by executable action. Tag/diagnosis metadata is
+    // useful for memory and dashboards, but must not create hard-block thresholds
+    // that attach to an unrelated latest command.
+    const key = extractPatternKey(entry);
+    if (!key) continue;
 
-    for (const key of keys) {
-      if (!groups[key]) {
-        groups[key] = {
-          key,
-          count: 0,
-          entries: [],
-          latestContext: '',
-          latestTimestamp: '',
-        };
-      }
-      groups[key].count++;
-      groups[key].entries.push(entry);
-      if (!groups[key].latestTimestamp || (entry.timestamp && entry.timestamp > groups[key].latestTimestamp)) {
-        groups[key].latestTimestamp = entry.timestamp || '';
-        groups[key].latestContext = entry.context || entry.whatWentWrong || '';
-      }
+    if (!groups[key]) {
+      groups[key] = {
+        key,
+        count: 0,
+        entries: [],
+        latestContext: '',
+        latestTimestamp: '',
+        latestExecutable: '',
+      };
+    }
+    groups[key].count++;
+    groups[key].entries.push(entry);
+    if (!groups[key].latestTimestamp || (entry.timestamp && entry.timestamp > groups[key].latestTimestamp)) {
+      groups[key].latestTimestamp = entry.timestamp || '';
+      const action = extractExecutableAction(entry);
+      groups[key].latestContext = action || entry.context || entry.whatWentWrong || '';
+      groups[key].latestExecutable = action || '';
     }
   }
 
@@ -293,12 +324,13 @@ function gateMatchesOwnContext(gate, context) {
 function buildGateRule(group, actionOverride) {
   const action = actionOverride || (group.count === 'MANUAL' ? group.manualAction || 'block' : (group.count >= BLOCK_THRESHOLD ? 'block' : 'warn'));
   const severity = action === 'block' ? 'critical' : action === 'approve' ? 'high' : 'medium';
-  const context = group.latestContext.slice(0, 120);
+  const executable = (group.latestExecutable || extractExecutableAction({ context: group.latestContext }) || group.latestContext || '').slice(0, 120);
+  const context = executable;
   const kind = group.key.startsWith('diagnosis:')
     ? 'repeated diagnosis'
     : group.key.startsWith('constraint:')
       ? 'repeated constraint violation'
-      : 'repeated pattern';
+      : 'repeated executable action';
 
   const occurrencesText = group.count === 'MANUAL' ? 'manual' : `${group.count} occurrences`;
   const suggestedMessage = `Auto-promoted ${kind}: "${context}" (${occurrencesText} in ${WINDOW_DAYS} days)`;
@@ -313,8 +345,8 @@ function buildGateRule(group, actionOverride) {
   return {
     id: patternToGateId(group.key),
     trigger: `auto:${group.key}`,
-    // Derived from the captured command, NOT from group.key — see contextToPattern.
-    pattern: contextToPattern(group.latestContext),
+    // Derived from the executable action, NOT from tag keys — see contextToPattern.
+    pattern: contextToPattern(executable),
     action,
     message: suggestedMessage,
     severity,
@@ -592,6 +624,7 @@ module.exports = {
   getAuditTrailPath,
   REGRESSION_FALSE_BLOCK_LIMIT,
   extractPatternKey,
+  extractExecutableAction,
   normalizeCommandSignature,
   isNegative,
   expireGates,

--- a/scripts/auto-promote-gates.js
+++ b/scripts/auto-promote-gates.js
@@ -84,8 +84,32 @@ function regressionCheck(gate, options = {}) {
   let matchesGate;
   try { ({ matchesGate } = require('./gates-engine')); } catch { return null; }
   if (typeof matchesGate !== 'function') return null;
-  const allowed = entries.filter((e) => e && e.decision === 'allow' && e.toolName);
+  let allowed = entries.filter((e) => e && e.decision === 'allow' && e.toolName);
   if (!allowed.length) return null;
+
+  // The command we just learned to block was, by definition, ALLOWED before we
+  // learned it — that prior allow IS the incident the operator thumbs-downed.
+  // Counting it as a false block quarantines every gate learned from a real
+  // failure, which is the normal path (run it, get burned, 👎 it). Exclude the
+  // originating contexts so the check only measures collateral damage to
+  // genuinely unrelated actions.
+  // Match on normalized command EQUALITY, not substring containment: a longer,
+  // genuinely different command that merely quotes the incident text (e.g.
+  // `notify-team --dry-run "<incident>"`) is real collateral damage and must
+  // still count toward quarantine.
+  const incidentSignatures = new Set(
+    (options.incidentContexts || [])
+      .map((c) => normalizeCommandSignature(String(c || '')))
+      .filter(Boolean),
+  );
+  if (incidentSignatures.size > 0) {
+    allowed = allowed.filter((e) => {
+      const cmd = (e.toolInput && (e.toolInput.command || e.toolInput.pattern)) || '';
+      return !incidentSignatures.has(normalizeCommandSignature(String(cmd)));
+    });
+    if (!allowed.length) return { falseBlocks: 0, allowSampleSize: 0 };
+  }
+
   let falseBlocks = 0;
   for (const e of allowed) {
     try {
@@ -234,6 +258,38 @@ function patternToGateId(key) {
   return 'auto-' + key.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').slice(0, 50).toLowerCase();
 }
 
+/**
+ * Turn a captured context string into a pattern the gates engine can actually
+ * match. `gates-engine.js` compiles `gate.pattern` with `new RegExp(...)` and
+ * tests it against the tool-call text, so the pattern MUST be regex-safe text
+ * drawn from the command itself.
+ *
+ * It must NOT be the group key: keys are frequently tag-derived
+ * ("entity:Customer+entity:Funnel"), which is both meaningless against a command
+ * string and actively hazardous as a regex ('+' is a quantifier). Grouping by tag
+ * is correct — reusing that key as the match pattern is not.
+ */
+function contextToPattern(context) {
+  const raw = String(context || '').trim();
+  if (raw.length < 4) return null;
+  // Escape every regex metacharacter: the captured command is literal text.
+  return raw.slice(0, 120).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * A gate that cannot match the very context that produced it is inert — it
+ * shows up in the dashboard as an active blocking rule while enforcing nothing.
+ * That failure mode is worse than no gate at all, so callers drop these.
+ */
+function gateMatchesOwnContext(gate, context) {
+  if (!gate || !gate.pattern) return false;
+  try {
+    return new RegExp(gate.pattern).test(String(context || ''));
+  } catch {
+    return false;
+  }
+}
+
 function buildGateRule(group, actionOverride) {
   const action = actionOverride || (group.count === 'MANUAL' ? group.manualAction || 'block' : (group.count >= BLOCK_THRESHOLD ? 'block' : 'warn'));
   const severity = action === 'block' ? 'critical' : action === 'approve' ? 'high' : 'medium';
@@ -257,7 +313,8 @@ function buildGateRule(group, actionOverride) {
   return {
     id: patternToGateId(group.key),
     trigger: `auto:${group.key}`,
-    pattern: group.key.replace(/^diagnosis:|constraint:/, ''),
+    // Derived from the captured command, NOT from group.key — see contextToPattern.
+    pattern: contextToPattern(group.latestContext),
     action,
     message: suggestedMessage,
     severity,
@@ -393,6 +450,16 @@ function promote(feedbackLogPath, options) {
 
     const gateId = patternToGateId(group.key);
 
+    // Contexts that produced this gate. Their prior "allow" decisions are the
+    // incident the operator thumbs-downed, not false positives — both the
+    // new-gate and the warn->block upgrade path must exclude them from the
+    // regression check, or every gate learned from a real failure is held at warn.
+    const incidentContexts = [
+      group.latestContext,
+      ...(group.entries || []).map((e) => e && (e.context || e.whatWentWrong)),
+    ].filter(Boolean);
+    const regressionOpts = { ...opts, incidentContexts };
+
     // Check for existing gate — possibly upgrade
     const existingIdx = data.gates.findIndex((g) => g.id === gateId);
     if (existingIdx !== -1) {
@@ -400,7 +467,7 @@ function promote(feedbackLogPath, options) {
       const newAction = group.count >= BLOCK_THRESHOLD ? 'block' : 'warn';
       if (existing.action !== newAction && newAction === 'block') {
         // Self-Harness stage 3: regression-test before upgrading warn -> block.
-        const regression = opts.skipRegression ? null : safeRegressionCheck(buildGateRule(group, 'block'), opts);
+        const regression = opts.skipRegression ? null : safeRegressionCheck(buildGateRule(group, 'block'), regressionOpts);
         if (regression && regression.falseBlocks > REGRESSION_FALSE_BLOCK_LIMIT) {
           // Would block prior safe actions — hold at warn instead of upgrading.
           promotions.push({ type: 'upgrade-quarantined', gateId, from: existing.action, occurrences: group.count, falseBlocks: regression.falseBlocks });
@@ -418,12 +485,25 @@ function promote(feedbackLogPath, options) {
     // New gate — respect explicit gateAction override (e.g. 'approve' for human-approval rules)
     const gate = buildGateRule(group, opts.gateAction);
 
+    // Never persist a gate that cannot match the context that produced it. Such a
+    // gate renders in the dashboard as an active blocking rule while enforcing
+    // nothing, which reads as "the agent learned" when it did not.
+    if (!gateMatchesOwnContext(gate, group.latestContext)) {
+      promotions.push({
+        type: 'skipped-unmatchable',
+        gateId: gate.id,
+        reason: 'derived pattern does not match originating context',
+        occurrences: group.count,
+      });
+      continue;
+    }
+
     // Self-Harness stage 3: before a feedback rule goes live as a hard block,
     // regression-test it against prior allowed actions. If it would have blocked
     // safe actions, quarantine it to `warn` instead of `block`.
     let regression = null;
     if (gate.action === 'block' && !opts.gateAction && !opts.skipRegression) {
-      regression = safeRegressionCheck(gate, opts);
+      regression = safeRegressionCheck(gate, regressionOpts);
       if (regression && regression.falseBlocks > REGRESSION_FALSE_BLOCK_LIMIT) {
         gate.action = 'warn';
         gate.severity = 'medium';
@@ -506,6 +586,8 @@ module.exports = {
   groupNegativeFeedback,
   patternToGateId,
   buildGateRule,
+  contextToPattern,
+  gateMatchesOwnContext,
   regressionCheck,
   getAuditTrailPath,
   REGRESSION_FALSE_BLOCK_LIMIT,

--- a/tests/auto-promote-gates.test.js
+++ b/tests/auto-promote-gates.test.js
@@ -42,10 +42,11 @@ function recentTimestamp(daysAgo = 0) {
 }
 
 function makeNegativeEntry(tags, context, daysAgo = 0) {
+  // Default context is an executable action — enforcement groups by command, not tags.
   return {
     signal: 'negative',
     tags,
-    context: context || `Error context for ${tags.join(',')}`,
+    context: context || `npm test -- ${tags.join('-')}`,
     whatWentWrong: 'Something broke',
     timestamp: recentTimestamp(daysAgo),
   };
@@ -67,20 +68,31 @@ test('isNegative: returns false for positive/unknown signals', () => {
 
 // -- extractPatternKey --
 
-test('extractPatternKey: uses sorted tags as key', () => {
-  const key = extractPatternKey({ tags: ['git-workflow', 'push'], signal: 'negative' });
-  assert.strictEqual(key, 'git-workflow+push');
+test('extractPatternKey: groups by executable command, not tags', () => {
+  const key = extractPatternKey({
+    tags: ['git-workflow', 'push'],
+    signal: 'negative',
+    context: 'git push --force origin main',
+  });
+  assert.strictEqual(key, normalizeCommandSignature('git push --force origin main'));
 });
 
-test('extractPatternKey: falls back to normalized context', () => {
-  const key = extractPatternKey({ tags: [], context: 'this is a long enough context string for grouping', signal: 'negative' });
+test('extractPatternKey: accepts known CLI prefixes as executable', () => {
+  const key = extractPatternKey({
+    tags: [],
+    context: 'kubectl delete deploy checkout-api -n prod',
+    signal: 'negative',
+  });
   assert.ok(key);
-  assert.ok(!key.includes('/Users/'));
+  assert.match(key, /kubectl delete deploy/);
 });
 
-test('extractPatternKey: returns null for short context and no tags', () => {
-  const key = extractPatternKey({ tags: [], context: 'short', signal: 'negative' });
-  assert.strictEqual(key, null);
+test('extractPatternKey: returns null for pure prose or short context', () => {
+  assert.strictEqual(
+    extractPatternKey({ tags: ['testing'], context: 'agent broke deploy', signal: 'negative' }),
+    null,
+  );
+  assert.strictEqual(extractPatternKey({ tags: [], context: 'short', signal: 'negative' }), null);
 });
 
 test('getAutoGatesPath: resolves inside the active feedback directory', () => {
@@ -111,56 +123,57 @@ test('patternToGateId: converts pattern to kebab-case id', () => {
 
 // -- groupNegativeFeedback --
 
-test('groupNegativeFeedback: groups by tags within window', () => {
+test('groupNegativeFeedback: groups by executable action within window', () => {
   const entries = [
-    makeNegativeEntry(['testing'], 'test failure 1', 1),
-    makeNegativeEntry(['testing'], 'test failure 2', 2),
-    makeNegativeEntry(['testing'], 'test failure 3', 3),
-    makeNegativeEntry(['security'], 'sec issue', 1),
+    makeNegativeEntry(['testing'], 'npm test -- unit-a', 1),
+    makeNegativeEntry(['testing'], 'npm test -- unit-a', 2),
+    makeNegativeEntry(['testing'], 'npm test -- unit-a', 3),
+    makeNegativeEntry(['security'], 'npm audit --json', 1),
   ];
   const groups = groupNegativeFeedback(entries, WINDOW_DAYS);
-  assert.strictEqual(groups['testing'].count, 3);
-  assert.strictEqual(groups['security'].count, 1);
+  const unitKey = normalizeCommandSignature('npm test -- unit-a');
+  const auditKey = normalizeCommandSignature('npm audit --json');
+  assert.strictEqual(groups[unitKey].count, 3);
+  assert.strictEqual(groups[auditKey].count, 1);
 });
 
 test('groupNegativeFeedback: excludes entries outside window', () => {
   const entries = [
-    makeNegativeEntry(['testing'], 'old failure', 35), // outside 30-day window
-    makeNegativeEntry(['testing'], 'recent failure', 1),
+    makeNegativeEntry(['testing'], 'npm test -- old-failure', 35), // outside 30-day window
+    makeNegativeEntry(['testing'], 'npm test -- recent-failure', 1),
   ];
   const groups = groupNegativeFeedback(entries, WINDOW_DAYS);
-  assert.strictEqual(groups['testing'].count, 1);
+  const recentKey = normalizeCommandSignature('npm test -- recent-failure');
+  assert.strictEqual(groups[recentKey].count, 1);
+  assert.equal(groups[normalizeCommandSignature('npm test -- old-failure')], undefined);
 });
 
 test('groupNegativeFeedback: ignores positive signals', () => {
   const entries = [
-    { signal: 'positive', tags: ['testing'], context: 'good job', timestamp: recentTimestamp(1) },
-    makeNegativeEntry(['testing'], 'failure', 1),
+    { signal: 'positive', tags: ['testing'], context: 'npm test -- good', timestamp: recentTimestamp(1) },
+    makeNegativeEntry(['testing'], 'npm test -- failure', 1),
   ];
   const groups = groupNegativeFeedback(entries, WINDOW_DAYS);
-  assert.strictEqual(groups['testing'].count, 1);
+  const failKey = normalizeCommandSignature('npm test -- failure');
+  assert.strictEqual(groups[failKey].count, 1);
 });
 
-test('groupNegativeFeedback: also groups repeated diagnostic categories', () => {
+test('groupNegativeFeedback: does not create enforcement groups from diagnosis tags alone', () => {
   const entries = [
     {
-      ...makeNegativeEntry(['testing'], 'failure 1', 1),
+      signal: 'negative',
+      tags: ['testing'],
+      context: 'agent broke deploy',
       diagnosis: {
         rootCauseCategory: 'guardrail_triggered',
         violations: [{ constraintId: 'rubric:verification_evidence' }],
       },
-    },
-    {
-      ...makeNegativeEntry(['testing'], 'failure 2', 2),
-      diagnosis: {
-        rootCauseCategory: 'guardrail_triggered',
-        violations: [{ constraintId: 'rubric:verification_evidence' }],
-      },
+      timestamp: recentTimestamp(1),
     },
   ];
   const groups = groupNegativeFeedback(entries, WINDOW_DAYS);
-  assert.strictEqual(groups['diagnosis:guardrail_triggered'].count, 2);
-  assert.strictEqual(groups['constraint:rubric:verification_evidence'].count, 2);
+  assert.equal(groups['diagnosis:guardrail_triggered'], undefined);
+  assert.equal(Object.keys(groups).length, 0);
 });
 
 // -- promote: repeated failures below block threshold trigger warn gate --
@@ -176,7 +189,7 @@ test('promote: repeated failures below block threshold trigger warn gate', (t) =
 
   const warnCount = BLOCK_THRESHOLD - 1;
   for (let i = 0; i < warnCount; i++) {
-    appendJSONL(logPath, makeNegativeEntry(['pr-review'], 'forgot thread check', i));
+    appendJSONL(logPath, makeNegativeEntry(['pr-review'], 'git push --force origin main', i));
   }
 
   const result = promote(logPath);
@@ -204,15 +217,16 @@ test('promote: block threshold upgrades gate from warn to block', (t) => {
   });
 
   const warnCount = BLOCK_THRESHOLD - 1;
+  const cmd = 'git push --force origin feature/x';
   // First create a warn gate below the block threshold.
   for (let i = 0; i < warnCount; i++) {
-    appendJSONL(logPath, makeNegativeEntry(['execution-gap'], 'did not push', i));
+    appendJSONL(logPath, makeNegativeEntry(['execution-gap'], cmd, i));
   }
   promote(logPath);
 
   // Add enough additional failures to reach the block threshold.
   for (let i = warnCount; i < BLOCK_THRESHOLD; i++) {
-    appendJSONL(logPath, makeNegativeEntry(['execution-gap'], 'did not push again', i));
+    appendJSONL(logPath, makeNegativeEntry(['execution-gap'], cmd, i));
   }
   const result = promote(logPath);
   const upgrade = result.promotions.find((p) => p.type === 'upgrade');
@@ -220,7 +234,8 @@ test('promote: block threshold upgrades gate from warn to block', (t) => {
   assert.strictEqual(upgrade.to, 'block');
 
   const data = loadAutoGates();
-  const gate = data.gates.find((g) => g.id === 'auto-execution-gap');
+  const gate = data.gates.find((g) => (g.pattern || '').includes('git push --force'));
+  assert.ok(gate);
   assert.strictEqual(gate.action, 'block');
 });
 
@@ -235,18 +250,19 @@ test('promote: does not create duplicate gates', (t) => {
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
   });
 
+  const cmd = 'npm test -- dedup-suite';
   for (let i = 0; i < 4; i++) {
-    appendJSONL(logPath, makeNegativeEntry(['dedup-test'], 'same error', i));
+    appendJSONL(logPath, makeNegativeEntry(['dedup-test'], cmd, i));
   }
 
   promote(logPath);
   const first = loadAutoGates();
-  const countBefore = first.gates.filter((g) => g.id === 'auto-dedup-test').length;
+  const countBefore = first.gates.filter((g) => (g.pattern || '').includes('npm test -- dedup-suite')).length;
 
   // Run again — should not create duplicate
   promote(logPath);
   const second = loadAutoGates();
-  const countAfter = second.gates.filter((g) => g.id === 'auto-dedup-test').length;
+  const countAfter = second.gates.filter((g) => (g.pattern || '').includes('npm test -- dedup-suite')).length;
 
   assert.strictEqual(countBefore, 1);
   assert.strictEqual(countAfter, 1);
@@ -328,7 +344,7 @@ test('promote: called from feedback-loop on negative capture', (t) => {
   for (let i = 0; i < warnCount; i++) {
     captureFeedback({
       signal: 'down',
-      context: `Pipeline integration test failure ${i}`,
+      context: 'npm test -- pipeline-integration',
       whatWentWrong: 'Integration broke',
       tags: ['pipeline-integration-test'],
     });
@@ -336,7 +352,7 @@ test('promote: called from feedback-loop on negative capture', (t) => {
 
   // The auto-promote should create a warn gate before the hard block threshold.
   const data = loadAutoGates();
-  const gate = data.gates.find((g) => g.id === 'auto-pipeline-integration-test');
+  const gate = data.gates.find((g) => (g.pattern || '').includes('npm test -- pipeline-integration'));
   assert.ok(gate, 'auto-promoted gate should exist before the block threshold is reached');
   assert.strictEqual(gate.action, 'warn');
 });
@@ -345,10 +361,11 @@ test('promote: called from feedback-loop on negative capture', (t) => {
 
 test('buildGateRule: returns gate object with correct fields', () => {
   const group = {
-    key: 'testing',
+    key: normalizeCommandSignature('npm test -- suite'),
     count: BLOCK_THRESHOLD - 1,
     entries: [],
-    latestContext: 'Test failure context',
+    latestContext: 'npm test -- suite',
+    latestExecutable: 'npm test -- suite',
     latestTimestamp: new Date().toISOString(),
   };
   const gate = buildGateRule(group);
@@ -357,14 +374,16 @@ test('buildGateRule: returns gate object with correct fields', () => {
   assert.strictEqual(gate.severity, 'medium');
   assert.ok(gate.message.includes(`${BLOCK_THRESHOLD - 1} occurrences`));
   assert.strictEqual(gate.source, 'auto-promote');
+  assert.match(gate.pattern, /npm test -- suite/);
 });
 
 test('buildGateRule: count at block threshold produces block action', () => {
   const group = {
-    key: 'critical-error',
+    key: normalizeCommandSignature('kubectl delete ns prod'),
     count: BLOCK_THRESHOLD,
     entries: [],
-    latestContext: 'Critical failure',
+    latestContext: 'kubectl delete ns prod',
+    latestExecutable: 'kubectl delete ns prod',
     latestTimestamp: new Date().toISOString(),
   };
   const gate = buildGateRule(group);
@@ -625,13 +644,13 @@ test('extractPatternKey: variants of rm -rf node_modules produce the same gate k
   assert.ok(keys[0] && keys[0].includes('rm -rf node_modules'));
 });
 
-test('extractPatternKey: still prefers tags when present', () => {
+test('extractPatternKey: prefers executable command even when tags present', () => {
   const k = extractPatternKey({
     tags: ['feedback', 'destructive-fs', 'negative'],
     context: 'rm -rf node_modules',
   });
-  // Tag-based key wins over command normalization.
-  assert.strictEqual(k, 'destructive-fs');
+  // Executable action wins — tags are memory metadata, not enforcement keys.
+  assert.strictEqual(k, normalizeCommandSignature('rm -rf node_modules'));
 });
 
 // --- Regression: promoted gates must actually enforce -------------------------
@@ -739,4 +758,48 @@ test('P0: tagged multi-thumbs promote produces a pattern that gate-check denies'
   const parsed = JSON.parse(raw);
   const decision = (parsed.hookSpecificOutput || parsed).permissionDecision;
   assert.equal(decision, 'deny', 'auto-promoted gate must deny the originating command');
+});
+
+test('extractExecutableAction: prefers toolInput.command over prose context', () => {
+  const { extractExecutableAction } = require('../scripts/auto-promote-gates');
+  const action = extractExecutableAction({
+    context: 'agent broke the deploy again',
+    toolInput: { command: 'kubectl delete deploy checkout-api -n prod' },
+  });
+  assert.equal(action, 'kubectl delete deploy checkout-api -n prod');
+});
+
+test('extractExecutableAction: rejects pure prose', () => {
+  const { extractExecutableAction } = require('../scripts/auto-promote-gates');
+  assert.equal(extractExecutableAction({ context: 'agent broke deploy' }), null);
+});
+
+test('promote: tag-only groups without executable actions do not hard-block a single latest command', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-tag-only-'));
+  const logPath = path.join(dir, 'feedback-log.jsonl');
+  process.env.THUMBGATE_FEEDBACK_DIR = dir;
+
+  // Three different commands sharing the same tags — must NOT block only the latest
+  // using a count of 3 from unrelated tag co-occurrence.
+  const rows = [
+    { context: 'kubectl get pods -n staging', tags: ['entity:Customer', 'entity:Funnel'] },
+    { context: 'kubectl logs deploy/web -n staging', tags: ['entity:Customer', 'entity:Funnel'] },
+    { context: 'kubectl delete deploy checkout-api -n prod', tags: ['entity:Customer', 'entity:Funnel'] },
+  ].map((r) => JSON.stringify({
+    signal: 'negative',
+    feedback: 'down',
+    tags: r.tags,
+    context: r.context,
+    timestamp: new Date().toISOString(),
+  }));
+  fs.writeFileSync(logPath, rows.join('\n') + '\n');
+
+  const result = promote(logPath, { skipRegression: true });
+  // Each command appears once → below BLOCK_THRESHOLD; may warn at WARN_THRESHOLD=1
+  // but must not create a block for delete using a tag count of 3.
+  const deleteGate = (result.data.gates || []).find((g) => (g.pattern || '').includes('delete deploy'));
+  if (deleteGate) {
+    assert.notEqual(deleteGate.action, 'block', 'single-command delete must not hard-block from tag co-counts');
+    assert.equal(deleteGate.occurrences, 1);
+  }
 });

--- a/tests/auto-promote-gates.test.js
+++ b/tests/auto-promote-gates.test.js
@@ -220,7 +220,7 @@ test('promote: block threshold upgrades gate from warn to block', (t) => {
   assert.strictEqual(upgrade.to, 'block');
 
   const data = loadAutoGates();
-  const gate = data.gates.find((g) => g.pattern === 'execution-gap');
+  const gate = data.gates.find((g) => g.id === 'auto-execution-gap');
   assert.strictEqual(gate.action, 'block');
 });
 
@@ -241,12 +241,12 @@ test('promote: does not create duplicate gates', (t) => {
 
   promote(logPath);
   const first = loadAutoGates();
-  const countBefore = first.gates.filter((g) => g.pattern === 'dedup-test').length;
+  const countBefore = first.gates.filter((g) => g.id === 'auto-dedup-test').length;
 
   // Run again — should not create duplicate
   promote(logPath);
   const second = loadAutoGates();
-  const countAfter = second.gates.filter((g) => g.pattern === 'dedup-test').length;
+  const countAfter = second.gates.filter((g) => g.id === 'auto-dedup-test').length;
 
   assert.strictEqual(countBefore, 1);
   assert.strictEqual(countAfter, 1);
@@ -336,7 +336,7 @@ test('promote: called from feedback-loop on negative capture', (t) => {
 
   // The auto-promote should create a warn gate before the hard block threshold.
   const data = loadAutoGates();
-  const gate = data.gates.find((g) => g.pattern === 'pipeline-integration-test');
+  const gate = data.gates.find((g) => g.id === 'auto-pipeline-integration-test');
   assert.ok(gate, 'auto-promoted gate should exist before the block threshold is reached');
   assert.strictEqual(gate.action, 'warn');
 });
@@ -389,7 +389,7 @@ test('runCli: supports force-block without falling through to a second entrypoin
   assert.ok(lines.some((line) => line.includes('Forced block gate created')));
 
   const data = loadAutoGates();
-  const gate = data.gates.find((entry) => entry.pattern === 'pipeline-regression');
+  const gate = data.gates.find((entry) => entry.id === 'auto-pipeline-regression');
   assert.ok(gate);
   assert.strictEqual(gate.action, 'block');
 });
@@ -404,6 +404,8 @@ const {
   getRuleTtlDays,
   getRuleTtlMs,
   DEFAULT_RULE_TTL_DAYS,
+  contextToPattern,
+  gateMatchesOwnContext,
 } = require('../scripts/auto-promote-gates');
 
 test('buildGateRule sets expiresAt for auto-promoted gates (default 90 day TTL)', () => {
@@ -630,4 +632,111 @@ test('extractPatternKey: still prefers tags when present', () => {
   });
   // Tag-based key wins over command normalization.
   assert.strictEqual(k, 'destructive-fs');
+});
+
+// --- Regression: promoted gates must actually enforce -------------------------
+// 2026-07-31. `buildGateRule` used `group.key` as the gate's match `pattern`.
+// Keys are usually tag-derived ("entity:Customer+entity:Funnel"), which the gates
+// engine compiles via `new RegExp(...)` and tests against command text — so it
+// could never match. Result: a gate rendering as action:"block", severity:
+// "critical", occurrences:3 that enforced nothing. The suite passed because it
+// only asserted that promotion HAPPENED, never that the gate MATCHED.
+
+test('buildGateRule: pattern matches the originating command, not the group key', () => {
+  const command = 'kubectl delete deploy checkout-api -n prod';
+  const gate = buildGateRule({
+    key: 'entity:Customer+entity:Funnel', // tag-derived key, as the auto-tagger emits
+    count: 3,
+    latestContext: command,
+    entries: [],
+  });
+
+  assert.strictEqual(gate.action, 'block');
+  assert.ok(
+    new RegExp(gate.pattern).test(command),
+    `promoted gate must match its own command. pattern=${JSON.stringify(gate.pattern)}`,
+  );
+  assert.ok(
+    !new RegExp(gate.pattern).test('git status'),
+    'promoted gate must not match unrelated commands',
+  );
+});
+
+test('contextToPattern: escapes regex metacharacters in captured commands', () => {
+  const command = 'rm -rf build/ && echo "done" (cleanup)';
+  const pattern = contextToPattern(command);
+  assert.ok(new RegExp(pattern).test(command), 'escaped pattern must match the literal command');
+});
+
+test('contextToPattern: returns null for unusably short context', () => {
+  assert.strictEqual(contextToPattern(''), null);
+  assert.strictEqual(contextToPattern('ls'), null);
+});
+
+test('gateMatchesOwnContext: rejects a tag-string pattern against a command', () => {
+  const inert = { pattern: 'entity:Customer\\+entity:Funnel' };
+  assert.strictEqual(gateMatchesOwnContext(inert, 'kubectl delete deploy checkout-api -n prod'), false);
+});
+
+test('promote: skips gates whose pattern cannot match, rather than persisting them inert', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-unmatchable-'));
+  const logPath = path.join(dir, 'feedback-log.jsonl');
+  process.env.THUMBGATE_FEEDBACK_DIR = dir;
+
+  // Context too short to yield a usable pattern -> must not become a live gate.
+  const rows = [1, 2, 3].map(() => JSON.stringify({
+    signal: 'negative',
+    tags: ['entity:Customer', 'entity:Funnel'],
+    context: 'x',
+    timestamp: new Date().toISOString(),
+  }));
+  fs.writeFileSync(logPath, rows.join('\n') + '\n');
+
+  const result = promote(logPath);
+  const live = result.data.gates.filter((g) => g.pattern);
+  for (const g of live) {
+    assert.ok(
+      typeof g.pattern === 'string' && g.pattern.length > 0,
+      'no gate may be persisted without a usable pattern',
+    );
+  }
+  assert.strictEqual(
+    result.data.gates.some((g) => !g.pattern),
+    false,
+    'a gate with a null pattern must never be persisted',
+  );
+});
+
+test('P0: tagged multi-thumbs promote produces a pattern that gate-check denies', () => {
+  // Regression for 2026-07-31 inert auto-promote: tag group keys must not become match patterns.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-p0-tag-promote-'));
+  const logPath = path.join(dir, 'feedback-log.jsonl');
+  process.env.THUMBGATE_FEEDBACK_DIR = dir;
+  process.env.THUMBGATE_STRICT_ENFORCEMENT = '1';
+
+  const cmd = 'kubectl delete deploy checkout-api -n prod';
+  const rows = [1, 2, 3].map(() => JSON.stringify({
+    signal: 'negative',
+    feedback: 'down',
+    tags: ['entity:Customer', 'entity:Funnel', 'feedback', 'negative'],
+    context: cmd,
+    whatWentWrong: 'wiped prod checkout deployment',
+    whatToChange: 'never delete prod deployments',
+    timestamp: new Date().toISOString(),
+  }));
+  fs.writeFileSync(logPath, rows.join('\n') + '\n');
+
+  const result = promote(logPath, { skipRegression: true });
+  assert.ok(result.data.gates.length >= 1, 'expected at least one promoted gate');
+  const gate = result.data.gates.find((g) => (g.pattern || '').includes('kubectl'));
+  assert.ok(gate, 'promoted gate pattern must derive from the command, not the tag key');
+  assert.doesNotMatch(gate.pattern, /entity:Customer/, 'pattern must not be the tag group key');
+  assert.match(gate.pattern, /kubectl delete deploy checkout-api -n prod/);
+
+  // Live engine path — same as PreToolUse / CLI gate-check.
+  const { run } = require('../scripts/gates-engine');
+  const raw = run({ tool_name: 'Bash', tool_input: { command: cmd } });
+  const parsed = JSON.parse(raw);
+  const decision = (parsed.hookSpecificOutput || parsed).permissionDecision;
+  assert.equal(decision, 'deny', 'auto-promoted gate must deny the originating command');
 });

--- a/tests/auto-promote-regression-gate.test.js
+++ b/tests/auto-promote-regression-gate.test.js
@@ -92,7 +92,15 @@ test('promote: quarantines a would-be BLOCK to warn when it would block prior sa
     const grp = Object.values(groupNegativeFeedback(entries, 30)).find((g) => g.count >= 3);
     assert.ok(grp, 'expected a group with >=3 occurrences');
     const pattern = buildGateRule(grp, 'block').pattern;
-    writeAudit(dir, [{ decision: 'allow', toolName: 'Bash', toolInput: { command: pattern } }]);
+    // Collateral damage must be a DIFFERENT, genuinely safe action that the pattern
+    // happens to match — not a replay of the incident itself. A prior allow of the
+    // incident command is the failure the operator thumbs-downed, and counting it
+    // would quarantine every gate learned from a real failure (2026-07-31).
+    writeAudit(dir, [{
+      decision: 'allow',
+      toolName: 'Bash',
+      toolInput: { command: `notify-team --dry-run "agent ran echomarker and it failed"` },
+    }]);
 
     const result = promote(logPath);
     const gate = result.data.gates.find((g) => g.pattern === pattern);

--- a/tests/auto-promote-regression-gate.test.js
+++ b/tests/auto-promote-regression-gate.test.js
@@ -82,7 +82,7 @@ test('promote: quarantines a would-be BLOCK to warn when it would block prior sa
     const entries = [0, 1, 2].map((d) => ({
       signal: 'negative',
       tags: ['echomarker'],
-      context: 'agent ran echomarker and it failed',
+      context: 'python scripts/echomarker.py --apply',
       timestamp: recentTimestamp(d),
     }));
     fs.writeFileSync(logPath, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
@@ -99,7 +99,7 @@ test('promote: quarantines a would-be BLOCK to warn when it would block prior sa
     writeAudit(dir, [{
       decision: 'allow',
       toolName: 'Bash',
-      toolInput: { command: `notify-team --dry-run "agent ran echomarker and it failed"` },
+      toolInput: { command: 'notify-team --dry-run "python scripts/echomarker.py --apply"' },
     }]);
 
     const result = promote(logPath);


### PR DESCRIPTION
## Summary
- **P0 fix:** auto-promoted gates match the **command**, not the tag group key (`entity:Customer+entity:Funnel` was inert). Unmatchable gates are not persisted. Originating incidents excluded from regression quarantine.
- **E2E test:** tagged 3× 👎 → promote → `gates-engine` **deny** on the originating command.
- **Demo A+:** `demo/scale-the-vibe-demo.sh --learn` proves `ALLOW → 3× 👎 → auto-promote → DENY` with command-derived pattern proof.

## Live proof
```text
✓ pattern is the command (not entity:Customer+entity:Funnel)
✓ A+ learning loop: ALLOW → 3× 👎 → auto-promote → DENY
```

## Supersedes
- #3119 (conflicted with main) — same fix re-landed cleanly + demo + e2e

## Test plan
- [x] `node --test tests/auto-promote-gates.test.js tests/auto-promote-regression-gate.test.js` (52/52)
- [x] `bash demo/scale-the-vibe-demo.sh --learn`