### PR TITLE
fix(packaging): declare YAML runtime dependency

### DIFF
--- a/.changeset/direct-js-yaml-runtime.md
+++ b/.changeset/direct-js-yaml-runtime.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Declare the YAML parser used by the packaged API server as a production dependency so production-only installs can load the runtime without relying on a transitive development package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "apache-arrow": "^18.1.0",
         "better-sqlite3": "^12.9.0",
         "dotenv": "^17.4.2",
+        "js-yaml": "4.3.0",
         "playwright-core": "^1.59.1",
         "protobufjs": "^8.7.1",
         "stripe": "^22.2.0"
@@ -925,7 +926,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-back": {
@@ -2075,7 +2075,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -959,6 +959,7 @@
     "apache-arrow": "^18.1.0",
     "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.2",
+    "js-yaml": "4.3.0",
     "playwright-core": "^1.59.1",
     "protobufjs": "^8.7.1",
     "stripe": "^22.2.0"

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
+const packageJson = require('../package.json');
 
 const root = path.join(__dirname, '..');
 
@@ -114,6 +115,13 @@ test('npm package ships static dependencies needed for packaged entrypoints', ()
   assert.deepEqual(revenueEligibilityMissing, []);
   assert.deepEqual(revenueRemediationMissing, []);
   assert.deepEqual(workflowIntakeQueueMissing, []);
+});
+
+test('API runtime declares its YAML parser as a production dependency', () => {
+  const apiSource = fs.readFileSync(path.join(root, 'src', 'api', 'server.js'), 'utf8');
+
+  assert.match(apiSource, /require\(['"]js-yaml['"]\)/);
+  assert.equal(packageJson.dependencies['js-yaml'], '4.3.0');
 });
 
 test('npm package ships a slim runtime boundary instead of repo/dev surfaces', () => {


### PR DESCRIPTION
## Summary

- declare `js-yaml` as a production dependency because the packaged API server requires it directly
- add a package-boundary regression test that binds the runtime import to the production dependency declaration
- preserve the existing pinned version and override

## Verification

- `node --test tests/package-boundary.test.js tests/openapi-parity.test.js` (12/12)
- `npm ci --omit=dev`
- production-only `require('js-yaml')` and `require('./src/api/server.js')`
- pre-commit and pre-push guards

## Evidence boundary

The initial clean-suite run also observed the entire root `node_modules` directory missing before `test:api`. That disappearance has not reproduced: the API suite and every preceding stage now pass with dependencies intact. This PR fixes the independently reproducible packaged-runtime defect; it does not claim a cause for that one unexplained local anomaly.
