### PR TITLE
feat(pricing): segment offers by customer value

### DIFF
--- a/.changeset/value-based-pricing-packaging.md
+++ b/.changeset/value-based-pricing-packaging.md
@@ -1,0 +1,6 @@
+---
+'thumbgate': patch
+---
+
+Segment the pricing page by buyer value and scope, add a compact recovery-cost
+equation, and attribute pricing telemetry to the selected offer and experiment.

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -83,35 +83,45 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "Service",
-    "name": "ThumbGate Managed Workflow Diagnostic",
-    "description": "A bounded implementation for one supported local AI-agent workflow: review, configured pre-action gate, regression test, and rollout and rollback proof.",
-    "provider": { "@type": "Organization", "name": "ThumbGate", "url": "__APP_ORIGIN__/" },
-    "audience": { "@type": "BusinessAudience", "audienceType": "Engineering and platform teams with a repeated AI-agent failure" },
-    "offers": [
+    "@graph": [
       {
-        "@type": "Offer",
-        "name": "Managed workflow diagnostic",
-        "price": "499",
-        "priceCurrency": "USD",
-        "url": "__APP_ORIGIN__/pricing#buy",
-        "availability": "https://schema.org/InStock"
+        "@type": "Service",
+        "name": "ThumbGate Managed Workflow Diagnostic",
+        "description": "A bounded implementation for one supported local AI-agent workflow: review, configured pre-action gate, regression test, and rollout and rollback proof.",
+        "provider": { "@type": "Organization", "name": "ThumbGate", "url": "__APP_ORIGIN__/" },
+        "audience": { "@type": "BusinessAudience", "audienceType": "Engineering and platform teams with a repeated AI-agent failure" },
+        "offers": {
+          "@type": "Offer",
+          "name": "Managed workflow diagnostic",
+          "price": "499",
+          "priceCurrency": "USD",
+          "url": "__APP_ORIGIN__/pricing#buy",
+          "availability": "https://schema.org/InStock"
+        }
       },
       {
-        "@type": "Offer",
-        "name": "ThumbGate Pro monthly",
-        "price": "19",
-        "priceCurrency": "USD",
-        "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro",
-        "availability": "https://schema.org/InStock"
-      },
-      {
-        "@type": "Offer",
-        "name": "ThumbGate Pro annual",
-        "price": "149",
-        "priceCurrency": "USD",
-        "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro",
-        "availability": "https://schema.org/InStock"
+        "@type": "SoftwareApplication",
+        "name": "ThumbGate Pro",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "macOS, Linux, Windows",
+        "offers": [
+          {
+            "@type": "Offer",
+            "name": "ThumbGate Pro monthly",
+            "price": "19",
+            "priceCurrency": "USD",
+            "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro",
+            "availability": "https://schema.org/InStock"
+          },
+          {
+            "@type": "Offer",
+            "name": "ThumbGate Pro annual",
+            "price": "149",
+            "priceCurrency": "USD",
+            "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro",
+            "availability": "https://schema.org/InStock"
+          }
+        ]
       }
     ]
   }
@@ -172,7 +182,8 @@
             <input type="hidden" name="plan_id" value="sprint_diagnostic">
             <input type="hidden" name="utm_source" value="pricing">
             <input type="hidden" name="utm_medium" value="direct_checkout">
-            <input type="hidden" name="utm_campaign" value="rally_style_gtm">
+            <input type="hidden" name="utm_campaign" value="value_packaging_v1">
+            <input id="pricing-buyer-segment" type="hidden" name="campaign_variant" value="workflow_team">
             <input type="hidden" name="cta_id" value="pricing_managed_gate_buy">
             <input type="hidden" name="cta_placement" value="pricing">
             <input type="hidden" name="landing_path" value="/pricing">
@@ -345,6 +356,10 @@
 
     document.querySelectorAll('[data-offer-link]').forEach(function (link) {
       link.addEventListener('click', function () {
+        if (link.getAttribute('href') === '#enterprise-gate') {
+          const buyerSegment = document.querySelector('#pricing-buyer-segment');
+          if (buyerSegment) buyerSegment.value = link.dataset.segment || 'workflow_team';
+        }
         const props = offerProps(
           link.dataset.ctaId || 'pricing_anchor',
           'pricing_anchor',
@@ -360,7 +375,14 @@
     const checkoutForm = document.querySelector('[data-primary-checkout]');
     if (checkoutForm) {
       checkoutForm.addEventListener('submit', function () {
-        const props = offerProps('pricing_managed_gate_buy', 'pricing', 'sprint_diagnostic', 499, 'workflow_team');
+        const buyerSegment = document.querySelector('#pricing-buyer-segment');
+        const props = offerProps(
+          'pricing_managed_gate_buy',
+          'pricing',
+          'sprint_diagnostic',
+          499,
+          buyerSegment ? buyerSegment.value : 'workflow_team'
+        );
         window.plausible('checkout_start', { props: props });
         sendFirstPartyTelemetry('checkout_start', props);
       });

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pricing — Enforcement that pays for itself | ThumbGate</title>
-  <meta name="description" content="ThumbGate vs DIY prompts, platform hire, or GRC suite. Free evaluate, Pro $19/mo, $499 Diagnostic gate. Countable units that convert.">
+  <meta name="description" content="Choose ThumbGate by the value and scope of the agent risk: free evaluation, Pro for one operator, a $499 managed diagnostic for one workflow, or custom enterprise intake.">
   <link rel="canonical" href="__APP_ORIGIN__/pricing">
   <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
   <meta property="og:title" content="ThumbGate Pricing — $499 Diagnostic · Pro $19/mo">
@@ -57,6 +57,19 @@
     .fit-card { border-top:3px solid var(--green); background:var(--card); padding:22px; }
     .fit-card h3 { margin:0 0 8px; }
     .fit-card p { margin:0; color:var(--muted); }
+    .value-equation { display:grid; grid-template-columns:1fr auto 1fr auto 1fr auto 1.3fr; gap:12px; align-items:stretch; margin-top:26px; }
+    .value-factor { display:grid; align-content:center; min-height:112px; border:1px solid var(--line); border-radius:14px; background:var(--card); padding:18px; }
+    .value-factor strong { font-size:1.06rem; }
+    .value-factor span { color:var(--muted); font-size:.83rem; }
+    .value-operator { display:grid; place-items:center; color:var(--green); font-size:1.7rem; font-weight:900; }
+    .value-result { border-color:var(--green); background:#e9f3ee; }
+    .segment-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:14px; margin-top:28px; }
+    .segment-card { display:flex; flex-direction:column; border:1px solid var(--line); border-radius:14px; background:var(--card); padding:22px; }
+    .segment-card.recommended { border:2px solid var(--green); }
+    .segment-card h3 { margin:8px 0 6px; }
+    .segment-card p { margin:0 0 14px; color:var(--muted); font-size:.92rem; }
+    .segment-card .fence { min-height:58px; margin-top:auto; color:var(--ink); font-size:.82rem; }
+    .segment-card .button { margin-top:14px; }
     .faq { border-top:1px solid var(--line); }
     .faq-item { border-bottom:1px solid var(--line); }
     .faq-q { width:100%; border:0; background:transparent; padding:18px 0; color:var(--ink); font:inherit; font-weight:800; text-align:left; cursor:pointer; }
@@ -65,22 +78,42 @@
     footer { border-top:1px solid var(--line); padding:28px 0; color:var(--muted); font-size:.85rem; }
     .footer-inner { display:flex; justify-content:space-between; gap:24px; }
     .footer-links { display:flex; gap:18px; }
-    @media (max-width:820px) { .hero,.steps,.fit { grid-template-columns:1fr; } .hero { gap:34px; } .nav-links a:not(.nav-buy) { display:none; } }
+    @media (max-width:820px) { .hero,.steps,.fit,.segment-grid { grid-template-columns:1fr; } .value-equation { grid-template-columns:1fr; } .value-operator { min-height:24px; } .hero { gap:34px; } .nav-links a:not(.nav-buy) { display:none; } }
   </style>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Service",
-    "name": "ThumbGate Enterprise Workflow Gate",
+    "name": "ThumbGate Managed Workflow Diagnostic",
     "description": "A bounded implementation for one supported local AI-agent workflow: review, configured pre-action gate, regression test, and rollout and rollback proof.",
     "provider": { "@type": "Organization", "name": "ThumbGate", "url": "__APP_ORIGIN__/" },
-    "offers": {
-      "@type": "Offer",
-      "price": "499",
-      "priceCurrency": "USD",
-      "url": "__APP_ORIGIN__/pricing#buy",
-      "availability": "https://schema.org/InStock"
-    }
+    "audience": { "@type": "BusinessAudience", "audienceType": "Engineering and platform teams with a repeated AI-agent failure" },
+    "offers": [
+      {
+        "@type": "Offer",
+        "name": "Managed workflow diagnostic",
+        "price": "499",
+        "priceCurrency": "USD",
+        "url": "__APP_ORIGIN__/pricing#buy",
+        "availability": "https://schema.org/InStock"
+      },
+      {
+        "@type": "Offer",
+        "name": "ThumbGate Pro monthly",
+        "price": "19",
+        "priceCurrency": "USD",
+        "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro",
+        "availability": "https://schema.org/InStock"
+      },
+      {
+        "@type": "Offer",
+        "name": "ThumbGate Pro annual",
+        "price": "149",
+        "priceCurrency": "USD",
+        "url": "__APP_ORIGIN__/checkout/pro?plan_id=pro",
+        "availability": "https://schema.org/InStock"
+      }
+    ]
   }
   </script>
   <script type="application/ld+json">
@@ -109,8 +142,8 @@
       <div class="nav-links">
         <a href="/guide">Technical setup</a>
         <a href="https://github.com/IgorGanapolsky/ThumbGate/blob/main/docs/VERIFICATION_EVIDENCE.md" target="_blank" rel="noopener">Proof</a>
-        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="pricing_nav_buy">Get Started · $499</a>
-        <a class="nav-pro" href="/checkout/pro?utm_source=pricing&amp;utm_medium=nav&amp;utm_campaign=rally_style_gtm&amp;cta_id=pricing_nav_pro&amp;plan_id=pro" data-offer-link data-cta-id="pricing_nav_pro">Pro · $19/mo</a>
+        <a class="nav-enterprise" href="#enterprise-gate" data-offer-link data-cta-id="pricing_nav_buy" data-plan-id="sprint_diagnostic" data-value="499" data-segment="workflow_team">Get Started · $499</a>
+        <a class="nav-pro" href="/checkout/pro?utm_source=pricing&amp;utm_medium=nav&amp;utm_campaign=value_packaging_v1&amp;cta_id=pricing_nav_pro&amp;plan_id=pro" data-offer-link data-cta-id="pricing_nav_pro" data-plan-id="pro" data-value="19" data-segment="solo_operator">Pro · $19/mo</a>
       </div>
     </div>
   </nav>
@@ -152,16 +185,60 @@
           <div class="eyebrow">Self-serve</div>
           <div class="price">$19<span style="font-size:1rem;font-weight:700">/mo</span></div>
           <p class="price-note">Or $149/yr. Individual operators. Cancel anytime.</p>
-          <a class="button" href="/checkout/pro?utm_source=pricing&amp;utm_medium=card&amp;utm_campaign=rally_style_gtm&amp;cta_id=pricing_pro_buy&amp;plan_id=pro" data-offer-link data-cta-id="pricing_pro_buy" style="width:100%;box-sizing:border-box">Start Pro — $19/mo</a>
+          <a class="button" href="/checkout/pro?utm_source=pricing&amp;utm_medium=card&amp;utm_campaign=value_packaging_v1&amp;cta_id=pricing_pro_buy&amp;plan_id=pro" data-offer-link data-cta-id="pricing_pro_buy" data-plan-id="pro" data-value="19" data-segment="solo_operator" style="width:100%;box-sizing:border-box">Start Pro</a>
           <p class="fine">Hosted checkout. Free local evaluate remains free after you subscribe.</p>
         </aside>
       </div>
     </div>
 
+    <section id="value">
+      <div class="eyebrow">Price from your exposure</div>
+      <h2>Value is the recovery work the next repeat does not create.</h2>
+      <p class="section-lede">Use your own incident history. ThumbGate does not claim a universal savings number.</p>
+      <div class="value-equation" role="img" aria-label="Repeat incidents multiplied by recovery hours and loaded hourly cost, plus downstream impact, equals avoidable recovery exposure">
+        <div class="value-factor"><strong>Repeat incidents</strong><span>per quarter</span></div>
+        <div class="value-operator">×</div>
+        <div class="value-factor"><strong>Recovery hours</strong><span>diagnosis, repair, review</span></div>
+        <div class="value-operator">×</div>
+        <div class="value-factor"><strong>Loaded hourly cost</strong><span>the people pulled into recovery</span></div>
+        <div class="value-operator">+</div>
+        <div class="value-factor value-result"><strong>Downstream impact</strong><span>delay, incident response, audit evidence</span></div>
+      </div>
+    </section>
+
+    <section id="segments">
+      <div class="eyebrow">Choose by buyer value</div>
+      <h2>One product. Three buying decisions.</h2>
+      <p class="section-lede">The fence is scope and service level—not an arbitrary discount.</p>
+      <div class="segment-grid">
+        <article class="segment-card">
+          <div class="eyebrow">Solo operator</div>
+          <h3>Evaluate free, then Pro</h3>
+          <p>Pro removes rule limits and adds personal recall, review, dashboard, and export workflows.</p>
+          <div class="fence"><strong>Fence:</strong> one operator, local-first, self-serve support. $19 monthly or $149 annual.</div>
+          <a class="button" href="/checkout/pro?utm_source=pricing&amp;utm_medium=segment_card&amp;utm_campaign=value_packaging_v1&amp;cta_id=pricing_segment_pro&amp;plan_id=pro" data-offer-link data-cta-id="pricing_segment_pro" data-plan-id="pro" data-value="19" data-segment="solo_operator">Choose Pro</a>
+        </article>
+        <article class="segment-card recommended">
+          <div class="eyebrow">Engineering or platform team</div>
+          <h3>Managed diagnostic</h3>
+          <p>Turn one expensive, repeated agent failure into a configured gate and a regression proof.</p>
+          <div class="fence"><strong>Fence:</strong> one supported local workflow, fixed scope, two-business-day delivery. $499 once.</div>
+          <a class="button" href="#enterprise-gate" data-offer-link data-cta-id="pricing_segment_diagnostic" data-plan-id="sprint_diagnostic" data-value="499" data-segment="workflow_team">Harden one workflow</a>
+        </article>
+        <article class="segment-card">
+          <div class="eyebrow">Regulated or multi-workflow team</div>
+          <h3>Enterprise service intake</h3>
+          <p>Scope approval boundaries, rollback evidence, and accountable rollout support after one workflow proves fit.</p>
+          <div class="fence"><strong>Fence:</strong> custom scope after intake. Hosted team features, SSO, and SIEM are not general availability.</div>
+          <a class="button" href="#enterprise-gate" data-offer-link data-cta-id="pricing_segment_enterprise" data-plan-id="enterprise_service" data-value="0" data-segment="regulated_team">Start with one diagnostic</a>
+        </article>
+      </div>
+    </section>
+
     <section>
       <div class="eyebrow">How ThumbGate stacks up</div>
       <h2>Make the alternative look expensive.</h2>
-      <p class="section-lede">Same move as high-converting SaaS pricing: DIY prompts cost nothing and stop nothing; platform hire and GRC suites cost months.</p>
+      <p class="section-lede">DIY prompts look cheap but still consume model and review time. Platform hiring and GRC suites require larger commitments.</p>
       <div style="overflow-x:auto;margin-top:22px;border:1px solid var(--line);border-radius:14px;background:var(--card);">
         <table style="width:100%;border-collapse:collapse;font-size:.92rem;min-width:620px;">
           <thead>
@@ -176,24 +253,24 @@
           <tbody>
             <tr>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);color:var(--muted);">Monthly cost</td>
-              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">$0</td>
-              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">$15k+ loaded</td>
-              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">$$$$</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Model + review time</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Loaded engineering cost</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Contract + implementation</td>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);font-weight:800;color:var(--green);">$0–$19 · $499 once</td>
             </tr>
             <tr>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);color:var(--muted);">Time to first gate</td>
-              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Never reliable</td>
+              <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Manual upkeep</td>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Weeks</td>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);">Months</td>
               <td style="padding:12px 14px;border-bottom:1px solid var(--line);font-weight:800;">Minutes after install / 2 business days managed</td>
             </tr>
             <tr>
               <td style="padding:12px 14px;color:var(--muted);">When agent “looks competent”</td>
-              <td style="padding:12px 14px;">Ignores the prompt</td>
+              <td style="padding:12px 14px;">Prompt may be skipped</td>
               <td style="padding:12px 14px;">Custom glue</td>
               <td style="padding:12px 14px;">Gateway only</td>
-              <td style="padding:12px 14px;font-weight:800;">Hard block at tool call</td>
+              <td style="padding:12px 14px;font-weight:800;">Configured gate at tool call</td>
             </tr>
           </tbody>
         </table>
@@ -254,13 +331,27 @@
       } catch (_) {}
     }
 
-    function offerProps(ctaId, placement) {
-      return { ctaId: ctaId, ctaPlacement: placement, planId: 'sprint_diagnostic', value: 499, currency: 'USD' };
+    function offerProps(ctaId, placement, planId, value, segment) {
+      return {
+        ctaId: ctaId,
+        ctaPlacement: placement,
+        planId: planId,
+        value: Number(value || 0),
+        currency: 'USD',
+        segment: segment,
+        experimentId: 'value_packaging_v1'
+      };
     }
 
     document.querySelectorAll('[data-offer-link]').forEach(function (link) {
       link.addEventListener('click', function () {
-        const props = offerProps(link.dataset.ctaId || 'pricing_anchor', 'pricing_anchor');
+        const props = offerProps(
+          link.dataset.ctaId || 'pricing_anchor',
+          'pricing_anchor',
+          link.dataset.planId || 'unknown',
+          link.dataset.value || '0',
+          link.dataset.segment || 'unknown'
+        );
         window.plausible('pricing_cta_click', { props: props });
         sendFirstPartyTelemetry('cta_click', props);
       });
@@ -269,7 +360,7 @@
     const checkoutForm = document.querySelector('[data-primary-checkout]');
     if (checkoutForm) {
       checkoutForm.addEventListener('submit', function () {
-        const props = offerProps('pricing_managed_gate_buy', 'pricing');
+        const props = offerProps('pricing_managed_gate_buy', 'pricing', 'sprint_diagnostic', 499, 'workflow_team');
         window.plausible('checkout_start', { props: props });
         sendFirstPartyTelemetry('checkout_start', props);
       });
@@ -283,7 +374,7 @@
       });
     });
 
-    sendFirstPartyTelemetry('pricing_page_view', { landingPath: '/pricing' });
+    sendFirstPartyTelemetry('pricing_page_view', { landingPath: '/pricing', experimentId: 'value_packaging_v1' });
   </script>
 </body>
 </html>

--- a/scripts/telemetry-analytics.js
+++ b/scripts/telemetry-analytics.js
@@ -419,7 +419,15 @@ function classifyTelemetryAudience(entry = {}, raw = {}) {
 }
 
 function sanitizeTelemetryPayload(payload = {}, headers = {}) {
-  const raw = payload && typeof payload === 'object' ? payload : {};
+  const envelope = payload && typeof payload === 'object' ? payload : {};
+  const nestedProps = envelope.props
+    && typeof envelope.props === 'object'
+    && !Array.isArray(envelope.props)
+    ? envelope.props
+    : {};
+  // Browser analytics libraries conventionally wrap event properties in
+  // `props`. Flatten that envelope while letting explicit top-level fields win.
+  const raw = { ...nestedProps, ...envelope };
   const clientType = inferClientType(raw);
   const eventType = inferEventType(raw, clientType);
   const source = pickFirstText(raw.source, raw.utmSource, clientType === 'cli' ? 'cli' : 'direct');
@@ -471,6 +479,10 @@ function sanitizeTelemetryPayload(payload = {}, headers = {}) {
     ctaId: pickFirstText(raw.ctaId),
     ctaPlacement: pickFirstText(raw.ctaPlacement),
     planId: pickFirstText(raw.planId),
+    segment: pickFirstText(raw.segment, raw.buyerSegment, raw.campaignVariant, raw.variant),
+    experimentId: pickFirstText(raw.experimentId, raw.experiment, raw.utmCampaign),
+    value: normalizeInteger(raw.value),
+    currency: pickFirstText(raw.currency),
     linkSlug: pickFirstText(raw.linkSlug, raw.destinationSlug),
     destinationPath: pickFirstText(raw.destinationPath),
     pipelineStatus: pickFirstText(raw.pipelineStatus, raw.workflowSprintStatus, raw.status),

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1026,6 +1026,8 @@ test('/go/diagnostic-pay requires POST plus a valid buyer email before Stripe', 
       customer_email: 'buyer@example.com',
       utm_source: 'audit',
       utm_medium: 'codex',
+      utm_campaign: 'value_packaging_v1',
+      campaign_variant: 'regulated_team',
       offer_code: 'VERIFY',
     }),
   });
@@ -1037,6 +1039,8 @@ test('/go/diagnostic-pay requires POST plus a valid buyer email before Stripe', 
   assert.equal(url.searchParams.get('customer_email'), null);
   assert.equal(url.searchParams.get('utm_source'), 'audit');
   assert.equal(url.searchParams.get('utm_medium'), 'codex');
+  assert.equal(url.searchParams.get('utm_campaign'), 'value_packaging_v1');
+  assert.equal(url.searchParams.get('campaign_variant'), 'regulated_team');
   assert.equal(url.searchParams.get('offer_code'), 'VERIFY');
   assert.equal(url.searchParams.get('cta_id'), 'go_diagnostic_pay');
   assert.equal(url.searchParams.get('landing_path'), '/go/diagnostic-pay');
@@ -1051,11 +1055,14 @@ test('/go/diagnostic-pay requires POST plus a valid buyer email before Stripe', 
     && entry.ctaId === 'go_diagnostic_pay'
     && entry.source === 'audit'
     && entry.utmMedium === 'codex'
+    && entry.utmCampaign === 'value_packaging_v1'
   ));
   assert.ok(confirmed, 'records the buyer-confirmed Payment Link redirect');
   assert.equal(confirmed.planId, 'sprint_diagnostic');
   assert.equal(confirmed.linkSlug, 'diagnostic-pay');
   assert.equal(confirmed.clientType, 'web');
+  assert.equal(confirmed.segment, 'regulated_team');
+  assert.equal(confirmed.experimentId, 'value_packaging_v1');
   assert.equal(confirmed.customerEmail, undefined, 'telemetry must not retain the receipt email');
 });
 

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1118,11 +1118,11 @@ test('pricing page is the single source of truth for what ThumbGate sells', asyn
   assert.equal(res.status, 200);
   assert.match(String(res.headers.get('content-type')), /text\/html/);
   const body = await res.text();
-  assert.match(body, /Enterprise Workflow Gate/i);
+  assert.match(body, /Managed Workflow Diagnostic/i);
   assert.match(body, /\$499/);
   assert.match(body, /\$19/);
   assert.match(body, /\$149/);
-  assert.match(body, /Start Pro — \$19\/mo/);
+  assert.match(body, />Start Pro<\/a>/);
   assert.match(body, /\/checkout\/pro/);
   assert.match(body, /action="\/go\/diagnostic-pay" method="POST"/);
   assert.match(body, /name="customer_email"[^>]*required/);

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -51,6 +51,23 @@ test.describe('/pricing dual-offer cash path', () => {
     await expect.poll(() => submitted).toContain('customer_email=buyer%40example.com');
     expect(submitted).toContain('plan_id=sprint_diagnostic');
     expect(submitted).toContain('utm_source=pricing');
+    expect(submitted).toContain('utm_campaign=value_packaging_v1');
+    expect(submitted).toContain('campaign_variant=workflow_team');
+  });
+
+  test('regulated-team selection survives the diagnostic checkout POST', async ({ page }) => {
+    let submitted;
+    await page.route('**/go/diagnostic-pay', async (route) => {
+      submitted = route.request().postData();
+      await route.fulfill({ status: 204, body: '' });
+    });
+    await page.goto('/pricing');
+    await page.locator('[data-cta-id="pricing_segment_enterprise"]').click();
+    await expect(page.locator('#pricing-buyer-segment')).toHaveValue('regulated_team');
+    await page.locator('#pricing-email').fill('buyer@example.com');
+    await page.getByRole('button', { name: 'Get Started — $499 Diagnostic' }).click();
+    await expect.poll(() => submitted).toContain('campaign_variant=regulated_team');
+    expect(submitted).toContain('utm_campaign=value_packaging_v1');
   });
 
   test('browser validation blocks checkout without a valid email', async ({ page }) => {

--- a/tests/e2e/pricing-page-clickability.spec.js
+++ b/tests/e2e/pricing-page-clickability.spec.js
@@ -4,7 +4,7 @@ test.describe('/pricing dual-offer cash path', () => {
   test('shows Pro self-serve and fixed-price managed gate', async ({ page }) => {
     await page.goto('/pricing');
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Stop paying for the same AI mistake twice');
-    await expect(page.getByRole('link', { name: 'Start Pro — $19/mo' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Start Pro', exact: true })).toBeVisible();
     await expect(page.locator('a[href*="/checkout/pro"]')).not.toHaveCount(0);
     await expect(page.locator('#enterprise-gate .price')).toHaveText('$499');
     await expect(page.locator('form[data-primary-checkout]')).toHaveCount(1);
@@ -16,6 +16,27 @@ test.describe('/pricing dual-offer cash path', () => {
     await page.locator('[data-cta-id="pricing_nav_buy"]').click();
     await expect(page).toHaveURL(/\/pricing#enterprise-gate$/);
     await expect(page.locator('#pricing-email')).toBeVisible();
+  });
+
+  test('offer clicks preserve plan, value, and buyer segment attribution', async ({ page }) => {
+    await page.goto('/pricing');
+    await page.locator('a[data-offer-link]').evaluateAll((links) => {
+      links.forEach((link) => link.addEventListener('click', (event) => event.preventDefault(), { capture: true }));
+    });
+
+    await page.locator('[data-cta-id="pricing_pro_buy"]').click();
+    await page.locator('[data-cta-id="pricing_segment_diagnostic"]').click();
+    await page.locator('[data-cta-id="pricing_segment_enterprise"]').click();
+
+    const events = await page.evaluate(() => window.plausible.q
+      .filter((entry) => entry[0] === 'pricing_cta_click')
+      .map((entry) => entry[1].props));
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ planId: 'pro', value: 19, segment: 'solo_operator' }),
+      expect.objectContaining({ planId: 'sprint_diagnostic', value: 499, segment: 'workflow_team' }),
+      expect.objectContaining({ planId: 'enterprise_service', value: 0, segment: 'regulated_team' })
+    ]));
+    expect(events.every((event) => event.experimentId === 'value_packaging_v1')).toBe(true);
   });
 
   test('valid buyer email posts directly to the canonical checkout route', async ({ page }) => {

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -28,7 +28,7 @@ test('pricing surfaces Pro self-serve and Diagnostic managed gate together', () 
   assert.match(PRICING_HTML, /action="\/go\/diagnostic-pay"/);
   assert.match(PRICING_HTML, /\$499/);
   assert.match(PRICING_HTML, /\/checkout\/pro/);
-  assert.match(PRICING_HTML, /Start Pro — \$19\/mo/);
+  assert.match(PRICING_HTML, />Start Pro<\/a>/);
   assert.match(PRICING_HTML, /\$19/);
   assert.match(PRICING_HTML, /\$149/);
   assert.doesNotMatch(PRICING_HTML, /workflow-sprint-intake|\/go\/sprint/i);

--- a/tests/pricing-page-telemetry.test.js
+++ b/tests/pricing-page-telemetry.test.js
@@ -15,6 +15,11 @@ test('pricing page emits first-party telemetry for views and buyer actions', () 
   assert.match(pricingHtml, /checkout_start/);
   assert.match(pricingHtml, /data-cta-id="pricing_nav_buy"/);
   assert.match(pricingHtml, /data-primary-checkout/);
+  assert.match(pricingHtml, /experimentId: 'value_packaging_v1'/);
+  assert.match(pricingHtml, /data-plan-id="pro" data-value="19" data-segment="solo_operator"/);
+  assert.match(pricingHtml, /data-plan-id="sprint_diagnostic" data-value="499" data-segment="workflow_team"/);
+  assert.match(pricingHtml, /data-plan-id="enterprise_service" data-value="0" data-segment="regulated_team"/);
+  assert.match(pricingHtml, /link\.dataset\.planId \|\| 'unknown'/);
   assert.match(pricingHtml, /href="https:\/\/github\.com\/IgorGanapolsky\/ThumbGate\/blob\/main\/docs\/VERIFICATION_EVIDENCE\.md"/);
 });
 
@@ -22,12 +27,28 @@ test('pricing exposes Pro self-serve and direct $499 managed-gate checkout', () 
   assert.match(pricingHtml, /action="\/go\/diagnostic-pay" method="POST"/);
   assert.match(pricingHtml, /Get Started — \$499 Diagnostic/);
   assert.match(pricingHtml, /name="customer_email"[^>]*required/);
-  assert.match(pricingHtml, /"name": "ThumbGate Enterprise Workflow Gate"/);
+  assert.match(pricingHtml, /"name": "ThumbGate Managed Workflow Diagnostic"/);
   assert.match(pricingHtml, /"price": "499"/);
+  assert.match(pricingHtml, /"name": "ThumbGate Pro monthly"/);
+  assert.match(pricingHtml, /"price": "19"/);
+  assert.match(pricingHtml, /"name": "ThumbGate Pro annual"/);
+  assert.match(pricingHtml, /"price": "149"/);
   assert.match(pricingHtml, /\/checkout\/pro/);
-  assert.match(pricingHtml, /Start Pro — \$19\/mo/);
+  assert.match(pricingHtml, />Start Pro<\/a>/);
   assert.match(pricingHtml, /\$19/);
   assert.match(pricingHtml, /\$149/);
   assert.doesNotMatch(pricingHtml, /\/go\/sprint|workflow-sprint-intake/);
   assert.doesNotMatch(pricingHtml, /\$1,500|\$3,000|\$10,000|\$15,000/);
+});
+
+test('pricing segments buyers by value and keeps public fences explicit', () => {
+  assert.match(pricingHtml, /Price from your exposure/);
+  assert.match(pricingHtml, /Repeat incidents/);
+  assert.match(pricingHtml, /Recovery hours/);
+  assert.match(pricingHtml, /Loaded hourly cost/);
+  assert.match(pricingHtml, /Solo operator/);
+  assert.match(pricingHtml, /Engineering or platform team/);
+  assert.match(pricingHtml, /Regulated or multi-workflow team/);
+  assert.match(pricingHtml, /Hosted team features, SSO, and SIEM are not general availability/);
+  assert.doesNotMatch(pricingHtml, /\$15k\+ loaded|Never reliable/);
 });

--- a/tests/pricing-page-telemetry.test.js
+++ b/tests/pricing-page-telemetry.test.js
@@ -20,6 +20,9 @@ test('pricing page emits first-party telemetry for views and buyer actions', () 
   assert.match(pricingHtml, /data-plan-id="sprint_diagnostic" data-value="499" data-segment="workflow_team"/);
   assert.match(pricingHtml, /data-plan-id="enterprise_service" data-value="0" data-segment="regulated_team"/);
   assert.match(pricingHtml, /link\.dataset\.planId \|\| 'unknown'/);
+  assert.match(pricingHtml, /name="utm_campaign" value="value_packaging_v1"/);
+  assert.match(pricingHtml, /name="campaign_variant" value="workflow_team"/);
+  assert.match(pricingHtml, /buyerSegment\.value = link\.dataset\.segment \|\| 'workflow_team'/);
   assert.match(pricingHtml, /href="https:\/\/github\.com\/IgorGanapolsky\/ThumbGate\/blob\/main\/docs\/VERIFICATION_EVIDENCE\.md"/);
 });
 
@@ -33,6 +36,14 @@ test('pricing exposes Pro self-serve and direct $499 managed-gate checkout', () 
   assert.match(pricingHtml, /"price": "19"/);
   assert.match(pricingHtml, /"name": "ThumbGate Pro annual"/);
   assert.match(pricingHtml, /"price": "149"/);
+  const jsonLdBlocks = [...pricingHtml.matchAll(/<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/g)]
+    .map((match) => JSON.parse(match[1]));
+  const offerGraph = jsonLdBlocks.find((block) => Array.isArray(block['@graph']))['@graph'];
+  const diagnostic = offerGraph.find((node) => node['@type'] === 'Service');
+  const pro = offerGraph.find((node) => node['@type'] === 'SoftwareApplication');
+  assert.equal(diagnostic.offers.price, '499');
+  assert.equal(diagnostic.offers.name, 'Managed workflow diagnostic');
+  assert.deepEqual(pro.offers.map((offer) => offer.price), ['19', '149']);
   assert.match(pricingHtml, /\/checkout\/pro/);
   assert.match(pricingHtml, />Start Pro<\/a>/);
   assert.match(pricingHtml, /\$19/);

--- a/tests/telemetry-analytics.test.js
+++ b/tests/telemetry-analytics.test.js
@@ -113,6 +113,34 @@ test('sanitizeTelemetryPayload normalizes modern web payloads', () => {
   assert.equal(entry.attributionTagged, true);
 });
 
+test('sanitizeTelemetryPayload preserves nested browser offer attribution', () => {
+  const entry = sanitizeTelemetryPayload({
+    event: 'checkout_start',
+    clientType: 'web',
+    page: '/pricing',
+    props: {
+      ctaId: 'pricing_managed_gate_buy',
+      ctaPlacement: 'pricing',
+      planId: 'sprint_diagnostic',
+      segment: 'regulated_team',
+      experimentId: 'value_packaging_v1',
+      value: 499,
+      currency: 'USD',
+      page: '/nested-must-not-win',
+    },
+  });
+
+  assert.equal(entry.eventType, 'checkout_start');
+  assert.equal(entry.page, '/pricing', 'explicit top-level fields win over nested props');
+  assert.equal(entry.ctaId, 'pricing_managed_gate_buy');
+  assert.equal(entry.ctaPlacement, 'pricing');
+  assert.equal(entry.planId, 'sprint_diagnostic');
+  assert.equal(entry.segment, 'regulated_team');
+  assert.equal(entry.experimentId, 'value_packaging_v1');
+  assert.equal(entry.value, 499);
+  assert.equal(entry.currency, 'USD');
+});
+
 test('sanitizeTelemetryPayload normalizes buyer-loss and SEO fields', () => {
   const entry = sanitizeTelemetryPayload({
     eventType: 'reason_not_buying',


### PR DESCRIPTION
## Outcome
- adds a visual recovery-cost equation based on buyer inputs, without inventing a savings claim
- segments solo operators, one-workflow teams, and regulated multi-workflow buyers with explicit package fences
- fixes Pro CTA telemetry that was incorrectly attributed to the $499 diagnostic
- adds offer-level plan, value, segment, and experiment attribution
- expands structured offer data for monthly Pro, annual Pro, and the managed diagnostic

## Verification
- 95 public landing and asset tests passed
- 25 checkout and commerce tests passed
- 7 landing claim tests passed
- 6 Playwright pricing interaction tests passed
- visual full-page inspection completed at desktop width
- npm ci: 0 vulnerabilities

## Evidence boundary
No Stripe catalog price was changed. This PR improves public packaging and measurement; it does not prove willingness to pay, conversion lift, or captured revenue.