### PR TITLE
fix(deploy): retry transient marketing probes

### DIFF
--- a/.changeset/retry-transient-marketing-probes.md
+++ b/.changeset/retry-transient-marketing-probes.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Retry bounded transient network and server failures in post-deploy marketing-page verification while continuing to fail deterministic content-contract mismatches immediately.

--- a/scripts/verify-marketing-pages-deployed.js
+++ b/scripts/verify-marketing-pages-deployed.js
@@ -109,7 +109,10 @@ async function probePageOnce({ prodUrl, route, sentinel, mustNotContain = [], us
         Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
       },
     });
-    const body = await res.text().catch(() => '');
+    // Keep body-read transport failures visible to the outer retry classifier.
+    // Treating a disconnected 2xx stream as an empty body would incorrectly
+    // turn an operational failure into a deterministic sentinel mismatch.
+    const body = await res.text();
     const sentinelPresent = body.includes(sentinel);
     const forbiddenPresent = Array.isArray(mustNotContain)
       ? mustNotContain.filter((value) => body.includes(value))

--- a/scripts/verify-marketing-pages-deployed.js
+++ b/scripts/verify-marketing-pages-deployed.js
@@ -22,6 +22,8 @@
  *   --json    machine-readable report on stdout, suitable for piping
  *             into the GitHub Actions PR comment step.
  *   --quiet   suppress per-route lines; only print the final summary.
+ *   --max-attempts=N     retry only transient transport/5xx failures.
+ *   --retry-delay-ms=N   bounded delay between transient retries.
  *
  * Exit code is 0 when every page passes, 1 if any sentinel is missing
  * or any route returns non-200.
@@ -32,6 +34,8 @@ const path = require('node:path');
 
 const DEFAULT_PROD_URL = 'https://thumbgate-production.up.railway.app';
 const DEFAULT_TIMEOUT_MS = 12000;
+const DEFAULT_MAX_ATTEMPTS = 2;
+const DEFAULT_RETRY_DELAY_MS = 500;
 const DEFAULT_MANIFEST_PATH = path.resolve(__dirname, '..', 'config', 'post-deploy-marketing-pages.json');
 
 function parseArgs(argv = []) {
@@ -41,6 +45,8 @@ function parseArgs(argv = []) {
     json: false,
     quiet: false,
     timeoutMs: DEFAULT_TIMEOUT_MS,
+    maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    retryDelayMs: DEFAULT_RETRY_DELAY_MS,
   };
   for (const arg of argv) {
     if (arg === '--json') out.json = true;
@@ -50,6 +56,12 @@ function parseArgs(argv = []) {
     else if (arg.startsWith('--timeout-ms=')) {
       const n = Number(arg.slice('--timeout-ms='.length));
       if (Number.isFinite(n) && n > 0) out.timeoutMs = n;
+    } else if (arg.startsWith('--max-attempts=')) {
+      const n = Number(arg.slice('--max-attempts='.length));
+      if (Number.isInteger(n) && n > 0 && n <= 5) out.maxAttempts = n;
+    } else if (arg.startsWith('--retry-delay-ms=')) {
+      const n = Number(arg.slice('--retry-delay-ms='.length));
+      if (Number.isInteger(n) && n >= 0 && n <= 5000) out.retryDelayMs = n;
     }
   }
   return out;
@@ -80,7 +92,7 @@ function loadManifest(manifestPath) {
   return parsed;
 }
 
-async function probePage({ prodUrl, route, sentinel, mustNotContain = [], userAgent, fetchImpl = globalThis.fetch, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+async function probePageOnce({ prodUrl, route, sentinel, mustNotContain = [], userAgent, fetchImpl, timeoutMs }) {
   if (typeof fetchImpl !== 'function') {
     return { route, ok: false, error: 'fetch_unavailable' };
   }
@@ -122,7 +134,67 @@ async function probePage({ prodUrl, route, sentinel, mustNotContain = [], userAg
   }
 }
 
-async function runVerification({ prodUrl, manifestPath, fetchImpl = globalThis.fetch, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+function isTransientProbeFailure(result = {}) {
+  if (result.ok) return false;
+  if (result.error && result.error !== 'fetch_unavailable') return true;
+  return result.status === 429 || result.status >= 500;
+}
+
+function waitForRetry(delayMs) {
+  if (!delayMs) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function probePage({
+  prodUrl,
+  route,
+  sentinel,
+  mustNotContain = [],
+  userAgent,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+}) {
+  const boundedAttempts = Number.isInteger(maxAttempts)
+    ? Math.min(Math.max(maxAttempts, 1), 5)
+    : DEFAULT_MAX_ATTEMPTS;
+  let result;
+  for (let attempt = 1; attempt <= boundedAttempts; attempt += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    result = await probePageOnce({
+      prodUrl,
+      route,
+      sentinel,
+      mustNotContain,
+      userAgent,
+      fetchImpl,
+      timeoutMs,
+    });
+    if (!isTransientProbeFailure(result) || attempt === boundedAttempts) {
+      return {
+        ...result,
+        attempts: attempt,
+        recoveredAfterRetry: Boolean(result.ok && attempt > 1),
+      };
+    }
+    // A deploy can pass /health while the first buyer-page request still
+    // wakes a cold instance. Retry only transient failures; content contract
+    // mismatches remain immediate, deterministic failures.
+    // eslint-disable-next-line no-await-in-loop
+    await waitForRetry(retryDelayMs);
+  }
+  return { ...result, attempts: boundedAttempts, recoveredAfterRetry: false };
+}
+
+async function runVerification({
+  prodUrl,
+  manifestPath,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+} = {}) {
   const manifest = loadManifest(manifestPath);
   const results = [];
   // Sequential is fine — manifest has <20 entries; parallelism would
@@ -137,6 +209,8 @@ async function runVerification({ prodUrl, manifestPath, fetchImpl = globalThis.f
       userAgent: entry.userAgent,
       fetchImpl,
       timeoutMs,
+      maxAttempts,
+      retryDelayMs,
     });
     results.push({ ...result, sentinel: entry.sentinel, description: entry.description });
   }
@@ -183,6 +257,8 @@ async function main(argv) {
       prodUrl: args.prodUrl,
       manifestPath: args.manifestPath,
       timeoutMs: args.timeoutMs,
+      maxAttempts: args.maxAttempts,
+      retryDelayMs: args.retryDelayMs,
     });
   } catch (error) {
     process.stderr.write(`verify-marketing-pages-deployed FAILED: ${error.message}\n`);
@@ -199,9 +275,12 @@ async function main(argv) {
 module.exports = {
   DEFAULT_PROD_URL,
   DEFAULT_TIMEOUT_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_DELAY_MS,
   DEFAULT_MANIFEST_PATH,
   parseArgs,
   loadManifest,
+  isTransientProbeFailure,
   probePage,
   runVerification,
   renderHuman,

--- a/tests/verify-marketing-pages-deployed.test.js
+++ b/tests/verify-marketing-pages-deployed.test.js
@@ -201,6 +201,32 @@ test('probePage: retries a transient timeout and records recovery', async () => 
   assert.equal(calls, 2);
 });
 
+test('probePage: retries a transient response-body disconnect', async () => {
+  let calls = 0;
+  const r = await probePage({
+    prodUrl: 'https://x.test',
+    route: '/',
+    sentinel: 'buyer page',
+    retryDelayMs: 0,
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 200,
+          ok: true,
+          async text() { throw new Error('terminated'); },
+        };
+      }
+      return response('buyer page');
+    },
+  });
+
+  assert.equal(r.ok, true);
+  assert.equal(r.attempts, 2);
+  assert.equal(r.recoveredAfterRetry, true);
+  assert.equal(calls, 2);
+});
+
 test('probePage: does not retry a deterministic content mismatch', async () => {
   let calls = 0;
   const r = await probePage({

--- a/tests/verify-marketing-pages-deployed.test.js
+++ b/tests/verify-marketing-pages-deployed.test.js
@@ -14,6 +14,8 @@ const {
   renderHuman,
   DEFAULT_PROD_URL,
   DEFAULT_MANIFEST_PATH,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETRY_DELAY_MS,
 } = require('../scripts/verify-marketing-pages-deployed');
 
 function writeManifest(pages, extra = {}) {
@@ -38,16 +40,20 @@ test('parseArgs: defaults + each flag', () => {
   assert.equal(def.quiet, false);
   assert.equal(def.manifestPath, DEFAULT_MANIFEST_PATH);
 
-  const flagged = parseArgs(['--json', '--quiet', '--prod-url=https://staging.example.com', '--manifest=/tmp/x.json', '--timeout-ms=5000']);
+  const flagged = parseArgs(['--json', '--quiet', '--prod-url=https://staging.example.com', '--manifest=/tmp/x.json', '--timeout-ms=5000', '--max-attempts=3', '--retry-delay-ms=250']);
   assert.equal(flagged.json, true);
   assert.equal(flagged.quiet, true);
   assert.equal(flagged.prodUrl, 'https://staging.example.com');
   assert.equal(flagged.manifestPath, '/tmp/x.json');
   assert.equal(flagged.timeoutMs, 5000);
+  assert.equal(flagged.maxAttempts, 3);
+  assert.equal(flagged.retryDelayMs, 250);
 
   // Negative + non-numeric --timeout-ms is ignored (defaults preserved)
   const bad = parseArgs(['--timeout-ms=not-a-number']);
   assert.equal(bad.timeoutMs, 12000);
+  assert.equal(bad.maxAttempts, DEFAULT_MAX_ATTEMPTS);
+  assert.equal(bad.retryDelayMs, DEFAULT_RETRY_DELAY_MS);
 });
 
 test('loadManifest: rejects empty pages array', () => {
@@ -146,6 +152,7 @@ test('probePage: surfaces fetch errors as error field', async () => {
     prodUrl: 'https://x.test',
     route: '/whatever',
     sentinel: 'x',
+    retryDelayMs: 0,
     fetchImpl: async () => { throw new Error('ECONNREFUSED'); },
   });
   assert.equal(r.ok, false);
@@ -158,6 +165,7 @@ test('probePage: aborts on timeout', async () => {
     route: '/slow',
     sentinel: 'x',
     timeoutMs: 5,
+    retryDelayMs: 0,
     fetchImpl: async (_url, opts) => new Promise((_, reject) => {
       if (opts?.signal) opts.signal.addEventListener('abort', () => {
         const e = new Error('aborted'); e.name = 'AbortError'; reject(e);
@@ -166,6 +174,49 @@ test('probePage: aborts on timeout', async () => {
   });
   assert.equal(r.ok, false);
   assert.match(r.error, /^timeout_after_/);
+  assert.equal(r.attempts, DEFAULT_MAX_ATTEMPTS);
+});
+
+test('probePage: retries a transient timeout and records recovery', async () => {
+  let calls = 0;
+  const r = await probePage({
+    prodUrl: 'https://x.test',
+    route: '/',
+    sentinel: 'buyer page',
+    retryDelayMs: 0,
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        const error = new Error('aborted');
+        error.name = 'AbortError';
+        throw error;
+      }
+      return response('buyer page');
+    },
+  });
+
+  assert.equal(r.ok, true);
+  assert.equal(r.attempts, 2);
+  assert.equal(r.recoveredAfterRetry, true);
+  assert.equal(calls, 2);
+});
+
+test('probePage: does not retry a deterministic content mismatch', async () => {
+  let calls = 0;
+  const r = await probePage({
+    prodUrl: 'https://x.test',
+    route: '/',
+    sentinel: 'expected buyer page',
+    retryDelayMs: 0,
+    fetchImpl: async () => {
+      calls += 1;
+      return response('wrong content');
+    },
+  });
+
+  assert.equal(r.ok, false);
+  assert.equal(r.attempts, 1);
+  assert.equal(calls, 1);
 });
 
 test('probePage: ok=false when fetch is unavailable', async () => {


### PR DESCRIPTION
## Outcome

Makes post-deploy buyer-surface verification resilient to one cold-start transport failure without weakening the content contract.

## Why

Exact-main deploy run 30660741739 reached the new Railway `buildSha`, then failed twice because only the first apex `/` probe timed out after 12 seconds. The other 18 routes passed, and direct production readback was healthy. The verifier had no bounded retry.

## Changes

- retry transient network, HTTP 429, and HTTP 5xx failures at most twice
- retain immediate failures for missing sentinels and forbidden content
- emit `attempts` and `recoveredAfterRetry` evidence
- bound retry count and delay from the CLI

## Proof

- `node --test tests/verify-marketing-pages-deployed.test.js` — 22/22
- `node --test tests/deployment.test.js` — 59/59
- live verifier against `https://thumbgate.ai` — 19/19
- `npm ci` — 0 vulnerabilities
