### PR TITLE
fix(runtime): converge lesson stores and reap dashboard servers

### DIFF
--- a/.changeset/fix-runtime-store-search-integrity.md
+++ b/.changeset/fix-runtime-store-search-integrity.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Stop statusline-launched dashboard API servers from leaking detached child processes, keep project lesson stores stable and isolated, scope SQLite search to the selected feedback root, abstain on lesson queries with no topical evidence, and fail embedding health when IDs are missing, stale, or orphaned.

--- a/scripts/feedback-paths.js
+++ b/scripts/feedback-paths.js
@@ -78,6 +78,15 @@ function isTransientProjectDir(dirPath, options = {}) {
   if (!normalizedDir) return true;
   if (!dirExists(normalizedDir)) return true;
 
+  // MCP hosts and desktop launchers commonly start global servers from `/` or
+  // the user's home directory. Those are launcher contexts, not projects. If
+  // they win resolution they create `projects/default` / `~/.thumbgate` split
+  // stores and make the same lesson corpus depend on which client started the
+  // process. A durable active-project state is a better signal.
+  if (normalizedDir === path.parse(normalizedDir).root) return true;
+  const homeDir = normalizeDir(getHomeDir(options));
+  if (homeDir && normalizedDir === homeDir) return true;
+
   const runtimeDir = getRuntimeDir(options);
   if (isWithinDir(normalizedDir, runtimeDir)) return true;
 
@@ -119,11 +128,12 @@ function writeActiveProjectState(projectDir, options = {}) {
 function resolveProjectDir(options = {}) {
   const env = options.env || process.env;
   const stored = options.includeStored === false ? null : readActiveProjectState(options);
-  const cwdCandidates = uniquePaths([
-    options.cwd,
-    env.PWD,
-    process.cwd(),
-  ]);
+  // An injected cwd is authoritative for callers that resolve on behalf of a
+  // different process. Mixing in this Node process's cwd can silently route a
+  // global launcher back into ThumbGate's own checkout during diagnostics.
+  const cwdCandidates = uniquePaths(options.cwd
+    ? [options.cwd]
+    : [env.PWD, process.cwd()]);
   const isTransientExecution = cwdCandidates.length > 0
     && cwdCandidates.every((candidate) => isTransientProjectDir(candidate, options));
   const candidates = uniquePaths([
@@ -167,14 +177,11 @@ function getExplicitFeedbackDir(options = {}) {
   const env = options.env || process.env;
   if (options.feedbackDir) return options.feedbackDir;
   if (options.skipExplicitFeedbackDir) return null;
-  // A caller-provided feedback root should stay authoritative over stored
-  // active-project state so isolated CLI/test commands do not drift into a
-  // different project. Only direct project overrides suppress it.
-  if (env.THUMBGATE_FEEDBACK_DIR && !hasDirectProjectScope(options)) {
+  // An explicit storage root is the strongest storage instruction. Project
+  // metadata may still identify the project, but it must not redirect writes
+  // out of an isolated test/runtime directory.
+  if (env.THUMBGATE_FEEDBACK_DIR) {
     return env.THUMBGATE_FEEDBACK_DIR;
-  }
-  if (hasDirectProjectScope(options)) {
-    return null;
   }
   if (env.RAILWAY_VOLUME_MOUNT_PATH) {
     return path.join(env.RAILWAY_VOLUME_MOUNT_PATH, 'feedback');
@@ -213,7 +220,11 @@ function resolveFeedbackDir(options = {}) {
   if (explicit) return explicit;
 
   const localThumbgate = getThumbgateFeedbackDir(options);
-  if (dirExists(localThumbgate)) return localThumbgate;
+  const projectDir = resolveProjectDir(options);
+  // A real project always owns one stable local store. Directory existence is
+  // not a routing signal: using it caused a project to start in a basename-only
+  // global store and then silently switch roots after `.thumbgate` was created.
+  if (!isTransientProjectDir(projectDir, options)) return localThumbgate;
 
   const localFallback = getFallbackFeedbackDir(options);
   if (dirExists(localFallback)) return localFallback;

--- a/scripts/feedback-paths.js
+++ b/scripts/feedback-paths.js
@@ -220,11 +220,7 @@ function resolveFeedbackDir(options = {}) {
   if (explicit) return explicit;
 
   const localThumbgate = getThumbgateFeedbackDir(options);
-  const projectDir = resolveProjectDir(options);
-  // A real project always owns one stable local store. Directory existence is
-  // not a routing signal: using it caused a project to start in a basename-only
-  // global store and then silently switch roots after `.thumbgate` was created.
-  if (!isTransientProjectDir(projectDir, options)) return localThumbgate;
+  if (dirExists(localThumbgate)) return localThumbgate;
 
   const localFallback = getFallbackFeedbackDir(options);
   if (dirExists(localFallback)) return localFallback;
@@ -232,7 +228,19 @@ function resolveFeedbackDir(options = {}) {
   const localLegacy = getLegacyFeedbackDir(options);
   if (dirExists(localLegacy)) return localLegacy;
 
-  return getGlobalFeedbackDir(options);
+  // Existing installations may only have the pre-1.31 basename-scoped store.
+  // Preserve that corpus instead of silently switching to an empty directory.
+  // New projects never create this legacy global shape, so same-basename
+  // projects remain isolated going forward.
+  const globalLegacy = getGlobalFeedbackDir(options);
+  if (dirExists(globalLegacy)) return globalLegacy;
+
+  const projectDir = resolveProjectDir(options);
+  // New real projects select their collision-free local store before it is
+  // created, preventing the old first-write flip from global to local.
+  if (!isTransientProjectDir(projectDir, options)) return localThumbgate;
+
+  return globalLegacy;
 }
 
 function getFeedbackPaths(options = {}) {

--- a/scripts/filesystem-search.js
+++ b/scripts/filesystem-search.js
@@ -154,14 +154,19 @@ function scoreRecord(queryTokens, queryText, record) {
 // ---------------------------------------------------------------------------
 
 function searchFeedbackLog(queryText, limit = 5, options = {}) {
-  const logPath = path.join(options.feedbackDir || getFeedbackDir(), 'feedback-log.jsonl');
+  const feedbackDir = options.feedbackDir || getFeedbackDir();
+  const logPath = path.join(feedbackDir, 'feedback-log.jsonl');
   let records = readJsonl(logPath);
 
-  // SQLite fallback: if JSONL is empty/tiny, pull records from the lesson DB
-  if (records.length <= 1) {
+  // SQLite fallback is allowed only inside the exact selected feedback root.
+  // Falling back through lesson-db's ambient default can cross project/tenant
+  // boundaries when a sparse project has zero or one JSONL row.
+  const lessonDbPath = path.join(feedbackDir, 'lessons.sqlite');
+  if (records.length <= 1 && fs.existsSync(lessonDbPath)) {
+    let db = null;
     try {
       const { initDB } = require('./lesson-db');
-      const db = initDB();
+      db = initDB(lessonDbPath);
       const rows = db.prepare('SELECT * FROM lessons ORDER BY timestamp DESC LIMIT 500').all();
       if (rows.length > records.length) {
         records = rows.map((r) => ({
@@ -171,12 +176,17 @@ function searchFeedbackLog(queryText, limit = 5, options = {}) {
           title: r.title || r.context,
           tags: r.tags ? JSON.parse(r.tags) : [],
           timestamp: r.timestamp,
-          whatWentWrong: r.what_went_wrong,
-          whatWorked: r.what_worked,
-          whatToChange: r.what_to_change,
+          whatWentWrong: r.whatWentWrong ?? r.what_went_wrong,
+          whatWorked: r.whatWorked ?? r.what_worked,
+          whatToChange: r.whatToChange ?? r.what_to_change,
         }));
       }
     } catch { /* lesson-db not available */ }
+    finally {
+      if (db) {
+        try { db.close(); } catch { /* best-effort close */ }
+      }
+    }
   }
 
   // Wildcard query: return all records sorted by recency

--- a/scripts/lesson-db.js
+++ b/scripts/lesson-db.js
@@ -15,14 +15,16 @@
 const path = require('node:path');
 const fs = require('node:fs');
 const { readJsonl } = require('./fs-utils');
+const { resolveFeedbackDir } = require('./feedback-paths');
 
-const PROJECT_ROOT = path.join(__dirname, '..');
-const DEFAULT_DB_PATH = path.join(PROJECT_ROOT, '.claude', 'memory', 'lessons.sqlite');
+function resolveDefaultDbPath(options = {}) {
+  return path.join(resolveFeedbackDir(options), 'lessons.sqlite');
+}
 
 /** @returns {import('better-sqlite3').Database} */
 function initDB(dbPath) {
   const Database = require('better-sqlite3');
-  const resolvedPath = dbPath || process.env.LESSON_DB_PATH || DEFAULT_DB_PATH;
+  const resolvedPath = dbPath || process.env.LESSON_DB_PATH || resolveDefaultDbPath();
 
   // Ensure parent directory exists
   const dir = path.dirname(resolvedPath);
@@ -643,7 +645,7 @@ function safeParseTags(tagsStr) {
   }
 }
 
-module.exports = {
+const lessonDbApi = {
   initDB,
   upsertLesson,
   upsertSession,
@@ -655,5 +657,14 @@ module.exports = {
   getStats,
   getStatsFromDB,
   backfillFromJsonl,
-  DEFAULT_DB_PATH,
+  resolveDefaultDbPath,
 };
+
+// Preserve the public property while resolving it at access time so callers
+// cannot cache a package-checkout path before project selection is known.
+Object.defineProperty(lessonDbApi, 'DEFAULT_DB_PATH', {
+  enumerable: true,
+  get: resolveDefaultDbPath,
+});
+
+module.exports = lessonDbApi;

--- a/scripts/lesson-embedding-maintenance.js
+++ b/scripts/lesson-embedding-maintenance.js
@@ -35,9 +35,11 @@ function evaluateEmbeddingIndexDrift(options = {}) {
   );
   const cache = readCache(cachePath);
   let indexedCount = 0;
-  let staleCount = 0;
+  const missingIds = [];
+  const staleIds = [];
   const providers = {};
   const dimensions = {};
+  const corpusIds = new Set(lessons.map((lesson) => lesson.id));
 
   for (const lesson of lessons) {
     const entry = cache[lesson.id];
@@ -52,9 +54,17 @@ function evaluateEmbeddingIndexDrift(options = {}) {
       providers[entry.provider] = (providers[entry.provider] || 0) + 1;
       dimensions[entry.dimension] = (dimensions[entry.dimension] || 0) + 1;
     } else if (entry) {
-      staleCount += 1;
+      staleIds.push(lesson.id);
+    } else {
+      missingIds.push(lesson.id);
     }
   }
+
+  const orphanedIds = Object.keys(cache)
+    .filter((id) => !corpusIds.has(id))
+    .sort();
+  missingIds.sort();
+  staleIds.sort();
 
   const corpusCount = lessons.length;
   const coverage = corpusCount ? indexedCount / corpusCount : 1;
@@ -62,10 +72,17 @@ function evaluateEmbeddingIndexDrift(options = {}) {
     ? true
     : isEmbedderAvailable();
   const minCoverage = Math.max(0, Math.min(1, Number(options.minCoverage) || 0.95));
+  const requireExact = options.requireExact !== false;
   const enabled = semanticProviderAvailable || Object.keys(cache).length > 0;
+  const exactIdSet = missingIds.length === 0
+    && staleIds.length === 0
+    && orphanedIds.length === 0;
   const status = !enabled
     ? 'not_configured'
-    : coverage >= minCoverage && staleCount === 0
+    : coverage >= minCoverage
+      && staleIds.length === 0
+      && orphanedIds.length === 0
+      && (!requireExact || exactIdSet)
       ? 'healthy'
       : 'unhealthy';
   return {
@@ -74,8 +91,14 @@ function evaluateEmbeddingIndexDrift(options = {}) {
     semanticProviderAvailable,
     corpusCount,
     indexedCount,
-    staleCount,
-    orphanedCount: Object.keys(cache).filter((id) => !lessons.some((lesson) => lesson.id === id)).length,
+    missingCount: missingIds.length,
+    missingIds,
+    staleCount: staleIds.length,
+    staleIds,
+    orphanedCount: orphanedIds.length,
+    orphanedIds,
+    exactIdSet,
+    requireExact,
     coverage: Number(coverage.toFixed(4)),
     minCoverage,
     providers,

--- a/scripts/lesson-embedding-maintenance.js
+++ b/scripts/lesson-embedding-maintenance.js
@@ -62,9 +62,9 @@ function evaluateEmbeddingIndexDrift(options = {}) {
 
   const orphanedIds = Object.keys(cache)
     .filter((id) => !corpusIds.has(id))
-    .sort();
-  missingIds.sort();
-  staleIds.sort();
+    .sort((left, right) => left.localeCompare(right));
+  missingIds.sort((left, right) => left.localeCompare(right));
+  staleIds.sort((left, right) => left.localeCompare(right));
 
   const corpusCount = lessons.length;
   const coverage = corpusCount ? indexedCount / corpusCount : 1;

--- a/scripts/lesson-search.js
+++ b/scripts/lesson-search.js
@@ -403,6 +403,8 @@ function scoreLesson(queryText, memory, parsed, sourceFeedback) {
   if (!queryText) {
     return {
       score: recencyScore(memory.timestamp),
+      evidenceScore: 0,
+      priorScore: recencyScore(memory.timestamp),
       matchedTokens: [],
     };
   }
@@ -410,14 +412,16 @@ function scoreLesson(queryText, memory, parsed, sourceFeedback) {
   const lessonText = buildLessonQuery(memory, parsed, sourceFeedback);
   const queryTokens = tokenize(queryText);
   const lessonTokens = tokenize(lessonText);
-  const score = jaccardSimilarity(queryTokens, lessonTokens)
-    + substringBoost(queryText, lessonText)
-    + recencyScore(memory.timestamp)
+  const evidenceScore = jaccardSimilarity(queryTokens, lessonTokens)
+    + substringBoost(queryText, lessonText);
+  const priorScore = recencyScore(memory.timestamp)
     + (memory.category === 'error' ? 0.05 : 0)
     + Math.min(0.2, scoreHybridMemoryMatch(queryText, memory).score * 0.1);
 
   return {
-    score,
+    score: evidenceScore + priorScore,
+    evidenceScore,
+    priorScore,
     matchedTokens: unique(queryTokens.filter((token) => lessonTokens.includes(token))),
   };
 }
@@ -427,7 +431,7 @@ function buildLessonResult(memory, sourceFeedback, options = {}) {
   const lessonQuery = buildLessonQuery(memory, parsed, sourceFeedback);
   const ruleMatches = readPreventionRuleMatches(lessonQuery, Number(options.ruleLimit || 3), options);
   const gateMatches = buildGateMatches(memory, parsed, Number(options.gateLimit || 3), options);
-  const { score, matchedTokens } = scoreLesson(options.query || '', memory, parsed, sourceFeedback);
+  const { score, evidenceScore, priorScore, matchedTokens } = scoreLesson(options.query || '', memory, parsed, sourceFeedback);
   const harnessRecommendations = buildHarnessRecommendations(memory, parsed, sourceFeedback, ruleMatches, gateMatches);
   const lifecycle = buildLifecycle(memory, parsed, sourceFeedback, ruleMatches, gateMatches, harnessRecommendations);
   const memoryLifecycle = buildMemoryLifecycleView(memory, { query: options.query || '' });
@@ -441,6 +445,8 @@ function buildLessonResult(memory, sourceFeedback, options = {}) {
     timestamp: memory.timestamp || null,
     sourceFeedbackId: memory.sourceFeedbackId || null,
     score: Number(score.toFixed(4)),
+    evidenceScore: Number(evidenceScore.toFixed(4)),
+    priorScore: Number(priorScore.toFixed(4)),
     matchedTokens,
     lesson: {
       summary: parsed.summary,
@@ -510,7 +516,10 @@ function searchLessons(query = '', options = {}) {
     results = results.filter((entry) => requiredTags.every((tag) => entry.tags.includes(tag)));
   }
   if (query) {
-    results = results.filter((entry) => entry.score > 0);
+    // Recency, error severity, and lifecycle priors can reorder candidates,
+    // but they are never evidence that a lesson answers the query. Returning a
+    // recent unrelated incident is worse than an honest empty result.
+    results = results.filter((entry) => entry.evidenceScore > 0);
   }
 
   results.sort((a, b) => {
@@ -558,9 +567,10 @@ function tryFts5Search(query, options) {
   // silently searching across tenants or sessions.
   if (options.scope || options.requireScope) return null;
   if (!process.env.LESSON_DB_SEARCH && !options.useFts5) return null;
+  let db = null;
   try {
     const { initDB, searchLessons: fts5Search, getStats } = require('./lesson-db');
-    const db = initDB();
+    db = initDB();
     const stats = getStats(db);
 
     // If DB is empty, skip (not yet backfilled)
@@ -629,6 +639,10 @@ function tryFts5Search(query, options) {
     };
   } catch (_err) {
     return null; // SQLite unavailable — fall through to JSONL
+  } finally {
+    if (db) {
+      try { db.close(); } catch { /* best-effort close */ }
+    }
   }
 }
 

--- a/scripts/statusline-links.js
+++ b/scripts/statusline-links.js
@@ -109,7 +109,7 @@ function launchLocalServer(options = {}) {
 
   const child = spawn(
     process.execPath,
-    [path.join(PKG_ROOT, 'bin', 'cli.js'), 'start-api'],
+    [path.join(PKG_ROOT, 'src', 'api', 'server.js')],
     {
       cwd: projectDir,
       env: childEnv,

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -21,7 +21,14 @@ PROJECT_CWD="${PROJECT_CWD:-}"
 if [ -n "$PROJECT_CWD" ] && [ -d "$PROJECT_CWD" ]; then
   export THUMBGATE_PROJECT_DIR="$PROJECT_CWD"
   if [ -z "${THUMBGATE_FEEDBACK_DIR:-}" ]; then
-    export THUMBGATE_FEEDBACK_DIR="${PROJECT_CWD}/.claude/memory/feedback"
+    THUMBGATE_FEEDBACK_DIR="$(node -e '
+      const { resolveFeedbackDir } = require(process.argv[1]);
+      process.stdout.write(resolveFeedbackDir({
+        projectDir: process.env.THUMBGATE_PROJECT_DIR,
+        env: process.env,
+      }));
+    ' "${SCRIPT_DIR}/feedback-paths.js" 2>/dev/null)"
+    export THUMBGATE_FEEDBACK_DIR="${THUMBGATE_FEEDBACK_DIR:-${PROJECT_CWD}/.thumbgate}"
   fi
 fi
 

--- a/tests/feedback-history-distiller.test.js
+++ b/tests/feedback-history-distiller.test.js
@@ -197,7 +197,7 @@ test('distillFeedbackHistory can reuse related feedback context when follow-up a
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-test('getConversationPaths honors feedback-dir environment overrides and cwd fallbacks', () => {
+test('getConversationPaths honors environment overrides and keeps a stable project-local store', () => {
   const tmpDir = makeTmpDir();
   const savedFeedbackDir = process.env.THUMBGATE_FEEDBACK_DIR;
   const savedRailwayDir = process.env.RAILWAY_VOLUME_MOUNT_PATH;
@@ -211,16 +211,12 @@ test('getConversationPaths honors feedback-dir environment overrides and cwd fal
 
   delete process.env.RAILWAY_VOLUME_MOUNT_PATH;
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-history-cwd-'));
-  fs.mkdirSync(path.join(cwd, '.thumbgate'), { recursive: true });
   const prevCwd = process.cwd();
   process.chdir(cwd);
-  assert.equal(fs.realpathSync(getConversationPaths().feedbackDir), fs.realpathSync(path.join(cwd, '.thumbgate')));
-  fs.rmSync(path.join(cwd, '.thumbgate'), { recursive: true, force: true });
+  const expectedFeedbackDir = path.join(fs.realpathSync(cwd), '.thumbgate');
+  assert.equal(getConversationPaths().feedbackDir, expectedFeedbackDir);
   fs.mkdirSync(path.join(cwd, '.claude', 'memory', 'feedback'), { recursive: true });
-  assert.equal(
-    fs.realpathSync(getConversationPaths().feedbackDir),
-    fs.realpathSync(path.join(cwd, '.claude', 'memory', 'feedback'))
-  );
+  assert.equal(getConversationPaths().feedbackDir, expectedFeedbackDir);
   process.chdir(prevCwd);
 
   if (savedFeedbackDir === undefined) delete process.env.THUMBGATE_FEEDBACK_DIR;
@@ -232,7 +228,7 @@ test('getConversationPaths honors feedback-dir environment overrides and cwd fal
   fs.rmSync(cwd, { recursive: true, force: true });
 });
 
-test('getConversationPaths falls back to HOME project path when no local dirs exist', () => {
+test('getConversationPaths uses the project-local store when no local dirs exist yet', () => {
   const savedFeedbackDir = process.env.THUMBGATE_FEEDBACK_DIR;
   const savedRailwayDir = process.env.RAILWAY_VOLUME_MOUNT_PATH;
   const prevCwd = process.cwd();
@@ -242,7 +238,7 @@ test('getConversationPaths falls back to HOME project path when no local dirs ex
   delete process.env.RAILWAY_VOLUME_MOUNT_PATH;
   process.chdir(cwd);
 
-  const expected = path.join(process.env.HOME || process.env.USERPROFILE || '', '.thumbgate', 'projects', path.basename(cwd));
+  const expected = path.join(fs.realpathSync(cwd), '.thumbgate');
   assert.equal(getConversationPaths().feedbackDir, expected);
 
   process.chdir(prevCwd);

--- a/tests/feedback-history-distiller.test.js
+++ b/tests/feedback-history-distiller.test.js
@@ -215,7 +215,6 @@ test('getConversationPaths honors environment overrides and keeps a stable proje
   process.chdir(cwd);
   const expectedFeedbackDir = path.join(fs.realpathSync(cwd), '.thumbgate');
   assert.equal(getConversationPaths().feedbackDir, expectedFeedbackDir);
-  fs.mkdirSync(path.join(cwd, '.claude', 'memory', 'feedback'), { recursive: true });
   assert.equal(getConversationPaths().feedbackDir, expectedFeedbackDir);
   process.chdir(prevCwd);
 

--- a/tests/filesystem-search.test.js
+++ b/tests/filesystem-search.test.js
@@ -15,6 +15,7 @@ describe('filesystem-search', () => {
     originalEnv = {
       THUMBGATE_FEEDBACK_DIR: process.env.THUMBGATE_FEEDBACK_DIR,
       THUMBGATE_CONTEXTFS_DIR: process.env.THUMBGATE_CONTEXTFS_DIR,
+      LESSON_DB_PATH: process.env.LESSON_DB_PATH,
     };
 
     // Set up test data
@@ -58,8 +59,10 @@ describe('filesystem-search', () => {
   after(() => {
     process.env.THUMBGATE_FEEDBACK_DIR = originalEnv.THUMBGATE_FEEDBACK_DIR || '';
     process.env.THUMBGATE_CONTEXTFS_DIR = originalEnv.THUMBGATE_CONTEXTFS_DIR || '';
+    process.env.LESSON_DB_PATH = originalEnv.LESSON_DB_PATH || '';
     if (!originalEnv.THUMBGATE_FEEDBACK_DIR) delete process.env.THUMBGATE_FEEDBACK_DIR;
     if (!originalEnv.THUMBGATE_CONTEXTFS_DIR) delete process.env.THUMBGATE_CONTEXTFS_DIR;
+    if (!originalEnv.LESSON_DB_PATH) delete process.env.LESSON_DB_PATH;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -98,6 +101,74 @@ describe('filesystem-search', () => {
       const results = mod.searchFeedbackLog('quantum physics spacetime');
       // Unrelated queries should score very low (near zero)
       results.forEach((r) => assert.ok(r._score <= 0.2, `Unrelated result score should be <=0.2, got ${r._score}`));
+    });
+
+    it('never falls back from an explicitly scoped project to a global lesson database', () => {
+      const selectedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-search-selected-'));
+      const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-search-global-'));
+      const globalDbPath = path.join(globalDir, 'lessons.sqlite');
+      fs.writeFileSync(path.join(selectedDir, 'feedback-log.jsonl'), '');
+      const { initDB, upsertLesson } = require('../scripts/lesson-db');
+      const db = initDB(globalDbPath);
+      try {
+        upsertLesson(db, {
+          id: 'fb_global',
+          signal: 'negative',
+          context: 'dashboard search record from another project',
+          whatToChange: 'Never cross project boundaries.',
+          timestamp: new Date().toISOString(),
+        }, { id: 'mem_global', importance: 'high' });
+      } finally {
+        db.close();
+      }
+
+      process.env.LESSON_DB_PATH = globalDbPath;
+      try {
+        const mod = loadModule();
+        assert.deepEqual(
+          mod.searchFeedbackLog('dashboard search', 5, { feedbackDir: selectedDir }),
+          [],
+        );
+      } finally {
+        fs.rmSync(selectedDir, { recursive: true, force: true });
+        fs.rmSync(globalDir, { recursive: true, force: true });
+      }
+    });
+
+    it('uses only the selected project SQLite fallback and preserves corrective fields', () => {
+      const selectedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-search-local-'));
+      const unrelatedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fs-search-unrelated-'));
+      const localDbPath = path.join(selectedDir, 'lessons.sqlite');
+      fs.writeFileSync(path.join(selectedDir, 'feedback-log.jsonl'), '');
+      const { initDB, upsertLesson } = require('../scripts/lesson-db');
+      const db = initDB(localDbPath);
+      try {
+        upsertLesson(db, {
+          id: 'fb_local',
+          signal: 'negative',
+          context: 'dashboard search local project record',
+          whatWentWrong: 'Search used the wrong lesson store.',
+          whatWorked: 'The scoped database returned the local lesson.',
+          whatToChange: 'Open only the database under the selected feedback directory.',
+          timestamp: new Date().toISOString(),
+        }, { id: 'mem_local', importance: 'high' });
+      } finally {
+        db.close();
+      }
+
+      process.env.LESSON_DB_PATH = path.join(unrelatedDir, 'lessons.sqlite');
+      try {
+        const mod = loadModule();
+        const results = mod.searchFeedbackLog('dashboard search local', 5, { feedbackDir: selectedDir });
+        assert.equal(results.length, 1);
+        assert.equal(results[0].id, 'mem_local');
+        assert.equal(results[0].whatWentWrong, 'Search used the wrong lesson store.');
+        assert.equal(results[0].whatWorked, 'The scoped database returned the local lesson.');
+        assert.equal(results[0].whatToChange, 'Open only the database under the selected feedback directory.');
+      } finally {
+        fs.rmSync(selectedDir, { recursive: true, force: true });
+        fs.rmSync(unrelatedDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/tests/lesson-db.test.js
+++ b/tests/lesson-db.test.js
@@ -88,6 +88,26 @@ describe('lesson-db', () => {
       assert.ok(names.includes('idx_lessons_timestamp'));
       assert.ok(names.includes('idx_lessons_skill'));
     });
+
+    it('defaults SQLite to the active feedback store instead of the package checkout', () => {
+      const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lesson-db-scoped-'));
+      const previousFeedbackDir = process.env.THUMBGATE_FEEDBACK_DIR;
+      const previousDbPath = process.env.LESSON_DB_PATH;
+      process.env.THUMBGATE_FEEDBACK_DIR = feedbackDir;
+      delete process.env.LESSON_DB_PATH;
+      let scopedDb;
+      try {
+        scopedDb = initDB();
+        assert.equal(path.resolve(scopedDb.name), path.join(feedbackDir, 'lessons.sqlite'));
+      } finally {
+        if (scopedDb) scopedDb.close();
+        if (previousFeedbackDir === undefined) delete process.env.THUMBGATE_FEEDBACK_DIR;
+        else process.env.THUMBGATE_FEEDBACK_DIR = previousFeedbackDir;
+        if (previousDbPath === undefined) delete process.env.LESSON_DB_PATH;
+        else process.env.LESSON_DB_PATH = previousDbPath;
+        fs.rmSync(feedbackDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('upsertLesson', () => {

--- a/tests/lesson-embedding-maintenance.test.js
+++ b/tests/lesson-embedding-maintenance.test.js
@@ -86,3 +86,65 @@ test('embedding maintenance invalidates content changes instead of counting stal
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test('embedding maintenance fails exact-corpus coverage even when rounded coverage reaches 95%', async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-embedding-exact-'));
+  try {
+    const lessons = Array.from({ length: 20 }, (_, index) => ({
+      id: `lesson-${index}`,
+      title: `Lesson ${index}`,
+      content: `Corrective action ${index}`,
+      tags: ['negative'],
+      timestamp: new Date().toISOString(),
+    }));
+    fs.writeFileSync(
+      path.join(directory, 'memory-log.jsonl'),
+      `${lessons.map((lesson) => JSON.stringify(lesson)).join('\n')}\n`,
+    );
+    await backfillLessonEmbeddings({
+      feedbackDir: directory,
+      embedder: async () => [1, 0, 0],
+      embedderId: 'maintenance-test',
+    });
+    const cachePath = path.join(directory, 'lesson-embeddings.json');
+    const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    delete cache['lesson-19'];
+    fs.writeFileSync(cachePath, JSON.stringify(cache));
+
+    const report = evaluateEmbeddingIndexDrift({
+      feedbackDir: directory,
+      embedder: async () => [1, 0, 0],
+    });
+    assert.equal(report.coverage, 0.95);
+    assert.equal(report.status, 'unhealthy');
+    assert.deepEqual(report.missingIds, ['lesson-19']);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('embedding maintenance fails when the cache contains orphaned lesson vectors', async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-embedding-orphan-'));
+  try {
+    writeCorpus(directory);
+    await backfillLessonEmbeddings({
+      feedbackDir: directory,
+      embedder: async () => [1, 0, 0],
+      embedderId: 'maintenance-test',
+    });
+    const cachePath = path.join(directory, 'lesson-embeddings.json');
+    const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    cache['orphaned-lesson'] = { ...cache['lesson-a'] };
+    fs.writeFileSync(cachePath, JSON.stringify(cache));
+
+    const report = evaluateEmbeddingIndexDrift({
+      feedbackDir: directory,
+      embedder: async () => [1, 0, 0],
+    });
+    assert.equal(report.coverage, 1);
+    assert.equal(report.status, 'unhealthy');
+    assert.deepEqual(report.orphanedIds, ['orphaned-lesson']);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tests/lesson-search.test.js
+++ b/tests/lesson-search.test.js
@@ -252,3 +252,39 @@ test('searchLessons applies transport and size filters to SQLite FTS5 results', 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test('searchLessons abstains when recency and error priors have no query evidence', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lesson-search-abstain-'));
+  process.env.THUMBGATE_FEEDBACK_DIR = tmpDir;
+  try {
+    const timestamp = new Date().toISOString();
+    writeJsonl(path.join(tmpDir, 'memory-log.jsonl'), [
+      {
+        id: 'mem_reddit',
+        title: 'MISTAKE: Reddit campaign reply lacked a permalink',
+        content: 'How to avoid: verify the public social post before reporting it live.',
+        category: 'error',
+        tags: ['negative', 'marketing'],
+        timestamp,
+      },
+      {
+        id: 'mem_stripe',
+        title: 'MISTAKE: Stripe receipt was not reconciled',
+        content: 'How to avoid: verify a non-owner payment before claiming revenue.',
+        category: 'error',
+        tags: ['negative', 'billing'],
+        timestamp,
+      },
+    ]);
+
+    delete require.cache[require.resolve('../scripts/lesson-search')];
+    const { searchLessons } = require('../scripts/lesson-search');
+    const result = searchLessons('dashboard search export reliability', { limit: 10 });
+
+    assert.equal(result.totalLessons, 2);
+    assert.equal(result.returned, 0);
+    assert.deepEqual(result.results, []);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/server-stdio-lock.test.js
+++ b/tests/server-stdio-lock.test.js
@@ -6,6 +6,9 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { spawn } = require('child_process');
+
+const CLI = path.resolve(__dirname, '../bin/cli.js');
 
 let tmpDir;
 
@@ -165,4 +168,167 @@ test('acquireLock: registers exit handler that removes lock file', () => {
 
   // Clean up the listener to avoid side effects on other tests
   process.removeListener('exit', ourListener);
+});
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(predicate, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return predicate();
+}
+
+function spawnServe(feedbackDir) {
+  return spawn(process.execPath, [CLI, 'serve'], {
+    env: {
+      ...process.env,
+      THUMBGATE_FEEDBACK_DIR: feedbackDir,
+      THUMBGATE_NO_TELEMETRY: '1',
+    },
+    stdio: ['pipe', 'ignore', 'pipe'],
+  });
+}
+
+test('two live stdio sessions coexist and closing one does not terminate its peer', async () => {
+  const first = spawnServe(tmpDir);
+  const second = spawnServe(tmpDir);
+  try {
+    const bothStarted = await waitFor(
+      () => isProcessAlive(first.pid) && isProcessAlive(second.pid),
+      2000,
+    );
+    assert.equal(bothStarted, true, 'both MCP sessions should be alive');
+
+    first.stdin.end();
+    const firstExited = await waitFor(() => !isProcessAlive(first.pid), 5000);
+    assert.equal(firstExited, true, 'session should exit after its own stdin closes');
+    assert.equal(isProcessAlive(second.pid), true, 'closing one session must not terminate its live peer');
+  } finally {
+    try { first.stdin.end(); } catch { /* cleanup */ }
+    try { second.stdin.end(); } catch { /* cleanup */ }
+    await waitFor(() => !isProcessAlive(first.pid), 1000);
+    await waitFor(() => !isProcessAlive(second.pid), 1000);
+    if (isProcessAlive(first.pid)) try { process.kill(first.pid, 'SIGKILL'); } catch { /* cleanup */ }
+    if (isProcessAlive(second.pid)) try { process.kill(second.pid, 'SIGKILL'); } catch { /* cleanup */ }
+  }
+});
+
+test('project resolution prefers active project over unscoped launcher roots', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-home-'));
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-project-'));
+  const runtimeDir = path.join(homeDir, '.thumbgate', 'runtime');
+  fs.mkdirSync(runtimeDir, { recursive: true });
+
+  const {
+    resolveProjectDir,
+    writeActiveProjectState,
+  } = require('../scripts/feedback-paths');
+  const env = { HOME: homeDir, USERPROFILE: homeDir, PWD: path.parse(homeDir).root };
+  try {
+    writeActiveProjectState(projectDir, { env });
+
+    for (const cwd of [path.parse(homeDir).root, homeDir, runtimeDir]) {
+      assert.equal(
+        resolveProjectDir({ cwd, env: { ...env, PWD: cwd } }),
+        projectDir,
+        `${cwd} must not become a project store when a valid active project exists`,
+      );
+    }
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('explicit project and feedback scopes remain authoritative', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-home-'));
+  const activeProject = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-active-'));
+  const explicitProject = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-explicit-'));
+  const explicitFeedback = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-feedback-'));
+  const { resolveFeedbackDir, resolveProjectDir, writeActiveProjectState } = require('../scripts/feedback-paths');
+  const env = { HOME: homeDir, USERPROFILE: homeDir, PWD: path.parse(homeDir).root };
+  try {
+    writeActiveProjectState(activeProject, { env });
+    assert.equal(resolveProjectDir({ cwd: '/', env: { ...env, THUMBGATE_PROJECT_DIR: explicitProject } }), explicitProject);
+    assert.equal(resolveProjectDir({ cwd: '/', env: { ...env, CLAUDE_PROJECT_DIR: explicitProject } }), explicitProject);
+    assert.equal(resolveFeedbackDir({ cwd: '/', env: { ...env, THUMBGATE_FEEDBACK_DIR: explicitFeedback } }), explicitFeedback);
+  } finally {
+    for (const dir of [homeDir, activeProject, explicitProject, explicitFeedback]) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test('project feedback store is stable before and after local directory creation', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-home-'));
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-store-project-'));
+  const { resolveFeedbackDir } = require('../scripts/feedback-paths');
+  const env = { HOME: homeDir, USERPROFILE: homeDir, THUMBGATE_PROJECT_DIR: projectDir };
+  try {
+    const before = resolveFeedbackDir({ cwd: projectDir, env });
+    fs.mkdirSync(path.join(projectDir, '.thumbgate'), { recursive: true });
+    const after = resolveFeedbackDir({ cwd: projectDir, env });
+    assert.equal(before, path.join(projectDir, '.thumbgate'));
+    assert.equal(after, before);
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('same-basename projects resolve to isolated local feedback stores', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-home-'));
+  const parentA = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-parent-a-'));
+  const parentB = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-parent-b-'));
+  const projectA = path.join(parentA, 'service');
+  const projectB = path.join(parentB, 'service');
+  fs.mkdirSync(projectA);
+  fs.mkdirSync(projectB);
+  const { resolveFeedbackDir } = require('../scripts/feedback-paths');
+  try {
+    const first = resolveFeedbackDir({
+      cwd: projectA,
+      env: { HOME: homeDir, USERPROFILE: homeDir, THUMBGATE_PROJECT_DIR: projectA },
+    });
+    const second = resolveFeedbackDir({
+      cwd: projectB,
+      env: { HOME: homeDir, USERPROFILE: homeDir, THUMBGATE_PROJECT_DIR: projectB },
+    });
+    assert.equal(first, path.join(projectA, '.thumbgate'));
+    assert.equal(second, path.join(projectB, '.thumbgate'));
+    assert.notEqual(first, second);
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(parentA, { recursive: true, force: true });
+    fs.rmSync(parentB, { recursive: true, force: true });
+  }
+});
+
+test('explicit feedback directory wins even when a project directory is inherited', () => {
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-project-'));
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-explicit-feedback-'));
+  const { resolveFeedbackDir } = require('../scripts/feedback-paths');
+  try {
+    assert.equal(resolveFeedbackDir({
+      cwd: projectDir,
+      env: {
+        HOME: os.homedir(),
+        THUMBGATE_PROJECT_DIR: projectDir,
+        THUMBGATE_FEEDBACK_DIR: feedbackDir,
+      },
+    }), feedbackDir);
+  } finally {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
+  }
 });

--- a/tests/server-stdio-lock.test.js
+++ b/tests/server-stdio-lock.test.js
@@ -314,6 +314,31 @@ test('same-basename projects resolve to isolated local feedback stores', () => {
   }
 });
 
+test('existing local and global lesson stores remain selected during upgrade', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-home-'));
+  const localProject = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-local-legacy-'));
+  const globalProject = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-global-legacy-'));
+  const localLegacy = path.join(localProject, '.claude', 'memory', 'feedback');
+  const globalLegacy = path.join(homeDir, '.thumbgate', 'projects', path.basename(globalProject));
+  const { resolveFeedbackDir } = require('../scripts/feedback-paths');
+  try {
+    fs.mkdirSync(localLegacy, { recursive: true });
+    fs.mkdirSync(globalLegacy, { recursive: true });
+    assert.equal(resolveFeedbackDir({
+      cwd: localProject,
+      env: { HOME: homeDir, USERPROFILE: homeDir, THUMBGATE_PROJECT_DIR: localProject },
+    }), localLegacy);
+    assert.equal(resolveFeedbackDir({
+      cwd: globalProject,
+      env: { HOME: homeDir, USERPROFILE: homeDir, THUMBGATE_PROJECT_DIR: globalProject },
+    }), globalLegacy);
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(localProject, { recursive: true, force: true });
+    fs.rmSync(globalProject, { recursive: true, force: true });
+  }
+});
+
 test('explicit feedback directory wins even when a project directory is inherited', () => {
   const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-project-'));
   const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-explicit-feedback-'));

--- a/tests/statusline-links.test.js
+++ b/tests/statusline-links.test.js
@@ -5,15 +5,39 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const net = require('net');
 
 const {
   getStatuslineLinks,
   isLoopbackHost,
+  isPidAlive,
+  launchLocalServer,
+  probeLocalServer,
   readRuntimeState,
   runtimeStatePath,
   shouldReuseBootingState,
   writeRuntimeState,
 } = require('../scripts/statusline-links');
+
+async function unusedPort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitFor(predicate, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return predicate();
+}
 
 test('getStatuslineLinks returns clickable local URLs when the dashboard is live', async () => {
   const result = await getStatuslineLinks({
@@ -135,4 +159,43 @@ test('isLoopbackHost only allows localhost addresses', () => {
   assert.equal(isLoopbackHost('127.0.0.1'), true);
   assert.equal(isLoopbackHost('::1'), true);
   assert.equal(isLoopbackHost('thumbgate.example.com'), false);
+});
+
+test('launchLocalServer records the real API PID and SIGTERM closes its health endpoint', async () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-statusline-owned-pid-'));
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-statusline-project-'));
+  const port = await unusedPort();
+  const origin = `http://127.0.0.1:${port}`;
+  let state = null;
+  try {
+    state = launchLocalServer({
+      homeDir,
+      cwd: projectDir,
+      origin,
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        THUMBGATE_ALLOW_INSECURE: 'true',
+        THUMBGATE_NO_TELEMETRY: '1',
+      },
+      resolveKey: () => ({ key: 'tg_statusline_test' }),
+    });
+
+    assert.equal(await waitFor(() => probeLocalServer(origin, { timeoutMs: 250 }), 8000), true);
+    process.kill(state.pid, 'SIGTERM');
+    assert.equal(await waitFor(() => !isPidAlive(state.pid), 5000), true, 'recorded server PID should exit');
+    assert.equal(
+      await waitFor(async () => !(await probeLocalServer(origin, { timeoutMs: 250 })), 5000),
+      true,
+      'health endpoint must close when the recorded PID is terminated',
+    );
+  } finally {
+    if (state) {
+      try { process.kill(-state.pid, 'SIGKILL'); } catch { /* process group already gone */ }
+      try { process.kill(state.pid, 'SIGKILL'); } catch { /* process already gone */ }
+    }
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
 });

--- a/tests/statusline.test.js
+++ b/tests/statusline.test.js
@@ -386,6 +386,49 @@ test('statusline resolves project feedback from Claude cwd instead of the runtim
   }
 });
 
+test('statusline starts a new project in the collision-free local store', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-statusline-new-project-'));
+  const homeDir = path.join(tmpDir, 'home');
+  const projectDir = path.join(tmpDir, 'project-delta');
+  fs.mkdirSync(homeDir, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  const env = {
+    ...process.env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    PATH: SAFE_SYSTEM_PATH,
+    PWD: projectDir,
+  };
+  delete env.THUMBGATE_FEEDBACK_DIR;
+  delete env.THUMBGATE_PROJECT_DIR;
+  delete env.CLAUDE_PROJECT_DIR;
+
+  try {
+    execFileSync('bash', [STATUSLINE_PATH], {
+      cwd: projectDir,
+      encoding: 'utf8',
+      input: JSON.stringify({
+        cwd: projectDir,
+        context_window: { used_percentage: 1 },
+      }),
+      env,
+      timeout: 5000,
+    });
+
+    assert.ok(
+      fs.existsSync(path.join(projectDir, '.thumbgate', 'statusline_cache.json')),
+      'new project status must use the local ThumbGate store',
+    );
+    assert.equal(
+      fs.existsSync(path.join(projectDir, '.claude', 'memory', 'feedback')),
+      false,
+      'statusline must not create the retired split store for new projects',
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('statusline shows Pro when a valid ThumbGate license is present', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-statusline-license-'));
   const homeDir = path.join(tmpDir, 'home');


### PR DESCRIPTION
## Summary

- record the real dashboard API server PID so termination closes the server instead of orphaning a child
- converge feedback and lesson storage on the selected project, with explicit storage overrides and same-basename isolation
- prevent cross-project SQLite fallback and preserve corrective lesson fields
- require topical evidence before lesson-search priors can qualify a result
- require exact corpus/vector ID parity for embedding health

## Why

ThumbGate could split one project's lessons across storage roots depending on launcher cwd and local-directory creation order. Dashboard sparse search could then fall back to another SQLite store. Statusline startup also recorded a wrapper PID, so stopping that PID left the real API process running under PPID 1.

## Verification

- reproduced before/after lifecycle: terminating the recorded PID previously left `/health` reachable; it now closes the endpoint
- focused regression checks: 103 passed
- conversation history path contract: 18/18 passed
- full `npm test`: exited 0
- `npm run prove:adapters`: 48/48 passed
- `npm run prove:automation`: 55/55 passed
- pre-push package dry-run, public-link validation, and regression guards: passed
- Sonar reliability findings: explicit locale-aware ID sorting; embedding maintenance 4/4 and semantic retrieval 20/20 passed
- upgrade compatibility: existing local/global stores retained; new statusline projects use local `.thumbgate`; path/statusline/search/DB regressions 149/149 passed

## Release

- includes a patch changeset
- npm publication and Railway deployment will be verified independently after protected merge/release

## Deferred conflicts

This PR intentionally does not touch currently contested dashboard API deletion/export or gate-retriever files. Those independently discovered issues require their own non-conflicting fixes.
