### PR TITLE
feat(gates): verify configured factual claim templates

### DIFF
--- a/.changeset/fair-mirrors-verify.md
+++ b/.changeset/fair-mirrors-verify.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": minor
+---
+
+Verify operator-configured quantitative claim wording with safe literal templates and live sources.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3241,6 +3241,11 @@ function verifyClaimsCmd() {
   process.exitCode = runCli(process.argv.slice(3));
 }
 
+function claimStopCheckCmd() {
+  const { main } = require(path.join(PKG_ROOT, 'scripts', 'hook-stop-anti-claim'));
+  main();
+}
+
 function help() {
   const v = pkgVersion();
   const helpArgs = process.argv.slice(3);
@@ -3310,6 +3315,7 @@ function help() {
   console.log('  cache-update          Refresh Claude statusline cache from stdin');
   console.log('  statusline-render     Render ThumbGate Claude status line');
   console.log('  hook-auto-capture     Process Claude UserPromptSubmit inline feedback');
+  console.log('  claim-stop-check      Recheck configured factual claims before Claude stops');
   console.log('  session-start         Refresh local ThumbGate session cache');
   console.log('');
 
@@ -3418,6 +3424,7 @@ const SUBCOMMAND_HELP = {
   lessons:       'Usage: npx thumbgate lessons [--query="..."] [--limit=N]\n\nSearch the lesson database (Pro feature).',
   search:        'Usage: npx thumbgate search <query>\n\nSearch ThumbGate knowledge base (Pro feature).',
   'gate-check':  'Usage: npx thumbgate gate-check\n\nPreToolUse hook interface: reads tool call JSON from stdin, outputs gate verdict.',
+  'claim-stop-check': 'Usage: npx thumbgate claim-stop-check\n\nClaude Stop-hook interface: reads the hook payload from stdin and blocks factual claims that disagree with configured sources.',
   'verify-claims': 'Usage: npx thumbgate verify-claims --claim="the row count is 1,284" [--config=.thumbgate/claim-verifiers.json] [--cwd=path] [--json]\n\nRecheck supported factual claims against operator-configured SQLite, filesystem, and JSON sources. Exits non-zero on mismatch, missing verifier, or verifier error.',
   'hermes-gate': 'Usage: npx thumbgate hermes-gate\n\nNous Research Hermes Agent pre_tool_call shell hook: reads Hermes tool-call JSON from stdin, runs the ThumbGate gate pipeline (strict by default), and outputs {"decision":"block","reason":...} to veto or {} to allow. Gates terminal/patch/skill_manage etc. See adapters/hermes/config.yaml.',
   'break-glass': 'Usage: npx thumbgate break-glass --reason="why" [--ttl=5m] [--json]\n\nShort-lived recovery path for over-firing gates. Allows hook settings edits and satisfies PR-create/thread-check gates without disabling core destructive-action protections.',
@@ -3696,6 +3703,9 @@ switch (COMMAND) {
     break;
   case 'hook-auto-capture':
     hookAutoCapture();
+    break;
+  case 'claim-stop-check':
+    claimStopCheckCmd();
     break;
   case 'session-start':
     sessionStart();

--- a/config/gates/claim-verifiers.example.json
+++ b/config/gates/claim-verifiers.example.json
@@ -30,6 +30,13 @@
       },
       "path": "package.json",
       "jsonPath": "version"
+    },
+    {
+      "id": "nightly-invoices",
+      "kind": "json_path",
+      "claimTemplate": "The nightly batch built {{value}} invoices",
+      "path": "metrics.json",
+      "jsonPath": "nightly.invoices"
     }
   ]
 }

--- a/docs/UNIVERSAL_CLAIM_EVALUATOR.md
+++ b/docs/UNIVERSAL_CLAIM_EVALUATOR.md
@@ -15,8 +15,9 @@ Wired into:
 
 - `verifyClaimEvidence()` in `scripts/gates-engine.js`
 - MCP tools `verify_claim` and `require_evidence_for_claim`
-- the configured Claude Code Stop hook (`scripts/hook-stop-anti-claim.js`),
-  which hard-blocks a parsed mismatch even when the agent never calls MCP
+- the Claude Code Stop hook installed by `thumbgate init --agent claude-code`
+  (`thumbgate claim-stop-check`), which hard-blocks a parsed mismatch even when
+  the agent never calls MCP
 - the portable `thumbgate verify-claims` CLI for other agent runtimes and CI
 - npm script `test:universal-claim-evaluator`
 
@@ -32,6 +33,26 @@ Wired into:
 | `config.json exists` | `file_exists` |
 | `secrets.env does not exist` | `file_exists` |
 | `package version is 1.31.0` | `value` |
+| `The nightly batch built 17 invoices` | operator-configured `claimTemplate` |
+
+The built-in grammar stays deliberately small. For any other quantitative
+wording, bind the exact sentence shape to a source with one numeric
+`{{value}}` slot:
+
+```json
+{
+  "id": "nightly-invoices",
+  "kind": "json_path",
+  "claimTemplate": "The nightly batch built {{value}} invoices",
+  "path": "metrics.json",
+  "jsonPath": "nightly.invoices"
+}
+```
+
+Templates are literals, not regexes. ThumbGate escapes every character outside
+the value slot, requires a unique verifier `id`, and rechecks only the path,
+query, or JSON selector supplied by the operator configuration. A malformed
+template fails closed.
 
 ## Configure verifiers
 
@@ -125,11 +146,19 @@ do not support Claude Stop hooks must invoke this command or the MCP completion
 gate before accepting output; ThumbGate cannot intercept a runtime that has no
 hook, MCP, or CLI integration.
 
+Claude Code is automatically wired at install time because it exposes a
+blocking `Stop` lifecycle. Other hosts are enforced only when their adapter
+calls `require_evidence_for_claim` or treats `verify-claims` exit status as a
+completion gate. A runtime without one of those integration points cannot be
+made to fail by an external package.
+
 ## What this is not
 
 - Not an unbounded NL-to-SQL compiler. Queries are operator-authored only.
 - Not a substitute for session `track_action` evidence on qualitative claims ("design matches Figma").
 - Not a guarantee that every English sentence is parsed — only the listed factual shapes.
+- Arbitrary quantitative wording requires an explicit `claimTemplate`; ThumbGate
+  does not guess which database or file a sentence refers to.
 - Not permission to market an arbitrary-English or every-runtime guarantee.
   The deterministic guarantee covers supported claim shapes on runtimes wired
   through the Stop hook, MCP gate, or CLI exit code.

--- a/scripts/auto-wire-hooks.js
+++ b/scripts/auto-wire-hooks.js
@@ -17,6 +17,7 @@ const fs = require('fs');
 const path = require('path');
 const {
   cacheUpdateHookCommand,
+  claimStopHookCommand,
   codexCacheUpdateHookCommand,
   codexPreToolHookCommand,
   codexSessionStartHookCommand,
@@ -48,6 +49,9 @@ const CLAUDE_HOOKS = {
   },
   SessionStart: {
     hooks: [{ type: 'command', command: sessionStartHookCommand() }],
+  },
+  Stop: {
+    hooks: [{ type: 'command', command: claimStopHookCommand() }],
   },
 };
 
@@ -384,6 +388,7 @@ function wireClaudeHooks(options) {
     UserPromptSubmit: /(hook-auto-capture\.sh|hook-auto-capture\b)/,
     PostToolUse: /(hook-thumbgate-cache-updater|cache-update\b)/,
     SessionStart: /(thumbgate_session_start\.sh|session-start\b)/,
+    Stop: /(hook-stop-anti-claim\.js|claim-stop-check\b)/,
   };
 
   for (const [lifecycle, hookDef] of Object.entries(CLAUDE_HOOKS)) {
@@ -456,8 +461,13 @@ function codexTomlConfigPath(configPath = codexConfigPath()) {
   return path.join(path.dirname(configPath), 'config.toml');
 }
 
+function escapeRegexLiteral(value) {
+  return String(value).replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
 function tomlSectionRegex(name) {
-  return new RegExp(`^\\[${String(name).replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}\\]\\n(?:^(?!\\[).*(?:\\n|$))*`, 'm');
+  const sectionName = escapeRegexLiteral(name);
+  return new RegExp(String.raw`^\[${sectionName}\]\n(?:^(?!\[).*(?:\n|$))*`, 'm');
 }
 
 function codexUserPromptTomlBlock() {
@@ -470,10 +480,11 @@ function upsertCodexUserPromptToml(configPath, dryRun = false) {
   const current = fs.existsSync(tomlPath) ? fs.readFileSync(tomlPath, 'utf8') : '';
   const canonicalBlock = codexUserPromptTomlBlock();
   const sectionRegex = tomlSectionRegex('hooks.user_prompt_submit');
-  let next = current;
+  const existingMatch = sectionRegex.exec(current);
+  let next;
 
-  if (sectionRegex.test(current)) {
-    const existingBlock = current.match(sectionRegex)[0];
+  if (existingMatch) {
+    const existingBlock = existingMatch[0];
     if (existingBlock === canonicalBlock) {
       return { changed: false, settingsPath: tomlPath };
     }
@@ -765,6 +776,7 @@ module.exports = {
   pruneStaleHooksInFile,
   CLAUDE_HOOKS,
   preToolHookCommand,
+  claimStopHookCommand,
   userPromptHookCommand,
   sessionStartHookCommand,
 };

--- a/scripts/hook-runtime.js
+++ b/scripts/hook-runtime.js
@@ -92,6 +92,10 @@ function cacheUpdateHookCommand() {
   return buildPortableHookCommand('cache-update');
 }
 
+function claimStopHookCommand() {
+  return buildPortableHookCommand('claim-stop-check');
+}
+
 function statuslineCommand() {
   return buildPortableHookCommand('statusline-render');
 }
@@ -120,6 +124,7 @@ module.exports = {
   buildPortableHookCommand,
   buildCodexPortableHookCommand,
   cacheUpdateHookCommand,
+  claimStopHookCommand,
   codexCacheUpdateHookCommand,
   codexPreToolHookCommand,
   codexSessionStartHookCommand,

--- a/scripts/hook-stop-anti-claim.js
+++ b/scripts/hook-stop-anti-claim.js
@@ -30,7 +30,6 @@
 
 const fs = require('node:fs');
 const {
-  parseFactualClaims,
   evaluateUniversalClaims,
 } = require('./universal-claim-evaluator');
 
@@ -238,9 +237,6 @@ function readStdinSync() {
 }
 
 function factualClaimBlock(text, options = {}) {
-  const parsed = parseFactualClaims(text);
-  if (parsed.length === 0) return null;
-
   try {
     const result = evaluateUniversalClaims(text, {
       cwd: options.cwd,
@@ -248,6 +244,7 @@ function factualClaimBlock(text, options = {}) {
       feedbackDir: options.feedbackDir,
       failUnconfigured: true,
     });
+    if (result.parsedCount === 0) return null;
     if (result.verified) return null;
     const failures = result.checks.filter((check) => !check.passed);
     return {
@@ -261,7 +258,7 @@ function factualClaimBlock(text, options = {}) {
           kind: check.kind,
           verifierId: check.verifierId || null,
           expected: check.expected,
-          actual: Object.prototype.hasOwnProperty.call(check, 'actual') ? check.actual : null,
+          actual: Object.hasOwn(check, 'actual') ? check.actual : null,
         })),
       },
     };
@@ -271,7 +268,7 @@ function factualClaimBlock(text, options = {}) {
       reason: `ThumbGate factual-claim gate failed closed: ${error.message}`,
       verification: {
         verified: false,
-        parsedCount: parsed.length,
+        parsedCount: null,
         failures: [{ status: 'evaluator_error' }],
       },
     };
@@ -360,4 +357,5 @@ module.exports = {
   extractText,
   extractToolUseSummary,
   factualClaimBlock,
+  main,
 };

--- a/scripts/universal-claim-evaluator.js
+++ b/scripts/universal-claim-evaluator.js
@@ -13,16 +13,20 @@
  * so agents cannot inject SQL or path traversal through the claim string.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { resolveFeedbackDir } = require('./feedback-paths');
 
 const DEFAULT_VERIFIERS_FILENAME = 'claim-verifiers.json';
+const CLAIM_VALUE_MARKER = '{{value}}';
+const NUMBER_PATTERN_SOURCE = String.raw`[-+]?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?`;
+const INTEGER_PATTERN_SOURCE = String.raw`[-+]?(?:\d{1,3}(?:,\d{3})+|\d+)`;
+const FILE_PATTERN_SOURCE = String.raw`([^\s,]+\.[A-Za-z0-9]+)`;
 
 function parseNumberToken(raw) {
   if (raw == null) return null;
-  const cleaned = String(raw).replace(/,/g, '').trim();
-  if (!/^-?\d+(?:\.\d+)?$/.test(cleaned)) return null;
+  const cleaned = String(raw).replaceAll(',', '').trim();
+  if (!/^[+-]?\d+(?:\.\d+)?$/.test(cleaned)) return null;
   const value = Number(cleaned);
   return Number.isFinite(value) ? value : null;
 }
@@ -30,9 +34,77 @@ function parseNumberToken(raw) {
 function normalizeSubject(value) {
   return String(value || '')
     .toLowerCase()
-    .replace(/[_./\\-]+/g, ' ')
-    .replace(/\s+/g, ' ')
+    .replaceAll(/[_./\\-]+/g, ' ')
+    .replaceAll(/\s+/g, ' ')
     .trim();
+}
+
+function escapeRegExp(value) {
+  return String(value).replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+function configuredClaimTemplates(verifier) {
+  const templates = [];
+  if (typeof verifier?.claimTemplate === 'string') templates.push(verifier.claimTemplate);
+  if (Array.isArray(verifier?.claimTemplates)) templates.push(...verifier.claimTemplates);
+  return templates;
+}
+
+/**
+ * Compile an operator-authored literal template containing exactly one numeric
+ * {{value}} slot. Everything outside the slot is regex-escaped, so a template
+ * cannot smuggle in executable regex or redirect the configured verifier.
+ */
+function compileConfiguredClaimTemplate(template) {
+  if (typeof template !== 'string' || template.length === 0 || template.length > 500) {
+    throw new Error('claim template must be a non-empty string of at most 500 characters');
+  }
+  const parts = template.split(CLAIM_VALUE_MARKER);
+  if (parts.length !== 2) {
+    throw new Error(`claim template must contain exactly one ${CLAIM_VALUE_MARKER} marker`);
+  }
+  if (parts.join('').replaceAll(/\s+/g, '').length < 3) {
+    throw new Error('claim template needs at least three literal characters outside the value marker');
+  }
+  const literalPattern = parts
+    .map((part) => escapeRegExp(part).replaceAll(/\s+/g, String.raw`\s+`))
+    .join(`(?<value>${NUMBER_PATTERN_SOURCE})`);
+  return new RegExp(String.raw`(?:^|(?<=\s))${literalPattern}(?=$|[\s.,;:!?])`, 'giu');
+}
+
+function validateConfiguredClaimTemplates(verifiers = []) {
+  for (const verifier of verifiers) {
+    const templates = configuredClaimTemplates(verifier);
+    if (templates.length === 0) continue;
+    const verifierId = typeof verifier?.id === 'string' ? verifier.id.trim() : '';
+    if (!verifierId) {
+      throw new Error('a verifier with claimTemplate or claimTemplates requires a unique id');
+    }
+    const matchingIds = verifiers.filter((candidate) => candidate?.id === verifierId);
+    if (matchingIds.length !== 1) {
+      throw new Error(`duplicate configured claim-template verifier id: ${verifierId}`);
+    }
+    for (const template of templates) compileConfiguredClaimTemplate(template);
+  }
+}
+
+function parseConfiguredClaimTemplates(source, verifiers, push) {
+  for (const verifier of verifiers) {
+    for (const template of configuredClaimTemplates(verifier)) {
+      const pattern = compileConfiguredClaimTemplate(template);
+      for (const match of source.matchAll(pattern)) {
+        const expected = parseNumberToken(match.groups?.value);
+        if (expected == null) continue;
+        push({
+          kind: 'configured_value',
+          subject: normalizeSubject(verifier.id),
+          expected,
+          raw: match[0],
+          verifierId: verifier.id,
+        });
+      }
+    }
+  }
 }
 
 function resolveRepoRoot(cwd) {
@@ -91,161 +163,159 @@ function resolveSafePath(repoRoot, targetPath) {
   return resolved;
 }
 
-/**
- * Extract structured factual claims from free text.
- * @returns {Array<{kind:string, subject:string, expected:*, path?:string, raw:string}>}
- */
-function parseFactualClaims(text) {
-  const source = String(text || '');
-  if (!source.trim()) return [];
-
+function createClaimCollector() {
   const claims = [];
   const seen = new Set();
-
   const push = (claim) => {
     const key = `${claim.kind}|${claim.subject}|${claim.path || ''}|${String(claim.expected)}`;
     if (seen.has(key)) return;
     seen.add(key);
     claims.push(claim);
   };
+  return { claims, push };
+}
 
-  // "the row count is 1,284" / "row count = 1284" / "orders count: 42"
-  const countPatterns = [
-    /\b((?:the\s+)?(?:total\s+)?(?:[a-z][\w\s.-]{0,40}?)?\s*(?:row|rows|record|records|entry|entries|item|items|order|orders|user|users|lesson|lessons|line|lines)?\s+counts?\b)\s*(?:is|are|=|:|equals?)\s*([-+]?\d{1,3}(?:,\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)\b/gi,
-    /\bthere\s+(?:is|are)\s+([-+]?\d{1,3}(?:,\d{3})*|\d+)\s+((?:rows?|records?|entries|items?|orders?|users?|lessons?|lines?))\b/gi,
-    /\bCOUNT\s*\(\s*\*\s*\)\s*(?:=|is|:)\s*([-+]?\d{1,3}(?:,\d{3})*|\d+)\b/gi,
-  ];
-
-  for (const re of countPatterns) {
-    re.lastIndex = 0;
-    let match = re.exec(source);
-    while (match) {
-      if (re === countPatterns[1]) {
-        // there are N rows
-        const expected = parseNumberToken(match[1]);
-        if (expected != null) {
-          push({
-            kind: 'count',
-            subject: normalizeSubject(match[2]),
-            expected,
-            raw: match[0],
-          });
-        }
-      } else if (re === countPatterns[2]) {
-        const expected = parseNumberToken(match[1]);
-        if (expected != null) {
-          push({
-            kind: 'count',
-            subject: 'count',
-            expected,
-            raw: match[0],
-          });
-        }
-      } else {
-        const expected = parseNumberToken(match[2]);
-        if (expected != null) {
-          push({
-            kind: 'count',
-            subject: normalizeSubject(match[1]),
-            expected,
-            raw: match[0],
-          });
-        }
-      }
-      match = re.exec(source);
-    }
+function collectPatternClaims(source, pattern, buildClaim, push) {
+  for (const match of source.matchAll(pattern)) {
+    const claim = buildClaim(match);
+    if (claim) push(claim);
   }
+}
 
-  // "file README.md has 120 lines" / "README.md is 1024 bytes"
-  const fileLineRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:has|contains)\s+([-+]?\d{1,3}(?:,\d{3})*|\d+)\s+lines?\b/gi;
-  let fileMatch = fileLineRe.exec(source);
-  while (fileMatch) {
-    const expected = parseNumberToken(fileMatch[2]);
-    if (expected != null) {
-      push({
-        kind: 'file_lines',
-        subject: 'lines',
-        path: fileMatch[1],
-        expected,
-        raw: fileMatch[0],
-      });
-    }
-    fileMatch = fileLineRe.exec(source);
-  }
+function numericClaim(match, { kind, subjectIndex, valueIndex, subject }) {
+  const expected = parseNumberToken(match[valueIndex]);
+  if (expected == null) return null;
+  return {
+    kind,
+    subject: subject || normalizeSubject(match[subjectIndex]),
+    expected,
+    raw: match[0],
+  };
+}
 
-  const fileBytesRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:is|has)\s+([-+]?\d{1,3}(?:,\d{3})*|\d+)\s+bytes?\b/gi;
-  fileMatch = fileBytesRe.exec(source);
-  while (fileMatch) {
-    const expected = parseNumberToken(fileMatch[2]);
-    if (expected != null) {
-      push({
-        kind: 'file_bytes',
-        subject: 'bytes',
-        path: fileMatch[1],
-        expected,
-        raw: fileMatch[0],
-      });
-    }
-    fileMatch = fileBytesRe.exec(source);
-  }
+function collectCountClaims(source, push) {
+  const directCount = new RegExp(
+    String.raw`\b([A-Za-z][\w.-]*(?:\s+[A-Za-z][\w.-]*){0,7}\s+counts?)\s*(?:is|are|=|:|equals?)\s*(${NUMBER_PATTERN_SOURCE})\b`,
+    'giu',
+  );
+  const thereAreCount = new RegExp(
+    String.raw`\bthere\s+(?:is|are)\s+(${INTEGER_PATTERN_SOURCE})\s+(rows?|records?|entries|items?|orders?|users?|lessons?|lines?)\b`,
+    'giu',
+  );
+  const sqlCount = new RegExp(
+    String.raw`\bCOUNT\s*\(\s*\*\s*\)\s*(?:=|is|:)\s*(${INTEGER_PATTERN_SOURCE})\b`,
+    'giu',
+  );
+  collectPatternClaims(source, directCount, (match) => numericClaim(match, {
+    kind: 'count', subjectIndex: 1, valueIndex: 2,
+  }), push);
+  collectPatternClaims(source, thereAreCount, (match) => numericClaim(match, {
+    kind: 'count', subjectIndex: 2, valueIndex: 1,
+  }), push);
+  collectPatternClaims(source, sqlCount, (match) => numericClaim(match, {
+    kind: 'count', valueIndex: 1, subject: 'count',
+  }), push);
+}
 
-  const fileExistsRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:exists|is present|is on disk)\b/gi;
-  fileMatch = fileExistsRe.exec(source);
-  while (fileMatch) {
-    push({
-      kind: 'file_exists',
-      subject: 'exists',
-      path: fileMatch[1],
-      expected: true,
-      raw: fileMatch[0],
-    });
-    fileMatch = fileExistsRe.exec(source);
-  }
+function fileNumericClaim(match, kind, subject) {
+  const claim = numericClaim(match, { kind, valueIndex: 2, subject });
+  return claim ? { ...claim, path: match[1] } : null;
+}
 
-  const fileMissingRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:does not exist|is missing|is absent)\b/gi;
-  fileMatch = fileMissingRe.exec(source);
-  while (fileMatch) {
-    push({
-      kind: 'file_exists',
-      subject: 'exists',
-      path: fileMatch[1],
-      expected: false,
-      raw: fileMatch[0],
-    });
-    fileMatch = fileMissingRe.exec(source);
-  }
+function collectFileClaims(source, push) {
+  const fileLines = new RegExp(
+    String.raw`\b(?:file\s+)?${FILE_PATTERN_SOURCE}\s+(?:has|contains)\s+(${INTEGER_PATTERN_SOURCE})\s+lines?\b`,
+    'giu',
+  );
+  const fileBytes = new RegExp(
+    String.raw`\b(?:file\s+)?${FILE_PATTERN_SOURCE}\s+(?:is|has)\s+(${INTEGER_PATTERN_SOURCE})\s+bytes?\b`,
+    'giu',
+  );
+  const fileExists = new RegExp(
+    String.raw`\b(?:file\s+)?${FILE_PATTERN_SOURCE}\s+(?:exists|is present|is on disk)\b`,
+    'giu',
+  );
+  const fileMissing = new RegExp(
+    String.raw`\b(?:file\s+)?${FILE_PATTERN_SOURCE}\s+(?:does not exist|is missing|is absent)\b`,
+    'giu',
+  );
+  collectPatternClaims(source, fileLines, (match) => fileNumericClaim(match, 'file_lines', 'lines'), push);
+  collectPatternClaims(source, fileBytes, (match) => fileNumericClaim(match, 'file_bytes', 'bytes'), push);
+  collectPatternClaims(source, fileExists, (match) => ({
+    kind: 'file_exists', subject: 'exists', path: match[1], expected: true, raw: match[0],
+  }), push);
+  collectPatternClaims(source, fileMissing, (match) => ({
+    kind: 'file_exists', subject: 'exists', path: match[1], expected: false, raw: match[0],
+  }), push);
+}
 
-  // "version is 1.31.0" / "package version equals 1.2.3"
-  const versionRe = /\b((?:package\s+)?version)\s*(?:is|=|:|equals?)\s*([vV]?\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?)\b/gi;
-  let versionMatch = versionRe.exec(source);
-  while (versionMatch) {
-    push({
+function collectVersionClaims(source, push) {
+  const versionPattern = new RegExp(
+    String.raw`\b((?:package\s+)?version)\s*(?:is|=|:|equals?)\s*([vV]?\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?)\b`,
+    'giu',
+  );
+  collectPatternClaims(source, versionPattern, (match) => {
+    const rawVersion = String(match[2]);
+    const expected = /^[vV]/.test(rawVersion) ? rawVersion.slice(1) : rawVersion;
+    return {
       kind: 'value',
-      subject: normalizeSubject(versionMatch[1]),
-      expected: String(versionMatch[2]).replace(/^v/i, ''),
-      raw: versionMatch[0],
-    });
-    versionMatch = versionRe.exec(source);
+      subject: normalizeSubject(match[1]),
+      expected,
+      raw: match[0],
+    };
+  }, push);
+}
+
+function addConfiguredClaim(claim, claims, push) {
+  const alreadyParsed = claims.find((existing) => (
+    existing.raw.toLowerCase() === claim.raw.toLowerCase()
+    && valuesEqual(existing.expected, claim.expected)
+  ));
+  if (!alreadyParsed) {
+    push(claim);
+    return;
   }
+  if (alreadyParsed.verifierId && alreadyParsed.verifierId !== claim.verifierId) {
+    throw new Error(
+      `claim matched multiple configured verifiers: ${alreadyParsed.verifierId}, ${claim.verifierId}`,
+    );
+  }
+  alreadyParsed.verifierId = claim.verifierId;
+}
+
+/**
+ * Extract structured factual claims from free text.
+ * @returns {Array<{kind:string, subject:string, expected:*, path?:string, raw:string}>}
+ */
+function parseFactualClaims(text, options = {}) {
+  const source = String(text || '');
+  if (!source.trim()) return [];
+
+  let verifiers = [];
+  if (Array.isArray(options)) verifiers = options;
+  else if (Array.isArray(options.verifiers)) verifiers = options.verifiers;
+  validateConfiguredClaimTemplates(verifiers);
+
+  const { claims, push } = createClaimCollector();
+  collectCountClaims(source, push);
+  collectFileClaims(source, push);
+  collectVersionClaims(source, push);
+  parseConfiguredClaimTemplates(source, verifiers, (claim) => addConfiguredClaim(claim, claims, push));
 
   return claims;
 }
 
-function loadVerifierConfig(options = {}) {
-  if (Array.isArray(options.verifiers)) {
-    return { verifiers: options.verifiers, source: 'options' };
-  }
-  if (Array.isArray(options.claimVerifiers)) {
-    return { verifiers: options.claimVerifiers, source: 'options.claimVerifiers' };
-  }
-  if (options.config && Array.isArray(options.config.verifiers)) {
-    return { verifiers: options.config.verifiers, source: 'options.config' };
-  }
-  if (options.claimVerifiers && Array.isArray(options.claimVerifiers.verifiers)) {
-    return { verifiers: options.claimVerifiers.verifiers, source: 'options.claimVerifiers' };
-  }
+function inlineVerifierConfig(options) {
+  const candidates = [
+    { verifiers: options.verifiers, source: 'options' },
+    { verifiers: options.claimVerifiers, source: 'options.claimVerifiers' },
+    { verifiers: options.config?.verifiers, source: 'options.config' },
+    { verifiers: options.claimVerifiers?.verifiers, source: 'options.claimVerifiers' },
+  ];
+  return candidates.find((candidate) => Array.isArray(candidate.verifiers)) || null;
+}
 
-  const repoRoot = resolveRepoRoot(options.cwd);
+function verifierConfigPaths(options, repoRoot) {
   const candidates = [];
   const explicitConfigPath = options.configPath || process.env.THUMBGATE_CLAIM_VERIFIERS_PATH;
   if (explicitConfigPath) {
@@ -257,27 +327,39 @@ function loadVerifierConfig(options = {}) {
     }
     candidates.push(resolvedExplicit);
   }
-
   const feedbackDir = options.feedbackDir || resolveFeedbackDir({ cwd: repoRoot });
-  candidates.push(path.join(feedbackDir, DEFAULT_VERIFIERS_FILENAME));
+  candidates.push(
+    path.join(feedbackDir, DEFAULT_VERIFIERS_FILENAME),
+    path.join(repoRoot, '.thumbgate', DEFAULT_VERIFIERS_FILENAME),
+    path.join(repoRoot, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME),
+  );
+  return new Set(candidates);
+}
 
-  candidates.push(path.join(repoRoot, '.thumbgate', DEFAULT_VERIFIERS_FILENAME));
-  candidates.push(path.join(repoRoot, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME));
-
-  for (const candidate of [...new Set(candidates)]) {
-    if (!candidate || !fs.existsSync(candidate)) continue;
-    try {
-      const raw = JSON.parse(fs.readFileSync(candidate, 'utf8'));
-      const verifiers = Array.isArray(raw?.verifiers) ? raw.verifiers : Array.isArray(raw) ? raw : null;
-      if (!verifiers) {
-        throw new Error('expected an array or an object with a verifiers array');
-      }
-      return { verifiers, source: candidate, path: candidate };
-    } catch (error) {
-      throw new Error(`invalid claim verifier config ${candidate}: ${error.message}`);
+function readVerifierConfig(candidate) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+    let verifiers = null;
+    if (Array.isArray(raw?.verifiers)) verifiers = raw.verifiers;
+    else if (Array.isArray(raw)) verifiers = raw;
+    if (!verifiers) {
+      throw new Error('expected an array or an object with a verifiers array');
     }
+    return { verifiers, source: candidate, path: candidate };
+  } catch (error) {
+    throw new Error(`invalid claim verifier config ${candidate}: ${error.message}`);
   }
+}
 
+function loadVerifierConfig(options = {}) {
+  const inline = inlineVerifierConfig(options);
+  if (inline) return inline;
+
+  const repoRoot = resolveRepoRoot(options.cwd);
+  for (const candidate of verifierConfigPaths(options, repoRoot)) {
+    if (!candidate || !fs.existsSync(candidate)) continue;
+    return readVerifierConfig(candidate);
+  }
   return { verifiers: [], source: 'none' };
 }
 
@@ -293,8 +375,8 @@ function subjectMatches(claimSubject, matcherSubjects = []) {
 }
 
 function normalizeVerifierPath(value) {
-  const normalized = path.posix.normalize(String(value || '').replace(/\\/g, '/'));
-  return normalized.replace(/^\.\//, '').toLowerCase();
+  const normalized = path.posix.normalize(String(value || '').replaceAll('\\', '/'));
+  return normalized.startsWith('./') ? normalized.slice(2).toLowerCase() : normalized.toLowerCase();
 }
 
 function pathMatches(claimPath, matcherPaths = []) {
@@ -308,55 +390,55 @@ function pathMatches(claimPath, matcherPaths = []) {
   return false;
 }
 
-function findVerifierForClaim(claim, verifiers) {
-  for (const verifier of verifiers) {
-    if (!verifier || typeof verifier !== 'object') continue;
-    const match = verifier.match || {};
-    const kinds = Array.isArray(match.kinds) && match.kinds.length > 0
-      ? match.kinds
-      : [verifier.kind];
-
-    if (!kinds.includes(claim.kind) && !(claim.kind === 'count' && kinds.includes('sqlite_count'))) {
-      // allow sqlite_count verifiers to serve generic count claims
-      if (!(claim.kind === 'count' && verifier.kind === 'sqlite_count')) {
-        if (!(claim.kind === 'value' && ['json_path', 'value'].includes(verifier.kind))) {
-          if (!(claim.kind === 'file_lines' && verifier.kind === 'file_lines')) {
-            if (!(claim.kind === 'file_bytes' && verifier.kind === 'file_bytes')) {
-              if (!(claim.kind === 'file_exists' && verifier.kind === 'file_exists')) {
-                continue;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    const subjects = match.subjects || verifier.subjects || [];
-    const paths = match.paths || (verifier.path ? [verifier.path] : []);
-
-    if (claim.path) {
-      if (paths.length > 0 && !pathMatches(claim.path, paths)) continue;
-      // path claim without subject constraint is ok when path matches
-      if (subjects.length > 0 && claim.subject && !subjectMatches(claim.subject, subjects) && claim.kind === 'count') {
-        continue;
-      }
-      return verifier;
-    }
-
-    if (subjects.length === 0) {
-      // bare verifier without subject matchers only binds file-path claims above
-      continue;
-    }
-    if (subjectMatches(claim.subject, subjects)) return verifier;
+function verifierSupportsClaim(verifier, claim) {
+  const match = verifier.match || {};
+  const kinds = Array.isArray(match.kinds) && match.kinds.length > 0
+    ? match.kinds
+    : [verifier.kind];
+  if (kinds.includes(claim.kind)) return true;
+  if (claim.kind === 'count') {
+    return kinds.includes('sqlite_count') || verifier.kind === 'sqlite_count';
   }
-  return null;
+  const compatibleVerifierKinds = {
+    value: ['json_path', 'value'],
+    file_lines: ['file_lines'],
+    file_bytes: ['file_bytes'],
+    file_exists: ['file_exists'],
+  };
+  return compatibleVerifierKinds[claim.kind]?.includes(verifier.kind) || false;
+}
+
+function verifierMatchesClaim(verifier, claim) {
+  if (!verifier || typeof verifier !== 'object' || !verifierSupportsClaim(verifier, claim)) {
+    return false;
+  }
+  const match = verifier.match || {};
+  const subjects = match.subjects || verifier.subjects || [];
+  const paths = match.paths || (verifier.path ? [verifier.path] : []);
+  if (claim.path) {
+    if (paths.length > 0 && !pathMatches(claim.path, paths)) return false;
+    const countSubjectMismatch = claim.kind === 'count'
+      && subjects.length > 0
+      && claim.subject
+      && !subjectMatches(claim.subject, subjects);
+    return !countSubjectMismatch;
+  }
+  return subjects.length > 0 && subjectMatches(claim.subject, subjects);
+}
+
+function findVerifierForClaim(claim, verifiers) {
+  if (claim.verifierId) {
+    return verifiers.find((verifier) => verifier?.id === claim.verifierId) || null;
+  }
+  return verifiers.find((verifier) => verifierMatchesClaim(verifier, claim)) || null;
 }
 
 function assertSelectOnly(query) {
   const normalized = String(query || '').trim();
   if (!normalized) throw new Error('sqlite_count verifier requires query');
   // Strip trailing semicolon and require a single SELECT statement.
-  const body = normalized.replace(/;+\s*$/, '');
+  let body = normalized;
+  while (body.endsWith(';')) body = body.slice(0, -1).trimEnd();
   if (/;/.test(body)) throw new Error('sqlite_count query must be a single statement');
   if (!/^\s*select\b/i.test(body)) throw new Error('sqlite_count query must be SELECT-only');
   if (/\b(insert|update|delete|drop|alter|attach|pragma|create|replace|vacuum|reindex)\b/i.test(body)) {
@@ -396,7 +478,7 @@ function readFileLines(repoRoot, filePath) {
   if (content.length === 0) return 0;
   // Count newline-terminated lines; trailing content without newline still counts as a line.
   const parts = content.split(/\r?\n/);
-  return parts.length > 0 && parts[parts.length - 1] === '' ? parts.length - 1 : parts.length;
+  return parts.length > 0 && parts.at(-1) === '' ? parts.length - 1 : parts.length;
 }
 
 function readFileBytes(repoRoot, filePath) {
@@ -421,7 +503,7 @@ function readJsonPath(repoRoot, verifier) {
   for (const segment of segments) {
     if (cursor == null
       || typeof cursor !== 'object'
-      || !Object.prototype.hasOwnProperty.call(cursor, segment)) {
+      || !Object.hasOwn(cursor, segment)) {
       throw new Error(`json path not found: ${pointer}`);
     }
     cursor = cursor[segment];
@@ -460,6 +542,71 @@ function valuesEqual(expected, actual) {
   return String(actual) === String(expected);
 }
 
+function claimCheckBase(claim) {
+  return {
+    claim: claim.raw,
+    kind: claim.kind,
+    subject: claim.subject,
+    expected: claim.expected,
+  };
+}
+
+function unconfiguredClaimCheck(claim, failUnconfigured) {
+  let message = `Parsed factual claim "${claim.raw}" with no verifier (advisory).`;
+  if (failUnconfigured) {
+    message = `Parsed factual claim "${claim.raw}" but no matching verifier is configured. Add one under .thumbgate/claim-verifiers.json (or config/gates/claim-verifiers.json).`;
+  }
+  return {
+    ...claimCheckBase(claim),
+    path: claim.path || null,
+    passed: !failUnconfigured,
+    status: 'unconfigured',
+    missing: failUnconfigured ? ['claim_verifier_configured'] : [],
+    message,
+  };
+}
+
+function verifierClaimCheck(claim, verifier, repoRoot) {
+  const verifierLabel = verifier.id || verifier.kind;
+  try {
+    const actual = runVerifier(claim, verifier, repoRoot);
+    const passed = valuesEqual(claim.expected, actual);
+    const status = passed ? 'match' : 'mismatch';
+    const message = `Claim ${passed ? 'verified' : 'mismatch'} via ${verifierLabel}: expected ${String(claim.expected)}, observed ${String(actual)}`;
+    return {
+      ...claimCheckBase(claim),
+      claimedPath: claim.path || null,
+      path: verifier.path || null,
+      actual,
+      verifierId: verifier.id || null,
+      verifierKind: verifier.kind,
+      passed,
+      status,
+      missing: passed ? [] : ['claim_value_match'],
+      message,
+    };
+  } catch (error) {
+    return {
+      ...claimCheckBase(claim),
+      claimedPath: claim.path || null,
+      path: verifier.path || null,
+      verifierId: verifier.id || null,
+      verifierKind: verifier.kind,
+      passed: false,
+      status: 'verifier_error',
+      missing: ['claim_verifier_success'],
+      message: `Verifier ${verifierLabel} failed: ${error?.message || 'unknown error'}`,
+    };
+  }
+}
+
+function evaluateClaim(claim, verifiers, repoRoot, failUnconfigured) {
+  const verifier = findVerifierForClaim(claim, verifiers);
+  return verifier
+    ? verifierClaimCheck(claim, verifier, repoRoot)
+    : unconfiguredClaimCheck(claim, failUnconfigured);
+}
+
 /**
  * Evaluate free-text claims against configured verifiers.
  *
@@ -480,87 +627,29 @@ function valuesEqual(expected, actual) {
 function evaluateUniversalClaims(claimText, options = {}) {
   const repoRoot = resolveRepoRoot(options.cwd);
   const failUnconfigured = options.failUnconfigured !== false;
-  const parsed = parseFactualClaims(claimText);
+  const { verifiers, source: configSource } = loadVerifierConfig(options);
+  validateConfiguredClaimTemplates(verifiers);
+  const parsed = parseFactualClaims(claimText, { verifiers });
   if (parsed.length === 0) {
     return {
       verified: true,
       claims: [],
       checks: [],
-      configSource: 'not_loaded',
-      verifierCount: 0,
+      configSource,
+      verifierCount: verifiers.length,
       parsedCount: 0,
     };
   }
-
-  const { verifiers, source: configSource } = loadVerifierConfig(options);
-  const checks = [];
-  const claimResults = [];
-
-  for (const claim of parsed) {
-    const verifier = findVerifierForClaim(claim, verifiers);
-    if (!verifier) {
-      const check = {
-        claim: claim.raw,
-        kind: claim.kind,
-        subject: claim.subject,
-        path: claim.path || null,
-        expected: claim.expected,
-        passed: !failUnconfigured,
-        status: 'unconfigured',
-        missing: failUnconfigured ? ['claim_verifier_configured'] : [],
-        message: failUnconfigured
-          ? `Parsed factual claim "${claim.raw}" but no matching verifier is configured. Add one under .thumbgate/claim-verifiers.json (or config/gates/claim-verifiers.json).`
-          : `Parsed factual claim "${claim.raw}" with no verifier (advisory).`,
-      };
-      checks.push(check);
-      claimResults.push({ ...claim, ...check });
-      continue;
-    }
-
-    try {
-      const actual = runVerifier(claim, verifier, repoRoot);
-      const passed = valuesEqual(claim.expected, actual);
-      const check = {
-        claim: claim.raw,
-        kind: claim.kind,
-        subject: claim.subject,
-        claimedPath: claim.path || null,
-        path: verifier.path || null,
-        expected: claim.expected,
-        actual,
-        verifierId: verifier.id || null,
-        verifierKind: verifier.kind,
-        passed,
-        status: passed ? 'match' : 'mismatch',
-        missing: passed ? [] : ['claim_value_match'],
-        message: passed
-          ? `Claim verified via ${verifier.id || verifier.kind}: expected ${String(claim.expected)}, observed ${String(actual)}`
-          : `Claim mismatch via ${verifier.id || verifier.kind}: expected ${String(claim.expected)}, observed ${String(actual)}`,
-      };
-      checks.push(check);
-      claimResults.push({ ...claim, ...check });
-    } catch (error) {
-      const check = {
-        claim: claim.raw,
-        kind: claim.kind,
-        subject: claim.subject,
-        claimedPath: claim.path || null,
-        path: verifier.path || null,
-        expected: claim.expected,
-        verifierId: verifier.id || null,
-        verifierKind: verifier.kind,
-        passed: false,
-        status: 'verifier_error',
-        missing: ['claim_verifier_success'],
-        message: `Verifier ${verifier.id || verifier.kind} failed: ${error && error.message ? error.message : 'unknown error'}`,
-      };
-      checks.push(check);
-      claimResults.push({ ...claim, ...check });
-    }
-  }
+  const checks = parsed.map((claim) => evaluateClaim(
+    claim,
+    verifiers,
+    repoRoot,
+    failUnconfigured,
+  ));
+  const claimResults = parsed.map((claim, index) => ({ ...claim, ...checks[index] }));
 
   return {
-    verified: checks.length === 0 ? true : checks.every((check) => check.passed),
+    verified: checks.every((check) => check.passed),
     claims: claimResults,
     checks,
     configSource,
@@ -664,5 +753,7 @@ module.exports = {
   assertSelectOnly,
   resolveSafePath,
   pathMatches,
+  compileConfiguredClaimTemplate,
+  validateConfiguredClaimTemplates,
   DEFAULT_VERIFIERS_FILENAME,
 };

--- a/scripts/universal-claim-evaluator.js
+++ b/scripts/universal-claim-evaluator.js
@@ -69,7 +69,10 @@ function compileConfiguredClaimTemplate(template) {
   const literalPattern = parts
     .map((part) => escapeRegExp(part).replaceAll(/\s+/g, String.raw`\s+`))
     .join(`(?<value>${NUMBER_PATTERN_SOURCE})`);
-  return new RegExp(String.raw`(?:^|(?<=\s))${literalPattern}(?=$|[\s.,;:!?])`, 'giu');
+  return new RegExp(
+    String.raw`(?<![\p{L}\p{N}_])${literalPattern}(?![\p{L}\p{N}_])`,
+    'giu',
+  );
 }
 
 function validateConfiguredClaimTemplates(verifiers = []) {

--- a/tests/auto-wire-hooks.test.js
+++ b/tests/auto-wire-hooks.test.js
@@ -32,6 +32,7 @@ const {
   parseFlags,
   CLAUDE_HOOKS,
   preToolHookCommand,
+  claimStopHookCommand,
   userPromptHookCommand,
   sessionStartHookCommand,
   pruneStaleFileHooks,
@@ -180,13 +181,14 @@ describe('auto-wire-hooks', () => {
       try {
         const result = wireClaudeHooks({ settingsPath, sharedSettingsPath });
         assert.equal(result.changed, true);
-        assert.equal(result.added.length, 5);
+        assert.equal(result.added.length, 6);
 
         const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
         assert.ok(settings.hooks.PreToolUse, 'PreToolUse should exist');
         assert.ok(settings.hooks.UserPromptSubmit, 'UserPromptSubmit should exist');
         assert.ok(settings.hooks.PostToolUse, 'PostToolUse should exist');
         assert.ok(settings.hooks.SessionStart, 'SessionStart should exist');
+        assert.ok(settings.hooks.Stop, 'Stop should exist');
         assert.ok(settings.statusLine, 'statusLine should exist');
 
         // Check PreToolUse has matcher
@@ -202,6 +204,8 @@ describe('auto-wire-hooks', () => {
 
         const sessionEntry = settings.hooks.SessionStart[0];
         assert.equal(sessionEntry.hooks[0].command, sessionStartHookCommand());
+        const stopEntry = settings.hooks.Stop[0];
+        assert.equal(stopEntry.hooks[0].command, claimStopHookCommand());
         assert.equal(settings.statusLine.command, require('../scripts/hook-runtime').statuslineCommand());
         const sharedSettings = JSON.parse(fs.readFileSync(sharedSettingsPath, 'utf8'));
         assert.equal(sharedSettings.statusLine.command, require('../scripts/hook-runtime').statuslineCommand());
@@ -249,7 +253,7 @@ describe('auto-wire-hooks', () => {
       try {
         const result1 = wireClaudeHooks({ settingsPath, sharedSettingsPath });
         assert.equal(result1.changed, true);
-        assert.equal(result1.added.length, 5);
+        assert.equal(result1.added.length, 6);
 
         const result2 = wireClaudeHooks({ settingsPath, sharedSettingsPath });
         assert.equal(result2.changed, false);
@@ -261,6 +265,7 @@ describe('auto-wire-hooks', () => {
         assert.equal(settings.hooks.UserPromptSubmit.length, 1);
         assert.equal(settings.hooks.PostToolUse.length, 1);
         assert.equal(settings.hooks.SessionStart.length, 1);
+        assert.equal(settings.hooks.Stop.length, 1);
         assert.ok(settings.statusLine);
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -275,7 +280,7 @@ describe('auto-wire-hooks', () => {
       try {
         const result = wireClaudeHooks({ settingsPath, sharedSettingsPath, dryRun: true });
         assert.equal(result.changed, true);
-        assert.equal(result.added.length, 5);
+        assert.equal(result.added.length, 6);
         assert.equal(fs.existsSync(settingsPath), false);
         assert.equal(fs.existsSync(sharedSettingsPath), false);
       } finally {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1343,10 +1343,10 @@ describe('bin/cli.js', () => {
       }),
     });
     assert.strictEqual(result.status, 0);
-    assert.ok(
-      !result.stderr.includes('💡 ThumbGate Pro') && !result.stderr.includes('💡 Unlock Pro') && !result.stderr.includes('💡 Pro tip'),
-      `Pro nudge must be suppressed for Pro-tier env; got stderr:\n${result.stderr}`,
-    );
+    const failureMessage = `Pro nudge must be suppressed for Pro-tier env; got stderr:\n${result.stderr}`;
+    assert.doesNotMatch(result.stderr, /💡 ThumbGate Pro/, failureMessage);
+    assert.doesNotMatch(result.stderr, /💡 Unlock Pro/, failureMessage);
+    assert.doesNotMatch(result.stderr, /💡 Pro tip/, failureMessage);
   });
 
   test('pro command includes hosted link', () => {
@@ -2354,6 +2354,10 @@ describe('bin/cli.js', () => {
     assert.equal(
       settings.hooks.PreToolUse[0].hooks[0].command,
       `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} gate-check`
+    );
+    assert.equal(
+      settings.hooks.Stop[0].hooks[0].command,
+      `node ${JSON.stringify(path.join(PKG_ROOT, 'bin', 'cli.js'))} claim-stop-check`
     );
     assert.equal(
       settings.statusLine.command,

--- a/tests/hook-runtime-subcommands.test.js
+++ b/tests/hook-runtime-subcommands.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 
 const {
   preToolHookCommand,
+  claimStopHookCommand,
   userPromptHookCommand,
   sessionStartHookCommand,
   cacheUpdateHookCommand,
@@ -21,6 +22,7 @@ const {
 const HOOKS = [
   ['statuslineCommand', statuslineCommand, 'statusline-render'],
   ['preToolHookCommand', preToolHookCommand, 'gate-check'],
+  ['claimStopHookCommand', claimStopHookCommand, 'claim-stop-check'],
   ['userPromptHookCommand', userPromptHookCommand, 'hook-auto-capture'],
   ['sessionStartHookCommand', sessionStartHookCommand, 'session-start'],
   ['cacheUpdateHookCommand', cacheUpdateHookCommand, 'cache-update'],

--- a/tests/hook-stop-anti-claim.test.js
+++ b/tests/hook-stop-anti-claim.test.js
@@ -9,6 +9,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const HOOK = path.join(__dirname, '..', 'scripts', 'hook-stop-anti-claim.js');
+const CLI = path.join(__dirname, '..', 'bin', 'cli.js');
 
 const {
   CLAIM_PATTERNS,
@@ -44,13 +45,23 @@ function makeVerifierRoot() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-anticlaim-verifier-'));
   fs.mkdirSync(path.join(root, '.thumbgate'));
   fs.writeFileSync(path.join(root, 'README.md'), 'one\ntwo\nthree\n');
+  fs.writeFileSync(path.join(root, 'metrics.json'), JSON.stringify({ nightly: { invoices: 12 } }));
   fs.writeFileSync(path.join(root, '.thumbgate', 'claim-verifiers.json'), JSON.stringify({
-    verifiers: [{
-      id: 'readme-lines',
-      kind: 'file_lines',
-      match: { kinds: ['file_lines'], paths: ['README.md'] },
-      path: 'README.md',
-    }],
+    verifiers: [
+      {
+        id: 'readme-lines',
+        kind: 'file_lines',
+        match: { kinds: ['file_lines'], paths: ['README.md'] },
+        path: 'README.md',
+      },
+      {
+        id: 'nightly-invoices',
+        kind: 'json_path',
+        claimTemplate: 'The nightly batch built {{value}} invoices',
+        path: 'metrics.json',
+        jsonPath: 'nightly.invoices',
+      },
+    ],
   }));
   return root;
 }
@@ -259,6 +270,48 @@ test('hook allows a factual claim only after the configured source matches', () 
     timeout: 5000,
   });
   assert.equal((res.stdout || '').trim(), '');
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('hook hard-blocks an arbitrary configured claim-template mismatch', () => {
+  const root = makeVerifierRoot();
+  const res = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({
+      hook_event_name: 'Stop',
+      stop_hook_active: false,
+      cwd: root,
+      last_assistant_message: 'The nightly batch built 17 invoices.',
+    }),
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  const out = JSON.parse((res.stdout || '').trim());
+  assert.equal(out.decision, 'block');
+  assert.equal(out.verification.failures[0].status, 'mismatch');
+  assert.equal(out.verification.failures[0].verifierId, 'nightly-invoices');
+  assert.equal(out.verification.failures[0].expected, 17);
+  assert.equal(out.verification.failures[0].actual, 12);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('published CLI Stop-hook entrypoint hard-blocks a configured claim mismatch', () => {
+  const root = makeVerifierRoot();
+  const res = spawnSync(process.execPath, [CLI, 'claim-stop-check'], {
+    cwd: root,
+    input: JSON.stringify({
+      hook_event_name: 'Stop',
+      stop_hook_active: false,
+      cwd: root,
+      last_assistant_message: 'The nightly batch built 17 invoices.',
+    }),
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  assert.equal(res.status, 0);
+  const out = JSON.parse((res.stdout || '').trim());
+  assert.equal(out.decision, 'block');
+  assert.equal(out.verification.failures[0].verifierId, 'nightly-invoices');
+  assert.equal(out.verification.failures[0].actual, 12);
   fs.rmSync(root, { recursive: true, force: true });
 });
 

--- a/tests/universal-claim-evaluator.test.js
+++ b/tests/universal-claim-evaluator.test.js
@@ -66,6 +66,37 @@ describe('parseFactualClaims', () => {
     assert.equal(claims[0].verifierId, 'nightly-invoices');
   });
 
+  it('parses configured claims wrapped in common prose and Markdown punctuation', () => {
+    const options = {
+      verifiers: [{
+        id: 'nightly-invoices',
+        kind: 'json_path',
+        claimTemplate: 'The nightly batch built {{value}} invoices',
+      }],
+    };
+    for (const text of [
+      '**The nightly batch built 17 invoices.**',
+      '"The nightly batch built 17 invoices."',
+      '(The nightly batch built 17 invoices.)',
+    ]) {
+      const claims = parseFactualClaims(text, options);
+      assert.equal(claims.length, 1, text);
+      assert.equal(claims[0].expected, 17, text);
+      assert.equal(claims[0].verifierId, 'nightly-invoices', text);
+    }
+  });
+
+  it('does not parse a configured claim embedded inside a word', () => {
+    const claims = parseFactualClaims('prefixThe nightly batch built 17 invoicessuffix', {
+      verifiers: [{
+        id: 'nightly-invoices',
+        kind: 'json_path',
+        claimTemplate: 'The nightly batch built {{value}} invoices',
+      }],
+    });
+    assert.deepEqual(claims, []);
+  });
+
   it('rejects unsafe or ambiguous configured templates', () => {
     assert.throws(() => compileConfiguredClaimTemplate('{{value}}'), /literal characters/);
     assert.throws(

--- a/tests/universal-claim-evaluator.test.js
+++ b/tests/universal-claim-evaluator.test.js
@@ -13,6 +13,7 @@ const {
   assertSelectOnly,
   resolveSafePath,
   pathMatches,
+  compileConfiguredClaimTemplate,
   runCli,
 } = require('../scripts/universal-claim-evaluator');
 const { verifyClaimEvidence, clearSessionActions } = require('../scripts/gates-engine');
@@ -49,6 +50,37 @@ describe('parseFactualClaims', () => {
   it('does not parse count inside unrelated words', () => {
     assert.deepEqual(parseFactualClaims('the discount is 10%'), []);
     assert.deepEqual(parseFactualClaims('the account is 6'), []);
+  });
+
+  it('parses arbitrary operator-configured quantitative wording', () => {
+    const claims = parseFactualClaims('The nightly batch built 17 invoices.', {
+      verifiers: [{
+        id: 'nightly-invoices',
+        kind: 'json_path',
+        claimTemplate: 'The nightly batch built {{value}} invoices',
+      }],
+    });
+    assert.equal(claims.length, 1);
+    assert.equal(claims[0].kind, 'configured_value');
+    assert.equal(claims[0].expected, 17);
+    assert.equal(claims[0].verifierId, 'nightly-invoices');
+  });
+
+  it('rejects unsafe or ambiguous configured templates', () => {
+    assert.throws(() => compileConfiguredClaimTemplate('{{value}}'), /literal characters/);
+    assert.throws(
+      () => compileConfiguredClaimTemplate('built {{value}} of {{value}}'),
+      /exactly one/,
+    );
+    assert.throws(
+      () => parseFactualClaims('built 17 invoices', {
+        verifiers: [
+          { id: 'invoices-a', kind: 'json_path', claimTemplate: 'built {{value}} invoices' },
+          { id: 'invoices-b', kind: 'json_path', claimTemplate: 'built {{value}} invoices' },
+        ],
+      }),
+      /multiple configured verifiers/,
+    );
   });
 });
 
@@ -96,6 +128,7 @@ describe('evaluateUniversalClaims', () => {
     fs.mkdirSync(path.join(tmpDir, 'fake'));
     fs.writeFileSync(path.join(tmpDir, 'fake', 'README.md'), 'spoof\n'.repeat(99));
     fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '9.9.9' }));
+    fs.writeFileSync(path.join(tmpDir, 'metrics.json'), JSON.stringify({ nightly: { invoices: 12 } }));
 
     const Database = require('better-sqlite3');
     dbPath = path.join(tmpDir, 'data', 'app.sqlite');
@@ -129,6 +162,13 @@ describe('evaluateUniversalClaims', () => {
       path: 'package.json',
       jsonPath: 'version',
     },
+    {
+      id: 'nightly-invoices',
+      kind: 'json_path',
+      claimTemplate: 'The nightly batch built {{value}} invoices',
+      path: 'metrics.json',
+      jsonPath: 'nightly.invoices',
+    },
   ]);
 
   it('passes when row count matches the database', () => {
@@ -150,6 +190,64 @@ describe('evaluateUniversalClaims', () => {
     assert.equal(result.checks[0].status, 'mismatch');
     assert.equal(result.checks[0].expected, 1284);
     assert.equal(result.checks[0].actual, 3);
+  });
+
+  it('rechecks an arbitrary configured claim template and passes on a match', () => {
+    const result = evaluateUniversalClaims('The nightly batch built 12 invoices.', {
+      cwd: tmpDir,
+      verifiers: verifiers(),
+    });
+    assert.equal(result.verified, true);
+    assert.equal(result.checks[0].status, 'match');
+    assert.equal(result.checks[0].actual, 12);
+    assert.equal(result.checks[0].verifierId, 'nightly-invoices');
+  });
+
+  it('rechecks an arbitrary configured claim template and blocks a mismatch', () => {
+    const result = evaluateUniversalClaims('The nightly batch built 17 invoices.', {
+      cwd: tmpDir,
+      verifiers: verifiers(),
+    });
+    assert.equal(result.verified, false);
+    assert.equal(result.checks[0].status, 'mismatch');
+    assert.equal(result.checks[0].expected, 17);
+    assert.equal(result.checks[0].actual, 12);
+  });
+
+  it('binds a configured template directly even when built-in grammar also matches', () => {
+    const result = evaluateUniversalClaims('the row count is 12', {
+      cwd: tmpDir,
+      verifiers: [
+        ...verifiers(),
+        {
+          id: 'template-row-count',
+          kind: 'json_path',
+          claimTemplate: 'the row count is {{value}}',
+          path: 'metrics.json',
+          jsonPath: 'nightly.invoices',
+        },
+      ],
+    });
+    assert.equal(result.verified, true);
+    assert.equal(result.checks.length, 1);
+    assert.equal(result.checks[0].actual, 12);
+    assert.equal(result.checks[0].verifierId, 'template-row-count');
+  });
+
+  it('fails closed on malformed claim-template configuration before parsing', () => {
+    assert.throws(
+      () => evaluateUniversalClaims('No built-in factual wording here.', {
+        cwd: tmpDir,
+        verifiers: [{
+          id: 'invalid-template',
+          kind: 'json_path',
+          claimTemplate: 'The nightly batch built invoices',
+          path: 'metrics.json',
+          jsonPath: 'nightly.invoices',
+        }],
+      }),
+      /exactly one/,
+    );
   });
 
   it('fails closed when a claim is parseable but no verifier is configured', () => {
@@ -270,6 +368,30 @@ describe('verifyClaimEvidence integration', () => {
       assert.equal(result.verified, false);
       assert.ok(result.universal);
       assert.ok(result.checks.some((c) => String(c.claim).startsWith('universal:') || c.universal));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      clearSessionActions();
+    }
+  });
+
+  it('blocks MCP-style verification for an arbitrary configured claim template', () => {
+    clearSessionActions();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-claim-template-int-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'metrics.json'), JSON.stringify({ nightly: { invoices: 12 } }));
+      const result = verifyClaimEvidence('The nightly batch built 17 invoices.', {
+        cwd: tmpDir,
+        verifiers: [{
+          id: 'nightly-invoices',
+          kind: 'json_path',
+          claimTemplate: 'The nightly batch built {{value}} invoices',
+          path: 'metrics.json',
+          jsonPath: 'nightly.invoices',
+        }],
+      });
+      assert.equal(result.verified, false);
+      assert.equal(result.universal.checks[0].universal.status, 'mismatch');
+      assert.equal(result.universal.checks[0].universal.actual, 12);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
       clearSessionActions();


### PR DESCRIPTION
## What changed

- adds operator-configured literal `claimTemplate` / `claimTemplates` parsing with one numeric `{{value}}` slot
- binds each configured template directly to a unique verifier and its operator-owned database/filesystem/JSON source
- fails closed on malformed, ambiguous, unmatched, or mismatched configured claims
- exposes `thumbgate claim-stop-check` and auto-wires it into Claude Code's blocking `Stop` lifecycle
- documents the hard boundary: hosts without a blocking completion hook must use the MCP completion gate or `verify-claims` exit status

## Why

The evaluator merged in #3159 safely rechecked built-in shapes such as “the row count is 1,284”, but it did not parse arbitrary operator-specific wording such as “The nightly batch built 17 invoices”. Also, the repo-local Claude hook existed while `thumbgate init` did not install that completion hook for customers.

## Safety

Templates are literal text, not caller-controlled regex. Text outside `{{value}}` is escaped. Agents cannot select paths, SQL, or JSON selectors from their output. SQLite remains read-only `SELECT`; repository path and symlink protections remain in force.

## Validation

- clean Node 22 `npm ci`: 0 vulnerabilities
- focused evaluator/MCP/hook/installer/CLI suite: 229 passed, 0 failed
- pre-commit package parity guard: passed
- pre-push pack, public-link, and regression guards: passed
- full repository suite, coverage, and GitHub CI: running

## Scope limit

This does not claim arbitrary natural-language understanding or automatic interception of every agent host. Deterministic enforcement covers configured quantitative templates and built-in shapes when the host invokes the Claude Stop hook, MCP completion gate, or CLI completion gate.