### PR TITLE
feat(gates): default claim verifiers + readiness (rebased follow-up)

### DIFF
--- a/.changeset/claim-verifiers-default.md
+++ b/.changeset/claim-verifiers-default.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Ship default claim verifiers for package-version dogfood, surface factual claim recheck status in agent readiness, and expand the claim-verification proof lane (CLAIM-07/08).

--- a/config/gates/claim-verifiers.json
+++ b/config/gates/claim-verifiers.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "description": "Default factual claim verifiers shipped with ThumbGate. Override with .thumbgate/claim-verifiers.json or THUMBGATE_CLAIM_VERIFIERS_PATH. Queries and paths are operator-owned — never taken from claim text.",
+  "verifiers": [
+    {
+      "id": "package-version",
+      "kind": "json_path",
+      "match": {
+        "kinds": ["value"],
+        "subjects": ["version", "package version"]
+      },
+      "path": "package.json",
+      "jsonPath": "version"
+    },
+    {
+      "id": "package-json-exists",
+      "kind": "file_exists",
+      "match": {
+        "kinds": ["file_exists"],
+        "paths": ["package.json"]
+      },
+      "path": "package.json"
+    }
+  ]
+}

--- a/docs/UNIVERSAL_CLAIM_EVALUATOR.md
+++ b/docs/UNIVERSAL_CLAIM_EVALUATOR.md
@@ -35,7 +35,9 @@ Wired into:
 
 ## Configure verifiers
 
-Copy the example and edit:
+ThumbGate ships a default config at `config/gates/claim-verifiers.json` that
+rechecks `package version` and `package.json` existence. For project-specific
+facts (row counts, inventory files, service health), copy the example and edit:
 
 ```bash
 cp config/gates/claim-verifiers.example.json .thumbgate/claim-verifiers.json
@@ -47,7 +49,7 @@ Load order:
 2. `options.configPath` or `$THUMBGATE_CLAIM_VERIFIERS_PATH`
 3. `$THUMBGATE_FEEDBACK_DIR/claim-verifiers.json`
 4. `.thumbgate/claim-verifiers.json`
-5. `config/gates/claim-verifiers.json`
+5. `config/gates/claim-verifiers.json` (shipped default)
 
 An existing but malformed config is a verifier error. ThumbGate does not skip
 it and silently fall through to a different file.

--- a/scripts/agent-readiness.js
+++ b/scripts/agent-readiness.js
@@ -232,6 +232,7 @@ function summarizeClaimVerification(projectRoot = PROJECT_ROOT, deps = {}) {
     verifierCount,
     configSource,
     stopHookRegistered,
+    configLoadFailed,
     recommendation,
   };
 }
@@ -250,8 +251,11 @@ function generateAgentReadinessReport({
   if (!bootstrap.ready) warnings.push(bootstrap.recommendation);
   if (!permissions.ready) warnings.push(permissions.recommendation);
   // Missing operator verifiers is advisory (not every project asserts SQL row counts).
-  // A missing evaluator module is a packaging failure and must surface as needs_attention.
-  if (!claimVerification.evaluatorReady) warnings.push(claimVerification.recommendation);
+  // A missing evaluator module or a broken claim-verifier config is not advisory —
+  // both make factual recheck fail closed at runtime and must surface here.
+  if (!claimVerification.evaluatorReady || claimVerification.configLoadFailed) {
+    warnings.push(claimVerification.recommendation);
+  }
 
   return {
     generatedAt: new Date().toISOString(),

--- a/scripts/agent-readiness.js
+++ b/scripts/agent-readiness.js
@@ -165,13 +165,46 @@ function summarizePermissionTier(profileName = getActiveMcpProfile()) {
   };
 }
 
-function summarizeClaimVerification(projectRoot = PROJECT_ROOT, deps = {}) {
-  let evaluatorReady = false;
-  let verifierCount = 0;
-  let configSource = 'none';
-  let stopHookRegistered = false;
-  let recommendation = 'Install ThumbGate and configure claim verifiers under .thumbgate/claim-verifiers.json.';
 
+function detectStopHookRegistered(projectRoot, existsSync, readFileSync) {
+  try {
+    const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
+    if (!existsSync(settingsPath)) return false;
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    const stopHooks = settings?.hooks?.Stop || [];
+    const flat = Array.isArray(stopHooks)
+      ? stopHooks.flatMap((entry) => entry?.hooks || [entry])
+      : [];
+    return flat.some((hook) => String(hook?.command || '').includes('hook-stop-anti-claim'));
+  } catch {
+    return false;
+  }
+}
+
+function recommendationForClaimState({
+  evaluatorReady,
+  configLoadFailed,
+  verifierCount,
+  stopHookRegistered,
+  configSource,
+  loadErrorMessage,
+}) {
+  if (!evaluatorReady) {
+    return 'Universal claim evaluator module is missing from this install.';
+  }
+  if (configLoadFailed) {
+    return loadErrorMessage;
+  }
+  if (verifierCount === 0) {
+    return 'No claim verifiers configured. Copy config/gates/claim-verifiers.example.json to .thumbgate/claim-verifiers.json and point subjects at your sources of truth.';
+  }
+  if (!stopHookRegistered) {
+    return 'Claim verifiers are present, but the Claude Stop anti-claim hook is not registered in .claude/settings.json.';
+  }
+  return `Factual claim recheck is ready (${verifierCount} verifier(s) from ${configSource}).`;
+}
+
+function summarizeClaimVerification(projectRoot = PROJECT_ROOT, deps = {}) {
   const resolveEvaluator = deps.resolveEvaluator
     || (() => require.resolve('./universal-claim-evaluator'));
   const loadVerifierConfig = deps.loadVerifierConfig
@@ -179,6 +212,7 @@ function summarizeClaimVerification(projectRoot = PROJECT_ROOT, deps = {}) {
   const readFileSync = deps.readFileSync || fs.readFileSync;
   const existsSync = deps.existsSync || fs.existsSync;
 
+  let evaluatorReady = false;
   try {
     resolveEvaluator();
     evaluatorReady = true;
@@ -186,48 +220,31 @@ function summarizeClaimVerification(projectRoot = PROJECT_ROOT, deps = {}) {
     evaluatorReady = false;
   }
 
+  let verifierCount = 0;
+  let configSource = 'none';
   let configLoadFailed = false;
+  let loadErrorMessage = 'Install ThumbGate and configure claim verifiers under .thumbgate/claim-verifiers.json.';
   try {
     const loaded = loadVerifierConfig()({ cwd: projectRoot });
     verifierCount = Array.isArray(loaded.verifiers) ? loaded.verifiers.length : 0;
     configSource = loaded.source || 'none';
   } catch (error) {
     configLoadFailed = true;
-    recommendation = `Claim verifier config failed to load: ${error && error.message ? error.message : 'unknown error'}`;
+    loadErrorMessage = `Claim verifier config failed to load: ${error?.message || 'unknown error'}`;
   }
 
-  try {
-    const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
-    if (existsSync(settingsPath)) {
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-      const stopHooks = (((settings.hooks || {}).Stop) || []);
-      const flat = Array.isArray(stopHooks)
-        ? stopHooks.flatMap((entry) => (entry && entry.hooks) || [entry])
-        : [];
-      stopHookRegistered = flat.some((hook) => {
-        const command = String((hook && hook.command) || '');
-        return command.includes('hook-stop-anti-claim');
-      });
-    }
-  } catch {
-    stopHookRegistered = false;
-  }
-
-  const ready = evaluatorReady && verifierCount > 0 && stopHookRegistered && !configLoadFailed;
-  if (!evaluatorReady) {
-    recommendation = 'Universal claim evaluator module is missing from this install.';
-  } else if (configLoadFailed) {
-    // keep the load-error recommendation set above
-  } else if (verifierCount === 0) {
-    recommendation = 'No claim verifiers configured. Copy config/gates/claim-verifiers.example.json to .thumbgate/claim-verifiers.json and point subjects at your sources of truth.';
-  } else if (!stopHookRegistered) {
-    recommendation = 'Claim verifiers are present, but the Claude Stop anti-claim hook is not registered in .claude/settings.json.';
-  } else {
-    recommendation = `Factual claim recheck is ready (${verifierCount} verifier(s) from ${configSource}).`;
-  }
+  const stopHookRegistered = detectStopHookRegistered(projectRoot, existsSync, readFileSync);
+  const recommendation = recommendationForClaimState({
+    evaluatorReady,
+    configLoadFailed,
+    verifierCount,
+    stopHookRegistered,
+    configSource,
+    loadErrorMessage,
+  });
 
   return {
-    ready,
+    ready: evaluatorReady && verifierCount > 0 && stopHookRegistered && !configLoadFailed,
     evaluatorReady,
     verifierCount,
     configSource,
@@ -290,11 +307,13 @@ function reportToText(report) {
   lines.push(`  Write-capable tools: ${report.permissions.writeCapableTools.length}`);
   lines.push(`  Recommendation: ${report.permissions.recommendation}`);
   if (report.claimVerification) {
-    lines.push(`Claim verification: ${report.claimVerification.ready ? 'ready' : 'needs_attention'}`);
-    lines.push(`  Evaluator: ${report.claimVerification.evaluatorReady ? 'present' : 'missing'}`);
-    lines.push(`  Verifiers: ${report.claimVerification.verifierCount} (${report.claimVerification.configSource})`);
-    lines.push(`  Stop hook: ${report.claimVerification.stopHookRegistered ? 'registered' : 'missing'}`);
-    lines.push(`  Recommendation: ${report.claimVerification.recommendation}`);
+    lines.push(
+      `Claim verification: ${report.claimVerification.ready ? 'ready' : 'needs_attention'}`,
+      `  Evaluator: ${report.claimVerification.evaluatorReady ? 'present' : 'missing'}`,
+      `  Verifiers: ${report.claimVerification.verifierCount} (${report.claimVerification.configSource})`,
+      `  Stop hook: ${report.claimVerification.stopHookRegistered ? 'registered' : 'missing'}`,
+      `  Recommendation: ${report.claimVerification.recommendation}`,
+    );
   }
 
   if (report.warnings.length > 0) {
@@ -315,6 +334,8 @@ module.exports = {
   collectBootstrapFiles,
   summarizePermissionTier,
   summarizeClaimVerification,
+  recommendationForClaimState,
+  detectStopHookRegistered,
   generateAgentReadinessReport,
   reportToText,
 };

--- a/scripts/agent-readiness.js
+++ b/scripts/agent-readiness.js
@@ -165,33 +165,41 @@ function summarizePermissionTier(profileName = getActiveMcpProfile()) {
   };
 }
 
-function summarizeClaimVerification(projectRoot = PROJECT_ROOT) {
+function summarizeClaimVerification(projectRoot = PROJECT_ROOT, deps = {}) {
   let evaluatorReady = false;
   let verifierCount = 0;
   let configSource = 'none';
   let stopHookRegistered = false;
   let recommendation = 'Install ThumbGate and configure claim verifiers under .thumbgate/claim-verifiers.json.';
 
+  const resolveEvaluator = deps.resolveEvaluator
+    || (() => require.resolve('./universal-claim-evaluator'));
+  const loadVerifierConfig = deps.loadVerifierConfig
+    || (() => require('./universal-claim-evaluator').loadVerifierConfig);
+  const readFileSync = deps.readFileSync || fs.readFileSync;
+  const existsSync = deps.existsSync || fs.existsSync;
+
   try {
-    require.resolve('./universal-claim-evaluator');
+    resolveEvaluator();
     evaluatorReady = true;
   } catch {
     evaluatorReady = false;
   }
 
+  let configLoadFailed = false;
   try {
-    const { loadVerifierConfig } = require('./universal-claim-evaluator');
-    const loaded = loadVerifierConfig({ cwd: projectRoot });
+    const loaded = loadVerifierConfig()({ cwd: projectRoot });
     verifierCount = Array.isArray(loaded.verifiers) ? loaded.verifiers.length : 0;
     configSource = loaded.source || 'none';
   } catch (error) {
+    configLoadFailed = true;
     recommendation = `Claim verifier config failed to load: ${error && error.message ? error.message : 'unknown error'}`;
   }
 
   try {
     const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
-    if (fs.existsSync(settingsPath)) {
-      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    if (existsSync(settingsPath)) {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
       const stopHooks = (((settings.hooks || {}).Stop) || []);
       const flat = Array.isArray(stopHooks)
         ? stopHooks.flatMap((entry) => (entry && entry.hooks) || [entry])
@@ -205,9 +213,11 @@ function summarizeClaimVerification(projectRoot = PROJECT_ROOT) {
     stopHookRegistered = false;
   }
 
-  const ready = evaluatorReady && verifierCount > 0 && stopHookRegistered;
+  const ready = evaluatorReady && verifierCount > 0 && stopHookRegistered && !configLoadFailed;
   if (!evaluatorReady) {
     recommendation = 'Universal claim evaluator module is missing from this install.';
+  } else if (configLoadFailed) {
+    // keep the load-error recommendation set above
   } else if (verifierCount === 0) {
     recommendation = 'No claim verifiers configured. Copy config/gates/claim-verifiers.example.json to .thumbgate/claim-verifiers.json and point subjects at your sources of truth.';
   } else if (!stopHookRegistered) {

--- a/scripts/agent-readiness.js
+++ b/scripts/agent-readiness.js
@@ -165,6 +165,67 @@ function summarizePermissionTier(profileName = getActiveMcpProfile()) {
   };
 }
 
+function summarizeClaimVerification(projectRoot = PROJECT_ROOT) {
+  let evaluatorReady = false;
+  let verifierCount = 0;
+  let configSource = 'none';
+  let stopHookRegistered = false;
+  let recommendation = 'Install ThumbGate and configure claim verifiers under .thumbgate/claim-verifiers.json.';
+
+  try {
+    require.resolve('./universal-claim-evaluator');
+    evaluatorReady = true;
+  } catch {
+    evaluatorReady = false;
+  }
+
+  try {
+    const { loadVerifierConfig } = require('./universal-claim-evaluator');
+    const loaded = loadVerifierConfig({ cwd: projectRoot });
+    verifierCount = Array.isArray(loaded.verifiers) ? loaded.verifiers.length : 0;
+    configSource = loaded.source || 'none';
+  } catch (error) {
+    recommendation = `Claim verifier config failed to load: ${error && error.message ? error.message : 'unknown error'}`;
+  }
+
+  try {
+    const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
+    if (fs.existsSync(settingsPath)) {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      const stopHooks = (((settings.hooks || {}).Stop) || []);
+      const flat = Array.isArray(stopHooks)
+        ? stopHooks.flatMap((entry) => (entry && entry.hooks) || [entry])
+        : [];
+      stopHookRegistered = flat.some((hook) => {
+        const command = String((hook && hook.command) || '');
+        return command.includes('hook-stop-anti-claim');
+      });
+    }
+  } catch {
+    stopHookRegistered = false;
+  }
+
+  const ready = evaluatorReady && verifierCount > 0 && stopHookRegistered;
+  if (!evaluatorReady) {
+    recommendation = 'Universal claim evaluator module is missing from this install.';
+  } else if (verifierCount === 0) {
+    recommendation = 'No claim verifiers configured. Copy config/gates/claim-verifiers.example.json to .thumbgate/claim-verifiers.json and point subjects at your sources of truth.';
+  } else if (!stopHookRegistered) {
+    recommendation = 'Claim verifiers are present, but the Claude Stop anti-claim hook is not registered in .claude/settings.json.';
+  } else {
+    recommendation = `Factual claim recheck is ready (${verifierCount} verifier(s) from ${configSource}).`;
+  }
+
+  return {
+    ready,
+    evaluatorReady,
+    verifierCount,
+    configSource,
+    stopHookRegistered,
+    recommendation,
+  };
+}
+
 function generateAgentReadinessReport({
   projectRoot = PROJECT_ROOT,
   mcpProfile = null,
@@ -172,11 +233,15 @@ function generateAgentReadinessReport({
   const runtime = detectRuntimeIsolation();
   const bootstrap = collectBootstrapFiles(projectRoot);
   const permissions = summarizePermissionTier(mcpProfile || getActiveMcpProfile());
+  const claimVerification = summarizeClaimVerification(projectRoot);
 
   const warnings = [];
   if (!runtime.isolated) warnings.push(runtime.recommendation);
   if (!bootstrap.ready) warnings.push(bootstrap.recommendation);
   if (!permissions.ready) warnings.push(permissions.recommendation);
+  // Missing operator verifiers is advisory (not every project asserts SQL row counts).
+  // A missing evaluator module is a packaging failure and must surface as needs_attention.
+  if (!claimVerification.evaluatorReady) warnings.push(claimVerification.recommendation);
 
   return {
     generatedAt: new Date().toISOString(),
@@ -185,10 +250,12 @@ function generateAgentReadinessReport({
     runtime,
     bootstrap,
     permissions,
+    claimVerification,
     articleAlignment: {
       runtimeIsolation: runtime.isolated,
       contextConditioning: bootstrap.ready,
       permissionEnvelope: permissions.ready,
+      factualClaimRecheck: claimVerification.ready,
     },
     warnings,
   };
@@ -208,6 +275,13 @@ function reportToText(report) {
   lines.push(`Permissions: ${report.permissions.profile} (${report.permissions.tier})`);
   lines.push(`  Write-capable tools: ${report.permissions.writeCapableTools.length}`);
   lines.push(`  Recommendation: ${report.permissions.recommendation}`);
+  if (report.claimVerification) {
+    lines.push(`Claim verification: ${report.claimVerification.ready ? 'ready' : 'needs_attention'}`);
+    lines.push(`  Evaluator: ${report.claimVerification.evaluatorReady ? 'present' : 'missing'}`);
+    lines.push(`  Verifiers: ${report.claimVerification.verifierCount} (${report.claimVerification.configSource})`);
+    lines.push(`  Stop hook: ${report.claimVerification.stopHookRegistered ? 'registered' : 'missing'}`);
+    lines.push(`  Recommendation: ${report.claimVerification.recommendation}`);
+  }
 
   if (report.warnings.length > 0) {
     lines.push('');
@@ -226,6 +300,7 @@ module.exports = {
   detectRuntimeIsolation,
   collectBootstrapFiles,
   summarizePermissionTier,
+  summarizeClaimVerification,
   generateAgentReadinessReport,
   reportToText,
 };

--- a/scripts/prove-claim-verification.js
+++ b/scripts/prove-claim-verification.js
@@ -235,8 +235,8 @@ async function run() {
             if (result.verified) {
               throw new Error('Expected row-count mismatch to fail verification');
             }
-            const gateChecks = (result.universal && result.universal.checks) || [];
-            const claimResults = (result.universal && result.universal.claims) || [];
+            const gateChecks = result.universal?.checks || [];
+            const claimResults = result.universal?.claims || [];
             const universalFail = claimResults.find((check) => check.status === 'mismatch')
               || gateChecks.map((check) => check.universal || check).find((check) => check.status === 'mismatch');
             if (!universalFail) {

--- a/scripts/prove-claim-verification.js
+++ b/scripts/prove-claim-verification.js
@@ -208,6 +208,68 @@ async function run() {
         });
       },
     },
+    {
+      id: 'CLAIM-07',
+      desc: 'universal evaluator fails closed on row-count mismatch against a configured sqlite verifier',
+      fn: async () => {
+        await withIsolatedRuntime(async ({ gatesEngine }) => {
+          const root = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-claim-universal-'));
+          try {
+            fs.mkdirSync(path.join(root, 'data'), { recursive: true });
+            const Database = require('better-sqlite3');
+            const dbPath = path.join(root, 'data', 'app.sqlite');
+            const db = new Database(dbPath);
+            db.exec('CREATE TABLE orders (id INTEGER PRIMARY KEY); INSERT INTO orders (id) VALUES (1),(2);');
+            db.close();
+
+            const result = gatesEngine.verifyClaimEvidence('the row count is 1,284', {
+              cwd: root,
+              verifiers: [{
+                id: 'orders-row-count',
+                kind: 'sqlite_count',
+                match: { subjects: ['row count', 'rows', 'orders'] },
+                dbPath: 'data/app.sqlite',
+                query: 'SELECT COUNT(*) AS n FROM orders',
+              }],
+            });
+            if (result.verified) {
+              throw new Error('Expected row-count mismatch to fail verification');
+            }
+            const gateChecks = (result.universal && result.universal.checks) || [];
+            const claimResults = (result.universal && result.universal.claims) || [];
+            const universalFail = claimResults.find((check) => check.status === 'mismatch')
+              || gateChecks.map((check) => check.universal || check).find((check) => check.status === 'mismatch');
+            if (!universalFail) {
+              throw new Error(`Expected universal mismatch check, got ${JSON.stringify(result.universal)}`);
+            }
+            if (universalFail.actual !== 2 || universalFail.expected !== 1284) {
+              throw new Error(`Unexpected mismatch values: ${JSON.stringify(universalFail)}`);
+            }
+          } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+          }
+        });
+      },
+    },
+    {
+      id: 'CLAIM-08',
+      desc: 'universal evaluator verifies package version from the shipped default verifier config',
+      fn: async () => {
+        await withIsolatedRuntime(async ({ gatesEngine }) => {
+          const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+          const result = gatesEngine.verifyClaimEvidence(`package version is ${pkg.version}`, {
+            cwd: ROOT,
+            claimVerifiersPath: path.join(ROOT, 'config', 'gates', 'claim-verifiers.json'),
+          });
+          if (!result.verified) {
+            throw new Error(`Expected package version claim to verify, got ${JSON.stringify(result)}`);
+          }
+          if (!result.universal || result.universal.parsedCount < 1) {
+            throw new Error('Expected universal evaluator to parse the version claim');
+          }
+        });
+      },
+    },
   ];
 
   console.log('Claim Verification Gates - Proof Gate\n');

--- a/scripts/universal-claim-evaluator.js
+++ b/scripts/universal-claim-evaluator.js
@@ -117,7 +117,7 @@ function parseCountClaims(source, push) {
   // subject + count is N
   eachMatch(
     source,
-    /\b((?:the |total )?[a-z][\w .-]{0,40}? count)\s*(?:is|are|=|:)\s*([\d,]+(?:\.\d+)?)\b/gi,
+    /\b((?:the |total )?[a-z][\w .-]{0,40}? count)\s*(?:is|are|=|:|equals)\s*([\d,]+(?:\.\d+)?)\b/gi,
     (match) => {
       const expected = parseNumberToken(match[2]);
       if (expected == null) return;
@@ -139,7 +139,7 @@ function parseCountClaims(source, push) {
   // COUNT(*) = N
   eachMatch(
     source,
-    /\bCOUNT\s*\(\s*\*\s*\)\s*(?:=|is|:)\s*([\d,]+)\b/gi,
+    /\bCOUNT\s*\(\s*\*\s*\)\s*(?:=|is|:|equals)\s*([\d,]+)\b/gi,
     (match) => {
       const expected = parseNumberToken(match[1]);
       if (expected == null) return;
@@ -187,7 +187,7 @@ function parseFileMetricClaims(source, push) {
 function parseValueClaims(source, push) {
   eachMatch(
     source,
-    /\b((?:package )?version)\s*(?:is|=|:)\s*(v?\d+\.\d+\.\d+[\w.+-]*)\b/gi,
+    /\b((?:package )?version)\s*(?:is|=|:|equals)\s*(v?\d+\.\d+\.\d+[\w.+-]*)\b/gi,
     (match) => {
       push({
         kind: 'value',

--- a/scripts/universal-claim-evaluator.js
+++ b/scripts/universal-claim-evaluator.js
@@ -13,8 +13,8 @@
  * so agents cannot inject SQL or path traversal through the claim string.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { resolveFeedbackDir } = require('./feedback-paths');
 
 const DEFAULT_VERIFIERS_FILENAME = 'claim-verifiers.json';
@@ -23,7 +23,7 @@ const PACKAGE_ROOT = path.join(__dirname, '..');
 
 function parseNumberToken(raw) {
   if (raw == null) return null;
-  const cleaned = String(raw).replace(/,/g, '').trim();
+  const cleaned = String(raw).replaceAll(',', '').trim();
   if (!/^-?\d+(?:\.\d+)?$/.test(cleaned)) return null;
   const value = Number(cleaned);
   return Number.isFinite(value) ? value : null;
@@ -93,6 +93,112 @@ function resolveSafePath(repoRoot, targetPath) {
   return resolved;
 }
 
+
+function createClaimPush(claims) {
+  const seen = new Set();
+  return (claim) => {
+    const key = `${claim.kind}|${claim.subject}|${claim.path || ''}|${String(claim.expected)}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    claims.push(claim);
+  };
+}
+
+function eachMatch(source, re, onMatch) {
+  re.lastIndex = 0;
+  let match = re.exec(source);
+  while (match) {
+    onMatch(match);
+    match = re.exec(source);
+  }
+}
+
+function parseCountClaims(source, push) {
+  // subject + count is N
+  eachMatch(
+    source,
+    /\b((?:the |total )?[a-z][\w .-]{0,40}? count)\s*(?:is|are|=|:)\s*([\d,]+(?:\.\d+)?)\b/gi,
+    (match) => {
+      const expected = parseNumberToken(match[2]);
+      if (expected == null) return;
+      push({ kind: 'count', subject: normalizeSubject(match[1]), expected, raw: match[0] });
+    },
+  );
+
+  // there are N rows/orders/...
+  eachMatch(
+    source,
+    /\bthere (?:is|are) ([\d,]+) (rows?|records?|entries|items?|orders?|users?|lessons?|lines?)\b/gi,
+    (match) => {
+      const expected = parseNumberToken(match[1]);
+      if (expected == null) return;
+      push({ kind: 'count', subject: normalizeSubject(match[2]), expected, raw: match[0] });
+    },
+  );
+
+  // COUNT(*) = N
+  eachMatch(
+    source,
+    /\bCOUNT\s*\(\s*\*\s*\)\s*(?:=|is|:)\s*([\d,]+)\b/gi,
+    (match) => {
+      const expected = parseNumberToken(match[1]);
+      if (expected == null) return;
+      push({ kind: 'count', subject: 'count', expected, raw: match[0] });
+    },
+  );
+}
+
+function parseFileMetricClaims(source, push) {
+  const pathToken = '([^\\s,]+\\.[A-Za-z0-9]+)';
+  eachMatch(
+    source,
+    new RegExp(`\\b(?:file\\s+)?${pathToken}\\s+(?:has|contains)\\s+([\\d,]+)\\s+lines?\\b`, 'gi'),
+    (match) => {
+      const expected = parseNumberToken(match[2]);
+      if (expected == null) return;
+      push({ kind: 'file_lines', subject: 'lines', path: match[1], expected, raw: match[0] });
+    },
+  );
+  eachMatch(
+    source,
+    new RegExp(`\\b(?:file\\s+)?${pathToken}\\s+(?:is|has)\\s+([\\d,]+)\\s+bytes?\\b`, 'gi'),
+    (match) => {
+      const expected = parseNumberToken(match[2]);
+      if (expected == null) return;
+      push({ kind: 'file_bytes', subject: 'bytes', path: match[1], expected, raw: match[0] });
+    },
+  );
+  eachMatch(
+    source,
+    new RegExp(`\\b(?:file\\s+)?${pathToken}\\s+(?:exists|is present|is on disk)\\b`, 'gi'),
+    (match) => {
+      push({ kind: 'file_exists', subject: 'exists', path: match[1], expected: true, raw: match[0] });
+    },
+  );
+  eachMatch(
+    source,
+    new RegExp(`\\b(?:file\\s+)?${pathToken}\\s+(?:does not exist|is missing|is absent)\\b`, 'gi'),
+    (match) => {
+      push({ kind: 'file_exists', subject: 'exists', path: match[1], expected: false, raw: match[0] });
+    },
+  );
+}
+
+function parseValueClaims(source, push) {
+  eachMatch(
+    source,
+    /\b((?:package )?version)\s*(?:is|=|:)\s*(v?\d+\.\d+\.\d+[\w.+-]*)\b/gi,
+    (match) => {
+      push({
+        kind: 'value',
+        subject: normalizeSubject(match[1]),
+        expected: String(match[2]).replace(/^v/i, ''),
+        raw: match[0],
+      });
+    },
+  );
+}
+
 /**
  * Extract structured factual claims from free text.
  * @returns {Array<{kind:string, subject:string, expected:*, path?:string, raw:string}>}
@@ -100,140 +206,15 @@ function resolveSafePath(repoRoot, targetPath) {
 function parseFactualClaims(text) {
   const source = String(text || '');
   if (!source.trim()) return [];
-
   const claims = [];
-  const seen = new Set();
-
-  const push = (claim) => {
-    const key = `${claim.kind}|${claim.subject}|${claim.path || ''}|${String(claim.expected)}`;
-    if (seen.has(key)) return;
-    seen.add(key);
-    claims.push(claim);
-  };
-
-  // "the row count is 1,284" / "row count = 1284" / "orders count: 42"
-  const countPatterns = [
-    /\b((?:the\s+)?(?:total\s+)?(?:[a-z][\w\s.-]{0,40}?)?\s*(?:row|rows|record|records|entry|entries|item|items|order|orders|user|users|lesson|lessons|line|lines)?\s+counts?\b)\s*(?:is|are|=|:|equals?)\s*([-+]?\d{1,3}(?:,\d{3})*(?:\.\d+)?|\d+(?:\.\d+)?)\b/gi,
-    /\bthere\s+(?:is|are)\s+([-+]?\d{1,3}(?:,\d{3})*|\d+)\s+((?:rows?|records?|entries|items?|orders?|users?|lessons?|lines?))\b/gi,
-    /\bCOUNT\s*\(\s*\*\s*\)\s*(?:=|is|:)\s*([-+]?\d{1,3}(?:,\d{3})*|\d+)\b/gi,
-  ];
-
-  for (const re of countPatterns) {
-    re.lastIndex = 0;
-    let match = re.exec(source);
-    while (match) {
-      if (re === countPatterns[1]) {
-        // there are N rows
-        const expected = parseNumberToken(match[1]);
-        if (expected != null) {
-          push({
-            kind: 'count',
-            subject: normalizeSubject(match[2]),
-            expected,
-            raw: match[0],
-          });
-        }
-      } else if (re === countPatterns[2]) {
-        const expected = parseNumberToken(match[1]);
-        if (expected != null) {
-          push({
-            kind: 'count',
-            subject: 'count',
-            expected,
-            raw: match[0],
-          });
-        }
-      } else {
-        const expected = parseNumberToken(match[2]);
-        if (expected != null) {
-          push({
-            kind: 'count',
-            subject: normalizeSubject(match[1]),
-            expected,
-            raw: match[0],
-          });
-        }
-      }
-      match = re.exec(source);
-    }
-  }
-
-  // "file README.md has 120 lines" / "README.md is 1024 bytes"
-  const fileLineRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:has|contains)\s+([-+]?\d{1,3}(?:,\d{3})*|\d+)\s+lines?\b/gi;
-  let fileMatch = fileLineRe.exec(source);
-  while (fileMatch) {
-    const expected = parseNumberToken(fileMatch[2]);
-    if (expected != null) {
-      push({
-        kind: 'file_lines',
-        subject: 'lines',
-        path: fileMatch[1],
-        expected,
-        raw: fileMatch[0],
-      });
-    }
-    fileMatch = fileLineRe.exec(source);
-  }
-
-  const fileBytesRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:is|has)\s+([-+]?\d{1,3}(?:,\d{3})*|\d+)\s+bytes?\b/gi;
-  fileMatch = fileBytesRe.exec(source);
-  while (fileMatch) {
-    const expected = parseNumberToken(fileMatch[2]);
-    if (expected != null) {
-      push({
-        kind: 'file_bytes',
-        subject: 'bytes',
-        path: fileMatch[1],
-        expected,
-        raw: fileMatch[0],
-      });
-    }
-    fileMatch = fileBytesRe.exec(source);
-  }
-
-  const fileExistsRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:exists|is present|is on disk)\b/gi;
-  fileMatch = fileExistsRe.exec(source);
-  while (fileMatch) {
-    push({
-      kind: 'file_exists',
-      subject: 'exists',
-      path: fileMatch[1],
-      expected: true,
-      raw: fileMatch[0],
-    });
-    fileMatch = fileExistsRe.exec(source);
-  }
-
-  const fileMissingRe = /\b(?:file\s+)?([^\s,]+\.[A-Za-z0-9]+)\s+(?:does not exist|is missing|is absent)\b/gi;
-  fileMatch = fileMissingRe.exec(source);
-  while (fileMatch) {
-    push({
-      kind: 'file_exists',
-      subject: 'exists',
-      path: fileMatch[1],
-      expected: false,
-      raw: fileMatch[0],
-    });
-    fileMatch = fileMissingRe.exec(source);
-  }
-
-  // "version is 1.31.0" / "package version equals 1.2.3"
-  const versionRe = /\b((?:package\s+)?version)\s*(?:is|=|:|equals?)\s*([vV]?\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?)\b/gi;
-  let versionMatch = versionRe.exec(source);
-  while (versionMatch) {
-    push({
-      kind: 'value',
-      subject: normalizeSubject(versionMatch[1]),
-      expected: String(versionMatch[2]).replace(/^v/i, ''),
-      raw: versionMatch[0],
-    });
-    versionMatch = versionRe.exec(source);
-  }
-
+  const push = createClaimPush(claims);
+  parseCountClaims(source, push);
+  parseFileMetricClaims(source, push);
+  parseValueClaims(source, push);
   return claims;
 }
 
-function loadVerifierConfig(options = {}) {
+function loadConfigFromOptions(options) {
   if (Array.isArray(options.verifiers)) {
     return { verifiers: options.verifiers, source: 'options' };
   }
@@ -243,11 +224,13 @@ function loadVerifierConfig(options = {}) {
   if (options.config && Array.isArray(options.config.verifiers)) {
     return { verifiers: options.config.verifiers, source: 'options.config' };
   }
-  if (options.claimVerifiers && Array.isArray(options.claimVerifiers.verifiers)) {
+  if (options.claimVerifiers?.verifiers && Array.isArray(options.claimVerifiers.verifiers)) {
     return { verifiers: options.claimVerifiers.verifiers, source: 'options.claimVerifiers' };
   }
+  return null;
+}
 
-  const repoRoot = resolveRepoRoot(options.cwd);
+function collectConfigCandidates(options, repoRoot) {
   const candidates = [];
   const explicitConfigPath = options.configPath || process.env.THUMBGATE_CLAIM_VERIFIERS_PATH;
   if (explicitConfigPath) {
@@ -261,24 +244,35 @@ function loadVerifierConfig(options = {}) {
   }
 
   const feedbackDir = options.feedbackDir || resolveFeedbackDir({ cwd: repoRoot });
-  candidates.push(path.join(feedbackDir, DEFAULT_VERIFIERS_FILENAME));
+  candidates.push(
+    path.join(feedbackDir, DEFAULT_VERIFIERS_FILENAME),
+    path.join(repoRoot, '.thumbgate', DEFAULT_VERIFIERS_FILENAME),
+    path.join(repoRoot, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME),
+    path.join(PACKAGE_ROOT, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME),
+  );
+  return [...new Set(candidates)];
+}
 
-  // Project overrides first (consumer cwd), then the shipped package default.
-  // Verifier path fields still resolve against repoRoot/cwd so package-owned
-  // configs evaluate files inside the target project, not inside node_modules.
-  candidates.push(path.join(repoRoot, '.thumbgate', DEFAULT_VERIFIERS_FILENAME));
-  candidates.push(path.join(repoRoot, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME));
-  candidates.push(path.join(PACKAGE_ROOT, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME));
+function readVerifierFile(candidate) {
+  const raw = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+  const verifiers = Array.isArray(raw?.verifiers)
+    ? raw.verifiers
+    : (Array.isArray(raw) ? raw : null);
+  if (!verifiers) {
+    throw new Error('expected an array or an object with a verifiers array');
+  }
+  return { verifiers, source: candidate, path: candidate };
+}
 
-  for (const candidate of [...new Set(candidates)]) {
+function loadVerifierConfig(options = {}) {
+  const fromOptions = loadConfigFromOptions(options);
+  if (fromOptions) return fromOptions;
+
+  const repoRoot = resolveRepoRoot(options.cwd);
+  for (const candidate of collectConfigCandidates(options, repoRoot)) {
     if (!candidate || !fs.existsSync(candidate)) continue;
     try {
-      const raw = JSON.parse(fs.readFileSync(candidate, 'utf8'));
-      const verifiers = Array.isArray(raw?.verifiers) ? raw.verifiers : Array.isArray(raw) ? raw : null;
-      if (!verifiers) {
-        throw new Error('expected an array or an object with a verifiers array');
-      }
-      return { verifiers, source: candidate, path: candidate };
+      return readVerifierFile(candidate);
     } catch (error) {
       throw new Error(`invalid claim verifier config ${candidate}: ${error.message}`);
     }

--- a/scripts/universal-claim-evaluator.js
+++ b/scripts/universal-claim-evaluator.js
@@ -18,6 +18,8 @@ const path = require('path');
 const { resolveFeedbackDir } = require('./feedback-paths');
 
 const DEFAULT_VERIFIERS_FILENAME = 'claim-verifiers.json';
+// Package install root (node_modules/thumbgate), not the consumer project cwd.
+const PACKAGE_ROOT = path.join(__dirname, '..');
 
 function parseNumberToken(raw) {
   if (raw == null) return null;
@@ -261,8 +263,12 @@ function loadVerifierConfig(options = {}) {
   const feedbackDir = options.feedbackDir || resolveFeedbackDir({ cwd: repoRoot });
   candidates.push(path.join(feedbackDir, DEFAULT_VERIFIERS_FILENAME));
 
+  // Project overrides first (consumer cwd), then the shipped package default.
+  // Verifier path fields still resolve against repoRoot/cwd so package-owned
+  // configs evaluate files inside the target project, not inside node_modules.
   candidates.push(path.join(repoRoot, '.thumbgate', DEFAULT_VERIFIERS_FILENAME));
   candidates.push(path.join(repoRoot, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME));
+  candidates.push(path.join(PACKAGE_ROOT, 'config', 'gates', DEFAULT_VERIFIERS_FILENAME));
 
   for (const candidate of [...new Set(candidates)]) {
     if (!candidate || !fs.existsSync(candidate)) continue;

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -181,3 +181,34 @@ test('reportToText includes claim verification status', () => {
   assert.match(text, /Evaluator:/i);
   assert.match(text, /Stop hook:/i);
 });
+
+test('generateAgentReadinessReport warns when claim verifier config fails to load', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-claim-ready-warn-'));
+  try {
+    for (const fileName of ['AGENTS.md', 'CLAUDE.md', 'GEMINI.md']) {
+      fs.writeFileSync(path.join(projectRoot, fileName), `# ${fileName}\n`);
+    }
+    fs.writeFileSync(path.join(projectRoot, '.mcp.json'), JSON.stringify({ mcpServers: {} }));
+    fs.mkdirSync(path.join(projectRoot, '.thumbgate'), { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, '.thumbgate', 'config.json'), JSON.stringify({ version: 1 }));
+
+    // Force a load failure through summarizeClaimVerification deps by writing
+    // a malformed project config that is discovered first.
+    fs.writeFileSync(path.join(projectRoot, '.thumbgate', 'claim-verifiers.json'), '{not-json');
+
+    const previousContainer = process.env.container;
+    process.env.container = '1';
+    const report = generateAgentReadinessReport({
+      projectRoot,
+      mcpProfile: 'default',
+    });
+    if (previousContainer === undefined) delete process.env.container;
+    else process.env.container = previousContainer;
+
+    assert.equal(report.claimVerification.configLoadFailed, true);
+    assert.equal(report.overallStatus, 'needs_attention');
+    assert.ok(report.warnings.some((w) => /failed to load/i.test(w)));
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -75,7 +75,17 @@ test('generateAgentReadinessReport aligns bootstrap and permission findings', ()
   assert.equal(report.articleAlignment.contextConditioning, true);
   assert.equal(report.articleAlignment.permissionEnvelope, true);
   assert.equal(report.articleAlignment.runtimeIsolation, true);
+  assert.equal(report.claimVerification.evaluatorReady, true);
   assert.equal(report.overallStatus, 'ready');
 
   fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+test('summarizeClaimVerification reports shipped default verifiers in this repo', () => {
+  const { summarizeClaimVerification } = require('../scripts/agent-readiness');
+  const summary = summarizeClaimVerification(path.join(__dirname, '..'));
+  assert.equal(summary.evaluatorReady, true);
+  assert.ok(summary.verifierCount >= 1);
+  assert.equal(summary.stopHookRegistered, true);
+  assert.equal(summary.ready, true);
 });

--- a/tests/agent-readiness.test.js
+++ b/tests/agent-readiness.test.js
@@ -7,7 +7,9 @@ const path = require('node:path');
 const {
   collectBootstrapFiles,
   summarizePermissionTier,
+  summarizeClaimVerification,
   generateAgentReadinessReport,
+  reportToText,
 } = require('../scripts/agent-readiness');
 
 test('collectBootstrapFiles reports missing required context files', () => {
@@ -82,10 +84,100 @@ test('generateAgentReadinessReport aligns bootstrap and permission findings', ()
 });
 
 test('summarizeClaimVerification reports shipped default verifiers in this repo', () => {
-  const { summarizeClaimVerification } = require('../scripts/agent-readiness');
   const summary = summarizeClaimVerification(path.join(__dirname, '..'));
   assert.equal(summary.evaluatorReady, true);
   assert.ok(summary.verifierCount >= 1);
   assert.equal(summary.stopHookRegistered, true);
   assert.equal(summary.ready, true);
+  assert.match(summary.recommendation, /ready/i);
+});
+
+test('summarizeClaimVerification reports missing evaluator module', () => {
+  const summary = summarizeClaimVerification(path.join(__dirname, '..'), {
+    resolveEvaluator: () => {
+      throw new Error('missing module');
+    },
+    loadVerifierConfig: () => () => ({ verifiers: [], source: 'none' }),
+  });
+  assert.equal(summary.evaluatorReady, false);
+  assert.equal(summary.ready, false);
+  assert.match(summary.recommendation, /missing/i);
+});
+
+test('summarizeClaimVerification reports zero verifiers and missing stop hook', () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-claim-readiness-'));
+  try {
+    const noVerifiers = summarizeClaimVerification(projectRoot, {
+      resolveEvaluator: () => 'ok',
+      loadVerifierConfig: () => () => ({ verifiers: [], source: 'none' }),
+    });
+    assert.equal(noVerifiers.evaluatorReady, true);
+    assert.equal(noVerifiers.verifierCount, 0);
+    assert.equal(noVerifiers.stopHookRegistered, false);
+    assert.equal(noVerifiers.ready, false);
+    assert.match(noVerifiers.recommendation, /No claim verifiers configured/i);
+
+    fs.mkdirSync(path.join(projectRoot, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'echo noop' }] }],
+      },
+    }));
+    const noStopHook = summarizeClaimVerification(projectRoot, {
+      resolveEvaluator: () => 'ok',
+      loadVerifierConfig: () => () => ({ verifiers: [{ id: 'x' }], source: 'test' }),
+    });
+    assert.equal(noStopHook.verifierCount, 1);
+    assert.equal(noStopHook.stopHookRegistered, false);
+    assert.match(noStopHook.recommendation, /Stop anti-claim hook is not registered/i);
+
+    fs.writeFileSync(path.join(projectRoot, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'node scripts/hook-stop-anti-claim.js' }] }],
+      },
+    }));
+    const ready = summarizeClaimVerification(projectRoot, {
+      resolveEvaluator: () => 'ok',
+      loadVerifierConfig: () => () => ({ verifiers: [{ id: 'x' }, { id: 'y' }], source: 'injected' }),
+    });
+    assert.equal(ready.ready, true);
+    assert.equal(ready.stopHookRegistered, true);
+    assert.match(ready.recommendation, /2 verifier/);
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test('summarizeClaimVerification fails closed on config load errors and corrupt settings', () => {
+  const configError = summarizeClaimVerification(path.join(__dirname, '..'), {
+    resolveEvaluator: () => 'ok',
+    loadVerifierConfig: () => () => {
+      throw new Error('bad config');
+    },
+  });
+  assert.match(configError.recommendation, /failed to load: bad config/);
+
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-claim-bad-settings-'));
+  try {
+    fs.mkdirSync(path.join(projectRoot, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, '.claude', 'settings.json'), '{not-json');
+    const badSettings = summarizeClaimVerification(projectRoot, {
+      resolveEvaluator: () => 'ok',
+      loadVerifierConfig: () => () => ({ verifiers: [{ id: 'x' }], source: 'test' }),
+    });
+    assert.equal(badSettings.stopHookRegistered, false);
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test('reportToText includes claim verification status', () => {
+  const report = generateAgentReadinessReport({
+    projectRoot: path.join(__dirname, '..'),
+    mcpProfile: 'default',
+  });
+  const text = reportToText(report);
+  assert.match(text, /Claim verification:/i);
+  assert.match(text, /Evaluator:/i);
+  assert.match(text, /Stop hook:/i);
 });

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -416,8 +416,9 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     // public A+ evidence/runtime files documented in CHANGELOG.md. No headroom.
     // 416 -> 418 (2026-08-02): scripts/universal-claim-evaluator.js +
     // config/gates/claim-verifiers.example.json for fail-closed factual claim rechecks.
-    manifest.fileCount <= 418,
-    `npm package should stay <= 418 files, got ${manifest.fileCount}`
+    // 418 -> 419 (2026-08-02): default config/gates/claim-verifiers.json (package version + package.json exists).
+    manifest.fileCount <= 419,
+    `npm package should stay <= 419 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/prove-claim-verification.test.js
+++ b/tests/prove-claim-verification.test.js
@@ -9,7 +9,7 @@ const { execSync } = require('node:child_process');
 
 const ROOT = path.join(__dirname, '..');
 
-test('prove-claim-verification: proof gate passes with 6/6 checks', () => {
+test('prove-claim-verification: proof gate passes with 8/8 checks', () => {
   const tmpProofDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-claim-proof-test-'));
   try {
     const output = execSync('node scripts/prove-claim-verification.js', {
@@ -19,7 +19,7 @@ test('prove-claim-verification: proof gate passes with 6/6 checks', () => {
       env: { ...process.env, THUMBGATE_CLAIM_VERIFICATION_PROOF_DIR: tmpProofDir },
     });
 
-    assert.ok(output.includes('6 passed, 0 failed'), `Expected 6/6 pass, got: ${output}`);
+    assert.ok(output.includes('8 passed, 0 failed'), `Expected 8/8 pass, got: ${output}`);
   } finally {
     fs.rmSync(tmpProofDir, { recursive: true, force: true });
   }
@@ -39,10 +39,12 @@ test('prove-claim-verification: report.json captures all requirements', () => {
     assert.ok(fs.existsSync(reportPath), 'claim-verification-report.json must exist');
     const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
     assert.equal(report.phase, '13-claim-verification');
-    assert.equal(report.passed, 6);
+    assert.equal(report.passed, 8);
     assert.equal(report.failed, 0);
     assert.ok(report.requirements['CLAIM-01']);
     assert.ok(report.requirements['CLAIM-06']);
+    assert.ok(report.requirements['CLAIM-07']);
+    assert.ok(report.requirements['CLAIM-08']);
   } finally {
     fs.rmSync(tmpProofDir, { recursive: true, force: true });
   }
@@ -63,7 +65,9 @@ test('prove-claim-verification: report.md contains all requirement checkboxes', 
     const markdown = fs.readFileSync(markdownPath, 'utf8');
     assert.ok(markdown.includes('[x] **CLAIM-01**'));
     assert.ok(markdown.includes('[x] **CLAIM-06**'));
-    assert.ok(markdown.includes('6 passed, 0 failed'));
+    assert.ok(markdown.includes('[x] **CLAIM-07**'));
+    assert.ok(markdown.includes('[x] **CLAIM-08**'));
+    assert.ok(markdown.includes('8 passed, 0 failed'));
   } finally {
     fs.rmSync(tmpProofDir, { recursive: true, force: true });
   }

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -161,8 +161,10 @@ const path = require('node:path');
 // packed 406 files; this branch packs exactly 416.
 // Bumped 416 -> 418 (2026-08-02): universal claim evaluator runtime + claim
 // verifier example config so agents can recheck factual claims against SQLite/FS/JSON.
+// Bumped 418 -> 419 (2026-08-02): ship default config/gates/claim-verifiers.json
+// so package-version factual claims recheck without a local override.
 // Each file is directly callable from the package and contains no buyer state.
-const BASELINE_FILE_COUNT = 418;
+const BASELINE_FILE_COUNT = 419;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -226,9 +226,10 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // 416 -> 418 (2026-08-02): the universal claim evaluator runtime and its
   // operator-owned verifier example. Both are public enforcement surfaces;
   // neither imports private Core code or buyer state.
+  // 418 -> 419 (2026-08-02): default config/gates/claim-verifiers.json.
   // CI pack measured 403 during secret-exfil coverage PR (no intentional new package
   // entries beyond security/runtime scripts already on the enforcement path).
-  const CEILING = 418;
+  const CEILING = 419;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +

--- a/tests/universal-claim-evaluator.test.js
+++ b/tests/universal-claim-evaluator.test.js
@@ -10,6 +10,7 @@ const { spawnSync } = require('node:child_process');
 const {
   parseFactualClaims,
   evaluateUniversalClaims,
+  loadVerifierConfig,
   assertSelectOnly,
   resolveSafePath,
   pathMatches,
@@ -273,6 +274,33 @@ describe('verifyClaimEvidence integration', () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
       clearSessionActions();
+    }
+  });
+});
+
+describe('loadVerifierConfig package-root defaults', () => {
+  it('loads shipped package defaults when consumer cwd has no claim-verifiers.json', () => {
+    const consumerRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-claim-consumer-'));
+    try {
+      // Simulate npm install consumer project: empty cwd, no local config.
+      fs.writeFileSync(path.join(consumerRoot, 'package.json'), JSON.stringify({
+        name: 'consumer',
+        version: '2.3.4',
+      }));
+      const loaded = loadVerifierConfig({ cwd: consumerRoot });
+      assert.ok(loaded.verifierCount === undefined || Array.isArray(loaded.verifiers));
+      assert.ok(loaded.verifiers.length >= 1, 'expected shipped default verifiers');
+      assert.match(String(loaded.source), /config[\\/]gates[\\/]claim-verifiers\.json/);
+      // Source should be the package install path, not the empty consumer root.
+      assert.ok(!String(loaded.source).startsWith(consumerRoot));
+
+      const result = evaluateUniversalClaims('package version is 2.3.4', {
+        cwd: consumerRoot,
+      });
+      assert.equal(result.verified, true);
+      assert.equal(result.checks[0].status, 'match');
+    } finally {
+      fs.rmSync(consumerRoot, { recursive: true, force: true });
     }
   });
 });

--- a/tests/universal-claim-evaluator.test.js
+++ b/tests/universal-claim-evaluator.test.js
@@ -27,6 +27,15 @@ describe('parseFactualClaims', () => {
     assert.match(claims[0].subject, /row count/);
   });
 
+  it('parses equals wording for counts and versions', () => {
+    const countClaims = parseFactualClaims('the row count equals 1,284');
+    assert.equal(countClaims.length, 1);
+    assert.equal(countClaims[0].expected, 1284);
+    const versionClaims = parseFactualClaims('package version equals 1.31.0');
+    assert.equal(versionClaims.length, 1);
+    assert.equal(versionClaims[0].expected, '1.31.0');
+  });
+
   it('parses there-are-N-rows phrasing', () => {
     const claims = parseFactualClaims('There are 42 orders in the table.');
     assert.equal(claims.length, 1);


### PR DESCRIPTION
**Summary**
Follow-up to #3159 after Trunk reported a merge conflict on #3163.

- Ship `config/gates/claim-verifiers.json` defaults
- Load defaults from **package root** so npm consumers get dogfood without copying config
- Agent readiness reports factual claim recheck + config load failures
- Proof lane CLAIM-07/08
- Sonar maintainability refactors (complexity / regex / node: imports)

**Proof**
```
local: agent-readiness + universal-claim-evaluator tests green
prove-claim-verification 8/8
Sonar quality gate passed on prior tip; rebased cleanly onto origin/main
```

**Test plan**
- [x] rebased onto origin/main without conflicts
- [ ] CI green
- [ ] Trunk merge