### PR TITLE
feat(gates): ERP-lite operator spend gate (hard-block money disasters)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3989,6 +3989,12 @@ switch (COMMAND) {
     console.log(`Total auto-promoted gates: ${result.totalGates}`);
     break;
   }
+  case 'spend-gate':
+  case 'operator-spend-gate': {
+    // ERP-lite operator money gate CLI (2026-08-02)
+    require('../scripts/operator-spend-gate').main(process.argv.slice(3));
+    break;
+  }
   case 'meta-agent': {
     const metaArgs = parseArgs(process.argv.slice(3));
     if (metaArgs.status) {

--- a/docs/operator-spend-gate.md
+++ b/docs/operator-spend-gate.md
@@ -1,0 +1,38 @@
+# Operator spend gate (ERP-lite financial disaster prevention)
+
+Hard-blocks **operator-money** tool intents unless the operator message explicitly
+authorizes an exact USD amount in the **same message**.
+
+## Incident
+2026-08-02: Apollo Basic annual **$588** — thumbs-down alone only **warned**. Soft
+lessons ≠ payment interlock.
+
+## CLI
+```bash
+npx thumbgate spend-gate check --action "upgrade Apollo Basic" --message "continue"
+# exit 1 BLOCK
+
+npx thumbgate spend-gate check --action "buy credits $5" \
+  --message "I authorize spend $5 on Apollo credits"
+# exit 0 ALLOW
+
+npx thumbgate spend-gate log --limit 20
+```
+
+## PreToolUse integration
+`scripts/gates-engine.js` calls `evaluateOperatorSpendGate` early. Gate id
+`operator-spend-gate` is on the **unconditional hard floor** (never warn-downgraded,
+never free-tier daily-cap discounted).
+
+Pass operator message via:
+- `toolInput.operatorMessage` / `user_message` / `message`, or
+- env `THUMBGATE_OPERATOR_MESSAGE` / `HERMES_OPERATOR_MESSAGE`
+
+## Always allowed
+refund · cancel plan · chargeback/dispute · remove credit card · read-only billing diagnose
+
+## Ledger
+`~/.thumbgate/spend-ledger/commitments.jsonl` (override `THUMBGATE_SPEND_LEDGER`)
+
+## Related tags (first 👎 high-risk promote)
+`never-spend`, `money-crisis`, `billing`, `operator-spend`, `payment`, `checkout`

--- a/package.json
+++ b/package.json
@@ -358,7 +358,8 @@
     "scripts/pragmatic-hybrid-search.js",
     "server.json",
     "glama.json",
-    "smithery.yaml"
+    "smithery.yaml",
+    "scripts/operator-spend-gate.js"
   ],
   "scripts": {
     "canary:snapshot": "node scripts/gate-decision-canary.js --snapshot",
@@ -616,7 +617,7 @@
     "test:session-analyzer": "node --test tests/session-analyzer.test.js",
     "test:tessl": "node --test tests/tessl-export.test.js",
     "test:gates": "node --test --test-concurrency=1 tests/gate-templates.test.js tests/gates-engine.test.js tests/claim-verification.test.js tests/universal-claim-evaluator.test.js tests/secret-scanner.test.js tests/secret-fixture-safety.test.js tests/prompt-guard.test.js tests/audit-trail.test.js tests/profile-router.test.js tests/workflow-sentinel.test.js tests/docker-sandbox-planner.test.js tests/mcp-tools-suggest-fix.test.js tests/deny-network-egress-pattern.test.js tests/git-pathspec-scope.test.js tests/git-global-option-bypass.test.js tests/gate-evasion-matrix.test.js",
-    "test:budget": "node --test tests/budget-guard.test.js tests/budget-enforcer.test.js tests/tokenomics-cost-guard.test.js tests/hook-no-budget-lockout.test.js",
+    "test:budget": "node --test tests/budget-guard.test.js tests/budget-enforcer.test.js tests/tokenomics-cost-guard.test.js tests/hook-no-budget-lockout.test.js tests/operator-spend-gate.test.js tests/operator-spend-gate-engine.test.js",
     "test:workers": "npm --prefix workers ci && npm --prefix workers test",
     "test:evoskill": "node --test tests/evoskill.test.js",
     "test:gates-hardening": "node --test tests/gates-hardening.test.js",

--- a/scripts/feedback-to-rules.js
+++ b/scripts/feedback-to-rules.js
@@ -42,6 +42,8 @@ const HIGH_RISK_TAGS = new Set([
   'destructive', 'force-push', 'delete', 'drop', 'force-overwrite',
   'production', 'database', 'payment', 'credentials', 'secrets',
   'rm-rf', 'reset-hard', 'truncate', 'data-loss',
+  // Financial disaster class (2026-08-02 Apollo $588) — first 👎 can promote spend gates
+  'never-spend', 'money-crisis', 'billing', 'operator-spend', 'spend', 'checkout',
 ]);
 function analyze(entries) {
   let positiveCount = 0, negativeCount = 0;

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -157,6 +157,9 @@ const UNCONDITIONAL_HARD_FLOOR_GATE_IDS = new Set([
   'secret-exfiltration',
   'security-vuln-scan',
   'slopsquat-guard',
+  // Operator money: never warn-downgrade. Incident 2026-08-02 Apollo $588.
+  'operator-spend-gate',
+  'hard-ban-never-spend-operator-money',
   TASK_SCOPE_LEASE_EXPIRED_GATE_ID,
   ...SELF_PROTECT_HARD_FLOOR_GATE_IDS,
 ]);
@@ -174,6 +177,9 @@ const CATASTROPHIC_DECLARATIVE_GATE_IDS = new Set([
   'git-reset-hard',
   'git-clean-force',
   'rm-rf-home-or-root',
+  // Financial disaster class — never daily-cap discount (2026-08-02 $588 Apollo).
+  'operator-spend-gate',
+  'hard-ban-never-spend-operator-money',
 ]);
 const SELF_PROTECT_CONFIG_TARGET_PATTERN = /(?:^|\/)(?:config\/gates\/|config\/(?:budget|enforcement|mcp-allowlists)\.json$|\.thumbgate\/config\.json$|thumbgate\.json$)/i;
 const SELF_PROTECT_HOOK_TARGET_PATTERN = /(?:^|\/)(?:\.claude\/settings(?:\.local)?\.json|\.codex\/config\.toml|scripts\/hook-[^/]+\.(?:js|sh))$/i;
@@ -1936,6 +1942,47 @@ function recordStructuralGateBlock(toolName, toolInput, result) {
   return result;
 }
 
+/**
+ * ERP-lite operator money gate (2026-08-02 Apollo $588 incident).
+ * Blocks upgrade/credits/checkout/pay tool intents unless same-message
+ * authorization with exact USD amount. Refund/cancel/dispute always allowed.
+ * Hard floor: never warn-downgraded, never daily-cap discounted.
+ */
+function evaluateOperatorSpendGate(toolName, toolInput = {}) {
+  let spend;
+  try {
+    spend = require('./operator-spend-gate');
+  } catch {
+    return null;
+  }
+  const operatorMessage = String(
+    toolInput.operatorMessage
+      || toolInput.user_message
+      || toolInput.message
+      || process.env.HERMES_OPERATOR_MESSAGE
+      || process.env.THUMBGATE_OPERATOR_MESSAGE
+      || '',
+  );
+  const result = spend.evaluateToolCall({
+    toolName,
+    toolInput,
+    message: operatorMessage,
+    log: true,
+    agentId: toolInput.agentId || process.env.HERMES_AGENT_ID || 'gates-engine',
+  });
+  if (!result || result.decision !== 'BLOCK') return null;
+  return {
+    decision: 'deny',
+    gate: 'operator-spend-gate',
+    message:
+      `${result.reason}: never spend operator money without same-message ` +
+      `"I authorize spend $N on …". Refund/cancel/dispute are allowed. ` +
+      `hits=${(result.classification && result.classification.spendHits || []).join(',') || '-'}`,
+    severity: 'critical',
+    spendGate: result,
+  };
+}
+
 function isScopeEnforcedAction(toolName, toolInput = {}, affectedFiles = []) {
   if (EDIT_LIKE_TOOLS.has(toolName) && affectedFiles.length > 0) return true;
   if (toolName !== 'Bash') return false;
@@ -2776,6 +2823,11 @@ async function evaluateGatesAsyncInner(toolName, toolInput, configPath) {
     return boostedRiskGuard;
   }
 
+  const operatorSpendGate = evaluateOperatorSpendGate(toolName, toolInput);
+  if (operatorSpendGate) {
+    return recordStructuralGateBlock(toolName, toolInput, operatorSpendGate);
+  }
+
   // Tier 1b: Planning and Trajectory (v1.26.0 - CodeRabbit Pattern).
   // Keep runtime enforcement explicit so advisory planning checks do not mask
   // higher-priority deny/approve gates in established workflows.
@@ -3020,6 +3072,11 @@ function evaluateGatesInner(toolName, toolInput, configPath) {
     });
     auditToFeedback(auditRecord);
     return boostedRiskGuard;
+  }
+
+  const operatorSpendGate = evaluateOperatorSpendGate(toolName, toolInput);
+  if (operatorSpendGate) {
+    return recordStructuralGateBlock(toolName, toolInput, operatorSpendGate);
   }
 
   // Tier 1b: Planning and Trajectory (v1.26.0 - CodeRabbit Pattern).
@@ -4156,6 +4213,7 @@ module.exports = {
   isBoostedRiskHigh,
   riskTagMatchesAction,
   evaluateBoostedRiskTagGuard,
+  evaluateOperatorSpendGate,
   registerPrThreadResolutionClaimGate,
   evaluatePendingPrThreadResolutionGate,
   checkPrDormantForBranch,

--- a/scripts/operator-spend-gate.js
+++ b/scripts/operator-spend-gate.js
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * operator-spend-gate.js — ERP-lite spend control for agents (zero-cost local gate).
+ *
+ * Hard-blocks operator-money actions unless the *same message* explicitly
+ * authorizes an exact amount. Refund/cancel/dispute are always allowed.
+ *
+ * Usage:
+ *   node tools/operator-spend-gate.js check --action "upgrade Apollo Basic" --message "..."
+ *   node tools/operator-spend-gate.js classify --text "buy more credits"
+ *   node tools/operator-spend-gate.js authorize --message "I authorize spend $10 on X"
+ *   node tools/operator-spend-gate.js log --limit 20
+ *   node tools/operator-spend-gate.js --json check --action "..." --message "..."
+ *
+ * Exit: 0 ALLOW · 1 BLOCK · 2 usage/error
+ *
+ * Incident: 2026-08-02 Apollo Basic annual $588 — never-spend HARD BAN.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const GATE_ID = 'hard-ban-never-spend-operator-money';
+const SCHEMA = 'operator-spend-gate/v1';
+const DEFAULT_LEDGER = process.env.THUMBGATE_SPEND_LEDGER
+  || path.join(os.homedir(), '.thumbgate', 'spend-ledger', 'commitments.jsonl');
+
+/** Patterns that indicate a spend / paid upgrade intent (BLOCK without auth). */
+const SPEND_PATTERNS = [
+  { id: 'plan_upgrade', re: /\b(upgrade\s+(the\s+)?plan|plan\s+upgrade|upgrade\s+to\s+(basic|pro|professional|team|organization|enterprise|paid))\b/i },
+  { id: 'buy_credits', re: /\b(buy|purchase|add)\s+(more\s+)?credits?\b|\bcredit\s+packs?\b|\badd-on\s+credits?\b/i },
+  { id: 'checkout_pay', re: /\b(checkout|pay\s+now|subscribe|subscription\s+purchase|complete\s+purchase|place\s+order)\b/i },
+  { id: 'payment_method', re: /\b(add|update|enter)\s+(a\s+)?(credit\s+card|payment\s+method|billing\s+card)\b|\bupdate\s+credit\s+card\b/i },
+  { id: 'apollo_paid', re: /\bapollo\b.*\b(basic|professional|organization|enterprise|upgrade|paid\s+plan|annual)\b|\b(basic|professional)\s+(seat|plan)\b.*\bapollo\b/i },
+  { id: 'saas_upsell', re: /\b(thumbgate\s+pro|upgrade\s+to\s+pro|paid\s+tier|billing\s+cycle|per\s+seat\s+per\s+month)\b/i },
+  { id: 'reactivate_paid', re: /\breactivate\s+(your\s+)?plan\b|\brequest\s+upgrade\b/i },
+  { id: 'dollar_spend', re: /\b(spend|pay|charge|purchase|buy)\s+(\$?\d[\d,]*(?:\.\d{1,2})?)\b/i },
+  { id: 'due_today', re: /\bdue\s+today\b.*\$|\b\$\d+.*\b(upgrade|subscribe|checkout)\b/i },
+];
+
+/** Always allowed — money recovery / prevent further charges. */
+const SAFE_PATTERNS = [
+  { id: 'refund', re: /\brefund\b/i },
+  { id: 'cancel_plan', re: /\bcancel\s+(the\s+)?(plan|subscription)\b|\bpending\s+cancellation\b/i },
+  { id: 'dispute', re: /\b(chargeback|dispute|bank\s+dispute)\b/i },
+  { id: 'remove_card', re: /\bremove\s+(credit\s+)?card\b|\bremove\s+payment\s+method\b/i },
+  { id: 'read_only_billing', re: /\b(billing\s+page|invoice\s+history|read-?only|diagnose\s+billing)\b/i },
+];
+
+/**
+ * Same-message authorization phrases.
+ * Examples:
+ *   "I authorize spend $588 on Apollo"
+ *   "authorize paying $10 for X"
+ *   "you may spend up to $5 on Y"
+ */
+const AUTH_PATTERNS = [
+  /\bi\s+(?:explicitly\s+)?authorize\s+(?:spend(?:ing)?|pay(?:ing)?|payment|purchase)\s+(?:of\s+|up\s+to\s+)?\$?\s*([\d,]+(?:\.\d{1,2})?)/i,
+  /\b(?:spend|pay|purchase)\s+(?:up\s+to\s+)?\$?\s*([\d,]+(?:\.\d{1,2})?)\s+(?:is\s+)?(?:authorized|approved|ok|allowed)\b/i,
+  /\byou\s+may\s+(?:spend|pay|purchase)\s+(?:up\s+to\s+)?\$?\s*([\d,]+(?:\.\d{1,2})?)/i,
+  /\bapproved\s+(?:to\s+)?(?:spend|pay|charge)\s+\$?\s*([\d,]+(?:\.\d{1,2})?)/i,
+];
+
+const AMOUNT_ANYWHERE = /\$\s*([\d,]+(?:\.\d{1,2})?)/g;
+
+function parseUsd(raw) {
+  if (raw == null || raw === '') return null;
+  const n = Number(String(raw).replace(/,/g, ''));
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n * 100) / 100;
+}
+
+function classifySpendIntent(text) {
+  const t = String(text || '');
+  const safeHits = SAFE_PATTERNS.filter((p) => p.re.test(t)).map((p) => p.id);
+  const spendHits = SPEND_PATTERNS.filter((p) => p.re.test(t)).map((p) => p.id);
+  // Safe recovery language alone → not a spend intent
+  const isSafeOnly = safeHits.length > 0 && spendHits.length === 0;
+  // Mixed: "cancel and also upgrade" still spend
+  const isSpend = spendHits.length > 0 && !isSafeOnly;
+  return {
+    schema: SCHEMA,
+    isSpendIntent: isSpend,
+    isSafeRecovery: safeHits.length > 0 && !isSpend,
+    spendHits,
+    safeHits,
+    risk: isSpend ? 'high' : safeHits.length ? 'recovery' : 'none',
+  };
+}
+
+function parseAuthorization(message) {
+  const m = String(message || '');
+  const amounts = [];
+  for (const re of AUTH_PATTERNS) {
+    const match = m.match(re);
+    if (match) {
+      const usd = parseUsd(match[1]);
+      if (usd != null) amounts.push(usd);
+    }
+  }
+  // Explicit phrase without relying only on first pattern
+  const authorized = amounts.length > 0 || /\bi\s+authorize\s+spend\b/i.test(m);
+  // If "I authorize spend" without amount, still need amount for money
+  let maxAuthorizedUsd = amounts.length ? Math.max(...amounts) : null;
+  if (authorized && maxAuthorizedUsd == null) {
+    // try any $ in authorize sentence
+    const sentence = m.split(/[.!?\n]/).find((s) => /authorize/i.test(s)) || '';
+    const dollar = [...sentence.matchAll(AMOUNT_ANYWHERE)].map((x) => parseUsd(x[1])).filter((n) => n != null);
+    if (dollar.length) maxAuthorizedUsd = Math.max(...dollar);
+  }
+  return {
+    authorized: Boolean(authorized && maxAuthorizedUsd != null && maxAuthorizedUsd > 0),
+    maxAuthorizedUsd,
+    phrasesMatched: amounts.length,
+    raw: m.slice(0, 500),
+  };
+}
+
+function extractActionAmountUsd(actionText) {
+  const t = String(actionText || '');
+  const found = [...t.matchAll(AMOUNT_ANYWHERE)].map((x) => parseUsd(x[1])).filter((n) => n != null);
+  return found.length ? Math.max(...found) : null;
+}
+
+/**
+ * Evaluate whether an agent may proceed with an action given operator message.
+ * @param {{ action?: string, message?: string, text?: string, log?: boolean, ledgerPath?: string, agentId?: string }} input
+ */
+function evaluateSpendGate(input = {}) {
+  const action = String(input.action || input.text || '');
+  const message = String(input.message || input.operatorMessage || '');
+  const combined = `${action}\n${message}`;
+  const classification = classifySpendIntent(combined);
+  const auth = parseAuthorization(message);
+  const actionAmount = extractActionAmountUsd(action) ?? extractActionAmountUsd(message);
+
+  let decision = 'ALLOW';
+  let reason = 'no_spend_intent';
+  const reasons = [];
+
+  if (classification.isSafeRecovery && !classification.isSpendIntent) {
+    decision = 'ALLOW';
+    reason = 'safe_recovery_path';
+    reasons.push('refund/cancel/dispute/remove-card allowed without spend auth');
+  } else if (classification.isSpendIntent) {
+    if (!auth.authorized) {
+      decision = 'BLOCK';
+      reason = 'spend_intent_without_same_message_authorization';
+      reasons.push('spend intent detected; missing "I authorize spend $N" in same message');
+      reasons.push(`spendHits=${classification.spendHits.join(',')}`);
+    } else if (actionAmount != null && auth.maxAuthorizedUsd != null && actionAmount > auth.maxAuthorizedUsd + 1e-9) {
+      decision = 'BLOCK';
+      reason = 'amount_exceeds_authorization';
+      reasons.push(`actionAmount=${actionAmount} > authorized=${auth.maxAuthorizedUsd}`);
+    } else {
+      decision = 'ALLOW';
+      reason = 'explicit_same_message_authorization';
+      reasons.push(`authorized maxUsd=${auth.maxAuthorizedUsd}`);
+    }
+  }
+
+  const result = {
+    schema: SCHEMA,
+    gateId: GATE_ID,
+    ok: decision === 'ALLOW',
+    decision,
+    reason,
+    reasons,
+    classification,
+    authorization: {
+      authorized: auth.authorized,
+      maxAuthorizedUsd: auth.maxAuthorizedUsd,
+    },
+    actionAmountUsd: actionAmount,
+    checkedAt: new Date().toISOString(),
+  };
+
+  if (input.log !== false) {
+    try {
+      appendCommitment(
+        {
+          decision: result.decision,
+          reason: result.reason,
+          action: action.slice(0, 400),
+          message: message.slice(0, 400),
+          spendHits: classification.spendHits,
+          maxAuthorizedUsd: auth.maxAuthorizedUsd,
+          actionAmountUsd: actionAmount,
+          agentId: input.agentId || process.env.HERMES_AGENT_ID || 'unknown',
+        },
+        input.ledgerPath || DEFAULT_LEDGER,
+      );
+    } catch {
+      /* ledger failures must not flip allow→block incorrectly; keep decision */
+      result.ledgerError = true;
+    }
+  }
+
+  return result;
+}
+
+function ensureLedgerDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+}
+
+function appendCommitment(entry, ledgerPath = DEFAULT_LEDGER) {
+  const file = ledgerPath || DEFAULT_LEDGER;
+  ensureLedgerDir(file);
+  const row = {
+    schema: 'operator-spend-commitment/v1',
+    id: `spd-${crypto.randomBytes(6).toString('hex')}`,
+    ts: new Date().toISOString(),
+    ...entry,
+  };
+  fs.appendFileSync(file, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    /* ignore */
+  }
+  return row;
+}
+
+function readCommitments(limit = 20, ledgerPath = DEFAULT_LEDGER) {
+  const file = ledgerPath || DEFAULT_LEDGER;
+  if (!fs.existsSync(file)) return [];
+  const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+  const slice = lines.slice(-Math.max(1, limit));
+  return slice.map((line) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      return { parseError: true, line: line.slice(0, 200) };
+    }
+  });
+}
+
+/**
+ * PreToolUse helper: given a tool name + serialized input + operator message.
+ */
+function evaluateToolCall({ toolName, toolInput, message, log = true, agentId } = {}) {
+  const blob = [
+    toolName || '',
+    typeof toolInput === 'string' ? toolInput : JSON.stringify(toolInput || {}),
+  ].join(' ');
+  return evaluateSpendGate({ action: blob, message: message || '', log, agentId });
+}
+
+function parseArgs(argv) {
+  const args = {
+    cmd: '',
+    action: '',
+    message: '',
+    text: '',
+    json: false,
+    log: true,
+    limit: 20,
+    ledgerPath: DEFAULT_LEDGER,
+    help: false,
+  };
+  const rest = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--no-log') args.log = false;
+    else if (a === '--action') args.action = argv[++i] || '';
+    else if (a === '--message' || a === '--operator-message') args.message = argv[++i] || '';
+    else if (a === '--text') args.text = argv[++i] || '';
+    else if (a === '--limit') args.limit = Number(argv[++i] || 20);
+    else if (a === '--ledger') args.ledgerPath = path.resolve(argv[++i] || DEFAULT_LEDGER);
+    else if (!a.startsWith('-') && !args.cmd) args.cmd = a;
+    else rest.push(a);
+  }
+  args.rest = rest;
+  return args;
+}
+
+const usage = `Usage:
+  node tools/operator-spend-gate.js check --action "..." --message "..."
+  node tools/operator-spend-gate.js classify --text "..."
+  node tools/operator-spend-gate.js authorize --message "..."
+  node tools/operator-spend-gate.js log [--limit N]
+  node tools/operator-spend-gate.js tool --action '{"tool":"..."}' --message "..."
+
+Exit 0 ALLOW · 1 BLOCK · 2 error
+
+ERP-lite: same-message authorization with amount required for any spend intent.
+Safe: refund | cancel plan | chargeback | remove card.
+Ledger: ~/.thumbgate/spend-ledger/commitments.jsonl`;
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help || !args.cmd) {
+    console.log(usage);
+    process.exit(args.help ? 0 : 2);
+  }
+
+  if (args.cmd === 'classify') {
+    const c = classifySpendIntent(args.text || args.action || args.message);
+    if (args.json) console.log(JSON.stringify(c, null, 2));
+    else console.log(`${c.risk} spend=${c.isSpendIntent} hits=${c.spendHits.join(',') || '-'} safe=${c.safeHits.join(',') || '-'}`);
+    process.exit(0);
+  }
+
+  if (args.cmd === 'authorize') {
+    const a = parseAuthorization(args.message || args.text);
+    if (args.json) console.log(JSON.stringify(a, null, 2));
+    else console.log(`authorized=${a.authorized} maxUsd=${a.maxAuthorizedUsd}`);
+    process.exit(a.authorized ? 0 : 1);
+  }
+
+  if (args.cmd === 'log') {
+    const rows = readCommitments(args.limit, args.ledgerPath);
+    if (args.json) console.log(JSON.stringify({ ledger: args.ledgerPath, rows }, null, 2));
+    else {
+      console.log(`ledger ${args.ledgerPath} (last ${rows.length})`);
+      for (const r of rows) {
+        console.log(`${r.ts || '?'} ${r.decision || '?'} ${r.reason || ''} ${(r.action || '').slice(0, 60)}`);
+      }
+    }
+    process.exit(0);
+  }
+
+  if (args.cmd === 'check' || args.cmd === 'tool') {
+    const result = evaluateSpendGate({
+      action: args.action || args.text,
+      message: args.message,
+      log: args.log,
+      ledgerPath: args.ledgerPath,
+    });
+    if (args.json) console.log(JSON.stringify(result, null, 2));
+    else {
+      console.log(`${result.decision} reason=${result.reason}`);
+      for (const r of result.reasons) console.log(`  - ${r}`);
+    }
+    process.exit(result.ok ? 0 : 1);
+  }
+
+  console.error(`Unknown command: ${args.cmd}`);
+  console.error(usage);
+  process.exit(2);
+}
+
+module.exports = {
+  GATE_ID,
+  SCHEMA,
+  DEFAULT_LEDGER,
+  SPEND_PATTERNS,
+  SAFE_PATTERNS,
+  classifySpendIntent,
+  parseAuthorization,
+  extractActionAmountUsd,
+  evaluateSpendGate,
+  evaluateToolCall,
+  appendCommitment,
+  readCommitments,
+  parseArgs,
+  main,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(2);
+  }
+}

--- a/tests/operator-spend-gate-engine.test.js
+++ b/tests/operator-spend-gate-engine.test.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-spend-engine-'));
+process.env.THUMBGATE_SPEND_LEDGER = path.join(tmp, 'commitments.jsonl');
+// Keep default warn posture — spend gate must still hard-deny.
+delete process.env.THUMBGATE_STRICT_ENFORCEMENT;
+
+const {
+  evaluateGates,
+  evaluateOperatorSpendGate,
+  applyEnforcementPosture,
+} = require('../scripts/gates-engine');
+
+test.after(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test('evaluateOperatorSpendGate denies upgrade without auth', () => {
+  const r = evaluateOperatorSpendGate('Bash', {
+    command: 'open https://app.apollo.io and upgrade plan buy credits',
+  });
+  assert.ok(r);
+  assert.equal(r.decision, 'deny');
+  assert.equal(r.gate, 'operator-spend-gate');
+  assert.equal(r.severity, 'critical');
+});
+
+test('evaluateOperatorSpendGate allows refund', () => {
+  const r = evaluateOperatorSpendGate('Bash', {
+    command: 'curl mailto:support for refund and cancel plan',
+  });
+  assert.equal(r, null);
+});
+
+test('applyEnforcementPosture never warn-downgrades operator-spend-gate', () => {
+  const denied = {
+    decision: 'deny',
+    gate: 'operator-spend-gate',
+    message: 'spend blocked',
+    severity: 'critical',
+  };
+  const out = applyEnforcementPosture(denied);
+  assert.equal(out.decision, 'deny');
+  assert.equal(out.warnByDefault, undefined);
+});
+
+test('evaluateGates hard-denies spend bash under warn-by-default posture', () => {
+  const r = evaluateGates('Bash', {
+    command: 'echo upgrade plan buy credits apollo basic',
+  });
+  assert.ok(r, 'expected a gate result');
+  assert.equal(r.decision, 'deny');
+  assert.equal(r.gate, 'operator-spend-gate');
+});
+
+test('evaluateGates allows authorized spend when message carries amount', () => {
+  const r = evaluateGates('Bash', {
+    command: 'buy credits $5',
+    operatorMessage: 'I authorize spend $5 on Apollo credits',
+  });
+  // May be null (allow) or some other unrelated gate — must not be operator-spend deny
+  if (r) {
+    assert.notEqual(r.gate, 'operator-spend-gate');
+  }
+});

--- a/tests/operator-spend-gate.test.js
+++ b/tests/operator-spend-gate.test.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..');
+const GATE = path.join(ROOT, 'scripts', 'operator-spend-gate.js');
+const {
+  classifySpendIntent,
+  parseAuthorization,
+  evaluateSpendGate,
+  evaluateToolCall,
+  readCommitments,
+  GATE_ID,
+} = require(GATE);
+
+const tmpLedger = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'spend-gate-')), 'commitments.jsonl');
+
+test('CLI help exits 0', () => {
+  const r = spawnSync(process.execPath, [GATE, '--help'], { encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /operator-spend-gate/);
+});
+
+test('classify: upgrade Apollo is spend intent', () => {
+  const c = classifySpendIntent('you should upgrade Apollo to Basic plan');
+  assert.equal(c.isSpendIntent, true);
+  assert.ok(c.spendHits.length > 0);
+});
+
+test('classify: buy credits is spend intent', () => {
+  const c = classifySpendIntent('buy more credits on Apollo');
+  assert.equal(c.isSpendIntent, true);
+  assert.ok(c.spendHits.includes('buy_credits'));
+});
+
+test('classify: refund/cancel is safe recovery', () => {
+  const c = classifySpendIntent('request a full refund and cancel the plan');
+  assert.equal(c.isSpendIntent, false);
+  assert.equal(c.isSafeRecovery, true);
+});
+
+test('classify: remove credit card is safe', () => {
+  const c = classifySpendIntent('remove credit card from billing');
+  assert.equal(c.isSpendIntent, false);
+  assert.ok(c.safeHits.includes('remove_card'));
+});
+
+test('authorize: parses I authorize spend $N', () => {
+  const a = parseAuthorization('I authorize spend $25 on domain email SMTP only.');
+  assert.equal(a.authorized, true);
+  assert.equal(a.maxAuthorizedUsd, 25);
+});
+
+test('authorize: missing amount is not authorized', () => {
+  const a = parseAuthorization('I authorize spend on Apollo');
+  assert.equal(a.authorized, false);
+});
+
+test('evaluate: blocks upgrade without auth', () => {
+  const r = evaluateSpendGate({
+    action: 'upgrade Apollo Basic annual $588',
+    message: 'fix the people API please',
+    log: true,
+    ledgerPath: tmpLedger,
+  });
+  assert.equal(r.decision, 'BLOCK');
+  assert.equal(r.ok, false);
+  assert.equal(r.gateId, GATE_ID);
+});
+
+test('evaluate: allows upgrade with matching authorization', () => {
+  const r = evaluateSpendGate({
+    action: 'upgrade Apollo Basic for $49',
+    message: 'I authorize spend $49 on Apollo Basic this month only.',
+    log: true,
+    ledgerPath: tmpLedger,
+  });
+  assert.equal(r.decision, 'ALLOW');
+  assert.equal(r.reason, 'explicit_same_message_authorization');
+});
+
+test('evaluate: blocks when action amount exceeds auth', () => {
+  const r = evaluateSpendGate({
+    action: 'checkout $588 annual Basic',
+    message: 'I authorize spend $10 on snacks',
+    log: true,
+    ledgerPath: tmpLedger,
+  });
+  assert.equal(r.decision, 'BLOCK');
+  assert.equal(r.reason, 'amount_exceeds_authorization');
+});
+
+test('evaluate: always allows refund path', () => {
+  const r = evaluateSpendGate({
+    action: 'email support@apollo.io requesting refund of $588',
+    message: 'get my money back',
+    log: true,
+    ledgerPath: tmpLedger,
+  });
+  assert.equal(r.decision, 'ALLOW');
+});
+
+test('evaluateToolCall: blocks bash upgrade/credits', () => {
+  const r2 = evaluateToolCall({
+    toolName: 'Bash',
+    toolInput: { command: 'echo upgrade plan buy credits' },
+    message: 'do it',
+    log: true,
+  });
+  assert.equal(r2.decision, 'BLOCK');
+});
+
+test('CLI check exits 1 on block', () => {
+  const r = spawnSync(
+    process.execPath,
+    [GATE, 'check', '--action', 'buy more credits', '--message', 'fix api', '--ledger', tmpLedger, '--json'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(r.status, 1, r.stdout + r.stderr);
+  const body = JSON.parse(r.stdout);
+  assert.equal(body.decision, 'BLOCK');
+});
+
+test('CLI check exits 0 on authorized spend', () => {
+  const r = spawnSync(
+    process.execPath,
+    [
+      GATE,
+      'check',
+      '--action',
+      'buy credits $5',
+      '--message',
+      'I authorize spend $5 on Apollo credits',
+      '--ledger',
+      tmpLedger,
+      '--json',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+  assert.equal(JSON.parse(r.stdout).decision, 'ALLOW');
+});
+
+test('commitment ledger appends rows', () => {
+  const rows = readCommitments(50, tmpLedger);
+  assert.ok(rows.length >= 3, `expected ledger rows, got ${rows.length}`);
+  assert.ok(rows.some((r) => r.decision === 'BLOCK'));
+  assert.ok(rows.some((r) => r.decision === 'ALLOW'));
+});
+
+test('ThumbGate Pro upsell is spend intent', () => {
+  const c = classifySpendIntent('Upgrade to ThumbGate Pro for unlimited rules');
+  assert.equal(c.isSpendIntent, true);
+});


### PR DESCRIPTION
## Summary
- **ERP-lite spend control** for agents: block upgrade/credits/checkout/pay tool intents unless the operator message explicitly authorizes an **exact USD amount** (`I authorize spend $N on …`).
- **Always allow** refund / cancel plan / chargeback / remove card.
- Append-only commitment ledger: `~/.thumbgate/spend-ledger/commitments.jsonl`.
- Wired into `gates-engine` as **unconditional hard floor** (not warn-by-default, not daily-cap discounted).
- CLI: `npx thumbgate spend-gate check|classify|authorize|log`
- Expand `HIGH_RISK_TAGS` for first-capture promotion of money disasters.
- Docs: `docs/operator-spend-gate.md`

## Incident
2026-08-02 Apollo Basic annual **$588** — product warn-by-default + soft lesson promotion failed to prevent financial disaster. This hardens money class.

## Test plan
- [x] `node --test tests/operator-spend-gate.test.js tests/operator-spend-gate-engine.test.js` → 21/21
- [x] `evaluateGates` under default posture still **deny**s spend bash
- [x] authorized spend allows through
- [ ] CI green

## Note
Does **not** spend operator money. Does **not** reverse historical charges (refund/bank still required).