### PR TITLE
fix(mcp): keep read-only retrieval below client timeouts

### DIFF
--- a/.changeset/mcp-readonly-firewall-latency.md
+++ b/.changeset/mcp-readonly-firewall-latency.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Keep secret scanning on read-only MCP calls while bypassing mutation-only semantic gates that could delay lesson search past client timeouts.

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -59,6 +59,7 @@ const {
   evaluateGates,
   evaluateGatesAsync,
   evaluateSecretGuard,
+  isReadOnlyObservabilityTool,
   satisfyCondition,
   loadStats: loadGateStats,
   setTaskScope,
@@ -826,8 +827,15 @@ async function callTool(name, args = {}) {
     }
   }
 
-  if (name !== 'workflow_sentinel' && process.env.THUMBGATE_DISABLE_MCP_FIREWALL !== '1') {
-    const firewallResult = (await evaluateGatesAsync(name, args)) || evaluateSecretGuard({ tool_name: name, tool_input: args });
+  const firewallPlan = getMcpFirewallEvaluationPlan(name);
+  if (firewallPlan.secretGuard) {
+    let firewallResult = null;
+    if (firewallPlan.semantic) {
+      firewallResult = await evaluateGatesAsync(name, args);
+    }
+    if (!firewallResult) {
+      firewallResult = evaluateSecretGuard({ tool_name: name, tool_input: args });
+    }
     if (firewallResult && firewallResult.decision === 'deny') {
       const err = new Error(`Action blocked by Semantic Firewall: ${firewallResult.message}`);
       err.errorCategory = 'permission';
@@ -885,6 +893,17 @@ async function callTool(name, args = {}) {
     });
   } catch { /* audit write failure must never break tool response */ }
   return result;
+}
+
+function getMcpFirewallEvaluationPlan(
+  name,
+  disabled = process.env.THUMBGATE_DISABLE_MCP_FIREWALL === '1',
+) {
+  const enabled = name !== 'workflow_sentinel' && !disabled;
+  return {
+    semantic: enabled && !isReadOnlyObservabilityTool(name),
+    secretGuard: enabled,
+  };
 }
 
 function validateMcpToolOutput(toolDef, result) {
@@ -1909,6 +1928,7 @@ module.exports = {
     listAvailableTools,
     unavailablePrivateMcpFeature,
     callToolInner,
+    getMcpFirewallEvaluationPlan,
     validateMcpToolOutput,
   },
 };

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -88,6 +88,25 @@ function makeAcceptedVerification() {
   };
 }
 
+test('read-only MCP tools skip mutation gates but keep the secret guard', () => {
+  assert.deepEqual(__test__.getMcpFirewallEvaluationPlan('search_lessons', false), {
+    semantic: false,
+    secretGuard: true,
+  });
+  assert.deepEqual(__test__.getMcpFirewallEvaluationPlan('capture_feedback', false), {
+    semantic: true,
+    secretGuard: true,
+  });
+  assert.deepEqual(__test__.getMcpFirewallEvaluationPlan('workflow_sentinel', false), {
+    semantic: false,
+    secretGuard: false,
+  });
+  assert.deepEqual(__test__.getMcpFirewallEvaluationPlan('capture_feedback', true), {
+    semantic: false,
+    secretGuard: false,
+  });
+});
+
 test.after(() => {
   fs.rmSync(tmpFeedbackDir, { recursive: true, force: true });
   fs.rmSync(tmpProofDir, { recursive: true, force: true });


### PR DESCRIPTION
## Outcome

Read-only MCP observability calls now skip mutation-only semantic gates while preserving the existing secret guard. Mutating tools retain semantic-gate-first behavior.

Closes AGENT-46.

## Evidence

- full local `npm test`: exit 0
- post-refactor `npm run test:api`: 998/998
- focused MCP tests: 48/48
- gate + MCP focused tests: 245/245
- adapter proof: 48/48
- automation proof: 55/55
- self-healing sweep: 9/9 healthy, including a second full `npm test`
- real stdio initialize/list/search: 44 ms
- synthetic AWS-shaped secret on a read-only call: denied
- GitHub CI, CodeQL, SonarCloud, changeset, branch-contamination, Claude review, Vercel, Socket, and GitGuardian checks: green

## Boundaries

- No global firewall disable
- No secret-scanning bypass
- No mutation-tool behavior change
- Installed npm runtime remains unchanged until a release containing this commit ships and is installed
- Mutating-call latency is tracked separately in Linear AGENT-48