### PR TITLE
fix(finance): hard-block Apollo/Stripe checkout URLs on open/curl/WebFetch

### DIFF
--- a/.changeset/financial-url-spend-gaps.md
+++ b/.changeset/financial-url-spend-gaps.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fail-closed financial hard floor now treats Apollo upgrade and Stripe checkout URLs as economic actions for Bash open/curl and WebFetch, closing the URL-only spend path that prose patterns missed.

--- a/scripts/financial-control-plane.js
+++ b/scripts/financial-control-plane.js
@@ -78,6 +78,17 @@ const ECONOMIC_ACTION_PATTERNS = [
   /\b(?:finalize|pay|refund|send|update)\s+(?:a\s+)?(?:payout|refund|subscription|top-?up|transfer)\b/i,
 ];
 
+// Host/path URL surfaces that open paid checkout or plan-upgrade flows.
+// These are NOT covered by prose patterns alone (e.g. `open https://app.apollo.io/#/settings/plans/upgrade`
+// or WebFetch { url: 'https://checkout.stripe.com/...' }) — Apollo $588 incident class.
+const ECONOMIC_URL_PATTERNS = [
+  /(?:https?:\/\/)?(?:www\.)?checkout\.stripe\.com\b/i,
+  /(?:https?:\/\/)?(?:www\.)?buy\.stripe\.com\b/i,
+  /(?:https?:\/\/)?(?:www\.)?billing\.stripe\.com\b/i,
+  /(?:https?:\/\/)?(?:www\.)?app\.apollo\.io\b[^\s"'`]*?(?:plans|upgrade|billing|checkout|subscription)/i,
+  /(?:https?:\/\/)?(?:www\.)?apollo\.io\b[^\s"'`]*?(?:plans|upgrade|billing|checkout|subscription)/i,
+];
+
 const SCREEN_TOOL_PATTERN = /(?:browser|computer|playwright|puppeteer|selenium|click|tap|press)/i;
 const SCREEN_MUTATION_PATTERN = /(?:click|double[_ -]?click|tap|press|select|submit|confirm|activate)/i;
 const SCREEN_OBSERVATION_PATTERN = /(?:screenshot|snapshot)/i;
@@ -343,13 +354,24 @@ function detectEconomicAction(toolName, toolInput = {}) {
   const screenMutationProse = isDeclaredScreenMutation(normalizedToolName, toolInput)
     ? [toolInput.goal, toolInput.description, toolInput.prompt, metadata.context]
     : [];
+  // WebFetch / browser navigate often put the spend surface only in url/uri/href.
+  const navigationTargets = [
+    toolInput.url,
+    toolInput.uri,
+    toolInput.href,
+    toolInput.link,
+    toolInput.navigate,
+    toolInput.target,
+  ].map((value) => String(value || '')).join(' ');
   const combined = [
     normalizedToolName.replace(/[_-]+/g, ' '),
     command,
     toolInput.action,
     toolInput.operation,
+    navigationTargets,
     ...screenMutationProse,
   ].map((value) => String(value || '')).join(' ');
+  if (ECONOMIC_URL_PATTERNS.some((pattern) => pattern.test(combined))) return true;
   return ECONOMIC_ACTION_PATTERNS.some((pattern) => pattern.test(combined));
 }
 
@@ -1581,6 +1603,7 @@ function financialError(message) {
 
 module.exports = {
   ECONOMIC_ACTION_PATTERNS,
+  ECONOMIC_URL_PATTERNS,
   createPurchaseRequisition,
   buildActionAuthorization,
   detectEconomicAction,

--- a/tests/financial-control-plane.test.js
+++ b/tests/financial-control-plane.test.js
@@ -479,6 +479,33 @@ test('provider names in credential paths and read-only billing commands are not 
     element: 'Receipt',
     ref: 'e99',
   }), false);
+  // URL-only spend surfaces (Apollo $588 class): open/curl/WebFetch must hard-block.
+  assert.equal(detectEconomicAction('Bash', {
+    command: 'open https://app.apollo.io/#/settings/plans/upgrade',
+  }), true);
+  assert.equal(detectEconomicAction('Bash', {
+    command: 'open https://app.apollo.io/settings/plans/upgrade',
+  }), true);
+  assert.equal(detectEconomicAction('Bash', {
+    command: 'curl -X POST https://checkout.stripe.com/c/pay/cs_test_xxx',
+  }), true);
+  assert.equal(detectEconomicAction('WebFetch', {
+    url: 'https://checkout.stripe.com/c/pay/cs_test',
+  }), true);
+  assert.equal(detectEconomicAction('WebFetch', {
+    url: 'https://app.apollo.io/settings/plans/upgrade',
+  }), true);
+  assert.equal(detectEconomicAction('Bash', {
+    command: 'open https://buy.stripe.com/test_xxx',
+  }), true);
+  // Free-tier Apollo search must stay non-economic.
+  assert.equal(detectEconomicAction('Bash', {
+    command: 'apollo people search --q founder',
+  }), false);
+  // Docs / marketing pages that are not provider checkout hosts stay non-economic.
+  assert.equal(detectEconomicAction('WebFetch', {
+    url: 'https://docs.github.com/en/billing',
+  }), false);
 });
 
 test('signed human approval is bound to the immutable purchase request digest', () => {

--- a/tests/landing-page-claims.test.js
+++ b/tests/landing-page-claims.test.js
@@ -78,6 +78,12 @@ test('managed gate promise is bounded and backed by the canonical checkout rail'
 
 test('public enforcement claims match the implemented default and strict boundaries', () => {
   const { spawnSync } = require('node:child_process');
+  // Pin enforcement mode so an operator shell with THUMBGATE_STRICT_ENFORCEMENT=1
+  // (common after never-spend hardening) cannot flip the default-mode assertion.
+  const baseEnv = {
+    ...process.env,
+    THUMBGATE_STRICT_ENFORCEMENT: '',
+  };
   const runGate = (command, env = {}) => {
     const result = spawnSync('node', ['bin/cli.js', 'gate-check'], {
       cwd: ROOT,
@@ -86,7 +92,7 @@ test('public enforcement claims match the implemented default and strict boundar
         tool_input: { command },
         cwd: ROOT,
       }),
-      env: { ...process.env, ...env },
+      env: { ...baseEnv, ...env },
       encoding: 'utf8',
     });
     assert.equal(result.status, 0, result.stderr || result.stdout);


### PR DESCRIPTION
## Summary
- Extend `detectEconomicAction` to scan navigation targets (`url`/`uri`/`href`) and host-specific checkout/upgrade URL patterns for Stripe and Apollo, so `open`/`curl`/`WebFetch` cannot bypass the fail-closed financial hard floor.
- Add regression tests for deny on Apollo plans + Stripe checkout URL tools, and allow on free Apollo search.
- Isolate `THUMBGATE_STRICT_ENFORCEMENT` in the public enforcement-claims test so operator shells with never-spend STRICT=1 do not false-fail pre-push.

## Why
After the Apollo annual charge incident, hard floor blocked command-text spend patterns, but URL-only tool inputs (browser open, WebFetch, curl) still allowed checkout/plans hosts.

## Test plan
- [x] `node --test tests/financial-control-plane.test.js`
- [x] `node --test tests/landing-page-claims.test.js` with `THUMBGATE_STRICT_ENFORCEMENT=1` in the parent env
- [x] Pre-push regression-guard passed on push
- [ ] CI green on this PR

## Evidence posture
Not claiming published/main until this PR merges and main CI is green on the merge commit.