### PR TITLE
chore(release): ThumbGate 1.34.2 financial hard-floor + spend matrix

### DIFF
--- a/.changeset/brace-expansion-5.0.9.md
+++ b/.changeset/brace-expansion-5.0.9.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Bump brace-expansion override to 5.0.9 so npm audit --audit-level=low no longer fails Trunk merge on GHSA-rgw5-rvv9-x895.

--- a/.changeset/financial-spend-attack-matrix.md
+++ b/.changeset/financial-spend-attack-matrix.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Pin financial-control as a non-demotable hard floor and add a pre-push money attack matrix so Apollo/Stripe tool-surface regressions fail before CI.

--- a/.changeset/financial-url-spend-gaps.md
+++ b/.changeset/financial-url-spend-gaps.md
@@ -1,5 +1,0 @@
----
-"thumbgate": patch
----
-
-Fail-closed financial hard floor now treats Apollo upgrade and Stripe checkout URLs as economic actions for Bash open/curl and WebFetch, closing the URL-only spend path that prose patterns missed.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.34.1",
+      "version": "1.34.2",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.34.1"
+    "version": "1.34.2"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate.ai",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.34.2
+
+### Patch Changes
+
+- 7376069: Bump brace-expansion override to 5.0.9 so npm audit --audit-level=low no longer fails Trunk merge on GHSA-rgw5-rvv9-x895.
+- 7376069: Pin financial-control as a non-demotable hard floor and add a pre-push money attack matrix so Apollo/Stripe tool-surface regressions fail before CI.
+- 33f6a0d: Fail-closed financial hard floor now treats Apollo upgrade and Stripe checkout URLs as economic actions for Bash open/curl and WebFetch, closing the URL-only spend path that prose patterns missed.
+
 ## 1.34.1
 
 ### Patch Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.34.1 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.34.2 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/claw/.mcp.json
+++ b/adapters/claw/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"]
     }
   },
   "notes": "For claw-style agents (Automation Anywhere EnterpriseClaw, Nvidia OpenShell): enable ThumbGate gates for dynamic tool creation, screen/UI interaction, file system access, agent identity. See adapters/claw/CLAW.md. Combine with adapters/perplexity/HYBRID.md for hybrid local-cloud claw agents. Use new model candidates (automation-anywhere/enterprise-claw, nvidia/openshell-claw) and gate templates in 'Claw-Style Enterprise Agent Governance' category."

--- a/adapters/claw/config.toml
+++ b/adapters/claw/config.toml
@@ -2,7 +2,7 @@
 # Copy into ~/.codex/config.toml or merge. See CLAW.md and adapters/perplexity/HYBRID.md for hybrid+claw synergy.
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"]
 
 # Example for claw/orchestration awareness (extend MCP server or use sidecar when available)
 # [mcp_servers.claw]
@@ -12,7 +12,7 @@ args = ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
 # Hard PreToolUse hook for Codex - includes claw gates
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "gate-check"]
 
 # For hybrid claw: combine with Perplexity hybrid MCP for inference routing.
 # Use new gate templates: block-dynamic-tool-creation-without-approval, require-review-for-screen-ui-interaction, etc.

--- a/adapters/claw/opencode.json
+++ b/adapters/claw/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.34.1",
+        "thumbgate@1.34.2",
         "thumbgate",
         "serve"
       ],

--- a/adapters/forge/forge.yaml
+++ b/adapters/forge/forge.yaml
@@ -9,12 +9,12 @@ version: "1"
 skills:
   thumbgate-gate-check:
     description: "ThumbGate PreToolUse gate — blocks known-bad tool calls"
-    command: "npx --yes --package thumbgate@1.34.1 thumbgate gate-check"
+    command: "npx --yes --package thumbgate@1.34.2 thumbgate gate-check"
     trigger: pre_tool_use
 
   thumbgate-feedback:
     description: "ThumbGate feedback capture — logs user prompt context"
-    command: "npx --yes --package thumbgate@1.34.1 thumbgate hook-auto-capture"
+    command: "npx --yes --package thumbgate@1.34.2 thumbgate hook-auto-capture"
     trigger: user_prompt
 
 mcp:
@@ -23,6 +23,6 @@ mcp:
     args:
       - "--yes"
       - "--package"
-      - "thumbgate@1.34.1"
+      - "thumbgate@1.34.2"
       - "thumbgate"
       - "serve"

--- a/adapters/hermes/.mcp.json
+++ b/adapters/hermes/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"]
     }
   },
   "hooks": {
@@ -11,7 +11,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.34.1",
+        "thumbgate@1.34.2",
         "thumbgate",
         "gate-check"
       ]

--- a/adapters/hermes/config.toml
+++ b/adapters/hermes/config.toml
@@ -2,12 +2,12 @@
 # Copy into ~/.codex/config.toml or merge. See HERMES.md for skill-synthesis + channel-posting safety.
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"]
 
 # Hard PreToolUse hook for Codex - includes Hermes safety gates
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "gate-check"]
 
 # For Hermes Agent: enable templates like block-unauthorized-multi-channel-posts, prevent-infinite-skill-synthesis-loops, validate-synthesized-skills-against-rules.
 # See config/gate-templates.json for "Nous Research Hermes Agent Governance" category.

--- a/adapters/hermes/opencode.json
+++ b/adapters/hermes/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.34.1",
+        "thumbgate@1.34.2",
         "thumbgate",
         "serve"
       ],

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -328,7 +328,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.34.1' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.34.2' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.34.1",
+        "thumbgate@1.34.2",
         "thumbgate",
         "serve"
       ],

--- a/adapters/perplexity/.mcp.json
+++ b/adapters/perplexity/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"]
     },
     "perplexity": {
       "command": "npx",
@@ -18,7 +18,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.34.1",
+        "thumbgate@1.34.2",
         "thumbgate",
         "gate-check"
       ]

--- a/adapters/perplexity/config.toml
+++ b/adapters/perplexity/config.toml
@@ -2,7 +2,7 @@
 # Includes support for Perplexity hybrid local-cloud inference (see HYBRID.md for Personal Computer / Computex 2026 orchestrator integration).
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"]
 
 [mcp_servers.perplexity]
 command = "npx"
@@ -14,7 +14,7 @@ PERPLEXITY_API_KEY = "${PERPLEXITY_API_KEY}"
 # Hard PreToolUse hook for Codex
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.34.1", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.34.2", "thumbgate", "gate-check"]
 
 # For hybrid: when using Perplexity Personal Computer, add hybrid-routing gates
 # via custom rules in ThumbGate config/gates/ for "cloud-escalation" on sensitive paths.

--- a/adapters/perplexity/opencode.json
+++ b/adapters/perplexity/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.34.1",
+        "thumbgate@1.34.2",
         "thumbgate",
         "serve"
       ],

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.34.1`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.34.2`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.34.1 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.34.2 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.34.1", "serve"],
+      "args": ["-y", "thumbgate@1.34.2", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.34.1", "serve"],
+      "args": ["-y", "thumbgate@1.34.2", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.34.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.34.2 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.34.1
+1.34.2
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.34.1"
+version: "1.34.2"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.34.1",
+      "version": "1.34.2",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.",
   "homepage": "https://thumbgate.ai",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.34.1",
+        "thumbgate@1.34.2",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "ThumbGate for Codex turns one thumbs-down into a repeat-blocking pre-action check, backed by local MCP memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "author": {
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.34.1", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.34.2", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Deterministic pre-action checks, feedback capture, and MCP guardrails for AI coding agents in VS Code-compatible IDEs.",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="ThumbGate">
   <meta name="author" content="Igor Ganapolsky">
-  <meta name="thumbgate-version" content="1.34.1">
+  <meta name="thumbgate-version" content="1.34.2">
   __GOOGLE_SITE_VERIFICATION_META__
   <link rel="icon" type="image/png" href="/thumbgate-icon.png">
   <link rel="canonical" href="__APP_ORIGIN__/">
@@ -942,7 +942,7 @@ next      decision recorded before execution</pre>
 
   <footer>
     <div class="shell footer-inner">
-      <span>ThumbGate · MIT License · npm v1.34.1</span>
+      <span>ThumbGate · MIT License · npm v1.34.2</span>
       <div class="footer-links">
         <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub</a>
         <a href="/guide">Technical setup</a>

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.34.1",
+  "softwareVersion": "1.34.2",
   "url": "https://thumbgate-production.up.railway.app/numbers",
   "dateModified": "2026-08-03",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-08-03 · Version 1.34.1</div>
+  <div class="freshness">Updated: 2026-08-03 · Version 1.34.2</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.34.1",
+  "version": "1.34.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.34.1",
+      "version": "1.34.2",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Summary
Release **1.34.2** so npm `gitHead` matches main and the Deploy ownership gate can pass.

Consumes the three pending patch changesets left unshipped after #3201 / #3203:
- Apollo/Stripe checkout URL economic detection (open/curl/WebFetch)
- financial-control non-demotion + pre-push money attack matrix
- brace-expansion override 5.0.9 (audit/Trunk)

## Why
`1.34.1` on npm is still `35d9de27`. Main/prod were on `73760695` with the finance fixes, but npm and the GHA deploy SHA-ownership check still pointed at the old release.

## Test plan
- [x] `npm run changeset:version` → 1.34.2
- [x] `node scripts/sync-version.js --check` green
- [ ] CI green
- [ ] After merge: npm `thumbgate@1.34.2` gitHead equals release merge SHA
- [ ] Prod `/health` version `1.34.2` and buildSha = merge SHA