### PR TITLE
fix(ci): pin undici 8.10.0 and allow thumbgate.ai deploy proof

### DIFF
--- a/.changeset/undici-prod-allowlist.md
+++ b/.changeset/undici-prod-allowlist.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Clear the post-1.34.2 main CI audit on undici (pin 8.10.0) and allow the public thumbgate.ai origin in authenticated production deploy proof so GHA Deploy no longer fails the credential-safe host check.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@changesets/cli": "^2.31.0",
         "@playwright/test": "^1.60.0",
         "c8": "^12.0.0",
-        "undici": "^8.5.0"
+        "undici": "8.10.0"
       },
       "engines": {
         "node": ">=18.18.0"
@@ -3183,9 +3183,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1003,7 +1003,8 @@
     "express@4.22.1": {
       "path-to-regexp": "0.1.13"
     },
-    "js-yaml": "4.3.0"
+    "js-yaml": "4.3.0",
+    "undici": "8.10.0"
   },
   "mcpName": "io.github.IgorGanapolsky/thumbgate",
   "devDependencies": {
@@ -1011,7 +1012,7 @@
     "@changesets/cli": "^2.31.0",
     "@playwright/test": "^1.60.0",
     "c8": "^12.0.0",
-    "undici": "^8.5.0"
+    "undici": "8.10.0"
   },
   "hotfix": "gate-check-bypass-2026-06-03"
 }

--- a/scripts/prove-production-authenticated.js
+++ b/scripts/prove-production-authenticated.js
@@ -36,8 +36,13 @@ function validateBaseUrl(value, allowedHosts = []) {
     .split(',')
     .map((host) => host.trim().toLowerCase())
     .filter(Boolean);
+  // Canonical public origin is thumbgate.ai; Railway hostname is the
+  // infrastructure default. Both must accept credentials during post-deploy
+  // proof — vars.THUMBGATE_PUBLIC_APP_ORIGIN is set to thumbgate.ai in CI.
   const allowlist = new Set([
     new URL(DEFAULT_BASE_URL).host.toLowerCase(),
+    'thumbgate.ai',
+    'www.thumbgate.ai',
     ...configuredHosts,
     ...allowedHosts.map((host) => String(host || '').trim().toLowerCase()).filter(Boolean),
   ]);

--- a/scripts/prove-production-authenticated.js
+++ b/scripts/prove-production-authenticated.js
@@ -4,6 +4,13 @@
 const path = require('node:path');
 
 const DEFAULT_BASE_URL = 'https://thumbgate-production.up.railway.app';
+// Public buyer origin plus Railway hostname. Deploy workflows may probe either
+// (vars.THUMBGATE_PUBLIC_APP_ORIGIN defaults to thumbgate.ai in production CI).
+const DEFAULT_PRODUCTION_PROOF_HOSTS = Object.freeze([
+  'thumbgate-production.up.railway.app',
+  'thumbgate.ai',
+  'www.thumbgate.ai',
+]);
 const DEFAULT_TIMEOUT_MS = 12_000;
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAY_MS = 2_000;
@@ -22,6 +29,18 @@ function normalizeBaseUrl(value) {
   }
 }
 
+function buildProductionHostAllowlist(allowedHosts = [], env = process.env) {
+  const configuredHosts = String(env.THUMBGATE_PROD_ALLOWED_HOSTS || '')
+    .split(',')
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean);
+  return new Set([
+    ...DEFAULT_PRODUCTION_PROOF_HOSTS,
+    ...configuredHosts,
+    ...allowedHosts.map((host) => String(host || '').trim().toLowerCase()).filter(Boolean),
+  ]);
+}
+
 function validateBaseUrl(value, allowedHosts = []) {
   const raw = String(value || DEFAULT_BASE_URL).trim();
   let parsed;
@@ -32,20 +51,7 @@ function validateBaseUrl(value, allowedHosts = []) {
   }
 
   const loopbackHosts = new Set(['localhost', '127.0.0.1', '[::1]']);
-  const configuredHosts = String(process.env.THUMBGATE_PROD_ALLOWED_HOSTS || '')
-    .split(',')
-    .map((host) => host.trim().toLowerCase())
-    .filter(Boolean);
-  // Canonical public origin is thumbgate.ai; Railway hostname is the
-  // infrastructure default. Both must accept credentials during post-deploy
-  // proof — vars.THUMBGATE_PUBLIC_APP_ORIGIN is set to thumbgate.ai in CI.
-  const allowlist = new Set([
-    new URL(DEFAULT_BASE_URL).host.toLowerCase(),
-    'thumbgate.ai',
-    'www.thumbgate.ai',
-    ...configuredHosts,
-    ...allowedHosts.map((host) => String(host || '').trim().toLowerCase()).filter(Boolean),
-  ]);
+  const allowlist = buildProductionHostAllowlist(allowedHosts);
   const hostname = parsed.hostname.toLowerCase();
   const isLoopback = loopbackHosts.has(hostname);
   const safeBaseUrl = parsed.origin;
@@ -433,10 +439,12 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename
 
 module.exports = {
   DEFAULT_BASE_URL,
+  DEFAULT_PRODUCTION_PROOF_HOSTS,
   DEFAULT_TIMEOUT_MS,
   DEFAULT_MAX_ATTEMPTS,
   DEFAULT_RETRY_DELAY_MS,
   normalizeBaseUrl,
+  buildProductionHostAllowlist,
   validateBaseUrl,
   parseArgs,
   buildChecks,

--- a/tests/prove-production-authenticated.test.js
+++ b/tests/prove-production-authenticated.test.js
@@ -210,6 +210,19 @@ test('proof rejects credential destinations outside the production allowlist', a
   assert.doesNotMatch(JSON.stringify(report), /user|password|token=1/);
 });
 
+test('proof accepts the public thumbgate.ai origin used by deploy workflows', async () => {
+  const report = await runAuthenticatedProductionProof({
+    apiKey: 'secret-test-key',
+    baseUrl: 'https://thumbgate.ai',
+    expectedSha: 'abc123',
+    expectedVersion: '1.32.0',
+    maxAttempts: 1,
+    fetchImpl: passingFetch,
+  });
+  assert.equal(report.verdict, 'pass', report.reason || JSON.stringify(report.checks));
+  assert.equal(report.baseUrl, 'https://thumbgate.ai');
+});
+
 test('proof rejects shallow dashboard and zero-record export responses', async () => {
   const report = await runAuthenticatedProductionProof({
     apiKey: 'secret-test-key',

--- a/tests/prove-production-authenticated.test.js
+++ b/tests/prove-production-authenticated.test.js
@@ -5,6 +5,9 @@ const assert = require('node:assert/strict');
 
 const {
   DEFAULT_BASE_URL,
+  DEFAULT_PRODUCTION_PROOF_HOSTS,
+  buildProductionHostAllowlist,
+  validateBaseUrl,
   parseArgs,
   runAuthenticatedProductionProof,
   renderHuman,
@@ -221,6 +224,17 @@ test('proof accepts the public thumbgate.ai origin used by deploy workflows', as
   });
   assert.equal(report.verdict, 'pass', report.reason || JSON.stringify(report.checks));
   assert.equal(report.baseUrl, 'https://thumbgate.ai');
+});
+
+test('buildProductionHostAllowlist includes Railway and public buyer hosts', () => {
+  const hosts = buildProductionHostAllowlist();
+  for (const host of DEFAULT_PRODUCTION_PROOF_HOSTS) {
+    assert.equal(hosts.has(host), true, host);
+  }
+  assert.equal(validateBaseUrl('https://thumbgate.ai').valid, true);
+  assert.equal(validateBaseUrl('https://www.thumbgate.ai').valid, true);
+  assert.equal(validateBaseUrl('https://thumbgate-production.up.railway.app').valid, true);
+  assert.equal(validateBaseUrl('https://evil.example').valid, false);
 });
 
 test('proof rejects shallow dashboard and zero-record export responses', async () => {


### PR DESCRIPTION
## Summary
- Pin `undici@8.10.0` (dev + override) so `npm audit --audit-level=low` is clean after GHSA advisories on 8.0–8.8.
- Add `thumbgate.ai` / `www.thumbgate.ai` to the authenticated production-proof host allowlist so deploy workflows that probe the public origin stop failing with “outside the credential-safe allowlist”.
- Test coverage for the public origin accept path.

## Why
Not refusing residual reds after 1.34.2: main CI and Deploy GHA were red for these two independent reasons while npm/prod already carried the finance release.

## Test plan
- [x] `npm audit --audit-level=low` → 0 vulnerabilities
- [x] `node --test tests/prove-production-authenticated.test.js` (includes thumbgate.ai accept)
- [ ] CI green