### PR TITLE
test(finance): cover opaque screen-mutation detection

### DIFF
--- a/.changeset/screen-mutation-detection-coverage.md
+++ b/.changeset/screen-mutation-detection-coverage.md
@@ -1,0 +1,18 @@
+---
+"thumbgate": patch
+---
+
+Cover opaque screen-mutation detection in the financial control plane.
+
+`detectOpaqueScreenMutation` and the screen path through `detectEconomicAction`
+had no test coverage: all 30 existing cases exercised ledger mechanics only.
+Neutering the detector left the suite fully green, so a regression that let a
+blind browser click through would have shipped silently.
+
+Adds seven cases pinning the intended behaviour — coordinate, `ref`, `selector`
+and `elementId` locators are opaque; observation-only calls are not mutations;
+a non-screen tool carrying coordinates is not a screen mutation; routine shell
+commands stay allowed; and the control plane blocks a blind click while
+allowing a screenshot. The same mutation now fails five of them.
+
+Tests only; no behaviour change.

--- a/tests/financial-control-plane.test.js
+++ b/tests/financial-control-plane.test.js
@@ -1604,3 +1604,65 @@ test('authenticated financial head blocks rollback to a reusable reservation', (
     fs.rmSync(feedbackDir, { recursive: true, force: true });
   }
 });
+
+// --- opaque screen-mutation detection -------------------------------------
+// A native browser locator does not reveal what a click will do, so a blind
+// click is treated as an economic action until independently approved. These
+// cases had no coverage before; a regression here silently re-opens the
+// class of incident the control plane exists to prevent.
+
+test('a coordinate-addressed click is an opaque screen mutation', () => {
+  assert.equal(detectOpaqueScreenMutation('mcp__claude-in-chrome__computer', {
+    action: 'left_click', coordinate: [120, 240], tabId: 1,
+  }), true);
+});
+
+test('element-reference and selector locators are equally opaque', () => {
+  for (const locator of [{ ref: 'ref_7' }, { selector: '#confirm' }, { elementId: 'e12' }]) {
+    assert.equal(
+      detectOpaqueScreenMutation('mcp__claude-in-chrome__computer', { action: 'left_click', ...locator }),
+      true,
+      `expected ${Object.keys(locator)[0]} to be treated as opaque`,
+    );
+  }
+});
+
+test('observation-only screen calls are not mutations', () => {
+  assert.equal(detectOpaqueScreenMutation('mcp__claude-in-chrome__computer', {
+    action: 'screenshot', tabId: 1,
+  }), false);
+});
+
+test('a non-screen tool carrying coordinates is not a screen mutation', () => {
+  assert.equal(detectOpaqueScreenMutation('Bash', {
+    command: 'git status', coordinate: [1, 2],
+  }), false);
+});
+
+test('opaque screen mutation escalates to an economic action', () => {
+  assert.equal(detectEconomicAction('mcp__claude-in-chrome__computer', {
+    action: 'left_click', coordinate: [10, 20], tabId: 1,
+  }), true);
+});
+
+test('routine shell work is not an economic action', () => {
+  for (const command of ['git status', 'git switch -c wip', 'npm run test:ops', 'ls -la']) {
+    assert.equal(detectEconomicAction('Bash', { command }), false, `expected "${command}" to be allowed`);
+  }
+});
+
+test('control plane blocks a blind click but allows an observation', () => {
+  const clicked = evaluateFinancialControl({
+    toolName: 'mcp__claude-in-chrome__computer',
+    toolInput: { action: 'left_click', coordinate: [10, 20], tabId: 1 },
+  });
+  assert.equal(clicked.mode, 'block');
+  assert.equal(clicked.economicAction, true);
+
+  const observed = evaluateFinancialControl({
+    toolName: 'mcp__claude-in-chrome__computer',
+    toolInput: { action: 'screenshot', tabId: 1 },
+  });
+  assert.equal(observed.mode, 'allow');
+  assert.equal(observed.economicAction, false);
+});


### PR DESCRIPTION
## Why

`detectOpaqueScreenMutation` and the screen path through `detectEconomicAction` had **zero test coverage**. All 30 existing cases in `financial-control-plane.test.js` exercise ledger mechanics (anchors, hash chaining, tampering, reservations).

Proven by mutation: forcing the detector to `return false` left the suite **fully green**. A regression letting a blind browser click through would have shipped silently.

## What

Seven cases pinning intended behaviour:

- coordinate / `ref` / `selector` / `elementId` locators are opaque
- observation-only calls (screenshot) are not mutations
- a non-screen tool carrying coordinates is not a screen mutation
- routine shell commands stay allowed
- the control plane blocks a blind click while allowing a screenshot

## Evidence

| Check | Result |
|---|---|
| `node --test tests/financial-control-plane.test.js` | **37 pass / 0 fail** (was 30) |
| Same file vs. mutated detector | **5 fail** — coverage is real |
| `tests/test-suite-parity.test.js` | 5 pass / 0 fail |
| Reached by `npm test` | yes, via `test:ops` |

Tests only. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsSTuZMjotPXfbpi6SNxe