### PR TITLE
fix(api): allow operator key for hosted dashboard reads

### DIFF
--- a/.changeset/dashboard-operator-auth.md
+++ b/.changeset/dashboard-operator-auth.md
@@ -1,0 +1,15 @@
+---
+"thumbgate": patch
+---
+
+Allow operator key to read hosted dashboard JSON used by CLI.
+
+`thumbgate dashboard` and north-star call `GET /v1/dashboard` with the operator
+key from `~/.config/thumbgate/operator.json`. The general API gate only allowed
+operator GET on `/v1/billing/summary` (and a few other paths), so a valid
+operator key still returned HTTP 401 with a misleading "key does not match"
+message.
+
+Expand the read-only operator allowlist for dashboard GET routes
+(`/v1/dashboard`, render-spec, ai-inventory, review-state). Keep write/mutation
+surfaces admin-only.

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -883,7 +883,7 @@ function hashDataIdentity(prefix, value) {
 }
 
 function buildHostedTenantIdentity(validation = {}) {
-  if (!validation || validation.valid !== true || !validation.customerId) return null;
+  if (validation?.valid !== true || !validation.customerId) return null;
   const tenantSeed = validation.customerId;
   const principalSeed = validation.installId || tenantSeed;
   const tenantId = hashDataIdentity('tenant', tenantSeed);
@@ -2775,32 +2775,37 @@ function getTrackedLinkTarget(slug) {
     : null;
 }
 
-function appendTrackedLinkQueryParams(destinationUrl, parsed, target) {
-  const params = parsed.searchParams;
+function applyTrackedLinkDefaults(destinationUrl, target) {
   for (const [key, value] of Object.entries(target.defaults || {})) {
     if (!destinationUrl.searchParams.has(key)) {
       appendQueryParam(destinationUrl, key, value);
     }
   }
+}
+
+function applyTrackedLinkQueryKeys(destinationUrl, params) {
   for (const key of TRACKED_LINK_QUERY_KEYS) {
     const value = params.get(key);
-    if (value && value.trim()) {
-      const normalizedValue = key === 'utm_campaign'
-        ? normalizeCampaignId(value)
-        : value.trim();
-      destinationUrl.searchParams.set(key, normalizedValue);
-    }
+    if (!value || !value.trim()) continue;
+    const normalizedValue = key === 'utm_campaign'
+      ? normalizeCampaignId(value)
+      : value.trim();
+    destinationUrl.searchParams.set(key, normalizedValue);
   }
-  if (target.allowCustomerEmail) {
-    const customerEmail = normalizeCheckoutCustomerEmail(params.get('customer_email'));
-    if (customerEmail) {
-      appendQueryParam(
-        destinationUrl,
-        target.prefillStripeEmail ? 'prefilled_email' : 'customer_email',
-        customerEmail
-      );
-    }
-  }
+}
+
+function applyTrackedLinkCustomerEmail(destinationUrl, params, target) {
+  if (!target.allowCustomerEmail) return;
+  const customerEmail = normalizeCheckoutCustomerEmail(params.get('customer_email'));
+  if (!customerEmail) return;
+  appendQueryParam(
+    destinationUrl,
+    target.prefillStripeEmail ? 'prefilled_email' : 'customer_email',
+    customerEmail,
+  );
+}
+
+function applyTrackedLinkCtaDefaults(destinationUrl, target) {
   if (!destinationUrl.searchParams.has('cta_id')) {
     appendQueryParam(destinationUrl, 'cta_id', target.ctaId);
   }
@@ -2810,6 +2815,14 @@ function appendTrackedLinkQueryParams(destinationUrl, parsed, target) {
   if (!destinationUrl.searchParams.has('landing_path')) {
     appendQueryParam(destinationUrl, 'landing_path', `/go/${target.slug}`);
   }
+}
+
+function appendTrackedLinkQueryParams(destinationUrl, parsed, target) {
+  const params = parsed.searchParams;
+  applyTrackedLinkDefaults(destinationUrl, target);
+  applyTrackedLinkQueryKeys(destinationUrl, params);
+  applyTrackedLinkCustomerEmail(destinationUrl, params, target);
+  applyTrackedLinkCtaDefaults(destinationUrl, target);
 }
 
 function buildTrackedLinkDestination(target, hostedConfig, parsed) {
@@ -5167,6 +5180,23 @@ function isBillingSummaryAuthorized(req, expectedAdminKey, expectedOperatorKey) 
   if (expectedAdminKey && token === expectedAdminKey) return true;
   if (expectedOperatorKey && token === expectedOperatorKey) return true;
   return false;
+}
+
+/** Read-only paths the operator key may access (CLI dashboard / CFO / north-star). */
+const OPERATOR_READONLY_GET_PATHS = new Set([
+  '/v1/billing/summary',
+  '/v1/dashboard',
+  '/v1/dashboard/render-spec',
+  '/v1/dashboard/ai-inventory',
+  '/v1/dashboard/review-state',
+  '/v1/intake/workflow-sprint/queue',
+  '/v1/task-outcomes/monitor',
+]);
+
+function isOperatorReadonlyGet(req, expectedOperatorKey, pathname) {
+  if (!expectedOperatorKey || req.method !== 'GET') return false;
+  if (!OPERATOR_READONLY_GET_PATHS.has(pathname)) return false;
+  return safeKeyEqual(extractApiKey(req), expectedOperatorKey);
 }
 
 function extractTags(input) {
@@ -8736,25 +8766,8 @@ a{color:#8b9}</style></head><body><form class="card" method="post" action="/oaut
       return;
     }
 
-    // Operator key is allowed to bypass the general admin gate for dedicated
-    // read-only operational endpoints used by `thumbgate dashboard`, CFO, and
-    // north-star. Keep this list tight: operator must not reach write/mutation
-    // surfaces (lessons write, feedback capture, jobs, etc.).
-    const _reqToken = extractApiKey(req);
-    const isOperatorReadRequest = Boolean(expectedOperatorKey)
-      && safeKeyEqual(_reqToken, expectedOperatorKey)
-      && req.method === 'GET'
-      && [
-        '/v1/billing/summary',
-        '/v1/dashboard',
-        '/v1/dashboard/render-spec',
-        '/v1/dashboard/ai-inventory',
-        '/v1/dashboard/review-state',
-        '/v1/intake/workflow-sprint/queue',
-        '/v1/task-outcomes/monitor',
-      ].includes(pathname);
-
-    if (!isOperatorReadRequest && !isAuthorized(req, expectedApiKey)) {
+    // Operator key: read-only operational endpoints only (see OPERATOR_READONLY_GET_PATHS).
+    if (!isOperatorReadonlyGet(req, expectedOperatorKey, pathname) && !isAuthorized(req, expectedApiKey)) {
       sendProblem(res, {
         type: PROBLEM_TYPES.UNAUTHORIZED,
         title: 'Unauthorized',

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -8737,13 +8737,19 @@ a{color:#8b9}</style></head><body><form class="card" method="post" action="/oaut
     }
 
     // Operator key is allowed to bypass the general admin gate for dedicated
-    // read-only operational endpoints.
+    // read-only operational endpoints used by `thumbgate dashboard`, CFO, and
+    // north-star. Keep this list tight: operator must not reach write/mutation
+    // surfaces (lessons write, feedback capture, jobs, etc.).
     const _reqToken = extractApiKey(req);
     const isOperatorReadRequest = Boolean(expectedOperatorKey)
       && safeKeyEqual(_reqToken, expectedOperatorKey)
       && req.method === 'GET'
       && [
         '/v1/billing/summary',
+        '/v1/dashboard',
+        '/v1/dashboard/render-spec',
+        '/v1/dashboard/ai-inventory',
+        '/v1/dashboard/review-state',
         '/v1/intake/workflow-sprint/queue',
         '/v1/task-outcomes/monitor',
       ].includes(pathname);

--- a/tests/api-operator-key-auth.test.js
+++ b/tests/api-operator-key-auth.test.js
@@ -87,4 +87,23 @@ describe('operator key auth', () => {
     // 401 from general gate (operator key not valid for non-billing paths)
     assert.equal(res.status, 401);
   });
+
+  it('operator key reaches GET /v1/dashboard (CLI dashboard / north-star)', async () => {
+    const res = await fetch(`${origin}/v1/dashboard?window=today`, {
+      headers: { authorization: `Bearer ${TEST_VARS.THUMBGATE_OPERATOR_KEY}` },
+    });
+    assert.equal(res.status, 200, await res.text());
+  });
+
+  it('operator key still cannot mutate via POST /v1/dashboard/review-state', async () => {
+    const res = await fetch(`${origin}/v1/dashboard/review-state`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${TEST_VARS.THUMBGATE_OPERATOR_KEY}`,
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    });
+    assert.equal(res.status, 401);
+  });
 });


### PR DESCRIPTION
## Summary
- `thumbgate dashboard` / north-star call `GET /v1/dashboard` with `~/.config/thumbgate/operator.json` operator key.
- Server general gate only allowed operator on `/v1/billing/summary` (etc.), so a **valid** operator key still got HTTP 401 with a misleading "key does not match" message.
- Expand read-only operator allowlist for dashboard GET routes; keep mutations admin-only.

## Also fixed on this Mac
- Global `thumbgate` was a stale symlink to ThumbGate-main **v1.29.2** with **no** `thumbgate-dashboard` bin.
- Relinked `~/.npm-global/bin/thumbgate` + `thumbgate-dashboard` → current CLI (v1.34.3).

## Test plan
- [x] `node --test tests/api-operator-key-auth.test.js` (6/6)
- [x] operator key → `/v1/billing/summary` 200 (already)
- [x] local `thumbgate-dashboard` / `dashboard --open` serves HTML
- [ ] after merge: hosted `thumbgate dashboard` 200 with operator.json

## Evidence
Local before: `command not found: thumbgate-dashboard` + 401 on `/v1/dashboard`.