### PR TITLE
fix(ci): release guard treats "main is ahead" as healthy, not drift

### DIFF
--- a/.changeset/deploy-verify-ancestor-tolerant.md
+++ b/.changeset/deploy-verify-ancestor-tolerant.md
@@ -1,0 +1,14 @@
+---
+"thumbgate": patch
+---
+
+Stop the release-identity guard from reporting normal progress as deploy drift.
+
+The guard required the published npm version's gitHead to equal the commit
+under verification. Between releases that is never true: main is simply ahead
+of the last published version, so every content-only merge turned the check red
+until someone cut a release. It now passes when the published release commit is
+an ancestor of HEAD, and still fails when the published version came from a
+commit that is not in this history. Ancestry is resolved with local git, so the
+guard needs no network and no credentials; an ancestry it cannot prove is
+treated as drift, so the check fails closed on a shallow clone.

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 2
+          # 0: the release-identity guard resolves ancestry with local git,
+          # which needs the published release commit present in the clone.
+          fetch-depth: 0
 
       - name: Read expected version
         id: pkg

--- a/scripts/verify-npm-githead.js
+++ b/scripts/verify-npm-githead.js
@@ -60,6 +60,7 @@ function evaluateRegistryIdentity({
   allowUnpublished,
   registryResult,
   attempts = 1,
+  ancestry = 'unknown',
 }) {
   const base = { packageName, version, expectedSha, attempts };
   if (registryResult.state === 'unpublished') {
@@ -80,9 +81,42 @@ function evaluateRegistryIdentity({
     return { ...base, verdict: 'fail', state: 'published', observedSha: null, reason: 'published version has no gitHead attestation' };
   }
   if (observedSha !== expectedSha) {
+    // A SHA mismatch is only drift when the published commit is NOT in this
+    // commit's history. Between releases main is simply ahead of the last
+    // published version -- the normal state after every content-only merge.
+    // Requiring exact equality made this check go red on main after any push
+    // touching public/ or src/ until someone cut a release.
+    // 'unknown' fails closed: never pass on an ancestry we could not prove.
+    if (ancestry === 'ancestor') {
+      return {
+        ...base,
+        verdict: 'pass',
+        state: 'published',
+        observedSha,
+        reason: 'published release is an ancestor; main is ahead of the last release',
+      };
+    }
     return { ...base, verdict: 'fail', state: 'published', observedSha, reason: 'published version belongs to another commit' };
   }
   return { ...base, verdict: 'pass', state: 'published', observedSha, reason: 'registry gitHead matches the release commit' };
+}
+
+/**
+ * Is `ancestorSha` reachable from `descendantSha`? Answered with local git so
+ * the guard needs no network and no credentials. Returns 'unknown' when git
+ * cannot answer -- notably on a shallow clone, where the objects are absent --
+ * and the evaluator treats 'unknown' as drift.
+ */
+function resolveAncestryLocally(ancestorSha, descendantSha, deps = {}) {
+  if (!ancestorSha || !descendantSha) return 'unknown';
+  if (ancestorSha === descendantSha) return 'ancestor';
+  const run = deps.spawnSync || require('child_process').spawnSync;
+  const has = (sha) => run('git', ['cat-file', '-e', `${sha}^{commit}`], { encoding: 'utf8' }).status === 0;
+  if (!has(ancestorSha) || !has(descendantSha)) return 'unknown';
+  const res = run('git', ['merge-base', '--is-ancestor', ancestorSha, descendantSha], { encoding: 'utf8' });
+  if (res.status === 0) return 'ancestor';
+  if (res.status === 1) return 'unrelated';
+  return 'unknown';
 }
 
 function delay(ms) {
@@ -97,6 +131,7 @@ async function verifyNpmGitHead(options = {}) {
   const maxAttempts = positiveInteger(options.maxAttempts, DEFAULT_MAX_ATTEMPTS);
   const retryDelayMs = positiveInteger(options.retryDelayMs, DEFAULT_RETRY_DELAY_MS);
   const resolver = options.queryRegistry || queryRegistry;
+  const ancestryResolver = options.resolveAncestry || resolveAncestryLocally;
 
   if (!/^(@[a-z0-9._-]+\/)?[a-z0-9._-]+$/i.test(packageName) || !version || !expectedSha) {
     return {
@@ -113,13 +148,16 @@ async function verifyNpmGitHead(options = {}) {
 
   let report = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const registryResult = await resolver(packageName, version);
+    const observedSha = String((registryResult.metadata || {}).gitHead || '').trim();
     report = evaluateRegistryIdentity({
       packageName,
       version,
       expectedSha,
       allowUnpublished,
-      registryResult: await resolver(packageName, version),
+      registryResult,
       attempts: attempt,
+      ancestry: observedSha ? await ancestryResolver(observedSha, expectedSha) : 'unknown',
     });
     if (report.verdict !== 'retry') return report;
     if (attempt < maxAttempts) await delay(retryDelayMs);
@@ -148,6 +186,7 @@ module.exports = {
   DEFAULT_RETRY_DELAY_MS,
   parseArgs,
   queryRegistry,
+  resolveAncestryLocally,
   evaluateRegistryIdentity,
   verifyNpmGitHead,
 };

--- a/tests/verify-npm-githead.test.js
+++ b/tests/verify-npm-githead.test.js
@@ -7,6 +7,7 @@ const {
   parseArgs,
   queryRegistry,
   evaluateRegistryIdentity,
+  resolveAncestryLocally,
   verifyNpmGitHead,
 } = require('../scripts/verify-npm-githead');
 
@@ -126,4 +127,85 @@ test('missing immutable identity fails before querying npm', async () => {
   assert.equal(report.verdict, 'fail');
   assert.equal(report.state, 'invalid_input');
   assert.equal(calls, 0);
+});
+
+const published = (gitHead, version = '1.32.0') => ({
+  state: 'published',
+  metadata: { version, gitHead },
+});
+
+test('main being ahead of the last published release is not drift', () => {
+  const report = evaluateRegistryIdentity({
+    ...base,
+    registryResult: published('older-release-sha'),
+    ancestry: 'ancestor',
+  });
+  assert.equal(report.verdict, 'pass');
+  assert.equal(report.observedSha, 'older-release-sha');
+  assert.match(report.reason, /ancestor/);
+});
+
+test('a published release from a divergent commit is still drift', () => {
+  const report = evaluateRegistryIdentity({
+    ...base,
+    registryResult: published('divergent-sha'),
+    ancestry: 'unrelated',
+  });
+  assert.equal(report.verdict, 'fail');
+  assert.equal(report.reason, 'published version belongs to another commit');
+});
+
+test('unprovable ancestry fails closed rather than passing', () => {
+  const report = evaluateRegistryIdentity({
+    ...base,
+    registryResult: published('shallow-clone-sha'),
+    ancestry: 'unknown',
+  });
+  assert.equal(report.verdict, 'fail', 'unknown ancestry must never pass');
+});
+
+test('resolveAncestryLocally distinguishes ancestor, unrelated and unknown', () => {
+  const fake = (results) => {
+    const calls = [...results];
+    return () => calls.shift();
+  };
+  assert.equal(resolveAncestryLocally('a', 'a'), 'ancestor', 'identical SHAs are trivially ancestors');
+  assert.equal(resolveAncestryLocally('', 'b'), 'unknown');
+  // both objects present, merge-base says yes
+  assert.equal(
+    resolveAncestryLocally('a', 'b', { spawnSync: fake([{ status: 0 }, { status: 0 }, { status: 0 }]) }),
+    'ancestor'
+  );
+  // both objects present, merge-base says no
+  assert.equal(
+    resolveAncestryLocally('a', 'b', { spawnSync: fake([{ status: 0 }, { status: 0 }, { status: 1 }]) }),
+    'unrelated'
+  );
+  // object missing (shallow clone) -> unknown, never a pass
+  assert.equal(
+    resolveAncestryLocally('a', 'b', { spawnSync: fake([{ status: 128 }]) }),
+    'unknown'
+  );
+});
+
+test('verifyNpmGitHead passes when the published release is an ancestor of HEAD', async () => {
+  const report = await verifyNpmGitHead({
+    packageName: 'thumbgate',
+    version: '1.34.3',
+    expectedSha: 'head-sha',
+    queryRegistry: async () => published('release-sha', '1.34.3'),
+    resolveAncestry: async () => 'ancestor',
+  });
+  assert.equal(report.verdict, 'pass');
+});
+
+test('verifyNpmGitHead still fails when HEAD does not descend from the release', async () => {
+  const report = await verifyNpmGitHead({
+    packageName: 'thumbgate',
+    version: '1.34.3',
+    expectedSha: 'head-sha',
+    queryRegistry: async () => published('release-sha', '1.34.3'),
+    resolveAncestry: async () => 'unrelated',
+  });
+  assert.equal(report.verdict, 'fail');
 });


### PR DESCRIPTION
**The failure**

`Deploy to Railway` has been red on main. Failing step: **Verify deploy SHA owns the package version** (run 31029369388).

```
{ "version": "1.34.3",
  "expectedSha": "7467ca48...",   <- main head
  "observedSha": "c3e2d4b3...",   <- commit that published 1.34.3
  "verdict": "fail",
  "reason": "published version belongs to another commit" }
```

**Root cause**

Two workflows disagree about when a release exists:

- `publish-npm.yml` fires only on `package.json` / `package-lock.json` changes.
- `deploy-verify.yml` fires on `public/**`, `src/**`, `scripts/**` changes.

So any content-only merge runs the release-identity guard without publishing anything. The guard required the published version's `gitHead` to **equal** the verified commit — but between releases main is legitimately ahead of the last published version, so it reported drift for the normal, healthy state. Measured on main: `c3e2d4b3` (which published 1.34.3) is an ancestor of head `7467ca48`, **10 commits back**.

It has therefore been red continuously rather than signalling anything — the worst state for a guard, because people stop reading it.

**The fix**

Pass when the published release commit is an **ancestor** of HEAD; still fail when it is not — which is the drift the check exists to catch (published from a commit outside this history).

- Ancestry resolves through **local git**: no network call, no credentials in the script.
- Unprovable ancestry returns `unknown`, treated as drift, so a shallow clone **fails closed** instead of silently passing.
- `deploy-verify.yml` now fetches full history, since ancestry needs the release commit present (it cloned at `fetch-depth: 2`).

**Verification**

- `node --test tests/verify-npm-githead.test.js` -> **14 pass, 0 fail** (6 new).
- New tests: ancestor -> pass; divergent -> fail; **unknown -> fail** (explicit fail-closed assertion); and `resolveAncestryLocally` mapping git exit codes 0/1/128 to ancestor/unrelated/unknown.
- Real-data check: `git merge-base --is-ancestor c3e2d4b3 7467ca48` succeeds, so this exact red run goes green.
- Negative control preserved: a divergent SHA still fails.

Generated with [Claude Code](https://claude.com/claude-code)

[https://claude.ai/code/session_019N4wvkqUEB5L1R3y29kY7U](https://claude.ai/code/session_019N4wvkqUEB5L1R3y29kY7U)
