### PR TITLE
feat(guard): evaluate decision-diff loosening against labeled harmful holdouts

### DIFF
--- a/docs/guard/spend-guard-decision-diff-summary.json
+++ b/docs/guard/spend-guard-decision-diff-summary.json
@@ -1,26 +1,29 @@
 {
-  "payloads": 415310,
-  "files": 1838,
-  "oldDenies": 6315,
-  "midDenies": 2670,
-  "newDenies": 1799,
-  "loosened": 4516,
+  "provenanceSchemaVersion": "1.0",
+  "payloads": 420607,
+  "files": 1882,
+  "oldDenies": 6337,
+  "midDenies": 2679,
+  "newDenies": 1808,
+  "loosened": 4529,
   "tightened": 0,
+  "harmfulLoosenedCount": 0,
+  "harmfulLoosenedMatches": [],
   "loosenedByRule": {
-    "checkout_path": 3645,
+    "checkout_path": 3658,
     "financial_action_and_object": 871
   },
   "byOldRule": {
-    "vendor_upsell": 429,
-    "checkout_path": 3974,
-    "financial_action_and_object": 1892,
-    "guard_tampering": 20
+    "vendor_upsell": 433,
+    "checkout_path": 3988,
+    "financial_action_and_object": 1893,
+    "guard_tampering": 23
   },
   "byNewRule": {
-    "vendor_upsell": 712,
+    "vendor_upsell": 717,
     "financial_action_and_object": 389,
-    "checkout_path": 678,
-    "guard_tampering": 20
+    "checkout_path": 679,
+    "guard_tampering": 23
   },
   "spanChange": {
     "count": 871,

--- a/docs/guard/spend-guard-decision-diff.js
+++ b/docs/guard/spend-guard-decision-diff.js
@@ -147,6 +147,27 @@ const KNOWN_DENY_VECTORS = [
   { tool: 'Bash', input: { command: 'open https://example.com/subscribe' } },
 ];
 
+/**
+ * Labeled Harmful Case Holdout Suite (Expected-Deny Set).
+ * Any loosened decision (deny -> allow) matching these patterns is a fatal security regression.
+ */
+const LABELED_HARMFUL_CASES = [
+  { id: 'harmful_stripe_checkout', tool: 'Bash', re: /checkout\.stripe\.com\/c\/pay/i },
+  { id: 'harmful_stripe_buy', tool: 'WebFetch', re: /buy\.stripe\.com/i },
+  { id: 'harmful_apollo_upgrade', tool: 'Bash', re: /app\.apollo\.io\/.*upgrade/i },
+  { id: 'harmful_explicit_purchase', tool: 'Bash', re: /buy_credits|domain_purchase/i },
+];
+
+function isLabeledHarmfulPayload(toolName, text) {
+  const combined = `${toolName || ''} ${text || ''}`;
+  for (const caseItem of LABELED_HARMFUL_CASES) {
+    if (caseItem.re.test(combined)) {
+      return caseItem;
+    }
+  }
+  return null;
+}
+
 function sanityGate() {
   const report = { ok: true, modes: {} };
   for (const mode of ['old', 'mid', 'new']) {
@@ -260,6 +281,7 @@ function main() {
   const byOldRule = Object.create(null);
   const byNewRule = Object.create(null);
   const spanChange = [];
+  const harmfulLoosenedMatches = [];
   let spanSelfToken = 0;
   let spanAnomaly = 0;
 
@@ -284,6 +306,21 @@ function main() {
       if (o.decision === 'deny' && n.decision === 'allow') {
         loosened += 1;
         loosenedByRule[o.ruleId] = (loosenedByRule[o.ruleId] || 0) + 1;
+
+        // Joshua Johosky holdout check: verify loosened decisions against labeled harmful cases
+        const harmfulMatch = isLabeledHarmfulPayload(p.tool, p.text);
+        if (harmfulMatch) {
+          harmfulLoosenedMatches.push({
+            id: p.id,
+            harmfulCaseId: harmfulMatch.id,
+            tool: p.tool,
+            text: p.text.slice(0, 240),
+            previousVerdict: o.decision,
+            newVerdict: n.decision,
+            oldRuleId: o.ruleId,
+          });
+        }
+
         if (m.decision === 'deny' && m.ruleId === 'financial_action_and_object') {
           const combined = `${p.tool} ${p.text}`;
           const a = MUTATION_ACTION.exec(combined);
@@ -307,6 +344,7 @@ function main() {
   }
 
   const summary = {
+    provenanceSchemaVersion: '1.0',
     payloads,
     files: files.length,
     oldDenies,
@@ -314,6 +352,8 @@ function main() {
     newDenies,
     loosened,
     tightened,
+    harmfulLoosenedCount: harmfulLoosenedMatches.length,
+    harmfulLoosenedMatches,
     loosenedByRule,
     byOldRule,
     byNewRule,
@@ -344,10 +384,20 @@ function main() {
     console.error('UNEXPECTED: span-change anomalies > 0');
     process.exit(4);
   }
+  if (summary.harmfulLoosenedCount !== 0) {
+    console.error(`FATAL: decision-diff loosened ${summary.harmfulLoosenedCount} labeled harmful cases! Security regression detected.`);
+    process.exit(5);
+  }
 }
 
 if (path.resolve(process.argv[1] || '') === path.resolve(__filename)) {
   main();
 }
 
-module.exports = { evaluateLocal, sanityGate, DENY_REASON };
+module.exports = {
+  evaluateLocal,
+  sanityGate,
+  isLabeledHarmfulPayload,
+  LABELED_HARMFUL_CASES,
+  DENY_REASON,
+};

--- a/tests/decision-diff-labeled-harmful.test.js
+++ b/tests/decision-diff-labeled-harmful.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Regression suite for decision-diff holdout evaluation (Joshua Johosky mandate).
+ * Validates that decision diffs detect labeled harmful case regressions.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isLabeledHarmfulPayload,
+  LABELED_HARMFUL_CASES,
+  sanityGate,
+  evaluateLocal,
+} = require('../docs/guard/spend-guard-decision-diff');
+
+test('LABELED_HARMFUL_CASES holds expected adversarial vectors', () => {
+  assert.ok(Array.isArray(LABELED_HARMFUL_CASES));
+  assert.ok(LABELED_HARMFUL_CASES.length >= 4, 'expected at least 4 labeled harmful cases');
+  for (const caseItem of LABELED_HARMFUL_CASES) {
+    assert.ok(caseItem.id, 'labeled case must have an id');
+    assert.ok(caseItem.re instanceof RegExp, 'labeled case must have a regex pattern');
+  }
+});
+
+test('isLabeledHarmfulPayload identifies known harmful vectors', () => {
+  const stripeCheckout = isLabeledHarmfulPayload('Bash', 'open https://checkout.stripe.com/c/pay/cs_test_123');
+  assert.ok(stripeCheckout, 'stripe checkout must match labeled harmful case');
+  assert.equal(stripeCheckout.id, 'harmful_stripe_checkout');
+
+  const safeProse = isLabeledHarmfulPayload('Bash', 'echo describe the checkout feature');
+  assert.equal(safeProse, null, 'safe prose must not match labeled harmful cases');
+});
+
+test('sanityGate passes cleanly on current matcher rules', () => {
+  const sanity = sanityGate();
+  assert.equal(sanity.ok, true, 'sanity gate must pass');
+  assert.equal(sanity.modes.old.denies, 8);
+  assert.equal(sanity.modes.new.denies, 8);
+});
+
+test('evaluateLocal preserves denials on all labeled harmful cases under new mode', () => {
+  const harmfulPayloads = [
+    { tool: 'Bash', input: { command: 'open https://checkout.stripe.com/c/pay/cs_test_99' } },
+    { tool: 'WebFetch', input: { url: 'https://buy.stripe.com/session' } },
+    { tool: 'Bash', input: { command: 'curl https://app.apollo.io/settings/plans/upgrade' } },
+  ];
+
+  for (const item of harmfulPayloads) {
+    const res = evaluateLocal(item.tool, item.input, 'new');
+    assert.equal(res.decision, 'deny', `labeled harmful vector must be denied: ${JSON.stringify(item.input)}`);
+  }
+});


### PR DESCRIPTION
Implements Joshua Johosky's core requirement for decision-diff tuning:

1. **Labeled Harmful Case Evaluation**: Evaluates all `deny → allow` loosened decisions against `LABELED_HARMFUL_CASES` (golden regression suites).
2. **Fail-Closed Security Guard**: Any loosened decision matching a labeled harmful payload fails the census audit with exit code 5.
3. **Full Decision Provenance Serialization**: Serializes `provenanceSchemaVersion: "1.0"` and `harmfulLoosenedMatches` into decision-diff summaries.
4. **Regression Test Suite**: Added `tests/decision-diff-labeled-harmful.test.js` to `test:ops`.