### PR TITLE
fix(memory-guard): stop a corrupt entry from hard-blocking every action

### DIFF
--- a/.changeset/memory-guard-envelope-tokens.md
+++ b/.changeset/memory-guard-envelope-tokens.md
@@ -1,0 +1,30 @@
+---
+'thumbgate': patch
+---
+
+Stop a corrupt feedback entry from hard-blocking every action in a repository.
+
+A truncated hook payload leaked into the feedback store and was admitted as a
+recurring negative pattern. Its keywords were the payload's own field names —
+`workspaceroot`, `workspace`, `thumbgate` — which appear in every payload the
+agent sends. `workspaceroot` is long enough that `isSpecificKeyword()` treats it
+as decisive on its own, so a single hit produced a hard deny on every `Bash`
+call in the repository, including the commands needed to diagnose it. The gate
+blocked 20 times and warned zero times.
+
+Two changes:
+
+- `keywords()` now excludes envelope tokens (hook-payload field names and the
+  workspace identity). These describe the transport, never the mistake, so they
+  can never be evidence of a recurring failure.
+- Pattern building now rejects text that is a serialized payload fragment rather
+  than a description of a mistake.
+
+`tests/memory-guard-envelope-tokens.test.js` reproduces the exact fragment from
+the incident and asserts an unrelated command is no longer denied, while a
+genuine recurring pattern still blocks the action it describes.
+
+Known follow-up: patterns built from generic prose can still over-match. A
+lesson reading "test feedback on chatbot output manufacturing-copilot
+test-suite" (count 10) blocks any command containing two of those common words.
+That needs a discriminativeness threshold and is not addressed here.

--- a/package.json
+++ b/package.json
@@ -601,7 +601,7 @@
     "test:proof": "node --test tests/prove-adapters.test.js tests/prove-attribution.test.js tests/prove-cloudflare-sandbox.test.js tests/prove-data-quality.test.js tests/prove-intelligence.test.js tests/prove-lancedb.test.js tests/prove-loop-closure.test.js tests/prove-training-export.test.js tests/prove-local-intelligence.test.js tests/prove-workflow-contract.test.js tests/prove-autoresearch.test.js tests/prove-claim-verification.test.js tests/prove-data-pipeline.test.js tests/prove-evolution.test.js tests/prove-harnesses.test.js tests/prove-packaged-runtime.test.js tests/prove-runtime.test.js tests/prove-seo-gsd.test.js tests/prove-settings.test.js tests/prove-xmemory.test.js && node --test tests/prove-automation.test.js",
     "test:e2e": "node --test tests/e2e-pipeline.test.js tests/e2e-product-flows.test.js tests/e2e-coverage-contract.test.js tests/interaction-model-e2e.test.js",
     "test:rlaif": "node --test tests/rlaif-self-audit.test.js tests/dpo-optimizer.test.js tests/meta-policy.test.js tests/agent-reward-model.test.js",
-    "test:attribution": "node --test tests/feedback-attribution.test.js tests/hybrid-feedback-context.test.js tests/memory-guard-matching.test.js",
+    "test:attribution": "node --test tests/feedback-attribution.test.js tests/hybrid-feedback-context.test.js tests/memory-guard-matching.test.js tests/memory-guard-envelope-tokens.test.js",
     "test:quality": "node --test tests/validate-feedback.test.js tests/feedback-quality-eval-python.test.js tests/eval-gate-classifier.test.js",
     "test:intelligence": "node --test tests/intelligence.test.js",
     "test:training-export": "node --test tests/training-export.test.js tests/databricks-export.test.js",

--- a/scripts/hybrid-feedback-context.js
+++ b/scripts/hybrid-feedback-context.js
@@ -203,13 +203,49 @@ function getTimestampMs(value) {
  * Extract meaningful keywords from text.
  * min 4 chars, no stopwords, max 8 tokens.
  */
+// Hook payloads are JSON envelopes. When a malformed one leaks into the feedback
+// store, its FIELD NAMES become "keywords" — and field names appear in every
+// payload, so the resulting pattern matches every action ever taken. One corrupt
+// entry becomes a universal block.
+//
+// Observed 2026-08-06: a truncated payload fragment
+//   { , , ,"workspaceroot":"/users/<redacted>/workspace/git/igor/thumbgate/", , , ,"pe"
+// was admitted as a recurring negative pattern with count 6. "workspaceroot" is
+// long enough that isSpecificKeyword() treats it as decisive on its own, so a
+// SINGLE hit hard-denied every Bash call in the repository — including the
+// commands needed to diagnose it. It blocked 20 times and warned zero times.
+//
+// These tokens describe the transport, never the mistake, so they can never be
+// evidence of a recurring failure.
+const ENVELOPE_TOKENS = new Set([
+  'workspaceroot', 'toolname', 'toolinput', 'tooloutput', 'toolresponse', 'tooluseid',
+  'sessionid', 'transcriptpath', 'hookeventname', 'permissionmode', 'promptid',
+  'cwd', 'timestamp', 'metadata', 'payload', 'stdout', 'stderr',
+  'users', 'workspace', 'thumbgate', 'igor',
+]);
+
 function keywords(text) {
   if (!text) return [];
   const tokens = normalize(text)
     .replace(/[^a-z0-9\s_-]/g, ' ')
     .split(/\s+/)
-    .filter((t) => t.length >= 4 && !STOPWORDS.has(t));
+    .filter((t) => t.length >= 4 && !STOPWORDS.has(t) && !ENVELOPE_TOKENS.has(t));
   return [...new Set(tokens)].slice(0, 8);
+}
+
+/**
+ * True when text is a serialized payload fragment rather than a description of
+ * a mistake. Real lessons are prose; fragments are punctuation and field names.
+ * Admitting one as a pattern is how a transport artifact becomes a gate.
+ */
+function looksLikeSerializedFragment(text) {
+  const raw = String(text || '');
+  if (!raw.trim()) return false;
+  // Runs of empty JSON slots (", , ,") only occur when a serializer dropped keys.
+  if (/(?:,\s*){3,}/.test(raw)) return true;
+  const wordChars = (raw.match(/[a-z]/gi) || []).length;
+  const structural = (raw.match(/["{}[\]:,]/g) || []).length;
+  return wordChars > 0 && structural >= wordChars / 2;
 }
 
 /**
@@ -346,6 +382,8 @@ function buildHybridState(opts) {
     ].join(' ');
     const norm = normalizePatternText(rawText);
     if (!norm) continue;
+    // A serialized payload fragment is a transport artifact, not a lesson.
+    if (looksLikeSerializedFragment(rawText) || looksLikeSerializedFragment(norm)) continue;
     const words = keywords(norm);
     if (words.length < 2) continue;
     const patKey = words.slice(0, 4).join('_');
@@ -861,6 +899,7 @@ module.exports = {
   inferToolName,
   classify,
   keywords,
+  looksLikeSerializedFragment,
   hashText,
   hasTwoKeywordHits,
   buildMatchHaystack,

--- a/tests/memory-guard-envelope-tokens.test.js
+++ b/tests/memory-guard-envelope-tokens.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+// One corrupt entry in the feedback store hard-blocked every action in the repo.
+//
+// On 2026-08-06 a truncated hook payload leaked into the store and was admitted
+// as a "recurring negative pattern" with count 6. Its keywords were the payload's
+// own FIELD NAMES — workspaceroot, workspace, thumbgate — which appear in every
+// payload this agent ever sends. "workspaceroot" is long enough that
+// isSpecificKeyword() treats it as decisive on its own, so a SINGLE hit produced
+// a hard deny on every Bash call, including the ones needed to diagnose it.
+// The gate blocked 20 times and warned zero times.
+//
+// A pattern learned from the transport rather than from the mistake cannot
+// discriminate, and a guard that matches everything protects nothing.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  keywords,
+  looksLikeSerializedFragment,
+  evaluatePretoolFromState,
+} = require('../scripts/hybrid-feedback-context');
+
+// The exact fragment from the incident, as it appeared in the gate's own output.
+const CORRUPT = '{ , , ,"workspaceroot":"/users/redacted/workspace/git/igor/thumbgate/", , , ,"pe"';
+
+// A representative command payload — every tool call in the repo looks like this.
+const ORDINARY_ACTION = JSON.stringify({
+  command: 'node scripts/patch.js scripts/gates-engine.js',
+  workspaceRoot: '/Users/redacted/workspace/git/igor/ThumbGate/',
+});
+
+test('the corrupt fragment is recognised as a serialized payload, not a lesson', () => {
+  assert.equal(looksLikeSerializedFragment(CORRUPT), true);
+});
+
+test('real prose lessons are not mistaken for fragments', () => {
+  // The filter must not swallow genuine lessons, or it silently disarms the guard.
+  for (const lesson of [
+    'never force-push to main',
+    'Do not claim a deploy is complete without curl output showing the buildSha.',
+    'Agent ran rm -rf on a tracked directory instead of the build output.',
+  ]) {
+    assert.equal(looksLikeSerializedFragment(lesson), false, `misclassified: ${lesson}`);
+  }
+});
+
+test('envelope field names never become pattern keywords', () => {
+  const words = keywords(CORRUPT);
+  for (const banned of ['workspaceroot', 'workspace', 'thumbgate', 'users']) {
+    assert.equal(
+      words.includes(banned),
+      false,
+      `"${banned}" describes the transport, not the mistake — it matches every action`,
+    );
+  }
+});
+
+test('the corrupt pattern no longer blocks an ordinary command', () => {
+  // Reproduces the live path exactly: state carries the pattern, words are derived
+  // by keywords() as the builder does, and the haystack is a normal tool call.
+  const state = {
+    recurringNegativePatterns: [{ text: CORRUPT, words: keywords(CORRUPT), count: 6 }],
+    negativeToolCounts: {},
+    negativeToolCountsAttributed: {},
+  };
+
+  const verdict = evaluatePretoolFromState(state, 'Bash', ORDINARY_ACTION);
+
+  assert.notEqual(
+    verdict.mode,
+    'block',
+    `an unrelated command must not be denied by a transport artifact (reason: ${verdict.reason})`,
+  );
+});
+
+test('a genuine recurring pattern still blocks the action it describes', () => {
+  // The whole point of the guard must survive the fix.
+  const lesson = 'agent ran destructive rm -rf against a tracked source directory';
+  const state = {
+    recurringNegativePatterns: [{ text: lesson, words: keywords(lesson), count: 6 }],
+    negativeToolCounts: {},
+    negativeToolCountsAttributed: {},
+  };
+
+  const verdict = evaluatePretoolFromState(
+    state,
+    'Bash',
+    JSON.stringify({ command: 'rm -rf ./src --destructive tracked directory' }),
+  );
+
+  assert.equal(verdict.mode, 'block', `expected a real pattern to still block (got: ${verdict.reason})`);
+});


### PR DESCRIPTION
A truncated hook payload leaked into the store and was admitted as a recurring negative pattern. Its keywords were the payload's own field names - workspaceroot, workspace, thumbgate - which appear in every payload the agent sends. workspaceroot is long enough that isSpecificKeyword() treats it as decisive alone, so a SINGLE hit hard denied every Bash call in the repo, including the commands needed to diagnose it. Blocked 20 times, warned zero.

keywords() now drops envelope tokens, and pattern building rejects serialized payload fragments. Both describe the transport, never the error, so neither can be evidence of a recurring problem.

Mutation-proven: 4 of 5 assertions do not hold without the fix. The fifth - a genuine pattern still blocks the action it describes - holds both ways, so this does not disarm the guard. 52/52 across all memory-guard suites.