### PR TITLE
test(ci): allow actions/cache v6 in SonarCloud contract

### DIFF
--- a/tests/sonarcloud-workflow.test.js
+++ b/tests/sonarcloud-workflow.test.js
@@ -85,7 +85,7 @@ test('SonarCloud workflow caches scanner packages for real scans', () => {
   const cacheSection = workflow.slice(cacheStart, installStart);
 
   assert.match(cacheSection, /if: steps\.sonar-scope\.outputs\.scan == 'true'/);
-  assert.match(cacheSection, /uses: actions\/cache@(?:v5|[0-9a-f]{40} # v5)/);
+  assert.match(cacheSection, /uses: actions\/cache@(?:v[56]|[0-9a-f]{40} # v[56])/);
   assert.match(cacheSection, /path: ~\/\.sonar\/cache/);
   assert.match(cacheSection, /key: \$\{\{\s*runner\.os\s*\}\}-sonar/);
   assert.match(cacheSection, /restore-keys: \$\{\{\s*runner\.os\s*\}\}-sonar/);


### PR DESCRIPTION
## Summary
- Update `tests/sonarcloud-workflow.test.js` to accept `actions/cache` v5 **or** v6 (pinned SHA + version comment).
- Unblocks Dependabot PR #3299 (`actions/cache` 5.1.0 → 6.1.0), which failed solely on this contract pin.

## Test plan
- [x] `node --test tests/sonarcloud-workflow.test.js` (5/5 pass)
- [ ] CI green on this PR
- [ ] Re-run / re-queue #3299 after merge