### PR TITLE
feat(ci): fast path for pure-deps PRs (~14m → smoke)

### DIFF
--- a/.changeset/ci-scope-deps-fast-path.md
+++ b/.changeset/ci-scope-deps-fast-path.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Speed PR CI: pure-deps/workflow PRs use a focused smoke path; skip coverage re-run on ordinary PRs (main + merge queue stay full).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Modes:
+          #   full — full suite + proofs (main, merge_group, runtime code PRs)
+          #   web  — marketing/public/dashboard-only PRs
+          #   deps — lockfiles, workflow pins, changesets only (biggest Dependabot win)
+          # Merge queue and main always run full CI so required gates stay honest.
+
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "mode=full" >> "$GITHUB_OUTPUT"
             echo "reason=non-pr-event" >> "$GITHUB_OUTPUT"
@@ -64,6 +70,15 @@ jobs:
             exit 0
           fi
 
+          # Pure dependency / CI-config surface (Dependabot action pins, lockfiles).
+          # Does not include application source — those stay full.
+          if ! grep -Ev '^(\.changeset/.*\.md|package\.json|package-lock\.json|workers/package\.json|workers/package-lock\.json|\.github/workflows/.*|\.github/dependabot\.yml)$' /tmp/ci-changed-files.txt > /tmp/ci-non-deps-files.txt; then
+            echo "mode=deps" >> "$GITHUB_OUTPUT"
+            echo "reason=deps-or-workflow-surface-only" >> "$GITHUB_OUTPUT"
+            echo "Focused deps/workflow CI selected. Merge queue and main pushes still run full CI."
+            exit 0
+          fi
+
           if grep -Ev '^(\.changeset/.*\.md|public/|config/post-deploy-marketing-pages\.json|scripts/dashboard\.js|scripts/verify-marketing-pages-deployed\.js|tests/(api-server|dashboard|public-landing|landing-page-claims|funnel-invariants|verify-marketing-pages-deployed|public-static-assets)\.test\.js|tests/e2e/)' /tmp/ci-changed-files.txt > /tmp/ci-full-required-files.txt; then
             echo "mode=full" >> "$GITHUB_OUTPUT"
             echo "reason=runtime-or-workflow-surface" >> "$GITHUB_OUTPUT"
@@ -77,13 +92,13 @@ jobs:
           echo "Focused web/revenue CI selected. Merge queue and main pushes still run full CI."
 
       - name: Setup Python
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install Python deps
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         # scikit-learn + joblib are required by scripts/eval_gate_classifier.py
         # so tests/eval-gate-classifier.test.js can exercise the actual ML
         # pipeline (train_and_score, joblib.dump, ROC-AUC, classification_report)
@@ -122,7 +137,7 @@ jobs:
       - name: Run budget status gate
         run: npm run budget:status
       - name: Check operational integrity
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         env:
           GH_TOKEN: ${{ github.token }}
         run: npm run ops:integrity:ci
@@ -152,8 +167,32 @@ jobs:
             tests/verify-marketing-pages-deployed.test.js \
             tests/public-static-assets.test.js
 
+      - name: Run focused deps/workflow smoke tests
+        if: steps.ci-scope.outputs.mode == 'deps'
+        # Dependabot / workflow-pin PRs were waiting ~14m on the full suite.
+        # Keep a tight smoke that still exercises packaging + CI contracts.
+        # Full suite still runs on merge_group and main.
+        env:
+          THUMBGATE_PUBLISH_STATE: unpublished
+          THUMBGATE_PUBLISHED_CLI_STATE: unavailable
+        run: |
+          set -euo pipefail
+          node --test \
+            tests/public-core-boundary.test.js \
+            tests/public-bundle-ratchet.test.js \
+            tests/package-boundary.test.js \
+            tests/deployment.test.js \
+            tests/sonarcloud-workflow.test.js \
+            tests/ci-cd-hygiene-audit.test.js
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -qE '^workers/'; then
+            npm run test:workers
+          fi
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -qE '^(package\.json|package-lock\.json)$'; then
+            npm run test:public-package-parity
+          fi
+
       - name: Run tests
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         # Hermetic suite: short-circuit the npm-registry publish probe in
         # scripts/mcp-config.js (isVersionPublished -> `npm view thumbgate@<v>`),
         # which several CLI/statusline tests exercise indirectly. Without this,
@@ -165,7 +204,7 @@ jobs:
         run: npm test
 
       - name: Run gate-eval regression suite
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         # Exits non-zero if any case in config/evals/*.json fails against
         # config/specs/*.json. Any constraint regex change that flips a
         # previously-blocking case to pass (or vice versa) blocks merge
@@ -173,7 +212,9 @@ jobs:
         run: npm run gate-eval:ci
 
       - name: Run coverage
-        if: steps.ci-scope.outputs.mode != 'web'
+        # Skip on ordinary PRs: coverage re-runs the full suite and doubles wall clock.
+        # Main + merge_group still re-run coverage so the merge gate keeps the signal.
+        if: steps.ci-scope.outputs.mode == 'full' && github.event_name != 'pull_request'
         # Same hermetic override as "Run tests" — coverage re-runs the suite.
         env:
           THUMBGATE_PUBLISH_STATE: unpublished
@@ -181,39 +222,39 @@ jobs:
         run: npm run test:coverage
 
       - name: Check congruence (branding, tech stack, version across all surfaces)
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run test:congruence
 
       - name: Run adapter proof
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run prove:adapters
 
       - name: Run automation proof
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run prove:automation
 
       - name: Run runtime proof
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run prove:runtime
 
       - name: Run evolution proof
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run prove:evolution
 
       - name: Run workflow contract proof
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run prove:workflow-contract
 
       - name: Run autoresearch proof
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run prove:autoresearch
 
       - name: Run Tessl distribution proof
-        if: steps.ci-scope.outputs.mode != 'web'
+        if: steps.ci-scope.outputs.mode == 'full'
         run: npm run prove:tessl
 
       - name: Run evaluation regression gates
-        if: always() && steps.ci-scope.outputs.mode != 'web'
+        if: always() && steps.ci-scope.outputs.mode == 'full'
         run: |
           mkdir -p proof
           node scripts/prompt-eval.js --min-score=100 --synthetic --synthetic-variants=1 --baseline=config/evals/prompt-eval-baseline.json --require-no-regressions --suite-output proof/prompt-eval-suite.generated.json --output proof/prompt-eval-report.json --json > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,13 @@ jobs:
             exit 0
           fi
 
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" | sed '/^$/d' > /tmp/ci-changed-files.txt
-          echo "Changed files:"
+          # Compare HEAD against the merge base, not the two branch tips.
+          # Two-tip diff includes commits already on main that the PR lacks,
+          # which wrongly forces full CI on stale Dependabot PRs.
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          echo "merge_base=$MERGE_BASE"
+          git diff --name-only "${MERGE_BASE}...${HEAD_SHA}" | sed '/^$/d' > /tmp/ci-changed-files.txt
+          echo "Changed files (vs merge base):"
           sed 's/^/- /' /tmp/ci-changed-files.txt || true
 
           if [[ ! -s /tmp/ci-changed-files.txt ]]; then
@@ -184,10 +189,11 @@ jobs:
             tests/deployment.test.js \
             tests/sonarcloud-workflow.test.js \
             tests/ci-cd-hygiene-audit.test.js
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -qE '^workers/'; then
+          MERGE_BASE=$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+          if git diff --name-only "${MERGE_BASE}...${{ github.event.pull_request.head.sha }}" | grep -qE '^workers/'; then
             npm run test:workers
           fi
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -qE '^(package\.json|package-lock\.json)$'; then
+          if git diff --name-only "${MERGE_BASE}...${{ github.event.pull_request.head.sha }}" | grep -qE '^(package\.json|package-lock\.json)$'; then
             npm run test:public-package-parity
           fi
 

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -844,6 +844,9 @@ test('CI workflow routes pure-deps and workflow-only PRs through focused smoke t
   assert.match(workflow, /name:\s*Run focused deps\/workflow smoke tests[\s\S]*?if:\s*steps\.ci-scope\.outputs\.mode == 'deps'[\s\S]*?tests\/public-core-boundary\.test\.js[\s\S]*?tests\/deployment\.test\.js/);
   // Coverage re-runs the full suite; skip it on ordinary PRs to cut wall clock.
   assert.match(workflow, /name:\s*Run coverage[\s\S]*?if:\s*steps\.ci-scope\.outputs\.mode == 'full' && github\.event_name != 'pull_request'/);
+  assert.match(workflow, /git merge-base/);
+  assert.match(workflow, /merge_base=/);
+  assert.match(workflow, /Changed files \(vs merge base\)/);
 });
 
 test('CodeQL workflow supports merge queue and cancels stale non-main runs', () => {

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -829,8 +829,21 @@ test('CI workflow routes web-only PRs through focused revenue tests', () => {
   assert.match(workflow, /scripts\/dashboard\\.js/);
   assert.match(workflow, /tests\/\(api-server\|dashboard\|public-landing\|landing-page-claims\|funnel-invariants\|verify-marketing-pages-deployed\|public-static-assets\)\\\.test\\\.js/);
   assert.match(workflow, /name:\s*Run focused web\/revenue tests[\s\S]*?if:\s*steps\.ci-scope\.outputs\.mode == 'web'[\s\S]*?tests\/api-server\.test\.js[\s\S]*?tests\/public-landing\.test\.js[\s\S]*?tests\/verify-marketing-pages-deployed\.test\.js/);
-  assert.match(workflow, /name:\s*Run tests[\s\S]*?if:\s*steps\.ci-scope\.outputs\.mode != 'web'[\s\S]*?run:\s*npm test/);
+  assert.match(workflow, /name:\s*Run tests[\s\S]*?if:\s*steps\.ci-scope\.outputs\.mode == 'full'[\s\S]*?run:\s*npm test/);
   assert.match(workflow, /Merge queue and main pushes still run full CI/);
+});
+
+test('CI workflow routes pure-deps and workflow-only PRs through focused smoke tests', () => {
+  const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+
+  assert.match(workflow, /reason=deps-or-workflow-surface-only/);
+  assert.match(workflow, /mode=deps/);
+  assert.match(workflow, /package-lock\.json/);
+  assert.match(workflow, /workers\/package-lock\.json/);
+  assert.match(workflow, /\\.github\/workflows\//);
+  assert.match(workflow, /name:\s*Run focused deps\/workflow smoke tests[\s\S]*?if:\s*steps\.ci-scope\.outputs\.mode == 'deps'[\s\S]*?tests\/public-core-boundary\.test\.js[\s\S]*?tests\/deployment\.test\.js/);
+  // Coverage re-runs the full suite; skip it on ordinary PRs to cut wall clock.
+  assert.match(workflow, /name:\s*Run coverage[\s\S]*?if:\s*steps\.ci-scope\.outputs\.mode == 'full' && github\.event_name != 'pull_request'/);
 });
 
 test('CodeQL workflow supports merge queue and cancels stale non-main runs', () => {


### PR DESCRIPTION
## Why
PRs felt stuck because even a 1-file Dependabot bump waited on the full ~14m `test` suite + proofs + coverage re-run.

## What
- **New CI scope `deps`**: when a PR only touches lockfiles / `package.json` / `workers/package*.json` / `.github/workflows/*` / changesets, run focused smoke tests instead of `npm test` + all prove lanes.
- **Skip coverage on ordinary PRs**: coverage re-runs the full suite and roughly doubles wall clock. **Main + merge_group still run full coverage + proofs.**
- Existing `web` scope unchanged.
- Contract tests updated in `tests/deployment.test.js`.

## Expected impact
| PR type | Before | After (PR job) |
|---------|--------|----------------|
| CodeQL action pin / workers types / lockfile-only | ~14m full suite | smoke (~few min) |
| Runtime code PR | ~14m + coverage re-run | ~14m suite, **no** PR coverage re-run |
| main / Trunk merge_group | full | full (unchanged) |

## Test plan
- [x] `node --test tests/deployment.test.js` (61 pass)
- [x] Scope classifier dry-run: codeql-only→deps, src→full, public→web
- [ ] CI green on this PR
- [ ] After merge: next Dependabot workflow-only PR should log `mode=deps`