### PR TITLE
chore(ci): bump codeql-action init+analyze to 4.37.5 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Analyze
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary
- Bumps `github/codeql-action/init` and `github/codeql-action/analyze` from 4.37.1 to **4.37.5** in the same commit.
- Replaces split Dependabot PRs #3295 and #3297, which only update one side and fail required `Analyze JavaScript` with a CodeQL configuration/unsuccessful SARIF processing error.

## Test plan
- [ ] Required CodeQL Analyze check green on this PR
- [ ] Other required contexts green
- [ ] Close #3295 and #3297 after merge