### PR TITLE
fix(test): mcp-gate-check stdin race (main CI red)

### DIFF
--- a/tests/harness-tool-names.test.js
+++ b/tests/harness-tool-names.test.js
@@ -46,24 +46,48 @@ function gateCheck(toolName, toolInput, env = {}) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';
-    const timer = setTimeout(() => { child.kill(); reject(new Error('timeout')); }, 60000);
-    child.stdout.on('data', (c) => { out += c; });
-    child.on('error', reject);
-    child.on('close', () => {
+    let settled = false;
+    const finish = (fn) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
-      fs.rmSync(home, { recursive: true, force: true });
-      for (const line of out.split('\n')) {
+      try { child.kill(); } catch { /* already exited */ }
+      try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+      fn();
+    };
+    const timer = setTimeout(() => finish(() => reject(new Error('timeout'))), 60000);
+    // Drain stderr so license/model noise cannot block the MCP child on a full pipe.
+    child.stderr.on('data', () => {});
+    child.stdout.on('data', (c) => {
+      out += c;
+      for (const line of String(c).split('\n')) {
         if (!line.trim().startsWith('{')) continue;
         let m; try { m = JSON.parse(line); } catch { continue; }
-        if (m.id === 9) return resolve(JSON.parse(m.result.content[0].text));
+        if (m.id === 9 && m.result && m.result.content && m.result.content[0]) {
+          // Keep stdin open until the tools/call reply arrives; early EOF races
+          // server shutdown and drops gate_check responses under CI load.
+          try { child.stdin.end(); } catch { /* ignore */ }
+          return finish(() => resolve(JSON.parse(m.result.content[0].text)));
+        }
       }
-      reject(new Error('no gate_check response'));
+    });
+    child.on('error', (err) => finish(() => reject(err)));
+    child.on('close', () => {
+      finish(() => {
+        for (const line of out.split('\n')) {
+          if (!line.trim().startsWith('{')) continue;
+          let m; try { m = JSON.parse(line); } catch { continue; }
+          if (m.id === 9 && m.result && m.result.content && m.result.content[0]) {
+            return resolve(JSON.parse(m.result.content[0].text));
+          }
+        }
+        reject(new Error('no gate_check response'));
+      });
     });
     const send = (o) => child.stdin.write(`${JSON.stringify(o)}\n`);
     send({ jsonrpc: '2.0', id: 0, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } } });
     send({ jsonrpc: '2.0', method: 'notifications/initialized' });
     send({ jsonrpc: '2.0', id: 9, method: 'tools/call', params: { name: 'gate_check', arguments: { tool_name: toolName, tool_input: toolInput } } });
-    child.stdin.end();
   });
 }
 

--- a/tests/harness-tool-names.test.js
+++ b/tests/harness-tool-names.test.js
@@ -46,6 +46,7 @@ function gateCheck(toolName, toolInput, env = {}) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';
+    let lineBuffer = '';
     let settled = false;
     const finish = (fn) => {
       if (settled) return;
@@ -59,8 +60,11 @@ function gateCheck(toolName, toolInput, env = {}) {
     // Drain stderr so license/model noise cannot block the MCP child on a full pipe.
     child.stderr.on('data', () => {});
     child.stdout.on('data', (c) => {
-      out += c;
-      for (const line of String(c).split('\n')) {
+      const chunk = String(c);
+      out += chunk;
+      const lines = (lineBuffer + chunk).split('\n');
+      lineBuffer = lines.pop();
+      for (const line of lines) {
         if (!line.trim().startsWith('{')) continue;
         let m; try { m = JSON.parse(line); } catch { continue; }
         if (m.id === 9 && m.result && m.result.content && m.result.content[0]) {

--- a/tests/mcp-gate-check-tool.test.js
+++ b/tests/mcp-gate-check-tool.test.js
@@ -24,6 +24,7 @@ function mcp(requests, env = {}) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';
+    let lineBuffer = '';
     const expectedIds = new Set(
       [0, ...requests.map((r) => r.id).filter((id) => id !== undefined && id !== null)].map(String)
     );
@@ -48,8 +49,11 @@ function mcp(requests, env = {}) {
     // Drain stderr so license/model noise cannot block the MCP child on a full pipe.
     child.stderr.on('data', () => {});
     child.stdout.on('data', (c) => {
-      out += c;
-      for (const line of String(c).split('\n')) {
+      const chunk = String(c);
+      out += chunk;
+      const lines = (lineBuffer + chunk).split('\n');
+      lineBuffer = lines.pop();
+      for (const line of lines) {
         if (!line.trim().startsWith('{')) continue;
         try {
           const msg = JSON.parse(line);

--- a/tests/mcp-gate-check-tool.test.js
+++ b/tests/mcp-gate-check-tool.test.js
@@ -24,24 +24,61 @@ function mcp(requests, env = {}) {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';
-    const timer = setTimeout(() => { child.kill(); reject(new Error('MCP server timeout')); }, 60000);
-    child.stdout.on('data', (c) => { out += c; });
-    child.on('error', reject);
-    child.on('close', () => {
+    const expectedIds = new Set(
+      [0, ...requests.map((r) => r.id).filter((id) => id !== undefined && id !== null)].map(String)
+    );
+    const seenIds = new Set();
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
-      fs.rmSync(home, { recursive: true, force: true });
+      try { child.kill(); } catch { /* already exited */ }
+      try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
       const messages = [];
       for (const line of out.split('\n')) {
         if (!line.trim().startsWith('{')) continue;
         try { messages.push(JSON.parse(line)); } catch { /* not a frame */ }
       }
       resolve(messages);
+    };
+    const timer = setTimeout(() => {
+      finish();
+    }, 60000);
+    // Drain stderr so license/model noise cannot block the MCP child on a full pipe.
+    child.stderr.on('data', () => {});
+    child.stdout.on('data', (c) => {
+      out += c;
+      for (const line of String(c).split('\n')) {
+        if (!line.trim().startsWith('{')) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg && msg.id !== undefined && msg.id !== null) {
+            seenIds.add(String(msg.id));
+          }
+        } catch { /* partial/non-json line */ }
+      }
+      if ([...expectedIds].every((id) => seenIds.has(id))) {
+        // Keep stdin open until all expected RPC responses arrive; closing stdin
+        // immediately races server shutdown and drops tools/call replies under load.
+        try { child.stdin.end(); } catch { /* ignore */ }
+        finish();
+      }
+    });
+    child.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      }
+    });
+    child.on('close', () => {
+      finish();
     });
     const send = (o) => child.stdin.write(`${JSON.stringify(o)}\n`);
     send({ jsonrpc: '2.0', id: 0, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } } });
     send({ jsonrpc: '2.0', method: 'notifications/initialized' });
     for (const r of requests) send(r);
-    child.stdin.end();
   });
 }
 
@@ -70,7 +107,7 @@ function verdict(msgs, id) {
 
 test.before(async () => {
   [defaultSession, strictSession] = await Promise.all([
-    session({}),
+    session({ THUMBGATE_STRICT_ENFORCEMENT: '0' }),
     session({ THUMBGATE_STRICT_ENFORCEMENT: '1' }),
   ]);
 });


### PR DESCRIPTION
## Summary
- Fixes main CI red on `764cee5` (`mcp-gate-check-tool.test.js`: `no response for id 2/3`).
- Root cause: test closed MCP stdin immediately; under load the server shut down before `gate_check` tools/call replies.
- Wait for expected RPC ids, drain stderr, pin `THUMBGATE_STRICT_ENFORCEMENT=0` for the warn-mode session.

## Test plan
- [x] `node --test tests/mcp-gate-check-tool.test.js` → 5/5 pass locally
- [ ] CI green on this PR
- [ ] Trunk merge restores green main