### PR TITLE
fix(pr-manage): ignore optional Vercel failures for Trunk queue

### DIFF
--- a/.changeset/pr-manager-optional-vercel.md
+++ b/.changeset/pr-manager-optional-vercel.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Ignore optional Vercel preview failures in pr:manage so free-plan rate limits do not block Trunk when required status checks are green.

--- a/config/merge-quality-checks.json
+++ b/config/merge-quality-checks.json
@@ -24,5 +24,9 @@
     "SonarCloud Code Analysis",
     "SonarCloud",
     "Merge blob reports"
+  ],
+  "optionalChecks": [
+    "Vercel",
+    "Vercel Preview Comments"
   ]
 }

--- a/scripts/pr-manager.js
+++ b/scripts/pr-manager.js
@@ -28,6 +28,9 @@ const PENDING_BUCKETS = new Set((MERGE_QUALITY_CHECKS.pendingBuckets || []).map(
 const FAILING_BUCKETS = new Set((MERGE_QUALITY_CHECKS.failingBuckets || []).map((value) => String(value || '').toLowerCase()));
 
 const SELF_REFERENTIAL_CHECKS = new Set(MERGE_QUALITY_CHECKS.selfReferentialChecks || []);
+// Optional CI (preview deploys, etc.) must not block Trunk when required protection contexts are green.
+// Vercel rate-limit failures are a common false BLOCKED on free plans.
+const OPTIONAL_CHECKS = new Set(MERGE_QUALITY_CHECKS.optionalChecks || []);
 
 function assertSafeGhArgs(args) {
   if (!Array.isArray(args) || args.length === 0) {
@@ -176,6 +179,7 @@ function summarizeChecks(checks = []) {
     const name = check.name || 'unknown-check';
 
     if (SELF_REFERENTIAL_CHECKS.has(name)) continue;
+    if (OPTIONAL_CHECKS.has(name)) continue;
 
     const bucket = String(check.bucket || '').toLowerCase();
     if (bucket) {

--- a/tests/pr-manager.test.js
+++ b/tests/pr-manager.test.js
@@ -694,6 +694,18 @@ test('a genuinely failing quality check STILL blocks', () => {
   assert.deepEqual(failing, ['Dependency Review']);
 });
 
+
+test('summarizeChecks ignores optional Vercel preview failures (rate-limit noise)', () => {
+  const { pending, failing } = summarizeChecks([
+    { name: 'test', bucket: 'pass' },
+    { name: 'CodeQL', bucket: 'pass' },
+    { name: 'Vercel', bucket: 'fail' },
+    { name: 'Vercel Preview Comments', bucket: 'fail' },
+  ]);
+  assert.deepEqual(failing, [], 'optional Vercel must not block Trunk when required checks pass');
+  assert.deepEqual(pending, []);
+});
+
 test('a lookalike queue check remains a blocker', () => {
   const { pending, failing } = summarizeChecks([
     { name: 'Trunk Merge Queue (main) Security Scan', bucket: 'pending' },


### PR DESCRIPTION
## Summary
Vercel free-plan rate-limit failures marked ready PRs as quality-blocked in `pr:manage` even when every **required** protection context was green (`mergeable_state: unstable` only).

## Change
- `config/merge-quality-checks.json` → `optionalChecks: [Vercel, Vercel Preview Comments]`
- `summarizeChecks` skips those names
- Test covers the rate-limit case

## Test plan
- [x] `node --test tests/pr-manager.test.js` (38 pass)