### PR TITLE
fix(mcp): wire unattended RAG loop — .mcp.json + remote capture

### DIFF
--- a/.changeset/unattended-rag-loop-wiring.md
+++ b/.changeset/unattended-rag-loop-wiring.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Close the unattended RAG loop gap: commit project `.mcp.json` with the thumbgate MCP server, expand the MCP wiring doctor to fail loud when capture/recall is uncallable, and add hosted remote feedback capture (`THUMBGATE_API_BASE_URL` + `THUMBGATE_API_KEY`) for container agents without a Mac-local lessons store.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "thumbgate": {
+      "command": "node",
+      "args": [
+        "adapters/mcp/server-stdio.js"
+      ]
+    }
+  }
+}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3015,7 +3015,7 @@ function sessionStart() {
   // MCP + lessons-store wiring — make unattended RAG-loop gaps loud at boot
   try {
     const { wiringReport } = require(path.join(PKG_ROOT, 'scripts', 'mcp-wiring-doctor'));
-    const wiring = wiringReport(PKG_ROOT);
+    const wiring = wiringReport(CWD);
     if (wiring && wiring.overall !== 'ok') {
       if (reminderLines.length > 0) reminderLines.push('');
       reminderLines.push(`ThumbGate RAG wiring: ${wiring.overall.toUpperCase()}`);
@@ -3946,7 +3946,7 @@ switch (COMMAND) {
     const report = generateAgentReadinessReport({ projectRoot: CWD });
     const wiring = wiringReport(CWD);
     if (args.json) {
-      console.log(JSON.stringify({ readiness: report, wiring }, null, 2));
+      console.log(JSON.stringify({ ...report, wiring }, null, 2));
     } else {
       process.stdout.write(reportToText(report));
       process.stdout.write(`\n${formatReport(wiring)}\n`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3012,6 +3012,24 @@ function sessionStart() {
     }
   } catch (_) { /* non-critical */ }
 
+  // MCP + lessons-store wiring — make unattended RAG-loop gaps loud at boot
+  try {
+    const { wiringReport } = require(path.join(PKG_ROOT, 'scripts', 'mcp-wiring-doctor'));
+    const wiring = wiringReport(PKG_ROOT);
+    if (wiring && wiring.overall !== 'ok') {
+      if (reminderLines.length > 0) reminderLines.push('');
+      reminderLines.push(`ThumbGate RAG wiring: ${wiring.overall.toUpperCase()}`);
+      reminderLines.push(
+        wiring.unattendedCaptureReady
+          ? '  Capture path available (local and/or hosted).'
+          : '  Capture path BROKEN for unattended runs — wire .mcp.json thumbgate server and set THUMBGATE_FEEDBACK_DIR or THUMBGATE_API_BASE_URL+THUMBGATE_API_KEY.'
+      );
+      (wiring.findings || []).slice(0, 4).forEach((finding) => {
+        reminderLines.push(`  - ${finding}`);
+      });
+    }
+  } catch (_) { /* non-critical */ }
+
   // Top high-risk tags — force agent to see them at session start, not opt-in
   try {
     const { getRiskSummary } = require(path.join(PKG_ROOT, 'scripts', 'risk-scorer'));
@@ -3923,14 +3941,29 @@ switch (COMMAND) {
       generateAgentReadinessReport,
       reportToText,
     } = require(path.join(PKG_ROOT, 'scripts', 'agent-readiness'));
+    const { wiringReport, formatReport } = require(path.join(PKG_ROOT, 'scripts', 'mcp-wiring-doctor'));
     const args = parseArgs(process.argv.slice(3));
     const report = generateAgentReadinessReport({ projectRoot: CWD });
+    const wiring = wiringReport(CWD);
     if (args.json) {
-      console.log(JSON.stringify(report, null, 2));
+      console.log(JSON.stringify({ readiness: report, wiring }, null, 2));
     } else {
       process.stdout.write(reportToText(report));
+      process.stdout.write(`\n${formatReport(wiring)}\n`);
     }
-    process.exit(report.overallStatus === 'ready' ? 0 : 1);
+    const ready = report.overallStatus === 'ready' && wiring.overall !== 'error';
+    process.exit(ready ? 0 : 1);
+    break;
+  }
+  case 'wiring-doctor':
+  case 'mcp-wiring-doctor': {
+    const { wiringReport, formatReport, applyFix } = require(path.join(PKG_ROOT, 'scripts', 'mcp-wiring-doctor'));
+    const args = parseArgs(process.argv.slice(3));
+    if (args.fix) applyFix(CWD);
+    const wiring = wiringReport(CWD);
+    if (args.json) console.log(JSON.stringify(wiring, null, 2));
+    else console.log(formatReport(wiring));
+    process.exit(wiring.overall === 'error' ? 2 : wiring.overall === 'warning' ? 1 : 0);
     break;
   }
   case 'export-dpo':

--- a/package.json
+++ b/package.json
@@ -167,6 +167,8 @@
     "scripts/mailer/index.js",
     "scripts/mailer/resend-mailer.js",
     "scripts/mcp-config.js",
+    "scripts/mcp-wiring-doctor.js",
+    "scripts/remote-feedback-capture.js",
     "scripts/mcp-oauth.js",
     "scripts/mcp-policy.js",
     "scripts/mcp-transport-strategy.js",

--- a/scripts/mcp-wiring-doctor.js
+++ b/scripts/mcp-wiring-doctor.js
@@ -1,39 +1,290 @@
+#!/usr/bin/env node
 'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
 
 /**
  * mcp-wiring-doctor.js
- * 
- * Detects silent ThumbGate capture failures and fixes them.
+ *
+ * Detects the structural RAG-loop break that unattended agents hit:
+ * AGENTS.md mandates recall/capture_feedback, but:
+ *  1. `.mcp.json` may not list the thumbgate MCP server
+ *  2. The lessons store may be missing (Mac-local only / empty container)
+ *  3. Remote hosted capture env may be unset, so cloud runs cannot write
+ *
+ * High-ROI: make the gap loud at session-start / doctor instead of silent.
  */
 
-function wiringReport(projectRoot = process.cwd()) {
-  const mcpPath = path.join(projectRoot, '.mcp.json');
+const fs = require('fs');
+const path = require('path');
+
+const LEGACY_MCP_KEYS = new Set(['mcp-memory-gateway', 'rlhf']);
+
+function readJsonIfExists(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return { __parseError: true };
+  }
+}
+
+function listMcpServers(config) {
+  if (!config || typeof config !== 'object') return [];
+  const servers = config.mcpServers || config.servers || {};
+  return Object.keys(servers || {});
+}
+
+function hasThumbgateServer(config) {
+  if (!config || config.__parseError) return false;
+  const servers = config.mcpServers || config.servers || {};
+  if (servers.thumbgate) return true;
+  // Accept explicit package/npx forms under alternate keys only if command mentions thumbgate
+  return Object.entries(servers).some(([key, entry]) => {
+    if (LEGACY_MCP_KEYS.has(key)) return false;
+    const blob = JSON.stringify(entry || {}).toLowerCase();
+    return blob.includes('thumbgate') || blob.includes('server-stdio.js');
+  });
+}
+
+function resolveLessonsStore(projectRoot, env = process.env) {
+  const candidates = [
+    env.THUMBGATE_FEEDBACK_DIR,
+    path.join(projectRoot, '.thumbgate'),
+    path.join(projectRoot, '.claude', 'memory', 'feedback'),
+    env.HOME ? path.join(env.HOME, '.thumbgate') : null,
+  ].filter(Boolean);
+
+  for (const dir of candidates) {
+    try {
+      if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
+        const writable = (() => {
+          try {
+            fs.accessSync(dir, fs.constants.W_OK);
+            return true;
+          } catch {
+            return false;
+          }
+        })();
+        return { path: dir, present: true, writable };
+      }
+    } catch {
+      /* continue */
+    }
+  }
+  return { path: null, present: false, writable: false };
+}
+
+function remoteCaptureConfigured(env = process.env) {
+  const base = String(env.THUMBGATE_API_BASE_URL || env.THUMBGATE_API_URL || '').trim();
+  const key = String(env.THUMBGATE_API_KEY || '').trim();
+  return {
+    configured: Boolean(base && key),
+    baseUrl: base || null,
+    hasKey: Boolean(key),
+  };
+}
+
+function isContainerLike(env = process.env) {
+  if (env.container || env.CONTAINER) return true;
+  if (fs.existsSync('/.dockerenv')) return true;
+  return false;
+}
+
+/**
+ * @returns {{
+ *   overall: 'ok'|'warning'|'error',
+ *   findings: string[],
+ *   mcp: object,
+ *   lessonsStore: object,
+ *   remote: object,
+ *   unattendedCaptureReady: boolean,
+ * }}
+ */
+function wiringReport(projectRoot = process.cwd(), env = process.env) {
+  const root = path.resolve(projectRoot);
   const findings = [];
   let overall = 'ok';
 
-  if (fs.existsSync(mcpPath)) {
-    const config = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
-    if (config.mcpServers && config.mcpServers['mcp-memory-gateway']) {
-      findings.push('Detected legacy mcp-memory-gateway entry in .mcp.json');
-      overall = 'warning';
+  const mcpPath = path.join(root, '.mcp.json');
+  const claudeSettingsPath = path.join(root, '.claude', 'settings.json');
+  const cursorMcpPath = path.join(root, '.cursor', 'mcp.json');
+
+  const mcpConfig = readJsonIfExists(mcpPath);
+  const claudeSettings = readJsonIfExists(claudeSettingsPath);
+  const cursorMcp = readJsonIfExists(cursorMcpPath);
+
+  const mcpServers = listMcpServers(mcpConfig);
+  const hasProjectMcpFile = fs.existsSync(mcpPath);
+  const thumbgateInProjectMcp = hasThumbgateServer(mcpConfig);
+  const thumbgateInCursor = hasThumbgateServer(cursorMcp);
+  const thumbgateInClaudeSettings = hasThumbgateServer(claudeSettings);
+
+  if (!hasProjectMcpFile) {
+    findings.push('Missing project .mcp.json — bootstrap file required by agent-readiness; MCP tools are not project-wired.');
+    overall = 'error';
+  } else if (mcpConfig && mcpConfig.__parseError) {
+    findings.push('.mcp.json is not valid JSON.');
+    overall = 'error';
+  } else if (!thumbgateInProjectMcp) {
+    findings.push(
+      `.mcp.json has no thumbgate server (found: ${mcpServers.join(', ') || 'none'}). ` +
+      'capture_feedback / recall are uncallable for agents using this project MCP config. ' +
+      'Add mcpServers.thumbgate (see adapters/claude/.mcp.json) or run: node scripts/install-mcp.js --project'
+    );
+    overall = 'error';
+  }
+
+  for (const key of mcpServers) {
+    if (LEGACY_MCP_KEYS.has(key)) {
+      findings.push(`Detected legacy MCP key "${key}" in .mcp.json — migrate to "thumbgate".`);
+      if (overall === 'ok') overall = 'warning';
     }
   }
 
-  return { overall, findings };
+  if (!thumbgateInClaudeSettings && !thumbgateInCursor && !thumbgateInProjectMcp) {
+    findings.push('No thumbgate MCP entry in .mcp.json, .claude/settings.json, or .cursor/mcp.json.');
+    overall = 'error';
+  }
+
+  const lessonsStore = resolveLessonsStore(root, env);
+  const remote = remoteCaptureConfigured(env);
+  const container = isContainerLike(env);
+
+  if (!lessonsStore.present) {
+    findings.push(
+      'No lessons store found (.thumbgate/ or THUMBGATE_FEEDBACK_DIR). ' +
+      'Local capture_feedback cannot persist. Unattended/cloud runs need THUMBGATE_FEEDBACK_DIR ' +
+      'or hosted capture via THUMBGATE_API_BASE_URL + THUMBGATE_API_KEY.'
+    );
+    if (overall === 'ok') overall = 'warning';
+    if (container) overall = 'error';
+  } else if (!lessonsStore.writable) {
+    findings.push(`Lessons store present but not writable: ${lessonsStore.path}`);
+    if (overall === 'ok') overall = 'warning';
+  }
+
+  if (container && !lessonsStore.present && !remote.configured) {
+    findings.push(
+      'Container/unattended runtime: neither local lessons store nor hosted capture env is configured. ' +
+      'AGENTS.md RAG loop (recall → act → capture_feedback) is unenforceable in this environment.'
+    );
+    overall = 'error';
+  }
+
+  if (container && remote.configured) {
+    findings.push('Hosted capture env is set — unattended runs can POST feedback to the API when local store is missing.');
+  }
+
+  const unattendedCaptureReady = Boolean(
+    (lessonsStore.present && lessonsStore.writable) || remote.configured
+  );
+
+  if (!unattendedCaptureReady && overall === 'ok') {
+    overall = 'warning';
+  }
+
+  return {
+    overall,
+    findings,
+    mcp: {
+      projectMcpPath: mcpPath,
+      projectMcpPresent: hasProjectMcpFile,
+      servers: mcpServers,
+      thumbgateInProjectMcp,
+      thumbgateInCursor,
+      thumbgateInClaudeSettings,
+    },
+    lessonsStore,
+    remote,
+    container,
+    unattendedCaptureReady,
+    recommendation: unattendedCaptureReady
+      ? 'RAG capture path is available (local store and/or hosted API).'
+      : 'Wire mcpServers.thumbgate in .mcp.json and set THUMBGATE_FEEDBACK_DIR or THUMBGATE_API_BASE_URL+THUMBGATE_API_KEY for unattended agents.',
+  };
+}
+
+function formatReport(report) {
+  const lines = [
+    `ThumbGate MCP wiring doctor: ${report.overall.toUpperCase()}`,
+    `  Project .mcp.json: ${report.mcp.projectMcpPresent ? 'present' : 'MISSING'} (thumbgate: ${report.mcp.thumbgateInProjectMcp ? 'yes' : 'NO'})`,
+    `  Lessons store: ${report.lessonsStore.present ? report.lessonsStore.path : 'NONE'} (writable: ${report.lessonsStore.writable})`,
+    `  Hosted capture: ${report.remote.configured ? 'configured' : 'not configured'}`,
+    `  Unattended capture ready: ${report.unattendedCaptureReady ? 'yes' : 'NO'}`,
+    `  Container-like: ${report.container ? 'yes' : 'no'}`,
+  ];
+  if (report.findings.length) {
+    lines.push('  Findings:');
+    for (const f of report.findings) lines.push(`    - ${f}`);
+  }
+  lines.push(`  ${report.recommendation}`);
+  return lines.join('\n');
 }
 
 function applyFix(projectRoot = process.cwd()) {
-  console.log(`Fixing wiring in ${projectRoot}...`);
-  // Implementation...
+  const root = path.resolve(projectRoot);
+  const mcpPath = path.join(root, '.mcp.json');
+  const desired = {
+    mcpServers: {
+      thumbgate: {
+        command: 'node',
+        args: ['adapters/mcp/server-stdio.js'],
+      },
+    },
+  };
+
+  let existing = {};
+  if (fs.existsSync(mcpPath)) {
+    try {
+      existing = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+    } catch {
+      existing = {};
+    }
+  }
+
+  if (!existing.mcpServers || typeof existing.mcpServers !== 'object') {
+    existing.mcpServers = {};
+  }
+  // Preserve other servers; force thumbgate entry.
+  existing.mcpServers.thumbgate = desired.mcpServers.thumbgate;
+  for (const legacy of LEGACY_MCP_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(existing.mcpServers, legacy)) {
+      delete existing.mcpServers[legacy];
+    }
+  }
+
+  fs.writeFileSync(mcpPath, `${JSON.stringify(existing, null, 2)}\n`, 'utf8');
+  return { wrote: mcpPath, config: existing };
 }
 
 if (path.resolve(process.argv[1] || '') === path.resolve(__filename)) {
-  const report = wiringReport();
-  console.log(JSON.stringify(report, null, 2));
+  const args = process.argv.slice(2);
+  const fix = args.includes('--fix');
+  const json = args.includes('--json');
+  const projectRoot = process.cwd();
+
+  if (fix) {
+    const result = applyFix(projectRoot);
+    if (json) {
+      console.log(JSON.stringify({ fixed: true, ...result }, null, 2));
+    } else {
+      console.log(`Wrote ${result.wrote}`);
+    }
+  }
+
+  const report = wiringReport(projectRoot);
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatReport(report));
+  }
+  process.exit(report.overall === 'error' ? 2 : report.overall === 'warning' ? 1 : 0);
 }
 
-module.exports = { wiringReport, applyFix };
+module.exports = {
+  wiringReport,
+  formatReport,
+  applyFix,
+  hasThumbgateServer,
+  resolveLessonsStore,
+  remoteCaptureConfigured,
+};

--- a/scripts/mcp-wiring-doctor.js
+++ b/scripts/mcp-wiring-doctor.js
@@ -16,6 +16,11 @@
 const fs = require('fs');
 const path = require('path');
 const { resolveMcpEntry } = require('./mcp-config');
+const {
+  isRemoteCaptureConfigured,
+  resolveApiKey,
+  resolveBaseUrl,
+} = require('./remote-feedback-capture');
 
 const PKG_ROOT = path.resolve(__dirname, '..');
 const PKG_VERSION = require('../package.json').version;
@@ -91,10 +96,10 @@ function resolveLessonsStore(projectRoot, env = process.env) {
 }
 
 function remoteCaptureConfigured(env = process.env) {
-  const base = String(env.THUMBGATE_API_BASE_URL || env.THUMBGATE_API_URL || '').trim();
-  const key = String(env.THUMBGATE_API_KEY || '').trim();
+  const base = resolveBaseUrl(env);
+  const key = resolveApiKey(env);
   return {
-    configured: Boolean(base && key),
+    configured: isRemoteCaptureConfigured(env),
     baseUrl: base || null,
     hasKey: Boolean(key),
   };

--- a/scripts/mcp-wiring-doctor.js
+++ b/scripts/mcp-wiring-doctor.js
@@ -15,6 +15,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const { resolveMcpEntry } = require('./mcp-config');
+
+const PKG_ROOT = path.resolve(__dirname, '..');
+const PKG_VERSION = require('../package.json').version;
 
 const LEGACY_MCP_KEYS = new Set(['mcp-memory-gateway', 'rlhf']);
 
@@ -70,7 +74,20 @@ function resolveLessonsStore(projectRoot, env = process.env) {
       /* continue */
     }
   }
-  return { path: null, present: false, writable: false };
+
+  const preferred = candidates[0] || path.join(projectRoot, '.thumbgate');
+  let parent = preferred;
+  while (!fs.existsSync(parent)) {
+    const next = path.dirname(parent);
+    if (next === parent) break;
+    parent = next;
+  }
+  try {
+    fs.accessSync(parent, fs.constants.W_OK);
+    return { path: preferred, present: false, writable: true, creatable: true };
+  } catch {
+    return { path: preferred, present: false, writable: false, creatable: false };
+  }
 }
 
 function remoteCaptureConfigured(env = process.env) {
@@ -149,7 +166,7 @@ function wiringReport(projectRoot = process.cwd(), env = process.env) {
   const remote = remoteCaptureConfigured(env);
   const container = isContainerLike(env);
 
-  if (!lessonsStore.present) {
+  if (!lessonsStore.present && !lessonsStore.writable) {
     findings.push(
       'No lessons store found (.thumbgate/ or THUMBGATE_FEEDBACK_DIR). ' +
       'Local capture_feedback cannot persist. Unattended/cloud runs need THUMBGATE_FEEDBACK_DIR ' +
@@ -162,7 +179,7 @@ function wiringReport(projectRoot = process.cwd(), env = process.env) {
     if (overall === 'ok') overall = 'warning';
   }
 
-  if (container && !lessonsStore.present && !remote.configured) {
+  if (container && !lessonsStore.writable && !remote.configured) {
     findings.push(
       'Container/unattended runtime: neither local lessons store nor hosted capture env is configured. ' +
       'AGENTS.md RAG loop (recall → act → capture_feedback) is unenforceable in this environment.'
@@ -175,7 +192,7 @@ function wiringReport(projectRoot = process.cwd(), env = process.env) {
   }
 
   const unattendedCaptureReady = Boolean(
-    (lessonsStore.present && lessonsStore.writable) || remote.configured
+    lessonsStore.writable || remote.configured
   );
 
   if (!unattendedCaptureReady && overall === 'ok') {
@@ -225,10 +242,12 @@ function applyFix(projectRoot = process.cwd()) {
   const mcpPath = path.join(root, '.mcp.json');
   const desired = {
     mcpServers: {
-      thumbgate: {
-        command: 'node',
-        args: ['adapters/mcp/server-stdio.js'],
-      },
+      thumbgate: resolveMcpEntry({
+        pkgRoot: PKG_ROOT,
+        pkgVersion: PKG_VERSION,
+        scope: 'project',
+        targetDir: root,
+      }),
     },
   };
 

--- a/scripts/remote-feedback-capture.js
+++ b/scripts/remote-feedback-capture.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * remote-feedback-capture.js
+ *
+ * Hosted capture path for unattended/cloud agents when the Mac-local
+ * lessons store is missing. POSTs to THUMBGATE_API_BASE_URL/v1/feedback/capture
+ * with Bearer THUMBGATE_API_KEY.
+ */
+
+const path = require('node:path');
+
+const DEFAULT_PATH = '/v1/feedback/capture';
+
+function resolveBaseUrl(env = process.env) {
+  return String(env.THUMBGATE_API_BASE_URL || env.THUMBGATE_API_URL || '').trim().replace(/\/$/, '');
+}
+
+function resolveApiKey(env = process.env) {
+  return String(env.THUMBGATE_API_KEY || '').trim();
+}
+
+function isRemoteCaptureConfigured(env = process.env) {
+  return Boolean(resolveBaseUrl(env) && resolveApiKey(env));
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.signal - up|down|positive|negative
+ * @param {string} params.context
+ * @param {string} [params.whatWentWrong]
+ * @param {string} [params.whatToChange]
+ * @param {string} [params.whatWorked]
+ * @param {string[]|string} [params.tags]
+ * @param {typeof fetch} [params.fetchImpl]
+ * @param {object} [params.env]
+ */
+async function captureFeedbackRemote(params = {}) {
+  const env = params.env || process.env;
+  const base = resolveBaseUrl(env);
+  const key = resolveApiKey(env);
+  if (!base || !key) {
+    return {
+      ok: false,
+      error: 'remote_capture_not_configured',
+      message: 'Set THUMBGATE_API_BASE_URL and THUMBGATE_API_KEY for hosted capture.',
+    };
+  }
+
+  const tags = Array.isArray(params.tags)
+    ? params.tags
+    : String(params.tags || '')
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+  const body = {
+    signal: params.signal || params.feedback || 'down',
+    context: params.context || '',
+    whatWentWrong: params.whatWentWrong || null,
+    whatToChange: params.whatToChange || null,
+    whatWorked: params.whatWorked || null,
+    tags,
+    source: params.source || 'remote-feedback-capture',
+  };
+
+  const fetchImpl = params.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    return { ok: false, error: 'fetch_unavailable', message: 'global fetch is not available' };
+  }
+
+  const url = `${base}${DEFAULT_PATH}`;
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${key}`,
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(params.timeoutMs || 20000),
+    });
+    const text = await response.text();
+    let json = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = { raw: text };
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: 'remote_capture_http_error',
+        status: response.status,
+        body: json,
+      };
+    }
+    return { ok: true, status: response.status, body: json };
+  } catch (err) {
+    return {
+      ok: false,
+      error: 'remote_capture_network_error',
+      message: err && err.message ? err.message : String(err),
+    };
+  }
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) continue;
+    const [k, ...rest] = arg.slice(2).split('=');
+    out[k] = rest.length ? rest.join('=') : true;
+  }
+  return out;
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log('Usage: node scripts/remote-feedback-capture.js --feedback=down --context="..." [--what-went-wrong=...] [--tags=a,b]');
+    process.exit(0);
+  }
+  const result = await captureFeedbackRemote({
+    signal: args.feedback || args.signal || 'down',
+    context: args.context || '',
+    whatWentWrong: args['what-went-wrong'],
+    whatToChange: args['what-to-change'],
+    whatWorked: args['what-worked'],
+    tags: args.tags,
+  });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.ok ? 0 : 2);
+}
+
+if (pathResolveMain()) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+function pathResolveMain() {
+  try {
+    return require('node:path').resolve(process.argv[1] || '') === require('node:path').resolve(__filename);
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  captureFeedbackRemote,
+  isRemoteCaptureConfigured,
+  resolveBaseUrl,
+  resolveApiKey,
+};

--- a/scripts/remote-feedback-capture.js
+++ b/scripts/remote-feedback-capture.js
@@ -153,6 +153,7 @@ function pathResolveMain() {
 module.exports = {
   captureFeedbackRemote,
   isRemoteCaptureConfigured,
+  parseArgs,
   resolveBaseUrl,
   resolveApiKey,
 };

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1517,7 +1517,9 @@ describe('bin/cli.js', () => {
     fs.writeFileSync(path.join(doctorDir, 'AGENTS.md'), '# Agents\n');
     fs.writeFileSync(path.join(doctorDir, 'CLAUDE.md'), '# Claude\n');
     fs.writeFileSync(path.join(doctorDir, 'GEMINI.md'), '# Gemini\n');
-    fs.writeFileSync(path.join(doctorDir, '.mcp.json'), JSON.stringify({ mcpServers: {} }, null, 2));
+    fs.writeFileSync(path.join(doctorDir, '.mcp.json'), JSON.stringify({
+      mcpServers: { thumbgate: { command: 'npx', args: ['-y', 'thumbgate', 'serve'] } },
+    }, null, 2));
     fs.mkdirSync(path.join(doctorDir, '.thumbgate'), { recursive: true });
     fs.writeFileSync(
       path.join(doctorDir, '.thumbgate', 'config.json'),
@@ -1545,6 +1547,7 @@ describe('bin/cli.js', () => {
     assert.equal(payload.articleAlignment.runtimeIsolation, true);
     assert.equal(payload.articleAlignment.contextConditioning, true);
     assert.equal(payload.articleAlignment.permissionEnvelope, true);
+    assert.equal(payload.wiring.mcp.thumbgateInProjectMcp, true);
 
     fs.rmSync(doctorDir, { recursive: true, force: true });
   });

--- a/tests/mcp-wiring-doctor.test.js
+++ b/tests/mcp-wiring-doctor.test.js
@@ -1,27 +1,141 @@
 'use strict';
 
 const test = require('node:test');
-const assert = require('node:assert');
-const fs = require('fs');
-const path = require('path');
-const { wiringReport, applyFix } = require('../scripts/mcp-wiring-doctor');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
-const TEST_ROOT = path.join(__dirname, 'fixtures', 'wiring-test');
+const {
+  wiringReport,
+  applyFix,
+  hasThumbgateServer,
+} = require('../scripts/mcp-wiring-doctor');
+const {
+  captureFeedbackRemote,
+  isRemoteCaptureConfigured,
+} = require('../scripts/remote-feedback-capture');
+
+test('hasThumbgateServer detects thumbgate and rejects legacy-only configs', () => {
+  assert.equal(hasThumbgateServer({ mcpServers: { thumbgate: { command: 'node' } } }), true);
+  assert.equal(hasThumbgateServer({ mcpServers: { github: {}, context7: {} } }), false);
+  assert.equal(hasThumbgateServer({ mcpServers: { 'mcp-memory-gateway': { command: 'x' } } }), false);
+});
 
 test('mcp-wiring-doctor detects legacy mcp-memory-gateway + rlhf in .mcp.json', () => {
-  if (fs.existsSync(TEST_ROOT)) fs.rmSync(TEST_ROOT, { recursive: true, force: true });
-  fs.mkdirSync(path.join(TEST_ROOT, '.claude'), { recursive: true });
-  
-  const mcpConfig = {
-    mcpServers: {
-      "mcp-memory-gateway": { command: "node", args: ["server.js"] },
-      "rlhf": { command: "node", args: ["rlhf.js"] },
-      "thumbgate": { command: "node", args: ["thumbgate.js"] }
-    }
-  };
-  fs.writeFileSync(path.join(TEST_ROOT, '.mcp.json'), JSON.stringify(mcpConfig));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-legacy-'));
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+      mcpServers: {
+        'mcp-memory-gateway': { command: 'node', args: ['server.js'] },
+        rlhf: { command: 'node', args: ['rlhf.js'] },
+        thumbgate: { command: 'node', args: ['thumbgate.js'] },
+      },
+    }));
+    fs.mkdirSync(path.join(dir, '.thumbgate'));
+    const report = wiringReport(dir, { HOME: dir });
+    assert.ok(report.findings.some((f) => /legacy MCP key/i.test(f) || /mcp-memory-gateway/.test(f)));
+    assert.ok(report.overall === 'warning' || report.overall === 'ok');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
-  const report = wiringReport(TEST_ROOT);
-  assert.equal(report.overall, 'warning');
-  assert.ok(report.findings.some(f => f.includes('legacy mcp-memory-gateway')));
+test('wiringReport errors when project .mcp.json omits thumbgate (unattended gap)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-'));
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+      mcpServers: { github: {}, context7: {}, grepai: {} },
+    }));
+    const report = wiringReport(dir, {
+      container: '1',
+      HOME: dir,
+    });
+    assert.equal(report.overall, 'error');
+    assert.equal(report.mcp.thumbgateInProjectMcp, false);
+    assert.equal(report.unattendedCaptureReady, false);
+    assert.ok(report.findings.some((f) => /no thumbgate server/i.test(f)));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('wiringReport is ok when .mcp.json has thumbgate and writable store exists', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-ok-'));
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+      mcpServers: {
+        thumbgate: { command: 'node', args: ['adapters/mcp/server-stdio.js'] },
+      },
+    }));
+    const store = path.join(dir, '.thumbgate');
+    fs.mkdirSync(store);
+    const report = wiringReport(dir, { HOME: dir });
+    assert.equal(report.mcp.thumbgateInProjectMcp, true);
+    assert.equal(report.lessonsStore.present, true);
+    assert.equal(report.unattendedCaptureReady, true);
+    assert.equal(report.overall, 'ok');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('applyFix writes thumbgate into .mcp.json without dropping other servers', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-fix-'));
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+      mcpServers: { github: { command: 'gh' }, 'mcp-memory-gateway': { command: 'legacy' } },
+    }));
+    applyFix(dir);
+    const written = JSON.parse(fs.readFileSync(path.join(dir, '.mcp.json'), 'utf8'));
+    assert.ok(written.mcpServers.thumbgate);
+    assert.ok(written.mcpServers.github);
+    assert.equal(written.mcpServers['mcp-memory-gateway'], undefined);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('isRemoteCaptureConfigured requires base URL and API key', () => {
+  assert.equal(isRemoteCaptureConfigured({}), false);
+  assert.equal(isRemoteCaptureConfigured({
+    THUMBGATE_API_BASE_URL: 'https://thumbgate-production.up.railway.app',
+    THUMBGATE_API_KEY: 'tg_test',
+  }), true);
+});
+
+test('captureFeedbackRemote posts JSON with bearer auth', async () => {
+  const calls = [];
+  const result = await captureFeedbackRemote({
+    signal: 'down',
+    context: 'test remote capture',
+    whatWentWrong: 'unit test',
+    tags: ['test'],
+    env: {
+      THUMBGATE_API_BASE_URL: 'https://example.test',
+      THUMBGATE_API_KEY: 'tg_key',
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ id: 'fb_test' }),
+      };
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://example.test/v1/feedback/capture');
+  assert.match(calls[0].init.headers.authorization, /Bearer tg_key/);
+  const body = JSON.parse(calls[0].init.body);
+  assert.equal(body.context, 'test remote capture');
+  assert.equal(body.signal, 'down');
+});
+
+test('repo root .mcp.json wires thumbgate (dogfood)', () => {
+  const mcpPath = path.join(__dirname, '..', '.mcp.json');
+  assert.ok(fs.existsSync(mcpPath), 'project .mcp.json must exist');
+  const config = JSON.parse(fs.readFileSync(mcpPath, 'utf8'));
+  assert.ok(config.mcpServers && config.mcpServers.thumbgate, 'thumbgate server required');
 });

--- a/tests/mcp-wiring-doctor.test.js
+++ b/tests/mcp-wiring-doctor.test.js
@@ -294,6 +294,43 @@ test('alternate non-legacy server keys can explicitly invoke ThumbGate', () => {
   assert.equal(hasThumbgateServer(null), false);
 });
 
+test('server discovery accepts legacy config shape and ignores malformed values', () => {
+  assert.equal(hasThumbgateServer({ servers: { thumbgate: { command: 'node' } } }), true);
+  assert.equal(hasThumbgateServer({ servers: { governance: null } }), false);
+  assert.equal(hasThumbgateServer('not-an-object'), false);
+});
+
+test('wiringReport diagnoses a missing project MCP file', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-missing-'));
+  try {
+    const report = wiringReport(dir, { HOME: dir });
+    assert.equal(report.overall, 'error');
+    assert.equal(report.mcp.projectMcpPresent, false);
+    assert.ok(report.findings.some((finding) => /Missing project \.mcp\.json/.test(finding)));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('wiringReport recognizes hosted capture in a container', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-hosted-'));
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+      mcpServers: { thumbgate: { command: 'npx', args: ['thumbgate', 'serve'] } },
+    }));
+    const report = wiringReport(dir, {
+      HOME: dir,
+      container: '1',
+      THUMBGATE_API_BASE_URL: 'https://example.test',
+      THUMBGATE_API_KEY: 'tg_key',
+    });
+    assert.equal(report.remote.configured, true);
+    assert.ok(report.findings.some((finding) => /Hosted capture env is set/.test(finding)));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('resolveLessonsStore honors an explicit existing feedback directory', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-explicit-store-'));
   try {

--- a/tests/mcp-wiring-doctor.test.js
+++ b/tests/mcp-wiring-doctor.test.js
@@ -53,7 +53,7 @@ test('wiringReport errors when project .mcp.json omits thumbgate (unattended gap
     });
     assert.equal(report.overall, 'error');
     assert.equal(report.mcp.thumbgateInProjectMcp, false);
-    assert.equal(report.unattendedCaptureReady, false);
+    assert.equal(report.unattendedCaptureReady, true);
     assert.ok(report.findings.some((f) => /no thumbgate server/i.test(f)));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -80,6 +80,23 @@ test('wiringReport is ok when .mcp.json has thumbgate and writable store exists'
   }
 });
 
+test('wiringReport treats a creatable lessons store as writable in a fresh container', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-fresh-'));
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({
+      mcpServers: { thumbgate: { command: 'npx', args: ['-y', 'thumbgate', 'serve'] } },
+    }));
+    const report = wiringReport(dir, { HOME: dir, container: '1' });
+    assert.equal(report.lessonsStore.present, false);
+    assert.equal(report.lessonsStore.writable, true);
+    assert.equal(report.lessonsStore.creatable, true);
+    assert.equal(report.unattendedCaptureReady, true);
+    assert.equal(report.overall, 'ok');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('applyFix writes thumbgate into .mcp.json without dropping other servers', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-fix-'));
   try {
@@ -91,6 +108,9 @@ test('applyFix writes thumbgate into .mcp.json without dropping other servers', 
     assert.ok(written.mcpServers.thumbgate);
     assert.ok(written.mcpServers.github);
     assert.equal(written.mcpServers['mcp-memory-gateway'], undefined);
+    assert.ok(['npx', 'sh'].includes(written.mcpServers.thumbgate.command));
+    assert.ok(written.mcpServers.thumbgate.args.some((arg) => arg.includes('thumbgate')));
+    assert.ok(!written.mcpServers.thumbgate.args.some((arg) => arg.includes('adapters/mcp/server-stdio.js')));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/mcp-wiring-doctor.test.js
+++ b/tests/mcp-wiring-doctor.test.js
@@ -17,6 +17,7 @@ const {
 const {
   captureFeedbackRemote,
   isRemoteCaptureConfigured,
+  parseArgs,
   resolveApiKey,
   resolveBaseUrl,
 } = require('../scripts/remote-feedback-capture');
@@ -170,6 +171,36 @@ test('remote capture configuration normalizes URL and key aliases', () => {
     baseUrl: 'https://example.test',
     hasKey: true,
   });
+});
+
+test('remote capture CLI parser handles values, flags, and embedded equals signs', () => {
+  assert.deepEqual(parseArgs([
+    '--feedback=down',
+    '--context=a=b',
+    '--help',
+    'ignored',
+  ]), {
+    feedback: 'down',
+    context: 'a=b',
+    help: true,
+  });
+});
+
+test('captureFeedbackRemote reports when fetch is unavailable', async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = undefined;
+    const result = await captureFeedbackRemote({
+      env: {
+        THUMBGATE_API_BASE_URL: 'https://example.test',
+        THUMBGATE_API_KEY: 'key',
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error, 'fetch_unavailable');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test('captureFeedbackRemote reports missing configuration without calling fetch', async () => {

--- a/tests/mcp-wiring-doctor.test.js
+++ b/tests/mcp-wiring-doctor.test.js
@@ -9,11 +9,16 @@ const path = require('node:path');
 const {
   wiringReport,
   applyFix,
+  formatReport,
   hasThumbgateServer,
+  remoteCaptureConfigured,
+  resolveLessonsStore,
 } = require('../scripts/mcp-wiring-doctor');
 const {
   captureFeedbackRemote,
   isRemoteCaptureConfigured,
+  resolveApiKey,
+  resolveBaseUrl,
 } = require('../scripts/remote-feedback-capture');
 
 test('hasThumbgateServer detects thumbgate and rejects legacy-only configs', () => {
@@ -151,6 +156,124 @@ test('captureFeedbackRemote posts JSON with bearer auth', async () => {
   const body = JSON.parse(calls[0].init.body);
   assert.equal(body.context, 'test remote capture');
   assert.equal(body.signal, 'down');
+});
+
+test('remote capture configuration normalizes URL and key aliases', () => {
+  const env = {
+    THUMBGATE_API_URL: 'https://example.test/',
+    THUMBGATE_API_KEY: '  tg_key  ',
+  };
+  assert.equal(resolveBaseUrl(env), 'https://example.test');
+  assert.equal(resolveApiKey(env), 'tg_key');
+  assert.deepEqual(remoteCaptureConfigured(env), {
+    configured: true,
+    baseUrl: 'https://example.test',
+    hasKey: true,
+  });
+});
+
+test('captureFeedbackRemote reports missing configuration without calling fetch', async () => {
+  let called = false;
+  const result = await captureFeedbackRemote({
+    env: {},
+    fetchImpl: async () => { called = true; },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'remote_capture_not_configured');
+  assert.equal(called, false);
+});
+
+test('captureFeedbackRemote accepts comma tags and preserves non-JSON error bodies', async () => {
+  const calls = [];
+  const result = await captureFeedbackRemote({
+    feedback: 'positive',
+    context: 'remote context',
+    whatWorked: 'hosted capture is reachable',
+    tags: 'cloud, unattended, ,rag',
+    source: 'acceptance-test',
+    env: {
+      THUMBGATE_API_BASE_URL: 'https://example.test/',
+      THUMBGATE_API_KEY: 'tg_key',
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: false,
+        status: 503,
+        text: async () => 'temporarily unavailable',
+      };
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'remote_capture_http_error');
+  assert.equal(result.status, 503);
+  assert.deepEqual(result.body, { raw: 'temporarily unavailable' });
+  const body = JSON.parse(calls[0].init.body);
+  assert.equal(body.signal, 'positive');
+  assert.equal(body.whatWorked, 'hosted capture is reachable');
+  assert.deepEqual(body.tags, ['cloud', 'unattended', 'rag']);
+  assert.equal(body.source, 'acceptance-test');
+});
+
+test('captureFeedbackRemote handles empty success and network failures', async () => {
+  const env = {
+    THUMBGATE_API_BASE_URL: 'https://example.test',
+    THUMBGATE_API_KEY: 'tg_key',
+  };
+  const empty = await captureFeedbackRemote({
+    env,
+    fetchImpl: async () => ({ ok: true, status: 204, text: async () => '' }),
+  });
+  assert.deepEqual(empty, { ok: true, status: 204, body: null });
+
+  const failed = await captureFeedbackRemote({
+    env,
+    fetchImpl: async () => { throw new Error('network down'); },
+  });
+  assert.equal(failed.ok, false);
+  assert.equal(failed.error, 'remote_capture_network_error');
+  assert.equal(failed.message, 'network down');
+});
+
+test('wiringReport surfaces invalid JSON and formats actionable findings', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-wiring-invalid-'));
+  try {
+    fs.writeFileSync(path.join(dir, '.mcp.json'), '{not-json');
+    const report = wiringReport(dir, { HOME: dir, container: '1' });
+    assert.equal(report.overall, 'error');
+    assert.equal(report.mcp.projectMcpPresent, true);
+    assert.equal(report.mcp.thumbgateInProjectMcp, false);
+    assert.ok(report.findings.some((finding) => /not valid JSON/.test(finding)));
+    const text = formatReport(report);
+    assert.match(text, /MCP wiring doctor: ERROR/);
+    assert.match(text, /Findings:/);
+    assert.match(text, /Unattended capture ready: yes/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('alternate non-legacy server keys can explicitly invoke ThumbGate', () => {
+  assert.equal(hasThumbgateServer({
+    servers: {
+      governance: { command: 'npx', args: ['thumbgate', 'serve'] },
+    },
+  }), true);
+  assert.equal(hasThumbgateServer({ __parseError: true }), false);
+  assert.equal(hasThumbgateServer(null), false);
+});
+
+test('resolveLessonsStore honors an explicit existing feedback directory', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-explicit-store-'));
+  try {
+    assert.deepEqual(resolveLessonsStore('/unused', { THUMBGATE_FEEDBACK_DIR: dir }), {
+      path: dir,
+      present: true,
+      writable: true,
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('repo root .mcp.json wires thumbgate (dogfood)', () => {

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -431,8 +431,10 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     // 431 -> 432 (2026-08-10): scripts/stealth-memory-injection-gate.js is
     // required by gates-engine.js to enforce the MemGhost durable-memory boundary.
     // Exact measured artifact, with no additional package headroom.
-    manifest.fileCount <= 432,
-    `npm package should stay <= 432 files, got ${manifest.fileCount}`
+    // 432 -> 434 (2026-08-11): mcp-wiring-doctor + remote-feedback-capture are
+    // packaged unattended RAG reliability surfaces. Exact count, no headroom.
+    manifest.fileCount <= 434,
+    `npm package should stay <= 434 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -175,7 +175,9 @@ const path = require('node:path');
 // Bumped 424 -> 431 (2026-08-10): WorkOS + Herdr + /peter partner landing + packaged prove scripts.
 // 2026-08-10: +1 scripts/stealth-memory-injection-gate.js (MemGhost/WhisperBench
 // durable-carrier pre-action defense — paper 2607.05189).
-const BASELINE_FILE_COUNT = 432;
+// 2026-08-11: +scripts/remote-feedback-capture.js (+ mcp-wiring-doctor if newly packed)
+// for unattended RAG loop (hosted capture fallback + loud wiring doctor).
+const BASELINE_FILE_COUNT = 434;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -240,8 +240,10 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // 424 -> 431 (2026-08-10): WorkOS + Herdr + /peter partner landing + packaged prove scripts.
   // 431 -> 432 (2026-08-10): scripts/stealth-memory-injection-gate.js is the
   // packaged MemGhost structural enforcement runtime. Exact count, no headroom.
+  // 432 -> 434 (2026-08-11): mcp-wiring-doctor + remote-feedback-capture for
+  // unattended RAG loop (project .mcp.json dogfood + hosted capture fallback).
   // Keep lockstep with package-boundary + public-bundle-ratchet.
-  const CEILING = 432;
+  const CEILING = 434;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
## Problem (verified product finding)

Unattended agents cannot obey the AGENTS.md RAG loop (`recall` → act → `capture_feedback`):

1. Project MCP configs often list only github/context7/grepai — **no thumbgate server**, so tools are uncallable.
2. Lessons store is Mac-local (`.thumbgate/`); containers report *no lessons store found*.
3. Result: the agent that most needs to record mistakes is structurally unable to.

## Fix

- Root **`.mcp.json`** with `mcpServers.thumbgate` (dogfood)
- Expanded **`mcp-wiring-doctor`** — fail loud; `--fix` writes thumbgate entry
- **`session-start` + `doctor` + `wiring-doctor` CLI** surface gaps at boot
- **`scripts/remote-feedback-capture.js`** for `THUMBGATE_API_BASE_URL` + `THUMBGATE_API_KEY`
- Bundle ceiling **432 → 434**

## Unattended env recipe

```bash
export THUMBGATE_API_BASE_URL=https://thumbgate-production.up.railway.app
export THUMBGATE_API_KEY=...
node scripts/remote-feedback-capture.js --feedback=down --context="..."
node bin/cli.js wiring-doctor
```

## Test plan

- [x] tests/mcp-wiring-doctor.test.js (8 pass)
- [x] public-bundle-ratchet 434
- [x] local wiring-doctor OK
- [x] incident feedback captured: fb_1786408042887_3mkgqw