### PR TITLE
fix(deploy): fetch history for npm ancestry gate

### DIFF
--- a/.changeset/railway-full-history.md
+++ b/.changeset/railway-full-history.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Check out full git history in the Railway deployment workflow so npm release ancestry verification can distinguish valid mainline commits from divergent package ownership.

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -52,7 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 2
+          # verify-npm-githead proves that the published npm gitHead is an
+          # ancestor of this deploy SHA. A shallow checkout makes older release
+          # commits unavailable and turns valid ancestry into fail-closed
+          # "unknown", blocking every main deployment between npm releases.
+          fetch-depth: 0
       - name: Detect deployable changes
         id: deploy-scope
         run: |

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -515,7 +515,11 @@ test('Deploy to Railway workflow skips non-runtime pushes and only deploys when 
   const workflow = fs.readFileSync(path.join(PROJECT_ROOT, '.github', 'workflows', 'deploy-railway.yml'), 'utf8');
   const scopeScript = fs.readFileSync(path.join(PROJECT_ROOT, 'scripts', 'deploy-scope.sh'), 'utf8');
 
-  assert.match(workflow, /fetch-depth:\s*2/);
+  assert.match(
+    workflow,
+    /fetch-depth:\s*0/,
+    'Railway ownership verification requires full history to prove the published npm gitHead is an ancestor',
+  );
   assert.match(workflow, /name: Detect deployable changes/);
   assert.match(workflow, /BEFORE_SHA='\$\{\{\s*github\.event\.before\s*\}\}'/);
   assert.match(workflow, /HEAD_SHA="\$GITHUB_SHA"/);


### PR DESCRIPTION
## Summary
- fetch full git history in the Railway deploy lane
- preserve the fail-closed npm gitHead ownership gate while allowing proven ancestor releases
- add a regression assertion and patch changeset

## Evidence
- 12 consecutive main Railway deploy runs failed at ancestry verification
- published npm gitHead `7b463ec4` is a verified ancestor of main `900adb5c`
- local ownership verifier now passes with reason: published release is an ancestor
- `node --test tests/deployment.test.js tests/verify-npm-githead.test.js`: 75/75 pass

See `VERIFICATION_EVIDENCE.md` for the project proof contract.