### PR TITLE
fix(statusline): isolate temporary feedback stores

### DIFF
--- a/.changeset/statusline-temp-root-isolation.md
+++ b/.changeset/statusline-temp-root-isolation.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Prevent statusline feedback aggregation from reading a shared operating-system temporary-directory store across unrelated tests, npx sessions, and sandboxed agents.

--- a/scripts/feedback-aggregate.js
+++ b/scripts/feedback-aggregate.js
@@ -71,11 +71,15 @@ function immediateChildDirs(parentDir) {
 function ancestorProjectFeedbackDirs(projectDir, options = {}) {
   const home = normalizePath(getHomeDir(options));
   const start = normalizePath(projectDir);
+  const tempRoot = normalizePath(os.tmpdir());
   if (!start) return [];
 
   const dirs = [];
   let cursor = start;
   while (cursor && cursor !== path.dirname(cursor)) {
+    // Temp projects share one OS-level parent. Reading that parent's store leaks
+    // feedback across unrelated test runs, npx sessions, and sandboxed agents.
+    if (tempRoot && cursor === tempRoot) break;
     dirs.push(
       path.join(cursor, '.thumbgate'),
       path.join(cursor, '.thumbgate-compat'),

--- a/scripts/feedback-aggregate.js
+++ b/scripts/feedback-aggregate.js
@@ -279,6 +279,7 @@ function getAggregateStatuslineCachePath(options = {}) {
 }
 
 module.exports = {
+  ancestorProjectFeedbackDirs,
   collectAggregateLogEntries,
   computeAggregateFeedbackStats,
   getAggregateStatuslineCachePath,

--- a/scripts/feedback-aggregate.js
+++ b/scripts/feedback-aggregate.js
@@ -189,7 +189,7 @@ function summarizeFeedbackEntries(entries) {
   for (const entry of entries) {
     if (entry.signal === 'positive') totalPositive += 1;
     if (entry.signal === 'negative') totalNegative += 1;
-    if (entry.rubric && entry.rubric.weightedScore != null) rubricSamples += 1;
+    if (entry.rubric?.weightedScore != null) rubricSamples += 1;
   }
 
   return { totalPositive, totalNegative, rubricSamples };

--- a/tests/statusline-aggregation.test.js
+++ b/tests/statusline-aggregation.test.js
@@ -14,6 +14,7 @@ const {
 const {
   collectAggregateLogEntries,
   computeAggregateFeedbackStats,
+  listFeedbackStoreDirs,
 } = require('../scripts/feedback-aggregate');
 
 function tmpDir(prefix) {
@@ -36,6 +37,21 @@ function feedback(id, signal, daysAgo = 0, extra = {}) {
     ...extra,
   };
 }
+
+test('temp projects never aggregate the shared OS temp-root store', () => {
+  const project = tmpDir('thumbgate-temp-boundary-');
+  const home = path.join(project, 'home');
+  try {
+    const stores = listFeedbackStoreDirs({
+      cwd: project,
+      projectDir: project,
+      env: { HOME: home, USERPROFILE: home },
+    });
+    assert.equal(stores.includes(path.join(os.tmpdir(), '.thumbgate')), false);
+  } finally {
+    fs.rmSync(project, { recursive: true, force: true });
+  }
+});
 
 test('statusline stats aggregate active project, parent workspace, and global stores', () => {
   const root = tmpDir('thumbgate-aggregate-');

--- a/tests/statusline-aggregation.test.js
+++ b/tests/statusline-aggregation.test.js
@@ -12,6 +12,7 @@ const {
   getStatuslineCacheCandidates,
 } = require('../scripts/statusline-cache-path');
 const {
+  ancestorProjectFeedbackDirs,
   collectAggregateLogEntries,
   computeAggregateFeedbackStats,
   listFeedbackStoreDirs,
@@ -42,11 +43,10 @@ test('temp projects never aggregate the shared OS temp-root store', () => {
   const project = tmpDir('thumbgate-temp-boundary-');
   const home = path.join(project, 'home');
   try {
-    const stores = listFeedbackStoreDirs({
-      cwd: project,
-      projectDir: project,
+    const stores = ancestorProjectFeedbackDirs(project, {
       env: { HOME: home, USERPROFILE: home },
     });
+    assert.equal(stores.includes(path.join(project, '.thumbgate')), true);
     assert.equal(stores.includes(path.join(os.tmpdir(), '.thumbgate')), false);
   } finally {
     fs.rmSync(project, { recursive: true, force: true });

--- a/tests/statusline-e2e.test.js
+++ b/tests/statusline-e2e.test.js
@@ -85,7 +85,9 @@ function runStatusline({ home, projectDir, extraEnv = {} }) {
     env: {
       PATH: process.env.PATH || '',
       HOME: home,
+      TMPDIR: process.env.TMPDIR || os.tmpdir(),
       THUMBGATE_PROJECT_DIR: projectDir,
+      THUMBGATE_DISABLE_CLAUDE_HISTORY_SYNC: '1',
       // Keep everything offline/local: no network, no DB side effects.
       THUMBGATE_OFFLINE: '1',
       NODE_ENV: 'test',


### PR DESCRIPTION
## Summary
- stop aggregate discovery before the shared OS temporary root
- preserve TMPDIR in isolated statusline E2E children
- disable separately tested Claude-history synchronization in aggregation-only E2E cases

## Evidence
- `npm run test:statusline`: 62/62 pass
- reproduces and fixes the four clean-worktree failures observed at exact main SHA `2a63bd49fffb6f0b097f413c69c6dfef3de8c13c`
- see `VERIFICATION_EVIDENCE.md` for the project verification contract