### PR TITLE
fix(observability): expose safe production proof errors

### DIFF
--- a/.changeset/production-proof-diagnostics.md
+++ b/.changeset/production-proof-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Include credential-safe RFC 9457 problem diagnostics in authenticated production proof reports so Railway failures identify the failing dashboard or retrieval boundary without exposing API keys.

--- a/scripts/prove-production-authenticated.js
+++ b/scripts/prove-production-authenticated.js
@@ -118,6 +118,24 @@ function isObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+function sanitizeDiagnosticText(value, secrets = []) {
+  let text = String(value || '').trim().slice(0, 500);
+  for (const secret of secrets) {
+    const normalized = String(secret || '').trim();
+    if (normalized) text = text.split(normalized).join('[REDACTED]');
+  }
+  return text || null;
+}
+
+function buildProblemDiagnostics(body, apiKey) {
+  if (!isObject(body)) return {};
+  return {
+    problemType: sanitizeDiagnosticText(body.type || body.code, [apiKey]),
+    problemTitle: sanitizeDiagnosticText(body.title || body.error, [apiKey]),
+    problemDetail: sanitizeDiagnosticText(body.detail || body.message, [apiKey]),
+  };
+}
+
 function buildChecks({
   expectedSha = '',
   expectedVersion = '',
@@ -323,6 +341,7 @@ async function probeCheck(check, options) {
         attempts: attempt,
         durationMs: Date.now() - startedAt,
         schemaValid: Boolean(validation.valid),
+        ...buildProblemDiagnostics(body, apiKey),
         ...validation.metrics,
       };
       const retryableStatus = response.status >= 500 || [408, 425, 429].includes(response.status);

--- a/scripts/prove-production-authenticated.js
+++ b/scripts/prove-production-authenticated.js
@@ -119,12 +119,12 @@ function isObject(value) {
 }
 
 function sanitizeDiagnosticText(value, secrets = []) {
-  let text = String(value || '').trim().slice(0, 500);
+  let text = String(value || '').trim();
   for (const secret of secrets) {
     const normalized = String(secret || '').trim();
     if (normalized) text = text.split(normalized).join('[REDACTED]');
   }
-  return text || null;
+  return text.slice(0, 500) || null;
 }
 
 function buildProblemDiagnostics(body, apiKey) {
@@ -313,21 +313,14 @@ async function probeCheck(check, options) {
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     const startedAt = Date.now();
     try {
-      const headers = { accept: 'application/json' };
-      if (check.authenticated) headers.authorization = `Bearer ${apiKey}`;
-      if (check.body) headers['content-type'] = 'application/json';
+      const headers = buildRequestHeaders(check, apiKey);
       const response = await fetchImpl(`${baseUrl}${check.path}`, {
         method: check.method,
         headers,
         body: check.body ? JSON.stringify(check.body) : undefined,
         signal: controller.signal,
       });
-      let body = null;
-      try {
-        body = await response.json();
-      } catch {
-        body = null;
-      }
+      const body = await readJsonBody(response);
       const acceptedStatus = Array.isArray(check.expectedStatuses)
         ? check.expectedStatuses.includes(response.status)
         : response.ok;
@@ -355,7 +348,7 @@ async function probeCheck(check, options) {
         attempts: attempt,
         durationMs: Date.now() - startedAt,
         schemaValid: false,
-        error: error && error.name === 'AbortError' ? 'timeout' : 'request_failed',
+        error: error?.name === 'AbortError' ? 'timeout' : 'request_failed',
       };
     } finally {
       clearTimeout(timer);
@@ -364,6 +357,21 @@ async function probeCheck(check, options) {
     if (attempt < maxAttempts) await delay(retryDelayMs);
   }
   return lastResult;
+}
+
+function buildRequestHeaders(check, apiKey) {
+  const headers = { accept: 'application/json' };
+  if (check.authenticated) headers.authorization = `Bearer ${apiKey}`;
+  if (check.body) headers['content-type'] = 'application/json';
+  return headers;
+}
+
+async function readJsonBody(response) {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
 }
 
 async function runAuthenticatedProductionProof(options = {}) {
@@ -386,7 +394,7 @@ async function runAuthenticatedProductionProof(options = {}) {
       checks: [],
     };
   }
-  const apiKeyInput = Object.prototype.hasOwnProperty.call(options, 'apiKey')
+  const apiKeyInput = Object.hasOwn(options, 'apiKey')
     ? options.apiKey
     : process.env.THUMBGATE_API_KEY;
   const apiKey = String(apiKeyInput || '').trim();

--- a/tests/prove-production-authenticated.test.js
+++ b/tests/prove-production-authenticated.test.js
@@ -151,6 +151,33 @@ test('401 fails without leaking the credential into report output', async () => 
   assert.doesNotMatch(renderHuman(report), new RegExp(secret));
 });
 
+test('failed production checks expose credential-safe problem diagnostics', async () => {
+  const secret = 'must-never-appear';
+  const report = await runAuthenticatedProductionProof({
+    apiKey: secret,
+    baseUrl: DEFAULT_BASE_URL,
+    expectedSha: 'abc123',
+    expectedVersion: '1.32.0',
+    maxAttempts: 1,
+    fetchImpl: async (url, options) => {
+      if (url.endsWith('/v1/dashboard')) {
+        return response(503, {
+          type: 'urn:thumbgate:error:internal',
+          title: 'Dashboard data too large',
+          detail: `bounded assembly failed for ${secret}`,
+        });
+      }
+      return passingFetch(url, options);
+    },
+  });
+
+  const dashboard = report.checks.find((check) => check.name === 'dashboard_data');
+  assert.equal(dashboard.problemType, 'urn:thumbgate:error:internal');
+  assert.equal(dashboard.problemTitle, 'Dashboard data too large');
+  assert.equal(dashboard.problemDetail, 'bounded assembly failed for [REDACTED]');
+  assert.doesNotMatch(JSON.stringify(report), new RegExp(secret));
+});
+
 test('empty retrieval results fail even when transport returns 200', async () => {
   const report = await runAuthenticatedProductionProof({
     apiKey: 'secret-test-key',

--- a/tests/prove-production-authenticated.test.js
+++ b/tests/prove-production-authenticated.test.js
@@ -178,6 +178,27 @@ test('failed production checks expose credential-safe problem diagnostics', asyn
   assert.doesNotMatch(JSON.stringify(report), new RegExp(secret));
 });
 
+test('problem diagnostics redact credentials before applying the length bound', async () => {
+  const secret = 'credential-crossing-the-boundary';
+  const prefix = 'x'.repeat(480);
+  const report = await runAuthenticatedProductionProof({
+    apiKey: secret,
+    baseUrl: DEFAULT_BASE_URL,
+    expectedSha: 'abc123',
+    expectedVersion: '1.32.0',
+    maxAttempts: 1,
+    fetchImpl: async (url, options) => url.endsWith('/v1/dashboard')
+      ? response(503, { detail: `${prefix}${secret}` })
+      : passingFetch(url, options),
+  });
+
+  const dashboard = report.checks.find((check) => check.name === 'dashboard_data');
+  assert.equal(dashboard.problemDetail.length, 490);
+  assert.match(dashboard.problemDetail, /\[REDACTED\]$/);
+  assert.doesNotMatch(JSON.stringify(report), new RegExp(secret));
+  assert.doesNotMatch(dashboard.problemDetail, /credential-crossing/);
+});
+
 test('empty retrieval results fail even when transport returns 200', async () => {
   const report = await runAuthenticatedProductionProof({
     apiKey: 'secret-test-key',


### PR DESCRIPTION
## Summary
- include RFC 9457 problem type, title, and bounded detail in production proof failures
- redact the active API key before diagnostics enter CI logs
- add regression coverage proving dashboard diagnostics remain credential-safe

## Verification
- `node --test tests/prove-production-authenticated.test.js` (13/13 pass)
- `git diff --check`

## Context
This is the observability-first step for #3367. Current exact-main failures report only status/schema metrics, hiding the dashboard data-limit cause. The next Railway run will expose the bounded server-generated problem detail without leaking credentials.

Authority evidence: `VERIFICATION_EVIDENCE.md`
