### PR TITLE
feat(ops): dual classic/ruleset congruence + zero-bypass governance

### DIFF
--- a/.changeset/ruleset-governance-roi.md
+++ b/.changeset/ruleset-governance-roi.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+feat(ops): dual classic/ruleset congruence, CI rulesets:check, PR-manager ruleset diagnosis, and zero-bypass gate templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,13 +152,20 @@ jobs:
         # Rulesets (Trunk-managed orgs do this), the script can't see
         # the rule and exits 1. We don't want a periodic monitor to
         # block PRs — surface drift in the run UI without failing the
-        # job. Permanent fix is to teach the script Rulesets, tracked
-        # separately.
+        # job. Companion step below checks repository rulesets.
         if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
         run: npm run branch-protection:check
+      - name: Check repository ruleset congruence
+        # Non-blocking drift monitor for the active main governance ruleset
+        # (zero bypass_actors + merge-quality required checks + dual classic/ruleset compare).
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: npm run rulesets:check
 
       - name: Run focused web/revenue tests
         if: steps.ci-scope.outputs.mode == 'web'

--- a/config/gate-templates.json
+++ b/config/gate-templates.json
@@ -1032,6 +1032,30 @@
       "problem": "For bulk, repetitive, or long-running agent workflows, Qwen3.8-Max is the optimal default: 30-60% cheaper output than Claude/Sonnet, with 1M context window for complex reasoning.",
       "roi": "Directs high-volume workloads to the most cost-effective model. Saves $9 per 1M output tokens vs Claude Sonnet 4.6 ($15/M).",
       "rollout": "Set Qwen3.8-Max as default for bulk operations. Allow explicit override with cost-delta documentation."
+    },
+    {
+      "id": "github-ruleset-migration-audit",
+      "name": "Audit GitHub Ruleset Migration & Bypass Permissions",
+      "category": "GitHub Ruleset Governance",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "critical",
+      "pattern": "(ruleset|branch_protection|bypass_actors)\\s+(delete|bypass|disable|override|admin_force)",
+      "problem": "Prevents agents or un-audited processes from disabling GitHub Rulesets or modifying bypass actors on protected repositories during migration.",
+      "roi": "Protects repository rulesets during branch-protection to rulesets migration; keeps zero-bypass policy enforceable.",
+      "rollout": "Enable on all production repos with layered classic protection + repository rulesets."
+    },
+    {
+      "id": "enforce-ruleset-bypass-actor-scoping",
+      "name": "Enforce strict scoping on Ruleset bypass actors",
+      "category": "GitHub Ruleset Governance",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "high",
+      "pattern": "(ruleset_bypass|bypass_actor)\\s+(add_user|all_admins|wildcard_actor)",
+      "problem": "Requires fine-grained app/bot scoping on Ruleset bypass permissions instead of granting broad user or admin bypass rights.",
+      "roi": "Blocks owner-token / admin soft-bypass of merge governance; keeps agent autonomy inside protection bounds.",
+      "rollout": "Pair with config/main-branch-ruleset.json zero bypass_actors and npm run rulesets:check."
     }
   ]
 }

--- a/scripts/pr-manager.js
+++ b/scripts/pr-manager.js
@@ -225,6 +225,43 @@ function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+
+/**
+ * Read-only repository ruleset inventory for diagnosis.
+ * Never mutates rulesets or bypass actors.
+ */
+function inspectRepositoryRulesets(repo = '', runner = runGh) {
+  const normalizedRepo = String(repo || '').trim();
+  const args = normalizedRepo
+    ? ['api', `repos/${normalizedRepo}/rulesets`, '-H', 'Accept: application/vnd.github+json']
+    : ['api', 'repos/{owner}/{repo}/rulesets', '-H', 'Accept: application/vnd.github+json'];
+
+  try {
+    const result = runner(args);
+    if (result && result.status === 0 && result.stdout) {
+      const rulesets = JSON.parse(result.stdout);
+      if (Array.isArray(rulesets)) {
+        return {
+          ok: true,
+          count: rulesets.length,
+          activeRulesets: rulesets
+            .filter((rs) => String(rs?.enforcement || '').toLowerCase() === 'active')
+            .map((rs) => ({
+              id: rs.id,
+              name: rs.name,
+              target: rs.target || 'branch',
+              enforcement: rs.enforcement,
+            })),
+        };
+      }
+    }
+  } catch {
+    // Diagnostic only — never block merges on inventory failure.
+  }
+
+  return { ok: false, count: 0, activeRulesets: [] };
+}
+
 async function resolveBlockers(pr, runner = runGh) {
   const title = pr.title || 'Untitled PR';
   const mergeState = pr.mergeStateStatus || 'UNKNOWN';
@@ -232,6 +269,25 @@ async function resolveBlockers(pr, runner = runGh) {
 
   console.log(`[PR Manager] Diagnosing PR #${pr.number}: "${title}"`);
   console.log(`[PR Manager] Merge State: ${mergeState} | Mergeable: ${mergeable}`);
+
+  // Live-default runner only: injected test runners must not have their mock
+  // queues consumed by optional ruleset inventory.
+  if (runner === runGh) {
+    try {
+      const rulesetInventory = inspectRepositoryRulesets('', runner);
+      if (rulesetInventory.ok) {
+        const names = rulesetInventory.activeRulesets.map((rs) => rs.name).join(', ') || '(none)';
+        console.log(
+          `[PR Manager] Repository rulesets: ${rulesetInventory.count} total, `
+          + `${rulesetInventory.activeRulesets.length} active [${names}]`,
+        );
+      } else {
+        console.log('[PR Manager] Repository rulesets: unavailable (diagnostic only)');
+      }
+    } catch {
+      console.log('[PR Manager] Repository rulesets: unavailable (diagnostic only)');
+    }
+  }
 
   if (pr.isDraft) {
     console.log('[PR Manager] PR is a draft. Skipping.');
@@ -451,4 +507,5 @@ module.exports = {
   performMerge,
   managePrs,
   summarizeChecks,
+  inspectRepositoryRulesets,
 };

--- a/scripts/sync-repository-rulesets.js
+++ b/scripts/sync-repository-rulesets.js
@@ -477,6 +477,97 @@ function upsertRuleset(repo, body, existingId, runnerWithInput = runGhWithInput)
   return JSON.parse(result.stdout || '{}');
 }
 
+
+function loadClassicBranchProtectionContexts(repo, branch = 'main', runner = runGh) {
+  const { owner, name } = splitRepo(repo);
+  const safeBranch = String(branch || 'main').trim();
+  if (!/^[A-Za-z0-9._/-]+$/.test(safeBranch)) {
+    throw new Error(`Unsafe branch pattern: ${branch}`);
+  }
+
+  const result = runner([
+    'api',
+    `repos/${owner}/${name}/branches/${safeBranch}/protection`,
+    '-H',
+    'Accept: application/vnd.github+json',
+  ]);
+
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      present: false,
+      contexts: [],
+      error: formatGhError(result),
+    };
+  }
+
+  try {
+    const payload = JSON.parse(result.stdout || '{}');
+    const contexts = normalizeContexts(payload.required_status_checks?.contexts || []);
+    return {
+      ok: true,
+      present: true,
+      contexts,
+      enforceAdmins: Boolean(payload.enforce_admins?.enabled),
+      requiredConversationResolution: Boolean(payload.required_conversation_resolution?.enabled),
+      requiredLinearHistory: Boolean(payload.required_linear_history?.enabled),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      present: false,
+      contexts: [],
+      error: error.message,
+    };
+  }
+}
+
+/**
+ * High-ROI dual-surface drift: classic branch protection vs repository ruleset.
+ * Both may legitimately layer; required status checks must stay congruent.
+ */
+function compareClassicAndRulesetContexts(classic, rulesetContexts, expectedContexts) {
+  const classicContexts = normalizeContexts(classic?.contexts || []);
+  const ruleset = normalizeContexts(rulesetContexts || []);
+  const expected = normalizeContexts(expectedContexts || []);
+
+  const classicVsRuleset = diffContexts(classicContexts, ruleset);
+  const classicVsExpected = diffContexts(classicContexts, expected);
+  const rulesetVsExpected = diffContexts(ruleset, expected);
+
+  const issues = [];
+  if (classic?.present && classicVsRuleset.missing.length > 0) {
+    issues.push(
+      `classic missing checks present on ruleset: ${classicVsRuleset.missing.join(', ')}`,
+    );
+  }
+  if (classic?.present && classicVsRuleset.unexpected.length > 0) {
+    issues.push(
+      `classic has checks absent from ruleset: ${classicVsRuleset.unexpected.join(', ')}`,
+    );
+  }
+  if (classic?.present && classicVsExpected.missing.length > 0) {
+    issues.push(
+      `classic missing merge-quality checks: ${classicVsExpected.missing.join(', ')}`,
+    );
+  }
+  if (rulesetVsExpected.missing.length > 0) {
+    issues.push(
+      `ruleset missing merge-quality checks: ${rulesetVsExpected.missing.join(', ')}`,
+    );
+  }
+
+  return {
+    ok: issues.length === 0,
+    issues,
+    classicContexts,
+    rulesetContexts: ruleset,
+    expectedContexts: expected,
+    classicVsRuleset,
+    classicPresent: Boolean(classic?.present),
+  };
+}
+
 function syncRepositoryRulesets(options = {}, deps = {}) {
   const runner = deps.runner || runGh;
   const runnerWithInput = deps.runnerWithInput || runGhWithInput;
@@ -493,21 +584,40 @@ function syncRepositoryRulesets(options = {}, deps = {}) {
   }
 
   if (options.check) {
+    const classic = typeof deps.loadClassic === 'function'
+      ? deps.loadClassic(repo, 'main', runner)
+      : loadClassicBranchProtectionContexts(repo, 'main', runner);
+
     if (!detail) {
+      const expected = expectedStatusContexts(policy, mergeQuality);
+      const dual = compareClassicAndRulesetContexts(classic, [], expected);
       return {
         ok: false,
         repo,
         missing: true,
-        issues: ['main governance ruleset is not present'],
-        expectedContexts: expectedStatusContexts(policy, mergeQuality),
+        issues: ['main governance ruleset is not present', ...dual.issues],
+        expectedContexts: expected,
         actualContexts: [],
         bypass: analyzeBypassActors([], policy),
+        classic,
+        dual,
       };
     }
+    const analysis = analyzeRuleset(detail, policy, mergeQuality);
+    const dual = compareClassicAndRulesetContexts(
+      classic,
+      analysis.actualContexts,
+      analysis.expectedContexts,
+    );
+    const issues = [...analysis.issues, ...dual.issues];
     return {
       repo,
       missing: false,
-      ...analyzeRuleset(detail, policy, mergeQuality),
+      ...analysis,
+      ok: issues.length === 0,
+      issues,
+      classic,
+      dual,
     };
   }
 
@@ -566,11 +676,13 @@ module.exports = {
   assertSafeGhArgs,
   buildExpectedRulesetBody,
   buildExpectedRulesPayload,
+  compareClassicAndRulesetContexts,
   diffContexts,
   expectedStatusContexts,
   extractStatusCheckParams,
   extractStatusContexts,
   findMainGovernanceRuleset,
+  loadClassicBranchProtectionContexts,
   loadRulesetDetail,
   loadRulesets,
   normalizeContexts,

--- a/scripts/sync-repository-rulesets.js
+++ b/scripts/sync-repository-rulesets.js
@@ -536,6 +536,16 @@ function compareClassicAndRulesetContexts(classic, rulesetContexts, expectedCont
   const rulesetVsExpected = diffContexts(ruleset, expected);
 
   const issues = [];
+  // Classic branch protection is a required layered surface for ThumbGate.
+  // Fail closed when it cannot be inspected (403/404/malformed), rather than
+  // treating absence as optional success.
+  if (classic && classic.ok === false) {
+    issues.push(
+      `classic branch protection could not be inspected${
+        classic.error ? `: ${classic.error}` : ''
+      }`,
+    );
+  }
   if (classic?.present && classicVsRuleset.missing.length > 0) {
     issues.push(
       `classic missing checks present on ruleset: ${classicVsRuleset.missing.join(', ')}`,
@@ -565,6 +575,7 @@ function compareClassicAndRulesetContexts(classic, rulesetContexts, expectedCont
     expectedContexts: expected,
     classicVsRuleset,
     classicPresent: Boolean(classic?.present),
+    classicInspectOk: classic ? classic.ok !== false : null,
   };
 }
 

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -805,6 +805,7 @@ test('CI workflow supports merge queue and cancels stale non-main runs', () => {
   assert.match(workflow, /cancel-in-progress:\s*\$\{\{\s*github\.ref != 'refs\/heads\/main'\s*\}\}/);
   assert.match(workflow, /name: Check operational integrity[\s\S]*?GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}[\s\S]*?npm run ops:integrity:ci/);
   assert.match(workflow, /name: Check branch protection congruence[\s\S]*?if:\s*github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.user\.login != 'dependabot\[bot\]'[\s\S]*?GH_TOKEN:\s*\$\{\{\s*secrets\.GH_PAT \|\| github\.token\s*\}\}[\s\S]*?npm run branch-protection:check/);
+  assert.match(workflow, /name: Check repository ruleset congruence[\s\S]*?npm run rulesets:check/);
 });
 
 test('CI workflow gives the full suite enough runtime budget', () => {

--- a/tests/gate-templates.test.js
+++ b/tests/gate-templates.test.js
@@ -60,6 +60,11 @@ test('gate template library exposes curated templates with shared rollout metada
   assert.ok(templates.some((template) => template.id === 'gate-qwen-model-studio-egress'));
   assert.ok(templates.some((template) => template.id === 'block-unverified-qwen-gui-actions'));
 
+  // GitHub Ruleset Governance templates
+  assert.ok(templates.some((template) => template.category === 'GitHub Ruleset Governance'));
+  assert.ok(templates.some((template) => template.id === 'github-ruleset-migration-audit'));
+  assert.ok(templates.some((template) => template.id === 'enforce-ruleset-bypass-actor-scoping'));
+
   assert.ok(templates.every((template) => template.category));
   assert.ok(templates.every((template) => template.problem));
   assert.ok(templates.every((template) => template.roi));

--- a/tests/pr-manager.test.js
+++ b/tests/pr-manager.test.js
@@ -17,6 +17,7 @@ const {
   performMerge,
   summarizeChecks,
   waitForMergeCommit,
+  inspectRepositoryRulesets,
 } = require('../scripts/pr-manager');
 
 function createRunner(results) {
@@ -748,4 +749,37 @@ test('resolveBlockers still refuses UNSTABLE when a real check is failing', asyn
   const outcome = await resolveBlockers(pr, runner);
   assert.equal(outcome.status, 'blocked');
   assert.equal(outcome.reason, 'ci_failure');
+});
+
+
+test('inspectRepositoryRulesets returns active rulesets from gh api', () => {
+  const mockRunner = createRunner([
+    {
+      status: 0,
+      stdout: JSON.stringify([
+        { id: 101, name: 'main governance', target: 'branch', enforcement: 'active' },
+        { id: 102, name: 'Tag Protection', target: 'tag', enforcement: 'disabled' },
+      ]),
+      stderr: '',
+    },
+  ]);
+  const result = inspectRepositoryRulesets('IgorGanapolsky/ThumbGate', mockRunner);
+  assert.equal(result.ok, true);
+  assert.equal(result.count, 2);
+  assert.equal(result.activeRulesets.length, 1);
+  assert.equal(result.activeRulesets[0].name, 'main governance');
+});
+
+test('inspectRepositoryRulesets handles API failure gracefully', () => {
+  const mockRunner = createRunner([
+    {
+      status: 1,
+      stdout: '',
+      stderr: '404 Not Found',
+    },
+  ]);
+  const result = inspectRepositoryRulesets('IgorGanapolsky/ThumbGate', mockRunner);
+  assert.equal(result.ok, false);
+  assert.equal(result.count, 0);
+  assert.equal(result.activeRulesets.length, 0);
 });

--- a/tests/sync-repository-rulesets.test.js
+++ b/tests/sync-repository-rulesets.test.js
@@ -624,6 +624,18 @@ test('syncRepositoryRulesets reloads detail when upsert omits rules array', () =
   assert.equal(result.created, true);
 });
 
+test('compareClassicAndRulesetContexts fails closed when classic cannot be inspected', () => {
+  const { compareClassicAndRulesetContexts } = require('../scripts/sync-repository-rulesets');
+  const result = compareClassicAndRulesetContexts(
+    { ok: false, present: false, contexts: [], error: 'HTTP 403' },
+    ['test', 'CodeQL'],
+    ['test', 'CodeQL'],
+  );
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some((issue) => /could not be inspected/i.test(issue)));
+  assert.equal(result.classicInspectOk, false);
+});
+
 test('compareClassicAndRulesetContexts detects dual-surface status check drift', () => {
   const { compareClassicAndRulesetContexts } = require('../scripts/sync-repository-rulesets');
   const classic = {

--- a/tests/sync-repository-rulesets.test.js
+++ b/tests/sync-repository-rulesets.test.js
@@ -194,7 +194,12 @@ test('syncRepositoryRulesets --check reports missing main ruleset', () => {
 
   const result = syncRepositoryRulesets(
     { check: true, repo: 'IgorGanapolsky/ThumbGate' },
-    { runner, policy: POLICY, mergeQuality: MERGE_QUALITY },
+    {
+      runner,
+      policy: POLICY,
+      mergeQuality: MERGE_QUALITY,
+      loadClassic: () => ({ present: false, contexts: [] }),
+    },
   );
 
   assert.equal(result.ok, false);
@@ -223,7 +228,15 @@ test('syncRepositoryRulesets --check is ok when live ruleset matches policy', ()
 
   const result = syncRepositoryRulesets(
     { check: true, repo: 'IgorGanapolsky/ThumbGate' },
-    { runner, policy: POLICY, mergeQuality: MERGE_QUALITY },
+    {
+      runner,
+      policy: POLICY,
+      mergeQuality: MERGE_QUALITY,
+      loadClassic: () => ({
+        present: true,
+        contexts: MERGE_QUALITY.requiredStatusCheckContexts,
+      }),
+    },
   );
 
   assert.equal(result.ok, true);
@@ -313,7 +326,12 @@ test('runCli exits nonzero on ruleset drift', () => {
     ]);
     const exitCode = runCli(
       ['--check', '--repo', 'IgorGanapolsky/ThumbGate'],
-      { runner, policy: POLICY, mergeQuality: MERGE_QUALITY },
+      {
+        runner,
+        policy: POLICY,
+        mergeQuality: MERGE_QUALITY,
+        loadClassic: () => ({ present: false, contexts: [] }),
+      },
     );
     assert.equal(exitCode, 1);
   } finally {
@@ -551,16 +569,31 @@ test('runCli prints ok and json outputs', () => {
       },
     ]);
 
+    const matchingClassic = () => ({
+      present: true,
+      contexts: MERGE_QUALITY.requiredStatusCheckContexts,
+    });
+
     const checkCode = runCli(
       ['--check', '--json', '--repo', 'IgorGanapolsky/ThumbGate'],
-      { runner, policy: POLICY, mergeQuality: MERGE_QUALITY },
+      {
+        runner,
+        policy: POLICY,
+        mergeQuality: MERGE_QUALITY,
+        loadClassic: matchingClassic,
+      },
     );
     assert.equal(checkCode, 0);
     assert.match(output.join('\n'), /"ok": true/);
 
     const textCode = runCli(
       ['--check', '--repo', 'IgorGanapolsky/ThumbGate'],
-      { runner, policy: POLICY, mergeQuality: MERGE_QUALITY },
+      {
+        runner,
+        policy: POLICY,
+        mergeQuality: MERGE_QUALITY,
+        loadClassic: matchingClassic,
+      },
     );
     assert.equal(textCode, 0);
     assert.match(output.join('\n'), /Repository ruleset ok/);
@@ -589,4 +622,86 @@ test('syncRepositoryRulesets reloads detail when upsert omits rules array', () =
   assert.equal(result.ok, true);
   assert.equal(result.rulesetId, 88);
   assert.equal(result.created, true);
+});
+
+test('compareClassicAndRulesetContexts detects dual-surface status check drift', () => {
+  const { compareClassicAndRulesetContexts } = require('../scripts/sync-repository-rulesets');
+  const classic = {
+    present: true,
+    contexts: ['test', 'CodeQL'],
+  };
+  const ruleset = ['test', 'CodeQL', 'Verify changeset'];
+  const expected = ['test', 'CodeQL', 'Verify changeset', 'GitGuardian Security Checks'];
+  const result = compareClassicAndRulesetContexts(classic, ruleset, expected);
+  assert.equal(result.ok, false);
+  assert.ok(result.issues.some((issue) => issue.includes('classic missing checks present on ruleset')));
+  assert.ok(result.issues.some((issue) => issue.includes('merge-quality')));
+});
+
+test('compareClassicAndRulesetContexts is ok when classic and ruleset match merge-quality', () => {
+  const { compareClassicAndRulesetContexts } = require('../scripts/sync-repository-rulesets');
+  const contexts = [
+    'Analyze JavaScript (javascript-typescript)',
+    'CodeQL',
+    'GitGuardian Security Checks',
+    'Socket Security: Project Report',
+    'Socket Security: Pull Request Alerts',
+    'Verify changeset',
+    'test',
+  ];
+  const result = compareClassicAndRulesetContexts(
+    { present: true, contexts },
+    contexts,
+    contexts,
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.issues, []);
+});
+
+test('syncRepositoryRulesets --check folds classic/ruleset dual drift into issues', () => {
+  const detail = {
+    id: 42,
+    name: 'main governance',
+    target: 'branch',
+    enforcement: 'active',
+    bypass_actors: [],
+    conditions: { ref_name: { include: ['refs/heads/main'] } },
+    rules: [
+      { type: 'required_linear_history' },
+      { type: 'deletion' },
+      { type: 'non_fast_forward' },
+      {
+        type: 'pull_request',
+        parameters: {
+          required_approving_review_count: 0,
+          required_review_thread_resolution: true,
+        },
+      },
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: MERGE_QUALITY.requiredStatusCheckContexts.map((context) => ({ context })),
+        },
+      },
+    ],
+  };
+
+  const runner = createRunner([
+    { status: 0, stdout: JSON.stringify([{ id: 42, name: 'main governance', target: 'branch' }]), stderr: '' },
+    { status: 0, stdout: JSON.stringify(detail), stderr: '' },
+  ]);
+
+  const loadClassic = () => ({
+    present: true,
+    contexts: ['test', 'CodeQL'],
+  });
+
+  const result = syncRepositoryRulesets(
+    { check: true, repo: 'IgorGanapolsky/ThumbGate' },
+    { runner, policy: POLICY, mergeQuality: MERGE_QUALITY, loadClassic },
+  );
+  assert.equal(result.ok, false);
+  assert.ok(result.dual);
+  assert.equal(result.dual.classicPresent, true);
+  assert.ok(result.issues.some((issue) => /classic/i.test(issue)));
 });


### PR DESCRIPTION
## Summary
High-ROI follow-through on GitHub’s branch-protection → rulesets migration:

1. **`scripts/sync-repository-rulesets.js`** (from #3396 lineage) — sync/check `main governance` with **zero `bypass_actors`**, merge-quality required checks, plus **dual classic vs ruleset status-check congruence**.
2. **CI** — non-blocking `npm run rulesets:check` alongside classic `branch-protection:check`.
3. **`pr-manager`** — read-only repository ruleset inventory during live diagnosis (never mutates bypass/protection).
4. **Gate templates** — `github-ruleset-migration-audit` + `enforce-ruleset-bypass-actor-scoping`.
5. **Package boundary** — repo-ops policy JSON excluded from npm pack (keeps ceiling at 440).

Supersedes the incomplete slices in #3395 / #3396 once green (this PR includes their useful bits + dual congruence + CI).

## Verification
- `node --test tests/sync-repository-rulesets.test.js tests/pr-manager.test.js tests/gate-templates.test.js tests/never-bypass-branch-protection.test.js` → **pass**
- `npm run test:operational-integrity` → **pass**
- `node --test tests/package-boundary.test.js tests/public-bundle-ratchet.test.js` → **pass**
- Live: `npm run rulesets:check` → **`Repository ruleset ok: IgorGanapolsky/ThumbGate`**

## Policy
- Does **not** approve PRs or add bypass actors
- `rulesets:sync` is available for operators; CI only **checks** (continue-on-error)

Authority evidence: [VERIFICATION_EVIDENCE.md](https://github.com/IgorGanapolsky/ThumbGate/blob/main/VERIFICATION_EVIDENCE.md)