### PR TITLE
docs(sales): ThumbGate platform partner API spec, cost sheet, and public page

### DIFF
--- a/docs/sales/platform-partner-cost-sheet.md
+++ b/docs/sales/platform-partner-cost-sheet.md
@@ -1,0 +1,49 @@
+# ThumbGate — Partner Cost Sheet
+
+**For:** Shreyans Bhansali / Assistiv AI / MakersClaw platform listing  
+**Date:** 2026-08-13  
+**Currency:** USD
+
+## Billable units
+
+| Unit | Rate | Trigger |
+|------|------|---------|
+| Policy evaluation (`eval`) | **$0.001** | Each allow / warn / block decision |
+| Human escalation | **$0.010** | Escalation created |
+| Rule promotion | **$0.005** | Failure → durable prevention rule |
+| Execution receipt | **$0.001** | Idempotent audit receipt written |
+
+Enterprise eval overage after included volume: **$0.0008**
+
+## Tiers (monthly minimum = floor; included volume is creditable)
+
+| Tier | Minimum | Included evals | Overage |
+|------|---------|----------------|---------|
+| Starter | **$99** | 100,000 | $0.001 |
+| Team | **$499** | 500,000 | $0.001 |
+| Enterprise | **$2,499** | 3,000,000 | $0.0008 |
+
+## Worked examples (Team $499)
+
+| Monthly evals | Raw usage | Billed |
+|---------------|-----------|--------|
+| 50,000 | $50 | **$499** (floor) |
+| 400,000 | $400 | **$499** (floor) |
+| 700,000 | $700 | **$700** |
+
+## Direct retail (not the platform tier)
+
+- Pro self-serve: **$19/mo** or **$149/yr**
+- Sprint diagnostic: **$499** one-time
+
+## API status (one line)
+
+**Core evaluate / feedback / escalations / receipts APIs are LIVE** at `https://thumbgate.ai` with public OpenAPI.
+
+Partner overage invoicing is **soft-launch**: minimums sell now; overage is waived until rating productizes (~2 weeks).
+
+## Settlement
+
+Platform share: **open — match your standard.**
+
+First clients: manual API key provision by ThumbGate.

--- a/docs/sales/platform-partner-spec.md
+++ b/docs/sales/platform-partner-spec.md
@@ -1,0 +1,280 @@
+# ThumbGate — Partner API & Usage Pricing Spec
+
+**Prepared for:** Shreyans Bhansali (Assistiv AI / MakersClaw)
+**Prepared by:** Igor Ganapolsky — igor@igorganapolsky.com
+**Date:** 2026-08-13
+**Product:** ThumbGate — infrastructure firewall for AI coding agents
+**Primary hosts:**
+- App / billing base: `https://thumbgate.ai`
+- Railway production API: `https://thumbgate-production.up.railway.app`
+**Live version checked:** `1.35.0` (`buildSha: 40b1e1840079a09be7649c7d7fefd4dca230b948`)
+- `GET /health` returns `status: "ok"`
+**OpenAPI (public, no auth):**
+- `https://thumbgate.ai/openapi.json`
+- `https://thumbgate-production.up.railway.app/openapi.json`
+- OpenAPI version: `1.2.0`, 50 documented paths
+
+## 0. How to read this document
+
+| Marker | Meaning |
+|--------|---------|
+| **LIVE + OPENAPI** | Route exists in production source and is in the public OpenAPI catalog. |
+| **LIVE (source)** | Route exists in `src/api/server.js` and is deployed; not yet in OpenAPI. |
+| **PARTIAL** | Exists, but incomplete for marketplace-grade metering or self-serve. |
+| **NOT BUILT** | Do not integrate; estimate given. |
+
+Auth note: almost all `/v1/*` routes require `Authorization: Bearer <key>`.
+Unauthenticated probes return **401 for both real and unknown paths**, so 401 does **not** prove an endpoint is missing.
+
+Truth sources used here: live `/health` + live `/openapi.json` + production source.
+
+## 1. What ThumbGate is (one paragraph for listing copy)
+
+ThumbGate is a **pre-action governance layer** for autonomous AI coding agents. Before an agent executes a tool call, ThumbGate evaluates it against policy, blocks or escalates risky actions, records an audit trail, and learns from feedback to generate prevention rules. It is **not** a chatbot wrapper. Value is **interdiction + audit + learning loop** on agent tool calls.
+
+## 2. Are the API points deployed? (short answer)
+
+**Yes — core governance and learning APIs are live in production.**
+
+| Surface | Status | Proof |
+|---------|--------|-------|
+| Production API host | **LIVE** | `GET /health` → `status: "ok"`, version `1.35.0` |
+| Public OpenAPI | **LIVE** | `GET /openapi.json` → HTTP 200 on apex + Railway |
+| Auth'd API (`/v1/*`) | **LIVE** | HTTP 401 without key; routes defined in server source |
+| Synchronous evaluate over REST | **LIVE + OPENAPI** | `POST /v1/decisions/evaluate` |
+| Feedback / lessons / DPO | **LIVE + OPENAPI** | capture, stats, summary, rules, search, dpo/export |
+| Escalations + task receipts | **LIVE + OPENAPI** | `/v1/escalations`, `/v1/task-outcomes*` |
+| Gate configuration API | **LIVE (source)** | `/v1/gates/*` implemented; missing from OpenAPI |
+| Checkout (retail Pro) | **LIVE + OPENAPI** | `POST /v1/billing/checkout` |
+| Usage counter for key | **PARTIAL** | `GET /v1/billing/usage` returns `usageCount` only |
+| Partner-grade metered invoice true-up | **PARTIAL / NOT complete** | local metered ledger exists; automated rating pending |
+| Self-serve multi-tenant key portal for partners | **PARTIAL** | admin provision exists; partner portal not built |
+
+**Honest product gap for a pure marketplace listing:** OpenAPI is incomplete for gates; key issuance for partner clients is still mostly manual provisioning. You can still list and sell **today** with: monthly minimum + included units + manual onboarding for the first clients.
+
+## 3. Authentication
+
+```http
+Authorization: Bearer <thumbgate-api-key>
+```
+
+- Keys are provisioned after paid checkout or via admin provision (`POST /v1/billing/provision`).
+- Partner onboarding for first enterprise clients: ThumbGate provisions a dedicated key per end-customer manually.
+
+Unauthenticated health:
+
+```http
+GET /health
+```
+
+```json
+{
+  "status": "ok",
+  "degraded": false,
+  "version": "1.35.0",
+  "deployment": {
+    "appOrigin": "https://thumbgate.ai",
+    "billingApiBaseUrl": "https://thumbgate.ai"
+  }
+}
+```
+
+## 4. Integration surface (what to wire first)
+
+### 4.1 Primary path for a hosted agent platform
+
+1. **Evaluate** each sensitive tool-call: `POST /v1/decisions/evaluate`
+   - Body supports `toolName`, tool-call payloads (`toolCall` / `providerToolCall` / MCP shapes), and context.
+2. **Escalate** when human approval is required: `POST /v1/escalations`
+   - Decision via `POST /v1/escalations/{id}/decision`
+3. **Record outcomes** for audit: `POST /v1/task-outcomes` (idempotent)
+4. **Learn from failures**:
+   - `POST /v1/feedback/capture` → `POST /v1/feedback/rules`
+   - Search via `GET /v1/lessons/search`
+5. **Configure policy scope** (LIVE in source; add to OpenAPI next):
+   - `POST /v1/gates/task-scope`, constraints, branch governance, protected approval
+
+### 4.2 LIVE + OPENAPI endpoints (integrate against these now)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/health` / `/healthz` | Liveness |
+| POST | `/v1/decisions/evaluate` | Synchronous allow/deny-style evaluation |
+| POST | `/v1/decisions/outcome` | Record decision outcome |
+| GET | `/v1/decisions/metrics` | Decision metrics |
+| POST | `/v1/feedback/capture` | Capture thumbs / failure signals |
+| GET | `/v1/feedback/stats` | Counters |
+| GET | `/v1/feedback/summary` | Summary / rules view |
+| POST | `/v1/feedback/rules` | Regenerate prevention rules |
+| GET | `/v1/lessons/search` | Search lessons |
+| GET, POST | `/v1/search` | General search |
+| POST | `/v1/dpo/export` | Export DPO pairs |
+| POST, GET | `/v1/escalations` | Human-in-the-loop |
+| POST | `/v1/escalations/{escalationId}/decision` | Resolve escalation |
+| POST, GET | `/v1/task-outcomes` | Idempotent execution receipts |
+| GET | `/v1/task-outcomes/metrics` | Receipt aggregates |
+| GET | `/v1/task-outcomes/monitor` | Monitoring view |
+| POST | `/v1/billing/checkout` | Stripe checkout session (retail path) |
+| GET | `/v1/billing/usage` | Per-key usage counter |
+| GET | `/v1/billing/summary` | Admin business summary |
+| POST | `/v1/billing/provision` | Admin key provision |
+| POST | `/v1/jobs/harness` | Hosted harness launch |
+
+Full machine catalog: `https://thumbgate.ai/openapi.json`
+
+### 4.3 LIVE (source) but not in OpenAPI yet
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST/GET | `/v1/gates/constraint(s)` | Policy constraints |
+| POST/GET | `/v1/gates/task-scope` | Allowed path scope |
+| POST/GET | `/v1/gates/branch-governance` | Branch rules |
+| POST | `/v1/gates/protected-approval` | Protected-path approval |
+| POST | `/v1/gates/satisfy` | Satisfy gate with evidence |
+| GET | `/v1/gates/stats` | Enforcement stats |
+| POST | `/v1/lessons/export` | Lesson export |
+
+These are safe for a **guided pilot** with our support; do not treat OpenAPI codegen alone as complete.
+
+## 5. Cost system for platform listing (pay-per-usage + floor)
+
+See `platform-partner-cost-sheet.md` for the one-page version.
+
+### 5.1 Design principle
+
+- **Billable unit** = one **policy evaluation** (`POST /v1/decisions/evaluate` or equivalent inline SDK call).
+- **Premium units** (separately metered or included as multipliers): human escalations, rule promotions, execution receipts.
+- **Monthly minimum** (floor) so small accounts remain supportable; included volume is **creditable** against the floor.
+
+### 5.2 Unit catalog (partner list price)
+
+Currency: **USD**. Platform revenue share open (match MakersClaw standard).
+
+| Unit code | What counts | List rate | Notes |
+|-----------|-------------|-----------|-------|
+| `eval` | One policy evaluation decision | **$0.001** | Default billable unit |
+| `escalation` | Human escalation created | **$0.010** | Includes decision workflow |
+| `rule_promotion` | Failure promoted into durable rule | **$0.005** | Learning loop |
+| `receipt` | Idempotent execution receipt written | **$0.001** | Compliance surface |
+
+**Volume discount on `eval` (Enterprise tier only):** **$0.0008** after included volume.
+
+### 5.3 Tiers (monthly, paid in advance)
+
+| Tier | Monthly minimum | Included evals | Overage | Intended buyer |
+|------|-----------------|----------------|---------|----------------|
+| **Starter** | **$99** | 100,000 | $0.001 / eval | Pilot team, 1 workspace |
+| **Team** | **$499** | 500,000 | $0.001 / eval | Multi-agent / multi-seat team |
+| **Enterprise** | **$2,499** | 3,000,000 | $0.0008 / eval | Fleet / compliance / custom policy |
+
+**Creditable minimum example (Team):**
+- 400k evals → raw $400 → billed **$499** (floor), not $499 + $400.
+- 700k evals → raw $700 → billed **$700**.
+
+Also included by tier (non-unit):
+- Starter: LIVE API access, 1 workspace, community / email support.
+- Team: dedicated key, hosted state, email support, 99.5% target availability.
+- Enterprise: custom policy authoring support, priority support, DPO export, optional self-hosting discussion.
+
+### 5.4 Retail (direct) vs partner listing
+
+| Channel | Offer | Status |
+|---------|-------|--------|
+| Direct self-serve | ThumbGate Pro **$19/mo** or **$149/yr** | LIVE checkout |
+| Direct services | Sprint / diagnostic **$499** one-time | LIVE product SKU |
+| **Partner platform listing** | Starter / Team / Enterprise above | **Ready to sell as minimums + manual onboarding** |
+
+Do **not** list pure $0 free unlimited hosted governance — support cost is real.
+
+### 5.5 Metering reality (important honesty)
+
+| Capability | Status |
+|------------|--------|
+| API key usage counter (`GET /v1/billing/usage` → `usageCount`) | LIVE |
+| Local blocked-event metered ledger (`scripts/metered-billing.js`) | LIVE (used for Pro self-serve) |
+| Partner-facing usage statement by unit code (`eval`, `escalation`, …) | **NOT complete** |
+| Automated overage invoice true-up | **~2 weeks** to productize cleanly |
+
+**Launch commercial rule:** sign clients on **monthly minimum + included volume** immediately. Any overage before rating lands is **waived once** (goodwill), not reconstructed from incomplete telemetry.
+
+### 5.6 Platform share / settlement
+
+Open — prefer **your standard MakersClaw / Assistiv marketplace share**.
+ThumbGate invoices end-customer **or** platform wholesale (your choice):
+
+| Model | How money moves |
+|-------|-----------------|
+| **A. Platform collects** | Platform bills end-customer; remits ThumbGate net after share. |
+| **B. ThumbGate collects** | Checkout / subscription on thumbgate.ai; platform invoices referral fee. |
+| **C. Wholesale seat** | Platform buys Enterprise at negotiated wholesale; resells. |
+
+Default recommendation for first 3 clients: **Model B or C** (simplest ops while metering finishes).
+
+## 6. Sample partner listing copy (short)
+
+**Title:** ThumbGate — Agent Tool-Call Firewall & Audit
+**Category:** AI agent governance / security / compliance
+**Pricing:** Usage-based from $99/mo (100k evaluations included)
+**API:** REST + OpenAPI — `https://thumbgate.ai/openapi.json`
+**Auth:** Bearer API key
+**Primary call:** `POST /v1/decisions/evaluate`
+**Also:** human escalations, execution receipts, feedback → prevention rules
+
+## 7. Minimal integration sketch
+
+```javascript
+const BASE = 'https://thumbgate.ai'; // or railway host
+const res = await fetch(`${BASE}/v1/decisions/evaluate`, {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${process.env.THUMBGATE_API_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    toolName: 'Bash',
+    source: 'partner_platform',
+    toolCall: { command: 'rm -rf ./dist' },
+  }),
+});
+const decision = await res.json();
+// enforce decision before executing the tool
+```
+
+```bash
+# health (no auth)
+curl -sS https://thumbgate.ai/health
+
+# openapi (no auth)
+curl -sS https://thumbgate.ai/openapi.json | head
+
+# usage (needs key)
+curl -sS https://thumbgate.ai/v1/billing/usage \
+  -H "Authorization: Bearer $THUMBGATE_API_KEY"
+```
+
+## 8. What is NOT ready for a self-serve mega-listing
+
+| Gap | Impact | Estimate |
+|-----|--------|----------|
+| Gates routes missing from OpenAPI | Codegen clients miss policy config | ~2–4 hours |
+| Partner usage statement by unit | Cannot auto-invoice overages cleanly | ~2 weeks |
+| Self-serve multi-tenant partner portal | Manual key provision | ~3–5 days |
+| Signed SLA + DPA package for enterprise | Legal, not engineering | concurrent |
+
+None of these block a **curated enterprise listing** with manual onboarding.
+
+## 9. What I need from you to list
+
+1. Preferred settlement model (A / B / C above).
+2. Your standard platform share %.
+3. Listing fields required by MakersClaw (logo, categories, screenshots).
+4. Whether first clients are **pilot** (manual keys) or must be **self-serve day one**.
+
+I will provision sandbox keys for one Assistiv / MakersClaw test workspace on request.
+
+---
+
+**Igor Ganapolsky**
+igor@igorganapolsky.com • https://igorganapolsky.com • https://thumbgate.ai
+
+*Corrections welcome. Prefer an accurate listing over an impressive one.*

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "public/lessons.html",
     "public/numbers.html",
     "public/partner-intake.html",
+    "public/platform-partners.html",
     "public/peter.html",
     "public/pricing.html",
     "public/privacy.html",

--- a/public/platform-partners.html
+++ b/public/platform-partners.html
@@ -1,0 +1,204 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ThumbGate for Platforms — Enterprise API & Usage Pricing</title>
+  <meta name="description" content="List ThumbGate on your platform: usage-based agent governance from $99/mo, REST + OpenAPI, live at thumbgate.ai.">
+  <link rel="canonical" href="__APP_ORIGIN__/platform-partners">
+  <link rel="alternate" type="text/markdown" title="ThumbGate LLM context" href="__APP_ORIGIN__/llm-context.md">
+  <meta property="og:title" content="ThumbGate for Platforms — Enterprise API & Usage Pricing">
+  <meta property="og:description" content="Usage-based agent governance: $99/mo Starter, $499/mo Team, $2,499/mo Enterprise. REST + OpenAPI.">
+  <meta property="og:url" content="__APP_ORIGIN__/platform-partners">
+  <meta property="og:type" content="product">
+  <style>
+    :root { --ink:#171d1a; --muted:#5b6761; --paper:#f5f2e9; --card:#fffdf8; --line:#d8d4c8; --green:#006e52; --green2:#004c3a; }
+    * { box-sizing:border-box; }
+    body { margin:0; color:var(--ink); background:var(--paper); font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; line-height:1.55; }
+    a { color:inherit; }
+    .shell { width:min(1040px,calc(100% - 40px)); margin:0 auto; }
+    nav { border-bottom:1px solid var(--line); background:rgba(245,242,233,.95); }
+    .nav-inner { min-height:70px; display:flex; align-items:center; justify-content:space-between; gap:24px; }
+    .brand { text-decoration:none; font-weight:850; letter-spacing:-.03em; font-size:1.25rem; }
+    .nav-links { display:flex; align-items:center; gap:18px; color:var(--muted); font-size:.92rem; }
+    .button { display:inline-flex; justify-content:center; align-items:center; border:0; border-radius:10px; background:var(--green); color:#fff; padding:12px 18px; font:inherit; font-weight:800; text-decoration:none; cursor:pointer; }
+    .button:hover { background:var(--green2); }
+    main { padding:64px 0 84px; }
+    .eyebrow { color:var(--green); font-size:.76rem; font-weight:850; letter-spacing:.14em; text-transform:uppercase; }
+    h1 { max-width:760px; margin:14px 0 18px; font-size:clamp(2.4rem,5.5vw,4.2rem); line-height:.98; letter-spacing:-.045em; }
+    .lede { max-width:680px; margin:0 0 28px; color:var(--muted); font-size:1.13rem; }
+    section { padding-top:64px; }
+    h2 { margin:0 0 14px; font-size:clamp(1.7rem,3.2vw,2.4rem); letter-spacing:-.035em; }
+    .section-lede { max-width:680px; color:var(--muted); }
+    .cards { display:grid; grid-template-columns:repeat(3,1fr); gap:18px; margin-top:28px; }
+    .card { border:1px solid var(--line); border-radius:18px; background:var(--card); box-shadow:0 18px 50px rgba(38,45,41,.09); padding:26px; }
+    .card h3 { margin:8px 0 6px; font-size:1.25rem; }
+    .card .price { margin:8px 0 4px; font-size:2.6rem; line-height:1; font-weight:900; letter-spacing:-.04em; color:var(--green); }
+    .card .price-note { margin:0 0 16px; color:var(--muted); font-size:.92rem; }
+    .card ul { margin:0; padding-left:18px; color:var(--muted); font-size:.92rem; }
+    .card li { margin-bottom:6px; }
+    .card.recommended { border:2px solid var(--green); }
+    table { width:100%; border-collapse:collapse; margin-top:18px; background:var(--card); border:1px solid var(--line); border-radius:14px; overflow:hidden; }
+    th, td { padding:12px 14px; text-align:left; border-bottom:1px solid var(--line); font-size:.92rem; }
+    th { background:#e9f3ee; color:var(--green2); font-weight:800; }
+    td { color:var(--ink); }
+    code { background:#e9e6dd; padding:2px 5px; border-radius:4px; font-size:.88em; }
+    .integration { background:var(--card); border:1px solid var(--line); border-radius:14px; padding:22px; margin-top:22px; }
+    pre { background:#0f1512; color:#e6f0e9; padding:18px; border-radius:12px; overflow:auto; font-size:.86rem; }
+    .cta-row { display:flex; gap:14px; flex-wrap:wrap; margin-top:28px; }
+    .secondary { background:transparent; color:var(--green); border:1px solid var(--green); }
+    .secondary:hover { background:#e9f3ee; }
+    footer { border-top:1px solid var(--line); padding:28px 0; color:var(--muted); font-size:.85rem; margin-top:64px; }
+    @media (max-width:860px) { .cards { grid-template-columns:1fr; } }
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareApplication",
+        "name": "ThumbGate Platform API",
+        "applicationCategory": "DeveloperApplication",
+        "description": "Pre-action governance layer for AI coding agents: policy evaluation, human escalation, feedback loops, and audit receipts.",
+        "offers": [
+          { "@type": "Offer", "name": "Starter", "price": "99", "priceCurrency": "USD", "billingIncrement": "month", "url": "__APP_ORIGIN__/platform-partners" },
+          { "@type": "Offer", "name": "Team", "price": "499", "priceCurrency": "USD", "billingIncrement": "month", "url": "__APP_ORIGIN__/platform-partners" },
+          { "@type": "Offer", "name": "Enterprise", "price": "2499", "priceCurrency": "USD", "billingIncrement": "month", "url": "__APP_ORIGIN__/platform-partners" }
+        ],
+        "provider": { "@type": "Organization", "name": "ThumbGate", "url": "__APP_ORIGIN__/" }
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          { "@type": "Question", "name": "What is the billable unit?", "acceptedAnswer": { "@type": "Answer", "text": "One policy evaluation (POST /v1/decisions/evaluate). Human escalations, rule promotions, and execution receipts are separately metered premium units." } },
+          { "@type": "Question", "name": "Can the platform resell ThumbGate?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. ThumbGate can invoice the end-customer, the platform can collect and remit, or the platform can buy wholesale. Revenue share is open to match the platform's standard." } },
+          { "@type": "Question", "name": "Is the API already deployed?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Core evaluate, feedback, escalation, and task-outcome APIs are live at https://thumbgate.ai with public OpenAPI at /openapi.json." } }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav>
+    <div class="shell nav-inner">
+      <a class="brand" href="/">ThumbGate</a>
+      <div class="nav-links">
+        <a href="/pricing">Pricing</a>
+        <a href="/partner-intake">Partner intake</a>
+        <a class="button" href="mailto:igor@igorganapolsky.com?subject=ThumbGate platform listing">List ThumbGate</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="shell">
+    <div class="eyebrow">For platforms, agencies, and marketplaces</div>
+    <h1>List ThumbGate where your enterprise clients buy AI infrastructure.</h1>
+    <p class="lede">Usage-based agent governance with a live REST + OpenAPI surface. Billable unit is one policy evaluation. Manual onboarding for the first enterprise pilots; self-serve portal follows.</p>
+
+    <section>
+      <div class="eyebrow">Live API status</div>
+      <h2>Production endpoints are deployed now.</h2>
+      <p class="section-lede">Verified 2026-08-13: <code>GET /health</code> returns <code>status: "ok"</code>, version <code>1.35.0</code>, build <code>40b1e184</code>. Public OpenAPI has 50 paths at <code>/openapi.json</code>.</p>
+      <table>
+        <tr><th>Surface</th><th>Status</th><th>Proof</th></tr>
+        <tr><td>Production API host</td><td><strong>LIVE</strong></td><td><code>GET /health</code> → 200 OK</td></tr>
+        <tr><td>Public OpenAPI</td><td><strong>LIVE</strong></td><td><code>GET /openapi.json</code> → 50 paths</td></tr>
+        <tr><td>Auth'd <code>/v1/*</code></td><td><strong>LIVE</strong></td><td>401 without key (gate present)</td></tr>
+        <tr><td>Synchronous evaluate</td><td><strong>LIVE + OPENAPI</strong></td><td><code>POST /v1/decisions/evaluate</code></td></tr>
+        <tr><td>Feedback / lessons / DPO</td><td><strong>LIVE + OPENAPI</strong></td><td>capture, stats, rules, search, dpo/export</td></tr>
+        <tr><td>Escalations + receipts</td><td><strong>LIVE + OPENAPI</strong></td><td><code>/v1/escalations</code>, <code>/v1/task-outcomes</code></td></tr>
+        <tr><td>Gate configuration</td><td><strong>LIVE (source)</strong></td><td><code>/v1/gates/*</code>; not yet in OpenAPI</td></tr>
+        <tr><td>Partner usage statement by unit</td><td><strong>PARTIAL</strong></td><td>~2 weeks to productize cleanly</td></tr>
+      </table>
+    </section>
+
+    <section>
+      <div class="eyebrow">Pricing</div>
+      <h2>Monthly minimum + included volume. Overage is creditable.</h2>
+      <div class="cards">
+        <article class="card">
+          <div class="eyebrow">Pilot</div>
+          <h3>Starter</h3>
+          <div class="price">$99<span style="font-size:1rem;font-weight:700">/mo</span></div>
+          <p class="price-note">100,000 evals included · $0.001 overage</p>
+          <ul>
+            <li>LIVE API access</li>
+            <li>1 workspace</li>
+            <li>Community / email support</li>
+          </ul>
+        </article>
+        <article class="card recommended">
+          <div class="eyebrow">Multi-agent teams</div>
+          <h3>Team</h3>
+          <div class="price">$499<span style="font-size:1rem;font-weight:700">/mo</span></div>
+          <p class="price-note">500,000 evals included · $0.001 overage</p>
+          <ul>
+            <li>Dedicated key</li>
+            <li>Hosted state + dashboard</li>
+            <li>Email support</li>
+            <li>99.5% availability target</li>
+          </ul>
+        </article>
+        <article class="card">
+          <div class="eyebrow">Fleet / compliance</div>
+          <h3>Enterprise</h3>
+          <div class="price">$2,499<span style="font-size:1rem;font-weight:700">/mo</span></div>
+          <p class="price-note">3,000,000 evals included · $0.0008 overage</p>
+          <ul>
+            <li>Custom policy authoring support</li>
+            <li>Priority support</li>
+            <li>DPO export</li>
+            <li>Optional self-hosting discussion</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <div class="eyebrow">Billable units</div>
+      <h2>Countable units, not vibes.</h2>
+      <table>
+        <tr><th>Unit code</th><th>What counts</th><th>List rate</th></tr>
+        <tr><td><code>eval</code></td><td>One policy evaluation decision</td><td><strong>$0.001</strong></td></tr>
+        <tr><td><code>escalation</code></td><td>Human escalation created</td><td><strong>$0.010</strong></td></tr>
+        <tr><td><code>rule_promotion</code></td><td>Failure promoted into durable rule</td><td><strong>$0.005</strong></td></tr>
+        <tr><td><code>receipt</code></td><td>Idempotent execution receipt written</td><td><strong>$0.001</strong></td></tr>
+      </table>
+    </section>
+
+    <section>
+      <div class="eyebrow">Integration</div>
+      <h2>Primary call: evaluate before the agent acts.</h2>
+      <div class="integration">
+        <pre><code>POST /v1/decisions/evaluate
+Authorization: Bearer &lt;thumbgate-api-key&gt;
+Content-Type: application/json
+
+{
+  "toolName": "Bash",
+  "source": "partner_platform",
+  "toolCall": { "command": "rm -rf ./dist" }
+}</code></pre>
+        <p class="section-lede">Then escalate, capture feedback, and write idempotent task receipts. Full catalog at <a href="__APP_ORIGIN__/openapi.json">__APP_ORIGIN__/openapi.json</a>.</p>
+      </div>
+    </section>
+
+    <section>
+      <div class="eyebrow">Next step</div>
+      <h2>Send the listing details and I will provision a sandbox key.</h2>
+      <p class="section-lede">What I need: preferred settlement model (platform collects / ThumbGate collects / wholesale), your standard platform share, required listing fields, and whether first clients are pilot or self-serve.</p>
+      <div class="cta-row">
+        <a class="button" href="mailto:igor@igorganapolsky.com?subject=ThumbGate platform listing">Email Igor</a>
+        <a class="button secondary" href="/partner-intake">Submit workflow intake</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell">
+      ThumbGate — infrastructure firewall for AI coding agents. Spec and cost sheet live in the repo at <code>docs/sales/</code>.
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What
Publishes the partner-facing API + usage-pricing package for platform listings (Assistiv / MakersClaw).

## Added
- docs/sales/platform-partner-spec.md — full spec: live API surface, integration path, units, tiers, settlement models, listing copy, gaps.
- docs/sales/platform-partner-cost-sheet.md — one-page cost reference.
- public/platform-partners.html — SEO/GEO-visible partner landing page.

## Verified
- GET https://thumbgate.ai/health → 200, version 1.35.0, buildSha 40b1e1840079a09be7649c7d7fefd4dca230b948.
- GET https://thumbgate.ai/openapi.json → 50 paths, OpenAPI 1.2.0.
- Auth gates return 401 on /v1/decisions/evaluate and /v1/billing/usage without key.

## Commercial rule
First enterprise clients sign on monthly minimum + included volume; overage invoicing is soft-launch (~2 weeks) and waived until rating is productized.

Closes nothing — this is a publishing / sales-enablement PR.