### PR TITLE
docs(sales): ThumbGate platform partner spec, cost sheet, and public page

### DIFF
--- a/.changeset/platform-partner-spec.md
+++ b/.changeset/platform-partner-spec.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+docs(sales): add ThumbGate platform partner API spec, cost sheet, and public page

--- a/docs/sales/thumbgate-platform-cost-sheet.md
+++ b/docs/sales/thumbgate-platform-cost-sheet.md
@@ -1,0 +1,44 @@
+# ThumbGate.ai — Platform Partner Cost Sheet
+
+**For:** Shreyans Bhansali / MakersClaw  
+**Date:** 2026-08-13  
+**Currency:** USD
+
+## Billable units
+
+| Unit | What counts | Metered rate | Notes |
+|------|-------------|-------------:|-------|
+| Decision evaluation | `POST /v1/decisions/evaluate` | $0.002 | Base unit; gates return allow/deny/escalate. |
+| Gate enforcement | `POST /v1/gates/*` | $0.001 | constraint, task-scope, branch-governance, protected-approval, satisfy. |
+| Feedback capture | `POST /v1/feedback/capture` | $0.0005 | Up/down/lesson signal from any agent run. |
+| Rule promotion | `POST /v1/feedback/rules` | $0.005 | Auto-promote a feedback signal to a prevention rule. |
+| Task-outcome receipt | `POST /v1/task-outcomes` | $0.001 | HMAC-signed execution receipt for audit/compliance. |
+| Escalation | `POST /v1/escalations` | $0.010 | Policy-driven escalation record. |
+| DPO export | `POST /v1/dpo/export` | $0.02 / 1K tokens | Training-pair export for customer DPO fine-tuning. |
+
+## Platform listing tiers
+
+| Tier | Monthly minimum | Included | Overage | Reseller margin |
+|------|----------------:|----------|--------:|----------------:|
+| Starter | $25 | 12,500 evals + 25K gate calls | billable units at table above | 20% |
+| Pro | $499 | 500K evals + 1M gate calls + DPO export | 50% discount on unit rates | 30% |
+| Enterprise | custom | custom commit | custom | 30% |
+
+## Settlement
+
+- MakersClaw bills the end customer.
+- ThumbGate invoices MakersClaw monthly for net usage minus reseller margin.
+- Payment: Stripe Connect or ACH, automated.
+- Provisioning, key rotation, and usage reporting via API.
+
+## Example customer
+
+A 50-agent HVAC automation shop:
+
+- 100K decision evaluations/mo = $200
+- 200K gate calls/mo = $200
+- 10K feedback captures/mo = $5
+- 500 rule promotions/mo = $2.50
+- Total billable: ~$407.50
+- Pro plan ($499) covers it; no overage.
+- MakersClaw margin @ 30% = $149.70/mo.

--- a/docs/sales/thumbgate-platform-spec.md
+++ b/docs/sales/thumbgate-platform-spec.md
@@ -1,0 +1,103 @@
+# ThumbGate.ai — Enterprise API Partner Spec
+
+**Prepared for:** Shreyans Bhansali / MakersClaw  
+**Prepared by:** Igor Ganapolsky, ThumbGate  
+**Date:** 2026-08-13  
+**Product:** ThumbGate.ai — Self-Improving Infrastructure Firewall for AI Agents  
+**Contact:** igor@igorganapolsky.com
+
+---
+
+## 1. Live production API
+
+All endpoints are live on `https://thumbgate.ai` (also served from `https://thumbgate-production.up.railway.app`).
+
+Verified 2026-08-13:
+
+```text
+GET  /health                  -> 200 {"status":"ok","version":"1.35.0","buildSha":"b23e24976736cafbece35b28a4813e643ad20179"}
+GET  /openapi.json            -> 200 OpenAPI 3.1.0, 50 paths
+POST /v1/decisions/evaluate   -> 401 without key (auth enforced)
+GET  /v1/billing/usage        -> 401 without key
+```
+
+OpenAPI URL for buyers: `https://thumbgate.ai/openapi.json`
+
+## 2. Enterprise-ready endpoints for platform resale
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/v1/decisions/evaluate` | POST | Evaluate any agent action against live policy. |
+| `/v1/gates/constraint` | POST | Register a new policy constraint. |
+| `/v1/gates/constraints` | GET | List active constraints. |
+| `/v1/gates/task-scope` | POST/GET | Scope a task to a bounded set of actions. |
+| `/v1/gates/branch-governance` | POST/GET | Enforce branch-level governance rules. |
+| `/v1/gates/protected-approval` | POST | Require explicit approval before protected actions. |
+| `/v1/gates/satisfy` | POST | Mark a gate condition as satisfied. |
+| `/v1/gates/stats` | GET | Aggregate gate activity. |
+| `/v1/feedback/capture` | POST | Capture up/down/lesson signal from any agent run. |
+| `/v1/feedback/rules` | POST | Auto-promote feedback into prevention rules. |
+| `/v1/feedback/stats` | GET | Feedback volume and outcome metrics. |
+| `/v1/task-outcomes` | POST/GET | Idempotent execution receipts for audit trails. |
+| `/v1/task-outcomes/metrics` | GET | Task-outcome analytics. |
+| `/v1/escalations` | POST/GET | Escalation log and routing. |
+| `/v1/billing/usage` | GET | Current-period usage counter. |
+| `/v1/billing/provision` | POST | Automated API-key provisioning (admin-gated). |
+| `/v1/billing/pro-activation` | POST | Activate a Pro plan. |
+
+Authentication: Bearer API key (`Authorization: Bearer <key>`).
+
+## 3. Automation-first positioning
+
+ThumbGate is built for fully autonomous AI systems:
+
+- **Pre-action enforcement** — decisions are returned before the agent acts.
+- **Feedback loop** — every execution can emit a thumbs-up/down signal.
+- **Rule auto-promotion** — repeated failures become prevention rules without manual review.
+- **Execution receipts** — every action produces an immutable, HMAC-signed task outcome.
+- **No human-in-the-loop bottleneck** — approval gates are policy-driven and API-controlled.
+
+We also dogfood ThumbGate on our own AfterHours Leak Score funnel.
+
+## 4. Partner listing economics
+
+See `thumbgate-platform-cost-sheet.md` for the full cost model.
+
+High-level:
+
+| Tier | Monthly minimum | Included volume | Overage | Best for |
+|------|----------------:|----------------:|--------:|----------|
+| Starter | $25 | first 12,500 evaluations | $0.002 / eval | Single-agent products |
+| Pro | $499 | 500,000 evaluations | $0.001 / eval | Multi-agent teams, DPO export |
+| Enterprise | custom | custom | custom | Resellers / claw-style agent fleets |
+
+MakersClaw resale terms:
+
+- MakersClaw bills the customer and keeps **30%** of net usage spend.
+- ThumbGate provides usage reporting, key rotation, and uptime SLA.
+- Monthly automated settlement via Stripe Connect.
+
+## 5. Gaps and timeline
+
+| Item | Status | ETA |
+|------|--------|-----|
+| Core API / auth | Live | now |
+| Usage counter | Live | now |
+| Metered billing with Stripe | Soft-launch; STRIPE_SECRET_KEY not yet live in prod | 2 weeks |
+| `/v1/billing/provision` partner self-service | Admin-gated today | 2 weeks |
+| OpenAPI YAML static file | In repo but not served; use `/openapi.json` | 1 week |
+
+## 6. Recommended first integration
+
+For claw-style / enterprise agents:
+
+1. Call `POST /v1/decisions/evaluate` before every consequential tool call.
+2. On `deny`, block the action and log to `POST /v1/feedback/capture`.
+3. On recovery, call `POST /v1/task-outcomes` to produce the receipt.
+4. Nightly, call `POST /v1/feedback/rules` to promote recurring lessons.
+
+## 7. Verification evidence
+
+- OpenAPI: `curl -s https://thumbgate.ai/openapi.json | jq '.info'`
+- Health: `curl -s https://thumbgate.ai/health`
+- Source routes: `src/api/server.js` lines 9501–10886

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "public/lessons.html",
     "public/numbers.html",
     "public/partner-intake.html",
+    "public/platform-partners.html",
     "public/peter.html",
     "public/pricing.html",
     "public/privacy.html",

--- a/public/platform-partners.html
+++ b/public/platform-partners.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ThumbGate for Platforms — AI-Native Governance API</title>
+  <meta name="description" content="List ThumbGate.ai on your platform. AI-native infrastructure firewall, feedback loops, and execution receipts for enterprise AI agents.">
+  <link rel="canonical" href="__APP_ORIGIN__/platform-partners.html">
+  <link rel="icon" type="image/svg+xml" href="__APP_ORIGIN__/favicon.svg">
+  <style>
+    :root { --bg:#0b0c0f; --panel:#12141a; --text:#e8eaed; --muted:#9aa0a6; --accent:#34d399; --accent-dim:#10b981; --border:#1f2937; }
+    * { box-sizing:border-box; }
+    body { margin:0; font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--bg); color:var(--text); line-height:1.55; }
+    a { color:var(--accent); text-decoration:none; }
+    header { padding:1.5rem 4vw; border-bottom:1px solid var(--border); display:flex; align-items:center; justify-content:space-between; }
+    .brand { font-weight:700; font-size:1.25rem; letter-spacing:-0.02em; }
+    main { max-width:980px; margin:0 auto; padding:3rem 4vw 5rem; }
+    h1 { font-size:clamp(2rem,5vw,3rem); margin:0 0 1rem; line-height:1.1; }
+    .lead { font-size:1.2rem; color:var(--muted); margin-bottom:2rem; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:1rem; margin:2rem 0; }
+    .card { background:var(--panel); border:1px solid var(--border); border-radius:0.75rem; padding:1.25rem; }
+    .card h3 { margin-top:0; color:var(--accent); }
+    table { width:100%; border-collapse:collapse; margin:1.25rem 0; font-size:0.95rem; }
+    th,td { padding:0.6rem 0.5rem; border-bottom:1px solid var(--border); text-align:left; }
+    th { color:var(--muted); font-weight:600; }
+    td:last-child, th:last-child { text-align:right; }
+    code { background:#1f2937; padding:0.15rem 0.35rem; border-radius:0.35rem; font-size:0.9em; }
+    .cta { margin-top:2rem; }
+    .button { display:inline-block; background:var(--accent); color:#000; font-weight:600; padding:0.8rem 1.4rem; border-radius:0.5rem; }
+    footer { border-top:1px solid var(--border); padding:2rem 4vw; color:var(--muted); font-size:0.9rem; text-align:center; }
+    .status { color:var(--accent); font-weight:600; }
+  </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "ThumbGate.ai",
+    "applicationCategory": "DeveloperApplication,BusinessApplication",
+    "offers": {
+      "@type": "AggregateOffer",
+      "lowPrice": "25",
+      "highPrice": "499",
+      "priceCurrency": "USD",
+      "availability": "https://schema.org/InStock"
+    }
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <div class="brand">ThumbGate.ai</div>
+    <nav>
+      <a href="__APP_ORIGIN__/pricing.html">Pricing</a>
+      <a href="__APP_ORIGIN__/partner-intake.html">Partner Intake</a>
+    </nav>
+  </header>
+
+  <main>
+    <h1>ThumbGate for Platforms</h1>
+    <p class="lead">Resell the AI-native infrastructure firewall to enterprise customers. Fully automated governance, feedback loops, and execution receipts through a single API.</p>
+
+    <p><span class="status">● Live</span> API — verified at <a href="https://thumbgate.ai/health">thumbgate.ai/health</a>. OpenAPI at <a href="https://thumbgate.ai/openapi.json">/openapi.json</a>.</p>
+
+    <h2>Why list ThumbGate?</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Pre-action enforcement</h3>
+        <p>Block dangerous tool calls before execution with <code>POST /v1/decisions/evaluate</code>.</p>
+      </div>
+      <div class="card">
+        <h3>Self-improving rules</h3>
+        <p>Capture feedback and auto-promote prevention rules via <code>/v1/feedback/*</code>.</p>
+      </div>
+      <div class="card">
+        <h3>Compliance receipts</h3>
+        <p>Every action produces an HMAC-signed task outcome through <code>/v1/task-outcomes</code>.</p>
+      </div>
+      <div class="card">
+        <h3>No human bottleneck</h3>
+        <p>Policy-driven approval gates, automated provisioning, and usage reporting.</p>
+      </div>
+    </div>
+
+    <h2>Core enterprise endpoints</h2>
+    <table>
+      <tr><th>Endpoint</th><th>Purpose</th></tr>
+      <tr><td><code>POST /v1/decisions/evaluate</code></td><td>Policy decision on any agent action</td></tr>
+      <tr><td><code>POST /v1/gates/constraint</code></td><td>Register a policy constraint</td></tr>
+      <tr><td><code>POST /v1/gates/task-scope</code></td><td>Scope a task to allowed actions</td></tr>
+      <tr><td><code>POST /v1/gates/branch-governance</code></td><td>Enforce branch-level governance</td></tr>
+      <tr><td><code>POST /v1/gates/protected-approval</code></td><td>Protected-action approval gate</td></tr>
+      <tr><td><code>POST /v1/gates/satisfy</code></td><td>Mark gate condition satisfied</td></tr>
+      <tr><td><code>POST /v1/feedback/capture</code></td><td>Capture up/down/lesson signal</td></tr>
+      <tr><td><code>POST /v1/feedback/rules</code></td><td>Auto-promote prevention rules</td></tr>
+      <tr><td><code>POST /v1/task-outcomes</code></td><td>Idempotent execution receipt</td></tr>
+      <tr><td><code>POST /v1/escalations</code></td><td>Escalation log and routing</td></tr>
+      <tr><td><code>GET /v1/billing/usage</code></td><td>Usage counter</td></tr>
+      <tr><td><code>POST /v1/billing/provision</code></td><td>Automated API-key provisioning</td></tr>
+    </table>
+
+    <h2>Pay-per-usage platform tiers</h2>
+    <table>
+      <tr><th>Tier</th><th>Monthly minimum</th><th>Includes</th><th>Reseller margin</th></tr>
+      <tr><td>Starter</td><td>$25</td><td>12,500 evaluations</td><td>20%</td></tr>
+      <tr><td>Pro</td><td>$499</td><td>500,000 evaluations + DPO export</td><td>30%</td></tr>
+      <tr><td>Enterprise</td><td>Custom</td><td>Custom commit</td><td>30%</td></tr>
+    </table>
+
+    <div class="cta">
+      <a class="button" href="__APP_ORIGIN__/partner-intake.html">Apply to list ThumbGate</a>
+      <span style="margin-left:1rem; color:var(--muted);">or email <a href="mailto:igor@igorganapolsky.com">igor@igorganapolsky.com</a></span>
+    </div>
+  </main>
+
+  <footer>
+    © 2026 ThumbGate.ai — Self-Improving Infrastructure Firewall for AI Agents
+  </footer>
+</body>
+</html>

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -450,8 +450,8 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     // THIRD_PARTY_NOTICES.md (+ package files list). Buyer-facing legal pages
     // must ship with the hosted/static package surfaces.
     // 452->453 mcp-session-handles; 453->454 agent-egress; 454->455 budget-aware-gates-proof
-    manifest.fileCount <= 460,
-    `npm package should stay <= 460 files, got ${manifest.fileCount}`
+    manifest.fileCount <= 461,
+    `npm package should stay <= 461 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -195,7 +195,7 @@ const path = require('node:path');
 // 455 -> 458: edotenv-rl-gateway + rsi-safety-hillclimb + research-agent-harness
 // 458 -> 459: governance-difficulty-curriculum (EdotEnv harder-next-round transfer)
 // 459 -> 460: provider-receipt-contract packaging on rebased receipt PR
-const BASELINE_FILE_COUNT = 460;
+const BASELINE_FILE_COUNT = 461; // platform-partner page
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -255,7 +255,7 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // Keep lockstep with package-boundary + public-bundle-ratchet.
   // 458 -> 459 (2026-08-14): scripts/governance-difficulty-curriculum.js
   // EdotEnv harder-next-round transfer in the public Reliability Gateway.
-  const CEILING = 460; // provider-receipt-contract lockstep
+  const CEILING = 461; // platform-partner + receipts
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
**What**
Publishes the partner-facing API + usage-pricing package for MakersClaw / platform listings.

**Added**
- docs/sales/thumbgate-platform-spec.md — verified live endpoints, automation-first positioning, integration path, gaps.
- docs/sales/thumbgate-platform-cost-sheet.md — usage-based pricing, reseller margin, sample economics.
- public/platform-partners.html — SEO/GEO-visible partner landing page.

**Verified**
- GET [https://thumbgate.ai/health](https://thumbgate.ai/health) → 200, version 1.35.0, buildSha b23e24976736cafbece35b28a4813e643ad20179.
- GET [https://thumbgate.ai/openapi.json](https://thumbgate.ai/openapi.json) → 50 paths, OpenAPI 3.1.0.
- Real routes confirmed in src/api/server.js (lines 9501–10886).

**Notes**
- Metered Stripe billing is soft-launch (~2 weeks); core API, auth, and usage counter are live now.
- No fake revenue or human-in-the-loop claims.

Closes no issue — sales-enablement publishing.