### PR TITLE
fix(policy): unblock Hermes Google Play review

### DIFF
--- a/.changeset/hermes-google-play-policy.md
+++ b/.changeset/hermes-google-play-policy.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add explicit Hermes Agent Remote & Leash privacy, developer identity, and account deletion disclosures required by Google Play.

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Privacy Policy — ThumbGate</title>
-  <meta name="description" content="ThumbGate Privacy Policy, Zero Workspace Telemetry Guarantee, data collection, sharing, retention, subprocessors, and contact.">
+  <meta name="description" content="Privacy Policy for ThumbGate and Hermes Agent Remote &amp; Leash, including data collection, sharing, retention, subprocessors, and account deletion.">
   <link rel="canonical" href="https://thumbgate.ai/privacy">
   <style>
     :root { --ink:#171d1a; --muted:#5b6761; --paper:#f5f2e9; --card:#fffdf8; --line:#d8d4c8; --green:#006e52; }
@@ -46,7 +46,11 @@
 
   <main class="shell">
     <h1>Privacy Policy</h1>
-    <div class="meta">Last Updated: August 12, 2026 · Version 1.3.0</div>
+    <div class="meta">Last Updated: August 13, 2026 · Version 1.4.0</div>
+
+    <h2>Hermes Agent Remote &amp; Leash</h2>
+    <p>This privacy policy applies to <strong>Hermes Agent Remote &amp; Leash</strong>, the Android app published on Google Play by <strong>IgorGanapolsky</strong> under package ID <code>com.iganapolsky.hermesmobile.paid</code>. Hermes Agent Remote &amp; Leash is developed and operated by Igor Ganapolsky.</p>
+    <p>Hermes lets a user connect to and control the user's own authorized agent gateway. Connection settings and credentials entered in the app are used to provide that connection and are not sold.</p>
 
     <div class="card">
       <strong>Zero Workspace Telemetry Guarantee.</strong> The local <code>thumbgate</code> CLI and open-source engine operate on your host disk (<code>~/.thumbgate/</code>, <code>.claude/</code>). Zero workspace source code, repository contents, or project file data is fetched, transmitted, or publicly rendered by ThumbGate.
@@ -86,7 +90,12 @@
     <p>Local data is retained until you delete the files. Hosted account data is retained while the account or API key remains active, or until you request deletion, subject to operational or legal retention. Cloud-runner logs target a 30-day purge. Billing records may be retained longer for tax and fraud prevention.</p>
 
     <h2>Deletion &amp; DPA</h2>
-    <p>Request deletion or export at <a href="mailto:privacy@thumbgate.ai">privacy@thumbgate.ai</a>. Enterprise customers may request a DPA covering GDPR / UK GDPR / CCPA where applicable. Security incidents affecting customer personal data target notice within 72 hours under signed enterprise terms when those terms apply.</p>
+    <p>Request ThumbGate hosted-data deletion or export at <a href="mailto:privacy@thumbgate.ai">privacy@thumbgate.ai</a>. Enterprise customers may request a DPA covering GDPR / UK GDPR / CCPA where applicable. Security incidents affecting customer personal data target notice within 72 hours under signed enterprise terms when those terms apply.</p>
+
+    <h2>Hermes Account and Data Deletion</h2>
+    <p>Users of <strong>Hermes Agent Remote &amp; Leash</strong> can request account and associated-data deletion without reinstalling or opening the app. Email <a href="mailto:privacy@thumbgate.ai?subject=Hermes%20account%20and%20data%20deletion%20request">privacy@thumbgate.ai</a> with the subject <strong>Hermes account and data deletion request</strong> and include the email address or account identifier used with Hermes.</p>
+    <p>After identity verification, we will delete the Hermes account and associated server-side personal data, connection metadata, and support records within 30 days. Credentials and connection settings stored only on the user's device can be deleted immediately by clearing the app's storage or uninstalling Hermes.</p>
+    <p>We may retain only information required for security, fraud prevention, legal compliance, or transaction records for the period required by law. Retained information is isolated from active product use and deleted when the applicable retention period ends.</p>
 
     <h2>Contact</h2>
     <p><a href="mailto:privacy@thumbgate.ai">privacy@thumbgate.ai</a> · <a href="mailto:security@thumbgate.ai">security@thumbgate.ai</a> · <a href="mailto:support@thumbgate.ai">support@thumbgate.ai</a></p>

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -1097,6 +1097,11 @@ test('privacy policy route covers collection, sharing, retention, and contact de
 
   const body = await res.text();
   assert.match(body, /Privacy Policy/i);
+  assert.match(body, /Hermes Agent Remote &amp; Leash/);
+  assert.match(body, /IgorGanapolsky/);
+  assert.match(body, /com\.iganapolsky\.hermesmobile\.paid/);
+  assert.match(body, /Hermes account and data deletion request/);
+  assert.match(body, /within 30 days/);
   assert.match(body, /Zero Workspace Telemetry/i);
   assert.match(body, /Collect/i);
   assert.match(body, /Retention/i);


### PR DESCRIPTION
## Summary
- identify Hermes Agent Remote & Leash, IgorGanapolsky, and the exact Android package on the declared privacy URL
- document an external account and associated-data deletion request process
- pin the Google Play compliance disclosures with API route tests

## Rejection evidence
Google Play rejected the release on 2026-08-13 because `https://thumbgate.ai/privacy` did not identify the app/developer and did not provide a valid data deletion path.

## Verification
- `node --test --test-name-pattern="privacy policy route" tests/api-server.test.js`
- `git diff --check`

Authority evidence: [VERIFICATION_EVIDENCE.md](https://github.com/IgorGanapolsky/ThumbGate/blob/main/VERIFICATION_EVIDENCE.md)