### PR TITLE
fix(ci): commit Dependabot changesets from the head checkout path

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -95,7 +95,7 @@ jobs:
 
           for file in "${changed_files[@]}"; do
             case "$file" in
-              package.json|package-lock.json) ;;
+              package.json|package-lock.json|workers/package.json|workers/package-lock.json) ;;
               *)
                 echo "Skipping generated changeset because $file is outside manifest-only dependency bumps."
                 exit 0
@@ -103,17 +103,22 @@ jobs:
             esac
           done
 
-          output_path=".dependabot-head/.changeset/dependabot-pr-${PR_NUMBER}.md"
-          node scripts/dependabot-changeset.js --title "$PR_TITLE" --output "$output_path" >/tmp/dependabot-changeset-path.txt
+          # Paths must be relative to the Dependabot head checkout. `git -C`
+          # plus a `.dependabot-head/` prefix looks for a nested directory that
+          # does not exist. `git diff --quiet` also ignores untracked files, so
+          # a newly written changeset looked "already committed" and Trunk test
+          # PRs later failed Verify changeset (observed on #3478/#3468/#3467).
+          rel_path=".changeset/dependabot-pr-${PR_NUMBER}.md"
+          node scripts/dependabot-changeset.js --title "$PR_TITLE" --output ".dependabot-head/${rel_path}" >/tmp/dependabot-changeset-path.txt
 
-          if git -C .dependabot-head diff --quiet -- "$output_path"; then
-            echo "Generated changeset already matches $output_path"
+          if [ -z "$(git -C .dependabot-head status --porcelain -- "$rel_path")" ]; then
+            echo "Generated changeset already matches $rel_path"
             exit 0
           fi
 
           git -C .dependabot-head config user.name 'github-actions[bot]'
           git -C .dependabot-head config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git -C .dependabot-head add "$output_path"
+          git -C .dependabot-head add "$rel_path"
           git -C .dependabot-head commit -m "chore: add changeset for dependabot PR #${PR_NUMBER}"
           git -C .dependabot-head push origin "HEAD:${HEAD_REF}"
 

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -971,7 +971,13 @@ test('Dependabot auto-merge trusts the pull request author instead of the trigge
   assert.match(workflow, /name:\s*Checkout trusted base workflow tools/);
   assert.match(workflow, /name:\s*Checkout Dependabot head/);
   assert.match(workflow, /name:\s*Add generated changeset for manifest-only dependency bumps/);
-  assert.match(workflow, /node scripts\/dependabot-changeset\.js --title "\$PR_TITLE" --output "\$output_path"/);
+  assert.match(workflow, /package\.json\|package-lock\.json\|workers\/package\.json\|workers\/package-lock\.json/);
+  assert.match(workflow, /rel_path="\.changeset\/dependabot-pr-\$\{PR_NUMBER\}\.md"/);
+  assert.match(workflow, /node scripts\/dependabot-changeset\.js --title "\$PR_TITLE" --output "\.dependabot-head\/\$\{rel_path\}"/);
+  assert.match(workflow, /git -C \.dependabot-head status --porcelain -- "\$rel_path"/);
+  assert.match(workflow, /git -C \.dependabot-head add "\$rel_path"/);
+  assert.doesNotMatch(workflow, /output_path="\.dependabot-head\/\.changeset\//);
+  assert.doesNotMatch(workflow, /git -C \.dependabot-head diff --quiet -- "\$output_path"/);
   assert.match(workflow, /git -C \.dependabot-head push origin "HEAD:\$\{HEAD_REF\}"/);
   assert.match(workflow, /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/issues\/\$\{PR_NUMBER\}\/comments"/);
   assert.match(workflow, /-f body='\/trunk merge'/);


### PR DESCRIPTION
## Why

Trunk dropped Dependabot PRs (#3478, #3468, #3467) after test PRs failed **Verify changeset**. The Dependabot Auto-Merge job already generates a changeset, but it never landed on the branch:

1. `git -C .dependabot-head` was given a `.dependabot-head/.changeset/...` path, so it looked in a nested directory that does not exist.
2. `git diff --quiet` ignores untracked files, so the new changeset looked already committed.

Trunk test PRs are not authored by `dependabot[bot]`, so the changeset bypass does not apply and the missing file fails the required check.

## Change

- Write and `git add` `.changeset/dependabot-pr-<n>.md` relative to the Dependabot head checkout.
- Detect a new file with `git status --porcelain`.
- Generate the same changeset for `workers/package.json` and `workers/package-lock.json` (also release-relevant).

Does **not** bypass Verify changeset on `trunk-merge/*`. Does **not** approve or merge any PR.

## Evidence

- Targeted tests: `node --test tests/deployment.test.js tests/dependabot-changeset.test.js tests/changeset-check.test.js` → 99 pass / 0 fail
- Quoted Trunk failures: #3492 / #3495 Verify changeset FAILURE; source PRs had no `.changeset` files

See `VERIFICATION_EVIDENCE.md`.