### PR TITLE
chore(package-boundary): bundle-cap baseline 467 to 470 for three in-flight runtime files

### DIFF
--- a/.changeset/bundle-cap-470.md
+++ b/.changeset/bundle-cap-470.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+chore: raise the npm bundle-cap baseline 467 -> 470 for three in-flight runtime files (override-audit, security-questionnaire, pipeline-compass) so concurrent PRs stop colliding on the cap

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -453,8 +453,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     // 466 -> 467 (2026-08-17): scripts/agent-security-central.js — free Agent
     // Security Central posture report. Lockstep with public-bundle-ratchet +
     // public-core-boundary.
-    manifest.fileCount <= 467,
-    `npm package should stay <= 467 files, got ${manifest.fileCount}`
+    // 467 -> 470 (2026-08-18): three concurrent PRs each add one runtime
+    // file that packaged entrypoints require: scripts/override-audit.js (#3515),
+    // src/security-questionnaire.js (#3519), src/pipeline-compass.js (#3521).
+    manifest.fileCount <= 470,
+    `npm package should stay <= 470 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -195,7 +195,8 @@ const path = require('node:path');
 // 455 -> 458: edotenv-rl-gateway + rsi-safety-hillclimb + research-agent-harness
 // 458 -> 459: governance-difficulty-curriculum (EdotEnv harder-next-round transfer)
 // 459 -> 460: provider-receipt-contract packaging on rebased receipt PR
-const BASELINE_FILE_COUNT = 467; // +scripts/agent-security-central.js (Oracle free-posture wedge)
+// 467 -> 470: three concurrent PRs (override-audit, security-questionnaire, pipeline-compass)
+const BASELINE_FILE_COUNT = 470;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -258,7 +258,8 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // 466 -> 467 (2026-08-17): scripts/agent-security-central.js — free Agent
   // Security Central posture report. Lockstep with package-boundary +
   // public-bundle-ratchet.
-  const CEILING = 467;
+  // 467 -> 470 (2026-08-18): lockstep baseline for in-flight PRs
+  const CEILING = 470;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
Deliberate baseline bump per the bundle-ratchet policy. Three concurrent PRs each add exactly one runtime file that packaged entrypoints require: scripts/override-audit.js (#3515), src/security-questionnaire.js (#3519), src/pipeline-compass.js (#3521). Each PR bumping the cap alone would re-break the others after every Trunk rebase; this single bump lands first so all three pass without touching the cap. Changeset included. After all three merge, the bundle sits exactly at 470 with zero slack.