### PR TITLE
fix(ratchet): bump file count ceilings to 469 for pipeline compass and setup guide

### DIFF
--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -453,8 +453,11 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
     // 466 -> 467 (2026-08-17): scripts/agent-security-central.js — free Agent
     // Security Central posture report. Lockstep with public-bundle-ratchet +
     // public-core-boundary.
-    manifest.fileCount <= 467,
-    `npm package should stay <= 467 files, got ${manifest.fileCount}`
+    // 467 -> 469 (2026-08-18): feat(cli) + feat(docs) pipeline compass + setup guide.
+    // Two new runtime files: src/pipeline-compass.js (CLI compass command) and
+    // public/guides/progressive-setup.html.
+    manifest.fileCount <= 469,
+    `npm package should stay <= 469 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -195,7 +195,12 @@ const path = require('node:path');
 // 455 -> 458: edotenv-rl-gateway + rsi-safety-hillclimb + research-agent-harness
 // 458 -> 459: governance-difficulty-curriculum (EdotEnv harder-next-round transfer)
 // 459 -> 460: provider-receipt-contract packaging on rebased receipt PR
-const BASELINE_FILE_COUNT = 467; // +scripts/agent-security-central.js (Oracle free-posture wedge)
+// 467 -> 469 (2026-08-18): feat(cli) + feat(docs) pipeline compass + setup guide.
+// Two new runtime files: src/pipeline-compass.js (CLI compass command) and
+// public/guides/progressive-setup.html.
+const BASELINE_FILE_COUNT = 469; // +scripts/agent-security-central.js (Oracle free-posture wedge)
+// + src/pipeline-compass.js (TradeMaster-style CLI compass) +
+// public/guides/progressive-setup.html (progressive setup guide)
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -258,7 +258,10 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // 466 -> 467 (2026-08-17): scripts/agent-security-central.js — free Agent
   // Security Central posture report. Lockstep with package-boundary +
   // public-bundle-ratchet.
-  const CEILING = 467;
+  // 467 -> 469 (2026-08-18): feat(cli) + feat(docs) pipeline compass + setup guide.
+  // Two new runtime files: src/pipeline-compass.js (CLI compass command) and
+  // public/guides/progressive-setup.html.
+  const CEILING = 469;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
Two new runtime files were added via merged PRs:
- src/pipeline-compass.js (TradeMaster-style CLI compass command)
- public/guides/progressive-setup.html (progressive setup guide)

This updates the test ceilings from 467 to 469 in all three boundary tests:
- tests/package-boundary.test.js
- tests/public-core-boundary.test.js
- tests/public-bundle-ratchet.test.js

Fixes CI failures on main branch after PR 3524 and related PRs.