### PR TITLE
fix(reliability): hard-bound dashboard JSONL against V8 string limit

### DIFF
--- a/.changeset/dashboard-jsonl-hard-bound.md
+++ b/.changeset/dashboard-jsonl-hard-bound.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Harden dashboard JSONL ingestion so omitted limits no longer full-read multi-hundred-MB feedback logs (prod `dashboard_data` 503 / V8 string limit). Defaults: 4 MiB / 20k-line tail; opt-in `{ full: true }` for lifetime scans.

--- a/scripts/feedback-aggregate.js
+++ b/scripts/feedback-aggregate.js
@@ -163,15 +163,20 @@ function collectAggregateLogEntries(fileName, options = {}) {
   for (const dir of stores) {
     const logPath = path.join(dir, fileName);
     if (!safeExists(logPath)) continue;
-    // Lifetime/statusline callers omit limits and still read the full file.
-    // Dashboard/production proof pass maxLines + maxBytes to keep /v1/dashboard
-    // inside the authenticated verifier budget.
-    const maxLines = Math.max(0, Number(options.maxLines) || 0);
-    const maxBytes = Math.max(0, Number(options.maxBytes) || 0);
+    // Never full-scan multi-hundred-MB feedback logs (prod dashboard_data 503).
+    // Callers that truly need lifetime history must pass { full: true }.
+    const wantFull = options.full === true;
+    const maxLines = wantFull
+      ? Math.max(0, Number(options.maxLines) || 0)
+      : (Number(options.maxLines) > 0 ? Number(options.maxLines) : 20_000);
+    const maxBytes = wantFull
+      ? Math.max(0, Number(options.maxBytes) || 0)
+      : (Number(options.maxBytes) > 0 ? Number(options.maxBytes) : 4 * 1024 * 1024);
     const rows = readJsonl(logPath, {
       maxLines,
-      tail: maxLines > 0 || maxBytes > 0,
       maxBytes,
+      tail: !wantFull,
+      full: wantFull,
     }) || [];
     for (let index = 0; index < rows.length; index += 1) {
       const rawEntry = rows[index];

--- a/scripts/fs-utils.js
+++ b/scripts/fs-utils.js
@@ -23,11 +23,18 @@ const DEFAULT_JSONL_TAIL_ENTRIES = 20_000;
  * @param {number} [maxBytes]
  * @returns {{ text: string, truncated: boolean, size: number }}
  */
+const HARD_FULL_READ_BYTES = 64 * 1024 * 1024;
+
 function readTextTail(filePath, maxBytes) {
   const stats = fs.statSync(filePath);
   const size = stats.size || 0;
   if (size <= 0) return { text: '', truncated: false, size: 0 };
-  const budget = Number(maxBytes);
+  let budget = Number(maxBytes);
+  // budget<=0 historically meant "read entire file". On oversized prod logs that
+  // throws "Cannot create a string longer than 0x1fffffe8 characters".
+  if (!budget && size > HARD_FULL_READ_BYTES) {
+    budget = DEFAULT_JSONL_TAIL_BYTES;
+  }
   if (!budget || size <= budget) {
     return { text: fs.readFileSync(filePath, 'utf-8'), truncated: false, size };
   }
@@ -82,7 +89,19 @@ function readJsonl(filePath, options = {}) {
   const normalizedOptions = typeof options === 'number'
     ? { maxLines: options, tail: true }
     : (options || {});
-  const maxBytes = positiveNumber(normalizedOptions.maxBytes);
+  const maxLines = positiveNumber(normalizedOptions.maxLines);
+  // Opt-in full reads only. Unbounded readFileSync blows past V8 string limits
+  // on production feedback/memory JSONL (dashboard_data 503 / 0x1fffffe8).
+  const wantFull = normalizedOptions.full === true;
+  let maxBytes = positiveNumber(normalizedOptions.maxBytes);
+  if (!wantFull && maxBytes <= 0) {
+    maxBytes = (maxLines > 0 || normalizedOptions.tail)
+      ? DEFAULT_JSONL_TAIL_BYTES
+      : DEFAULT_JSONL_TAIL_BYTES;
+  }
+  if (wantFull) {
+    maxBytes = 0; // readTextTail(0) => full file
+  }
   let raw = '';
   try {
     raw = readTextTail(filePath, maxBytes).text.trim();
@@ -92,16 +111,19 @@ function readJsonl(filePath, options = {}) {
   if (!raw) return [];
   let lines = raw.split('\n');
 
-  if (normalizedOptions.tail && normalizedOptions.maxLines > 0) {
-    lines = lines.slice(-normalizedOptions.maxLines);
+  const effectiveMaxLines = maxLines > 0 ? maxLines : DEFAULT_JSONL_TAIL_ENTRIES;
+  if (!wantFull) {
+    lines = lines.slice(-effectiveMaxLines);
+  } else if (normalizedOptions.tail && maxLines > 0) {
+    lines = lines.slice(-maxLines);
   }
 
   if (normalizedOptions.reverse) {
     lines = lines.reverse();
   }
 
-  if (!normalizedOptions.tail && normalizedOptions.maxLines && normalizedOptions.maxLines > 0) {
-    lines = lines.slice(0, normalizedOptions.maxLines);
+  if (wantFull && !normalizedOptions.tail && maxLines > 0) {
+    lines = lines.slice(0, maxLines);
   }
 
   return lines

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -2088,14 +2088,22 @@ function readRecentFeedbackEntries(feedbackDir, signal, windowMs, limit = 5, opt
   try {
     if (!feedbackDir) return [];
     const rows = shouldAggregateFeedback()
-      ? collectAggregateLogEntries('feedback-log.jsonl', { feedbackDir }).entries
+      ? collectAggregateLogEntries('feedback-log.jsonl', {
+          feedbackDir,
+          maxLines: 20_000,
+          maxBytes: 4 * 1024 * 1024,
+        }).entries
       : (() => {
           const fsLocal = require('node:fs');
           const pathLocal = require('node:path');
           const logPath = pathLocal.join(feedbackDir, 'feedback-log.jsonl');
           if (!fsLocal.existsSync(logPath)) return [];
           const { readJsonl } = require('../../scripts/fs-utils');
-          return readJsonl(logPath) || [];
+          return readJsonl(logPath, {
+            maxLines: 20_000,
+            maxBytes: 4 * 1024 * 1024,
+            tail: true,
+          }) || [];
         })();
     const cutoff = windowMs ? Date.now() - windowMs : 0;
     const filtered = rows

--- a/tests/dashboard-jsonl-bound.test.js
+++ b/tests/dashboard-jsonl-bound.test.js
@@ -105,7 +105,7 @@ test('operational dashboard reports progress stages', async () => {
   }
 });
 
-test('collectAggregateLogEntries without limits keeps lifetime history', () => {
+test('collectAggregateLogEntries full:true keeps lifetime history', () => {
   const { collectAggregateLogEntries } = require('../scripts/feedback-aggregate');
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-agg-lifetime-'));
   const lines = [];
@@ -120,8 +120,10 @@ test('collectAggregateLogEntries without limits keeps lifetime history', () => {
   const prevAgg = process.env.THUMBGATE_AGGREGATE_FEEDBACK;
   process.env.THUMBGATE_AGGREGATE_FEEDBACK = '1';
   try {
-    const all = collectAggregateLogEntries('feedback-log.jsonl', { feedbackDir: dir });
+    const all = collectAggregateLogEntries('feedback-log.jsonl', { feedbackDir: dir, full: true });
     assert.equal(all.entries.length, 40);
+    const boundedDefault = collectAggregateLogEntries('feedback-log.jsonl', { feedbackDir: dir });
+    assert.equal(boundedDefault.entries.length, 40); // 40 < default 20k ceiling
     const bounded = collectAggregateLogEntries('feedback-log.jsonl', {
       feedbackDir: dir,
       maxLines: 8,
@@ -179,5 +181,45 @@ test('feedback-loop analyzeFeedback accepts preloaded entries without a full fil
   const analysis = analyzeFeedback(file, { entries, maxLines: 8 });
   assert.ok(analysis);
   assert.ok(Number(analysis.total) >= 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('fs-utils readJsonl defaults to a recent tail (no full:true)', () => {
+  const { readJsonl, DEFAULT_JSONL_TAIL_BYTES } = require('../scripts/fs-utils');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-fs-jsonl-default-'));
+  const file = path.join(dir, 'feedback-log.jsonl');
+  const payload = 'y'.repeat(2048);
+  const lines = [];
+  for (let i = 0; i < 3000; i += 1) {
+    lines.push(JSON.stringify({ id: `r${i}`, payload }));
+  }
+  fs.writeFileSync(file, `${lines.join('\n')}\n`);
+  assert.ok(fs.statSync(file).size > DEFAULT_JSONL_TAIL_BYTES / 4);
+  const rows = readJsonl(file);
+  assert.ok(rows.length > 0);
+  assert.ok(rows.length < lines.length);
+  assert.equal(rows.at(-1).id, 'r2999');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('collectAggregateLogEntries defaults stay bounded without explicit limits', () => {
+  const { collectAggregateLogEntries } = require('../scripts/feedback-aggregate');
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-agg-bound-'));
+  const payload = 'z'.repeat(1024);
+  const lines = [];
+  for (let i = 0; i < 2500; i += 1) {
+    lines.push(JSON.stringify({
+      id: `a${i}`,
+      signal: 'down',
+      feedback: 'down',
+      context: payload,
+      timestamp: new Date(Date.UTC(2026, 7, 1, 0, 0, i % 60)).toISOString(),
+    }));
+  }
+  fs.writeFileSync(path.join(dir, 'feedback-log.jsonl'), `${lines.join('\n')}\n`);
+  const { entries } = collectAggregateLogEntries('feedback-log.jsonl', { feedbackDir: dir });
+  assert.ok(entries.length > 0);
+  assert.ok(entries.length <= 20_000);
+  assert.ok(entries.length < lines.length || lines.length <= 20_000);
   fs.rmSync(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- Production `dashboard_data` / Verify Production failed with `Cannot create a string longer than 0x1fffffe8 characters` after tip `13462e8071` despite `#3516` soft bounds.
- Root cause: `collectAggregateLogEntries` and `fs-utils.readJsonl` still full-`readFileSync` when callers omitted limits (`readRecentFeedbackEntries` on the dashboard path).
- Default to 4 MiB / 20k-line tails; opt-in `{ full: true }` for true lifetime scans; hard-cap accidental full reads over 64 MiB.

## Test plan
- [x] `node --test tests/dashboard-jsonl-bound.test.js tests/dashboard-limits.test.js`
- [x] statusline aggregation tests
- [ ] CI green on PR
- [ ] After merge: Verify Production / dashboard_data no longer 503 on oversized logs