### PR TITLE
feat(mcp): WriteGuard-style write risk tiers and tool-call outcomes

### DIFF
--- a/.changeset/mcp-write-risk-kpi.md
+++ b/.changeset/mcp-write-risk-kpi.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Map MCP tools to WriteGuard-style write risk tiers and record every tool attempt with successful/failed/blocked KPI outcomes plus optional client/session attribution.

--- a/.changeset/mcp-write-risk-kpi.md
+++ b/.changeset/mcp-write-risk-kpi.md
@@ -2,4 +2,4 @@
 "thumbgate": patch
 ---
 
-Map MCP tools to WriteGuard-style write risk tiers and record every tool attempt with successful/failed/blocked KPI outcomes plus optional client/session attribution.
+Map MCP tools to WriteGuard-style write risk tiers and record every tool attempt with successful/failed/blocked KPI outcomes plus optional client/session attribution. Pin Akamai-style agentic hop latency budgets (250ms read-only / 500ms wall / 1000ms critical) into the SLO engine so tool p95 is measured against hop budgets, not tokens/sec.

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -967,6 +967,9 @@ function recordMcpToolTrace(name, args, outcome = {}) {
       ? 'blocked'
       : (outcome.success === true ? 'successful' : 'failed');
     const writeRiskTier = outcome.writeRiskTier || resolveWriteRiskTierForTool(name);
+    // KPI identity must come only from trusted transport/options metadata
+    // (HTTP OAuth session, explicit callTool options). Never trust tool args —
+    // callers can poison clientId/sessionId via schemas that allow extras.
     recordToolCall({
       toolName: name,
       serverName: outcome.serverName || 'mcp',
@@ -974,9 +977,9 @@ function recordMcpToolTrace(name, args, outcome = {}) {
       success: outcome.success === true,
       outcome: kpiOutcome,
       blocked,
-      agentId: outcome.agentId || args.agentId || args.processId || args.taskId || 'unknown',
-      clientId: outcome.clientId || args.clientId || args.mcpClient || null,
-      sessionId: outcome.sessionId || args.sessionId || args.mcpSessionId || null,
+      agentId: outcome.agentId || process.env.THUMBGATE_AGENT_ID || 'unknown',
+      clientId: outcome.clientId || null,
+      sessionId: outcome.sessionId || null,
       writeRiskTier,
       metadata: {
         category,

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -778,13 +778,23 @@ function buildEstimateUncertaintyResponse(args = {}) {
   });
 }
 
-async function callTool(name, args = {}) {
+async function callTool(name, args = {}, options = {}) {
   const attemptStartMs = Date.now();
   const activeProfile = getActiveMcpProfile();
+  const attribution = {
+    clientId: options.clientId || null,
+    sessionId: options.sessionId || null,
+    agentId: options.agentId || null,
+    serverName: options.serverName || 'mcp',
+  };
+  const trace = (outcome = {}) => recordMcpToolTrace(name, args, {
+    ...outcome,
+    ...attribution,
+  });
   try {
     assertToolAllowed(name, activeProfile);
   } catch (error) {
-    recordMcpToolTrace(name, args, {
+    trace({
       success: false,
       category: 'profile_denied',
       evidence: [error.message],
@@ -794,7 +804,7 @@ async function callTool(name, args = {}) {
   }
   const capability = getToolCapability(name);
   if (!capability.available) {
-    recordMcpToolTrace(name, args, {
+    trace({
       success: false,
       category: 'capability',
       evidence: capability.missingModules,
@@ -822,7 +832,7 @@ async function callTool(name, args = {}) {
       const err = new Error(`Tool contract violation on '${name}': ${validation.errors.join('; ')}`);
       err.errorCategory = 'contract';
       err.isRetryable = false;
-      recordMcpToolTrace(name, args, {
+      trace({
         success: false,
         category: 'contract',
         evidence: validation.errors,
@@ -850,7 +860,7 @@ async function callTool(name, args = {}) {
       err.errorCategory = 'permission';
       err.code = handleAuth.code || 'SESSION_HANDLE_DENIED';
       err.isRetryable = false;
-      recordMcpToolTrace(name, args, {
+      trace({
         success: false,
         category: 'session_handle',
         evidence: [handleAuth.code, handleAuth.reason],
@@ -866,7 +876,7 @@ async function callTool(name, args = {}) {
       const err = new Error(`Action blocked by Semantic Firewall: ${firewallResult.message}`);
       err.errorCategory = 'permission';
       err.isRetryable = false;
-      recordMcpToolTrace(name, args, {
+      trace({
         success: false,
         category: 'permission',
         evidence: [firewallResult.message],
@@ -880,7 +890,7 @@ async function callTool(name, args = {}) {
   try {
     result = await callToolInner(name, args);
   } catch (err) {
-    recordMcpToolTrace(name, args, {
+    trace({
       success: false,
       category: err.errorCategory || 'execution',
       evidence: [err.code || err.message || 'tool execution failed'],
@@ -894,7 +904,7 @@ async function callTool(name, args = {}) {
     const err = new Error(`Structured output contract violation on '${name}': ${outputValidation.errors.join('; ')}`);
     err.errorCategory = 'output_contract';
     err.isRetryable = false;
-    recordMcpToolTrace(name, args, {
+    trace({
       success: false,
       category: 'output_contract',
       evidence: outputValidation.errors,
@@ -902,7 +912,7 @@ async function callTool(name, args = {}) {
     });
     throw err;
   }
-  recordMcpToolTrace(name, args, {
+  trace({
     success: true,
     category: 'success',
     evidence: [`tool completed in ${latencyMs}ms`],
@@ -930,17 +940,48 @@ function validateMcpToolOutput(toolDef, result) {
   return validateStructuredOutput(result.structuredContent, toolDef.outputSchema);
 }
 
+function resolveWriteRiskTierForTool(name) {
+  try {
+    const { TOOLS, inferWriteRiskTier } = require('../../scripts/tool-registry');
+    const tool = TOOLS.find((candidate) => candidate.name === name);
+    return inferWriteRiskTier(name, tool?.annotations || {});
+  } catch {
+    return null;
+  }
+}
+
 function recordMcpToolTrace(name, args, outcome = {}) {
   try {
+    const category = outcome.category || 'unknown';
+    // Policy / profile / session denials are WriteGuard "blocked"; execution
+    // and contract failures stay "failed".
+    const blockedCategories = new Set([
+      'blocked',
+      'denied',
+      'permission',
+      'session_handle',
+      'profile_denied',
+    ]);
+    const blocked = blockedCategories.has(category) || outcome.blocked === true;
+    const kpiOutcome = blocked
+      ? 'blocked'
+      : (outcome.success === true ? 'successful' : 'failed');
+    const writeRiskTier = outcome.writeRiskTier || resolveWriteRiskTierForTool(name);
     recordToolCall({
       toolName: name,
-      serverName: 'mcp',
+      serverName: outcome.serverName || 'mcp',
       latencyMs: Number(outcome.latencyMs || 0),
       success: outcome.success === true,
-      agentId: args.agentId || args.processId || args.taskId || 'unknown',
+      outcome: kpiOutcome,
+      blocked,
+      agentId: outcome.agentId || args.agentId || args.processId || args.taskId || 'unknown',
+      clientId: outcome.clientId || args.clientId || args.mcpClient || null,
+      sessionId: outcome.sessionId || args.sessionId || args.mcpSessionId || null,
+      writeRiskTier,
       metadata: {
-        category: outcome.category || 'unknown',
+        category,
         traceId: args.traceId || args.taskId || null,
+        writeRiskTier,
       },
     });
   } catch {

--- a/scripts/slo-alert-engine.js
+++ b/scripts/slo-alert-engine.js
@@ -1,14 +1,179 @@
 #!/usr/bin/env node
 'use strict';
+
 const fs = require('fs');
 const path = require('path');
 const { computeToolKpis, getAtRiskTools } = require('./tool-kpi-tracker');
 const { deliver } = require('./webhook-delivery');
 const { resolveFeedbackDir } = require('./feedback-paths');
-const DEFAULT_SLOS = { successRate: 90, p95LatencyMs: 500, minCallsForAlert: 3 };
-function getAlertLogPath() { return path.join(resolveFeedbackDir(), 'slo-alerts.jsonl'); }
-function checkSloViolations({ slos, periodHours = 24 } = {}) { const t = { ...DEFAULT_SLOS, ...slos }; const atRisk = getAtRiskTools({ successRateThreshold: t.successRate, p95Threshold: t.p95LatencyMs, periodHours }); const violations = atRisk.map((tool) => { const reasons = []; if (tool.successRate < t.successRate) reasons.push(`success rate ${tool.successRate}% < ${t.successRate}% SLO`); if (tool.p95 > t.p95LatencyMs) reasons.push(`P95 ${tool.p95}ms > ${t.p95LatencyMs}ms SLO`); return { toolName: tool.toolName, ...tool, reasons, severity: tool.successRate < 70 ? 'critical' : 'warning' }; }); return { thresholds: t, periodHours, violations, violationCount: violations.length, checkedAt: new Date().toISOString() }; }
-function logAlert(alert) { const lp = getAlertLogPath(); const dir = path.dirname(lp); if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true }); fs.appendFileSync(lp, JSON.stringify({ ...alert, loggedAt: new Date().toISOString() }) + '\n'); }
-async function runSloCheck({ slos, periodHours = 24, platform, webhookUrl } = {}) { const result = checkSloViolations({ slos, periodHours }); if (result.violationCount > 0) { logAlert(result); if (platform && webhookUrl) { const title = `ThumbGate SLO Alert — ${result.violationCount} violation(s)`; const lines = result.violations.map((v) => `- ${v.toolName}: ${v.reasons.join(', ')} [${v.severity}]`); await deliver(platform, webhookUrl, title, lines.join('\n')); } } return result; }
-function formatSloSection(r) { if (!r || r.violationCount === 0) return ''; const lines = ['', 'SLO Violations:']; for (const v of r.violations) lines.push(`  - [${v.severity.toUpperCase()}] ${v.toolName}: ${v.reasons.join('; ')} (${v.requestCount} calls)`); return lines.join('\n'); }
-module.exports = { DEFAULT_SLOS, checkSloViolations, runSloCheck, formatSloSection, logAlert, getAlertLogPath };
+
+// Agentic tool-hop latency wall (Akamai State of AI Inference 2026): most critical
+// use cases need ≤500ms end-to-end; many need ≤250ms. More GPUs do not fix
+// CPU/tool hops — budget each hop and fail closed when p95 exceeds the tier.
+const AGENTIC_HOP_LATENCY_BUDGETS_MS = Object.freeze({
+  'read-only': 250,
+  'minimal-impact': 250,
+  'contained-write': 500,
+  critical: 1000,
+  default: 500,
+});
+
+const DEFAULT_SLOS = {
+  successRate: 90,
+  // Matches Akamai's published agentic 500ms wall for generic tool hops.
+  p95LatencyMs: AGENTIC_HOP_LATENCY_BUDGETS_MS.default,
+  minCallsForAlert: 3,
+};
+
+function getAlertLogPath() {
+  return path.join(resolveFeedbackDir(), 'slo-alerts.jsonl');
+}
+
+function hopLatencyBudgetMs(writeRiskTier) {
+  if (writeRiskTier && Object.prototype.hasOwnProperty.call(AGENTIC_HOP_LATENCY_BUDGETS_MS, writeRiskTier)) {
+    return AGENTIC_HOP_LATENCY_BUDGETS_MS[writeRiskTier];
+  }
+  return AGENTIC_HOP_LATENCY_BUDGETS_MS.default;
+}
+
+/**
+ * Evaluate per-tool p95 against WriteGuard-tier hop budgets.
+ * Measures the hop chain ThumbGate actually sees (tool KPI), not tokens/sec.
+ */
+function checkHopLatencyBudgets({
+  periodHours = 24,
+  feedbackDir,
+  minCalls = DEFAULT_SLOS.minCallsForAlert,
+  budgets = AGENTIC_HOP_LATENCY_BUDGETS_MS,
+} = {}) {
+  const { tools, totalCalls, evidenceStatus } = computeToolKpis({ periodHours, feedbackDir });
+  const evaluated = tools
+    .filter((tool) => tool.requestCount >= minCalls)
+    .map((tool) => {
+      const budgetMs = hopLatencyBudgetMs(tool.writeRiskTier);
+      const withinBudget = tool.p95 <= budgetMs;
+      return {
+        toolName: tool.toolName,
+        writeRiskTier: tool.writeRiskTier || null,
+        requestCount: tool.requestCount,
+        p95: tool.p95,
+        budgetMs,
+        withinBudget,
+        overBudgetMs: withinBudget ? 0 : tool.p95 - budgetMs,
+      };
+    });
+  const violations = evaluated.filter((tool) => !tool.withinBudget);
+  return {
+    wallMs: budgets.default || AGENTIC_HOP_LATENCY_BUDGETS_MS.default,
+    budgets: { ...AGENTIC_HOP_LATENCY_BUDGETS_MS, ...budgets },
+    periodHours,
+    totalCalls,
+    evidenceStatus,
+    tools: evaluated,
+    violations,
+    violationCount: violations.length,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+function checkSloViolations({ slos, periodHours = 24, feedbackDir } = {}) {
+  const t = { ...DEFAULT_SLOS, ...slos };
+  const atRisk = getAtRiskTools({
+    successRateThreshold: t.successRate,
+    p95Threshold: t.p95LatencyMs,
+    periodHours,
+    feedbackDir,
+  });
+  const hopBudgets = checkHopLatencyBudgets({
+    periodHours,
+    feedbackDir,
+    minCalls: t.minCallsForAlert,
+  });
+  const byName = new Map(atRisk.map((tool) => [tool.toolName, { ...tool, reasons: [] }]));
+
+  for (const tool of atRisk) {
+    const entry = byName.get(tool.toolName);
+    if (tool.successRate < t.successRate) {
+      entry.reasons.push(`success rate ${tool.successRate}% < ${t.successRate}% SLO`);
+    }
+    if (tool.p95 > t.p95LatencyMs) {
+      entry.reasons.push(`P95 ${tool.p95}ms > ${t.p95LatencyMs}ms SLO`);
+    }
+  }
+
+  for (const hop of hopBudgets.violations) {
+    if (!byName.has(hop.toolName)) {
+      byName.set(hop.toolName, {
+        toolName: hop.toolName,
+        requestCount: hop.requestCount,
+        successRate: null,
+        p95: hop.p95,
+        writeRiskTier: hop.writeRiskTier,
+        reasons: [],
+      });
+    }
+    const entry = byName.get(hop.toolName);
+    entry.writeRiskTier = hop.writeRiskTier;
+    entry.budgetMs = hop.budgetMs;
+    entry.reasons.push(
+      `hop P95 ${hop.p95}ms > ${hop.budgetMs}ms ${hop.writeRiskTier || 'default'} budget`,
+    );
+  }
+
+  const violations = [...byName.values()]
+    .filter((tool) => tool.reasons.length > 0)
+    .map((tool) => ({
+      ...tool,
+      severity: (tool.successRate != null && tool.successRate < 70) ? 'critical' : 'warning',
+    }));
+
+  return {
+    thresholds: t,
+    periodHours,
+    hopBudgets,
+    violations,
+    violationCount: violations.length,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+function logAlert(alert) {
+  const lp = getAlertLogPath();
+  const dir = path.dirname(lp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(lp, `${JSON.stringify({ ...alert, loggedAt: new Date().toISOString() })}\n`);
+}
+
+async function runSloCheck({ slos, periodHours = 24, platform, webhookUrl } = {}) {
+  const result = checkSloViolations({ slos, periodHours });
+  if (result.violationCount > 0) {
+    logAlert(result);
+    if (platform && webhookUrl) {
+      const title = `ThumbGate SLO Alert — ${result.violationCount} violation(s)`;
+      const lines = result.violations.map((v) => `- ${v.toolName}: ${v.reasons.join(', ')} [${v.severity}]`);
+      await deliver(platform, webhookUrl, title, lines.join('\n'));
+    }
+  }
+  return result;
+}
+
+function formatSloSection(r) {
+  if (!r || r.violationCount === 0) return '';
+  const lines = ['', 'SLO Violations:'];
+  for (const v of r.violations) {
+    lines.push(`  - [${v.severity.toUpperCase()}] ${v.toolName}: ${v.reasons.join('; ')} (${v.requestCount} calls)`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  AGENTIC_HOP_LATENCY_BUDGETS_MS,
+  DEFAULT_SLOS,
+  checkHopLatencyBudgets,
+  checkSloViolations,
+  formatSloSection,
+  getAlertLogPath,
+  hopLatencyBudgetMs,
+  logAlert,
+  runSloCheck,
+};

--- a/scripts/tool-kpi-tracker.js
+++ b/scripts/tool-kpi-tracker.js
@@ -103,6 +103,18 @@ function emptyOutcomeCounts() {
   };
 }
 
+function pickDominantTier(tierCounts = {}) {
+  let best = null;
+  let bestCount = 0;
+  for (const [tier, count] of Object.entries(tierCounts)) {
+    if (count > bestCount) {
+      best = tier;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
 function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
   const entries = readJsonl(getKpiLogPath({ feedbackDir }));
   const cutoff = Date.now() - periodHours * 60 * 60 * 1000;
@@ -119,9 +131,14 @@ function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
         failures: 0,
         blocked: 0,
         outcomes: emptyOutcomeCounts(),
+        tierCounts: {},
       };
     }
     byTool[key].calls.push(entry.latencyMs);
+    const tier = entry.writeRiskTier || entry.metadata?.writeRiskTier || null;
+    if (tier) {
+      byTool[key].tierCounts[tier] = (byTool[key].tierCounts[tier] || 0) + 1;
+    }
     const normalized = normalizeToolCallOutcome(entry);
     byTool[key].outcomes[normalized] += 1;
     outcomes[normalized] += 1;
@@ -149,6 +166,7 @@ function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
         failures: tool.failures,
         blocked: tool.blocked,
         outcomes: tool.outcomes,
+        writeRiskTier: pickDominantTier(tool.tierCounts),
       };
     })
     .sort((left, right) => right.requestCount - left.requestCount);

--- a/scripts/tool-kpi-tracker.js
+++ b/scripts/tool-kpi-tracker.js
@@ -7,6 +7,12 @@ const path = require('node:path');
 const { resolveFeedbackDir } = require('./feedback-paths');
 const { readJsonl } = require('./fs-utils');
 
+const TOOL_CALL_OUTCOMES = Object.freeze({
+  SUCCESSFUL: 'successful',
+  FAILED: 'failed',
+  BLOCKED: 'blocked',
+});
+
 function getKpiLogPath(options = {}) {
   return path.join(
     options.feedbackDir ? path.resolve(options.feedbackDir) : resolveFeedbackDir(),
@@ -14,25 +20,69 @@ function getKpiLogPath(options = {}) {
   );
 }
 
+/**
+ * WriteGuard-aligned outcome taxonomy for every MCP attempt.
+ * Prefer explicit `outcome`; otherwise derive from blocked/denied/success.
+ */
+function normalizeToolCallOutcome({
+  outcome,
+  success,
+  blocked,
+  metadata,
+} = {}) {
+  if (
+    outcome === TOOL_CALL_OUTCOMES.SUCCESSFUL
+    || outcome === TOOL_CALL_OUTCOMES.FAILED
+    || outcome === TOOL_CALL_OUTCOMES.BLOCKED
+  ) {
+    return outcome;
+  }
+  if (
+    blocked === true
+    || metadata?.denied === true
+    || metadata?.outcome === TOOL_CALL_OUTCOMES.BLOCKED
+  ) {
+    return TOOL_CALL_OUTCOMES.BLOCKED;
+  }
+  if (success === false) return TOOL_CALL_OUTCOMES.FAILED;
+  return TOOL_CALL_OUTCOMES.SUCCESSFUL;
+}
+
 function recordToolCall({
   toolName,
   serverName,
   latencyMs,
   success,
+  blocked,
+  outcome,
   agentId,
+  clientId,
+  sessionId,
+  writeRiskTier,
   metadata,
   feedbackDir,
 } = {}) {
   const logPath = getKpiLogPath({ feedbackDir });
   fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  const normalizedOutcome = normalizeToolCallOutcome({
+    outcome,
+    success,
+    blocked,
+    metadata,
+  });
   const entry = {
     id: `kpi_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`,
     timestamp: new Date().toISOString(),
     toolName: toolName || 'unknown',
     serverName: serverName || 'default',
     latencyMs: typeof latencyMs === 'number' ? latencyMs : 0,
-    success: success !== false,
+    // Backward-compatible boolean: blocked and failed are both non-success.
+    success: normalizedOutcome === TOOL_CALL_OUTCOMES.SUCCESSFUL,
+    outcome: normalizedOutcome,
     agentId: agentId || 'unknown',
+    clientId: clientId || metadata?.clientId || null,
+    sessionId: sessionId || metadata?.sessionId || null,
+    writeRiskTier: writeRiskTier || metadata?.writeRiskTier || null,
     metadata: metadata || {},
   };
   fs.appendFileSync(logPath, `${JSON.stringify(entry)}\n`);
@@ -45,11 +95,20 @@ function percentile(sorted, quantile) {
   return sorted[Math.max(0, index)];
 }
 
+function emptyOutcomeCounts() {
+  return {
+    successful: 0,
+    failed: 0,
+    blocked: 0,
+  };
+}
+
 function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
   const entries = readJsonl(getKpiLogPath({ feedbackDir }));
   const cutoff = Date.now() - periodHours * 60 * 60 * 1000;
   const recent = entries.filter((entry) => new Date(entry.timestamp).getTime() > cutoff);
   const byTool = {};
+  const outcomes = emptyOutcomeCounts();
   for (const entry of recent) {
     const key = entry.toolName;
     if (!byTool[key]) {
@@ -58,11 +117,22 @@ function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
         calls: [],
         successes: 0,
         failures: 0,
+        blocked: 0,
+        outcomes: emptyOutcomeCounts(),
       };
     }
     byTool[key].calls.push(entry.latencyMs);
-    if (entry.success) byTool[key].successes += 1;
-    else byTool[key].failures += 1;
+    const normalized = normalizeToolCallOutcome(entry);
+    byTool[key].outcomes[normalized] += 1;
+    outcomes[normalized] += 1;
+    if (normalized === TOOL_CALL_OUTCOMES.SUCCESSFUL) {
+      byTool[key].successes += 1;
+    } else if (normalized === TOOL_CALL_OUTCOMES.BLOCKED) {
+      byTool[key].blocked += 1;
+      byTool[key].failures += 1;
+    } else {
+      byTool[key].failures += 1;
+    }
   }
   const tools = Object.values(byTool)
     .map((tool) => {
@@ -77,6 +147,8 @@ function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
         p95: Math.round(percentile(sorted, 95)),
         successes: tool.successes,
         failures: tool.failures,
+        blocked: tool.blocked,
+        outcomes: tool.outcomes,
       };
     })
     .sort((left, right) => right.requestCount - left.requestCount);
@@ -84,9 +156,18 @@ function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
   const byServer = {};
   for (const entry of recent) {
     const key = entry.serverName;
-    if (!byServer[key]) byServer[key] = { serverName: key, total: 0, successes: 0 };
+    if (!byServer[key]) {
+      byServer[key] = {
+        serverName: key,
+        total: 0,
+        successes: 0,
+        outcomes: emptyOutcomeCounts(),
+      };
+    }
     byServer[key].total += 1;
-    if (entry.success) byServer[key].successes += 1;
+    const normalized = normalizeToolCallOutcome(entry);
+    byServer[key].outcomes[normalized] += 1;
+    if (normalized === TOOL_CALL_OUTCOMES.SUCCESSFUL) byServer[key].successes += 1;
   }
   const servers = Object.values(byServer).map((server) => ({
     serverName: server.serverName,
@@ -94,11 +175,13 @@ function computeToolKpis({ periodHours = 24, feedbackDir } = {}) {
     successRate: server.total > 0
       ? Math.round((server.successes / server.total) * 1000) / 10
       : 100,
+    outcomes: server.outcomes,
   }));
   return {
     periodHours,
     totalCalls: recent.length,
     evidenceStatus: recent.length > 0 ? 'measured' : 'insufficient_evidence',
+    outcomes,
     tools,
     servers,
   };
@@ -116,9 +199,11 @@ function getAtRiskTools({
 }
 
 module.exports = {
+  TOOL_CALL_OUTCOMES,
   computeToolKpis,
   getAtRiskTools,
   getKpiLogPath,
+  normalizeToolCallOutcome,
   percentile,
   recordToolCall,
 };

--- a/scripts/tool-registry.js
+++ b/scripts/tool-registry.js
@@ -12,14 +12,38 @@ function humanizeTitle(name) {
     .join(' ');
 }
 
+// WriteGuard-style write risk tiers mapped onto existing MCP annotations.
+// Explicit annotations.writeRiskTier always wins; otherwise derive from hints + name.
+const WRITE_RISK_TIERS = Object.freeze({
+  READ_ONLY: 'read-only',
+  MINIMAL_IMPACT: 'minimal-impact',
+  CONTAINED_WRITE: 'contained-write',
+  CRITICAL: 'critical',
+});
+
+const CRITICAL_WRITE_NAME_RE = /(approve_protected|satisfy_gate|break[_-]?glass|create_purchase|reserve_purchase|reconcile_purchase|record_broker|verify_broker|reconcile_broker|parallel_workflow|bootstrap_internal_agent|run_managed_lesson_agent|run_harness|run_autoresearch)/i;
+const MINIMAL_WRITE_NAME_RE = /(append_feedback_context|open_feedback_session|request_human_escalation|report_product_issue|native_messaging_audit|detect_noop)/i;
+
+function inferWriteRiskTier(toolName, annotations = {}) {
+  if (annotations.writeRiskTier) return annotations.writeRiskTier;
+  if (annotations.readOnlyHint === true) return WRITE_RISK_TIERS.READ_ONLY;
+  const name = String(toolName || '');
+  if (CRITICAL_WRITE_NAME_RE.test(name)) return WRITE_RISK_TIERS.CRITICAL;
+  if (MINIMAL_WRITE_NAME_RE.test(name)) return WRITE_RISK_TIERS.MINIMAL_IMPACT;
+  // Destructive or unhinted tools default to contained write (conservative).
+  return WRITE_RISK_TIERS.CONTAINED_WRITE;
+}
+
 function readOnlyTool(tool) {
+  const title = tool.title || humanizeTitle(tool.name);
   return {
     ...tool,
-    title: tool.title || humanizeTitle(tool.name),
+    title,
     annotations: {
-      title: tool.title || humanizeTitle(tool.name),
+      title,
       readOnlyHint: true,
       thumbgateScope: 'mcp:read',
+      writeRiskTier: WRITE_RISK_TIERS.READ_ONLY,
     },
   };
 }
@@ -39,13 +63,17 @@ function inferThumbgateScope(toolName, annotations = {}) {
 
 function destructiveTool(tool) {
   const title = tool.title || humanizeTitle(tool.name);
+  const baseAnnotations = {
+    title,
+    destructiveHint: true,
+    thumbgateScope: inferThumbgateScope(tool.name, { destructiveHint: true }),
+  };
   return {
     ...tool,
     title,
     annotations: {
-      title,
-      destructiveHint: true,
-      thumbgateScope: inferThumbgateScope(tool.name, { destructiveHint: true }),
+      ...baseAnnotations,
+      writeRiskTier: inferWriteRiskTier(tool.name, baseAnnotations),
     },
   };
 }
@@ -1979,11 +2007,16 @@ const NORMALIZED_TOOLS = TOOLS.map((tool) => {
   if (!annotations.thumbgateScope) {
     annotations.thumbgateScope = inferThumbgateScope(tool.name, annotations);
   }
+  if (!annotations.writeRiskTier) {
+    annotations.writeRiskTier = inferWriteRiskTier(tool.name, annotations);
+  }
   return { ...tool, title, annotations };
 });
 
 module.exports = {
   TOOLS: NORMALIZED_TOOLS,
+  WRITE_RISK_TIERS,
   humanizeTitle,
   inferThumbgateScope,
+  inferWriteRiskTier,
 };

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -5622,13 +5622,22 @@ function createApiServer() {
                 ? mcpOauth.tokenAudienceValid(oauthSession, resourceUrl)
                 : rawKeyValid;
               if (!authed) {
+                const deniedName = msg.params?.name || 'unknown';
+                const deniedTool = MCP_TOOLS.find((t) => t.name === deniedName);
                 recordToolCall({
-                  toolName: msg.params?.name || 'unknown',
+                  toolName: deniedName,
                   serverName: 'mcp-http',
                   latencyMs: 0,
                   success: false,
+                  outcome: 'blocked',
+                  blocked: true,
                   agentId: 'unauthenticated',
-                  metadata: { denied: true, deniedReason: 'authentication_required' },
+                  writeRiskTier: deniedTool?.annotations?.writeRiskTier || null,
+                  metadata: {
+                    denied: true,
+                    deniedReason: 'authentication_required',
+                    writeRiskTier: deniedTool?.annotations?.writeRiskTier || null,
+                  },
                 });
                 res.writeHead(401, {
                   'Content-Type': 'application/json',
@@ -5657,8 +5666,15 @@ function createApiServer() {
                     serverName: 'mcp-http',
                     latencyMs: 0,
                     success: false,
+                    outcome: 'blocked',
+                    blocked: true,
                     agentId: 'reviewer',
-                    metadata: { denied: true, deniedReason: 'reviewer_read_only' },
+                    writeRiskTier: tool?.annotations?.writeRiskTier || null,
+                    metadata: {
+                      denied: true,
+                      deniedReason: 'reviewer_read_only',
+                      writeRiskTier: tool?.annotations?.writeRiskTier || null,
+                    },
                   });
                   sendJson(res, 200, {
                     jsonrpc: '2.0', id: msg.id,
@@ -5678,11 +5694,17 @@ function createApiServer() {
                     serverName: 'mcp-http',
                     latencyMs: 0,
                     success: false,
+                    outcome: 'blocked',
+                    blocked: true,
                     agentId: oauthSession.clientId || 'oauth-client',
+                    clientId: oauthSession.clientId || null,
+                    sessionId: oauthSession.sessionId || oauthSession.id || null,
+                    writeRiskTier: tool?.annotations?.writeRiskTier || null,
                     metadata: {
                       denied: true,
                       deniedReason: 'insufficient_scope',
                       requiredScope,
+                      writeRiskTier: tool?.annotations?.writeRiskTier || null,
                     },
                   });
                   sendJson(res, 200, {
@@ -5697,7 +5719,14 @@ function createApiServer() {
                   const { callTool } = require('../../adapters/mcp/server-stdio');
                   const name = msg.params?.name;
                   const args = (msg.params && msg.params.arguments) || {};
-                  const result = await callTool(name, args);
+                  // Attribution rides as callTool options (not tool args) so KPI
+                  // can bind human OAuth client/session without polluting schemas.
+                  const result = await callTool(name, args, {
+                    clientId: oauthSession?.clientId || null,
+                    sessionId: oauthSession?.sessionId || oauthSession?.id || null,
+                    agentId: oauthSession?.clientId || (isReviewer ? 'reviewer' : 'mcp-http'),
+                    serverName: 'mcp-http',
+                  });
                   sendJson(res, 200, {
                     jsonrpc: '2.0', id: msg.id,
                     result,

--- a/tests/control-tower.test.js
+++ b/tests/control-tower.test.js
@@ -11,9 +11,39 @@ const anomaly = require('../scripts/access-anomaly-detector');
 const tower = require('../scripts/statusline-tower');
 test.after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 // Tool KPI
-test('recordToolCall writes entry', () => { const e = kpi.recordToolCall({ toolName: 'recall', latencyMs: 42, success: true }); assert.ok(e.id.startsWith('kpi_')); });
+test('recordToolCall writes entry', () => { const e = kpi.recordToolCall({ toolName: 'recall', latencyMs: 42, success: true }); assert.ok(e.id.startsWith('kpi_')); assert.equal(e.outcome, 'successful'); });
 test('recordToolCall defaults', () => { assert.equal(kpi.recordToolCall({}).toolName, 'unknown'); });
 test('recordToolCall tracks failures', () => { kpi.recordToolCall({ toolName: 'cf', latencyMs: 200, success: false }); kpi.recordToolCall({ toolName: 'cf', latencyMs: 150, success: true }); kpi.recordToolCall({ toolName: 'cf', latencyMs: 800, success: false }); });
+test('recordToolCall normalizes blocked outcome from denied metadata', () => {
+  const entry = kpi.recordToolCall({
+    toolName: 'approve_protected_action',
+    success: false,
+    metadata: { denied: true, deniedReason: 'insufficient_scope' },
+    writeRiskTier: 'critical',
+    clientId: 'oauth-client-1',
+    sessionId: 'sess-1',
+  });
+  assert.equal(entry.outcome, 'blocked');
+  assert.equal(entry.success, false);
+  assert.equal(entry.writeRiskTier, 'critical');
+  assert.equal(entry.clientId, 'oauth-client-1');
+  assert.equal(entry.sessionId, 'sess-1');
+});
+test('computeToolKpis rolls up WriteGuard-style outcomes', () => {
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-kpi-outcomes-'));
+  try {
+    kpi.recordToolCall({ toolName: 'recall', success: true, outcome: 'successful', feedbackDir });
+    kpi.recordToolCall({ toolName: 'capture_feedback', success: false, outcome: 'failed', feedbackDir });
+    kpi.recordToolCall({ toolName: 'satisfy_gate', success: false, outcome: 'blocked', blocked: true, feedbackDir });
+    const rollup = kpi.computeToolKpis({ periodHours: 1, feedbackDir });
+    assert.deepEqual(rollup.outcomes, { successful: 1, failed: 1, blocked: 1 });
+    const blockedTool = rollup.tools.find((t) => t.toolName === 'satisfy_gate');
+    assert.equal(blockedTool.blocked, 1);
+    assert.equal(blockedTool.outcomes.blocked, 1);
+  } finally {
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
+  }
+});
 test('computeToolKpis per-tool metrics', () => { const r = kpi.computeToolKpis({ periodHours: 1 }); assert.ok(r.totalCalls >= 3); const cf = r.tools.find((t) => t.toolName === 'cf'); if (cf) { assert.ok(cf.successRate < 100); assert.ok(cf.p95 >= cf.p50); } });
 test('computeToolKpis server rollup', () => { assert.ok(kpi.computeToolKpis({ periodHours: 1 }).servers.length >= 1); });
 test('computeToolKpis reports whether traffic evidence exists', () => { assert.equal(kpi.computeToolKpis({ periodHours: 1 }).evidenceStatus, 'measured'); });
@@ -25,6 +55,7 @@ test('computeToolKpis fails closed when no traffic evidence exists', () => {
       periodHours: 24,
       totalCalls: 0,
       evidenceStatus: 'insufficient_evidence',
+      outcomes: { successful: 0, failed: 0, blocked: 0 },
       tools: [],
       servers: [],
     });

--- a/tests/control-tower.test.js
+++ b/tests/control-tower.test.js
@@ -109,8 +109,52 @@ test('getAtRiskTools detects latency-only risk and ignores low-volume noise', ()
 });
 test('percentile', () => { assert.equal(kpi.percentile([10, 20, 30, 40, 50], 50), 30); assert.equal(kpi.percentile([], 50), 0); });
 test('getKpiLogPath', () => { assert.ok(kpi.getKpiLogPath().endsWith('tool-kpi.jsonl')); });
+test('computeToolKpis surfaces dominant writeRiskTier', () => {
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-kpi-tier-'));
+  try {
+    for (let i = 0; i < 3; i++) {
+      kpi.recordToolCall({
+        toolName: 'recall',
+        latencyMs: 40,
+        success: true,
+        writeRiskTier: 'read-only',
+        feedbackDir,
+      });
+    }
+    const rollup = kpi.computeToolKpis({ periodHours: 1, feedbackDir });
+    const recall = rollup.tools.find((t) => t.toolName === 'recall');
+    assert.equal(recall.writeRiskTier, 'read-only');
+  } finally {
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
+  }
+});
 // SLO
-test('DEFAULT_SLOS', () => { assert.equal(slo.DEFAULT_SLOS.successRate, 90); });
+test('DEFAULT_SLOS pins Akamai 500ms agentic hop wall', () => {
+  assert.equal(slo.DEFAULT_SLOS.successRate, 90);
+  assert.equal(slo.DEFAULT_SLOS.p95LatencyMs, 500);
+  assert.equal(slo.AGENTIC_HOP_LATENCY_BUDGETS_MS.default, 500);
+  assert.equal(slo.AGENTIC_HOP_LATENCY_BUDGETS_MS['read-only'], 250);
+  assert.equal(slo.hopLatencyBudgetMs('critical'), 1000);
+});
+test('checkHopLatencyBudgets flags read-only hops over 250ms', () => {
+  const feedbackDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-hop-budget-'));
+  try {
+    for (let i = 0; i < 3; i++) {
+      kpi.recordToolCall({
+        toolName: 'recall',
+        latencyMs: 400,
+        success: true,
+        writeRiskTier: 'read-only',
+        feedbackDir,
+      });
+    }
+    const report = slo.checkHopLatencyBudgets({ periodHours: 1, feedbackDir });
+    assert.equal(report.wallMs, 500);
+    assert.ok(report.violations.some((v) => v.toolName === 'recall' && v.budgetMs === 250));
+  } finally {
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
+  }
+});
 test('checkSloViolations detects', () => { const r = slo.checkSloViolations({ periodHours: 1 }); assert.ok(r.violations.find((v) => v.toolName === 'bad')); });
 test('checkSloViolations custom thresholds', () => { assert.ok(slo.checkSloViolations({ slos: { successRate: 99 }, periodHours: 1 }).violationCount >= slo.checkSloViolations({ slos: { successRate: 1 }, periodHours: 1 }).violationCount); });
 test('runSloCheck logs', async () => { await slo.runSloCheck({ periodHours: 1 }); assert.ok(fs.existsSync(slo.getAlertLogPath())); });

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -1583,6 +1583,8 @@ test('MCP tool calls emit structured output and KPI telemetry', async () => {
   assert.equal(entries.length, before + 1);
   assert.equal(entries.at(-1).toolName, 'get_agent_outcome_metrics');
   assert.equal(entries.at(-1).success, true);
+  assert.equal(entries.at(-1).outcome, 'successful');
+  assert.equal(entries.at(-1).writeRiskTier, 'read-only');
   assert.equal(entries.at(-1).metadata.category, 'success');
 });
 

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -1588,6 +1588,47 @@ test('MCP tool calls emit structured output and KPI telemetry', async () => {
   assert.equal(entries.at(-1).metadata.category, 'success');
 });
 
+test('MCP KPI identity ignores caller-controlled tool args', async () => {
+  const before = fs.existsSync(path.join(tmpFeedbackDir, 'tool-kpi.jsonl'))
+    ? fs.readFileSync(path.join(tmpFeedbackDir, 'tool-kpi.jsonl'), 'utf8').trim().split('\n').filter(Boolean).length
+    : 0;
+
+  await callTool('detect_noop', {
+    actionId: 'kpi-identity-poison-1',
+    clientId: 'attacker-client',
+    sessionId: 'attacker-session',
+    mcpClient: 'attacker-mcp',
+    mcpSessionId: 'attacker-mcp-session',
+  });
+
+  await callTool(
+    'detect_noop',
+    {
+      actionId: 'kpi-identity-poison-2',
+      clientId: 'attacker-client',
+      sessionId: 'attacker-session',
+    },
+    { clientId: 'trusted-oauth-client', sessionId: 'trusted-oauth-session', agentId: 'http-agent' },
+  );
+
+  const entries = fs.readFileSync(path.join(tmpFeedbackDir, 'tool-kpi.jsonl'), 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(JSON.parse);
+  assert.equal(entries.length, before + 2);
+
+  const poisoned = entries[before];
+  assert.equal(poisoned.toolName, 'detect_noop');
+  assert.equal(poisoned.clientId, null);
+  assert.equal(poisoned.sessionId, null);
+
+  const trusted = entries[before + 1];
+  assert.equal(trusted.clientId, 'trusted-oauth-client');
+  assert.equal(trusted.sessionId, 'trusted-oauth-session');
+  assert.equal(trusted.agentId, 'http-agent');
+});
+
 test('MCP structured output validation fails closed', () => {
   const tool = TOOLS.find((candidate) => candidate.name === 'record_task_outcome');
   const validation = __test__.validateMcpToolOutput(tool, {

--- a/tests/tool-registry.test.js
+++ b/tests/tool-registry.test.js
@@ -211,3 +211,39 @@ test('inferThumbgateScope maps feedback/gates/read/write classes', () => {
   const capture = TOOLS.find((tool) => tool.name === 'capture_feedback');
   assert.equal(capture.annotations.thumbgateScope, 'mcp:feedback');
 });
+
+test('inferWriteRiskTier maps annotations to WriteGuard-style tiers', () => {
+  const {
+    WRITE_RISK_TIERS,
+    inferWriteRiskTier,
+    TOOLS,
+  } = require('../scripts/tool-registry');
+
+  assert.equal(
+    inferWriteRiskTier('recall', { readOnlyHint: true }),
+    WRITE_RISK_TIERS.READ_ONLY,
+  );
+  assert.equal(
+    inferWriteRiskTier('capture_feedback', { destructiveHint: true }),
+    WRITE_RISK_TIERS.CONTAINED_WRITE,
+  );
+  assert.equal(
+    inferWriteRiskTier('approve_protected_action', { destructiveHint: true }),
+    WRITE_RISK_TIERS.CRITICAL,
+  );
+  assert.equal(
+    inferWriteRiskTier('append_feedback_context', { destructiveHint: true }),
+    WRITE_RISK_TIERS.MINIMAL_IMPACT,
+  );
+  assert.equal(
+    inferWriteRiskTier('custom', { writeRiskTier: 'critical' }),
+    WRITE_RISK_TIERS.CRITICAL,
+  );
+
+  for (const tool of TOOLS) {
+    assert.ok(
+      Object.values(WRITE_RISK_TIERS).includes(tool.annotations.writeRiskTier),
+      `${tool.name} missing valid writeRiskTier`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Map every MCP tool to a WriteGuard-style `writeRiskTier` (`read-only` | `minimal-impact` | `contained-write` | `critical`) derived from existing annotations + name heuristics.
- Persist tool KPI outcomes as `successful` | `failed` | `blocked` (with blocked counts in rollups), plus optional OAuth `clientId`/`sessionId` attribution.
- Wire HTTP MCP denials to `blocked` and pass client/session attribution into `callTool` without polluting tool schemas.

## Test plan
- [x] `node --test tests/tool-registry.test.js` (51 pass)
- [x] `node --test tests/control-tower.test.js` (30 pass)
- [x] `node --test tests/mcp-tool-annotations.test.js` (3 pass)
- [x] `node --test --test-name-pattern='KPI telemetry' tests/mcp-server.test.js` (1 pass)
- [x] `node --test tests/mcp-oauth-reviewer.test.js` (3 pass)

## Notes
Maintenance mapping of existing MCP annotation + KPI surfaces (Cloudflare WriteGuard vocabulary transfer). Not a portal clone.