### PR TITLE
fix(gates): stop lexical false-denies and wrong-tree blast radius

### DIFF
--- a/.changeset/false-deny-lexical-wrong-tree.md
+++ b/.changeset/false-deny-lexical-wrong-tree.md
@@ -1,0 +1,11 @@
+---
+"thumbgate": patch
+---
+
+fix(gates): stop lexical false-denies on remedy prose and wrong-tree blast radius
+
+Commerce and permission matchers scanned full tool text, so satisfy_gate
+evidence, capture_feedback, and `gh issue create --body` quoting chmod/checkout
+deadlocked the documented unblock path (#3523). Blast radius and task-scope
+read the hook cwd / a global governance slot, so a one-file vault commit was
+scored as the primary dirty tree (#3522).

--- a/scripts/financial-control-plane.js
+++ b/scripts/financial-control-plane.js
@@ -41,6 +41,24 @@ const CONTROL_PLANE_TOOLS = new Set([
   'settle_purchase_requisition',
   'reconcile_purchase_ledger',
 ]);
+const REMEDY_TOOLS = new Set([
+  'satisfy_gate',
+  'capture_feedback',
+  'capture_memory_feedback',
+  'record_task_outcome',
+  'diagnose_failure',
+  'set_task_scope',
+  'approve_protected_action',
+  'track_action',
+  'verify_claim',
+  'break_glass_emergency',
+]);
+
+function isRemedyControlTool(toolName) {
+  const normalized = String(toolName || '').trim();
+  const bare = normalized.replace(/^mcp__.+?__/, '');
+  return REMEDY_TOOLS.has(bare) || CONTROL_PLANE_TOOLS.has(bare);
+}
 
 // Keep these expressions deliberately small and auditable. The second group
 // covers provider-native noun-first CLI forms such as `subscriptions create`.
@@ -339,6 +357,7 @@ function advanceFinancialLedgerAnchor(previousHead, event, options = {}) {
 
 function detectEconomicAction(toolName, toolInput = {}) {
   const normalizedToolName = String(toolName || '').trim();
+  if (isRemedyControlTool(normalizedToolName)) return false;
   if ([...CONTROL_PLANE_TOOLS].some((name) => (
     normalizedToolName === name || normalizedToolName.endsWith(`__${name}`)
   ))) return false;
@@ -1607,6 +1626,7 @@ module.exports = {
   createPurchaseRequisition,
   buildActionAuthorization,
   detectEconomicAction,
+  isRemedyControlTool,
   detectOpaqueScreenMutation,
   evaluateFinancialControl,
   getLedgerHeadPath,

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -108,6 +108,18 @@ const STATS_PATH = path.join(STATE_DIR, 'gate-stats.json');
 const SESSION_ACTIONS_PATH = path.join(STATE_DIR, 'session-actions.json');
 const CUSTOM_CLAIM_GATES_PATH = path.join(STATE_DIR, 'claim-verification.json');
 const GOVERNANCE_STATE_PATH = path.join(STATE_DIR, 'governance-state.json');
+const REMEDY_TOOL_NAMES = new Set([
+  'satisfy_gate',
+  'capture_feedback',
+  'capture_memory_feedback',
+  'record_task_outcome',
+  'diagnose_failure',
+  'set_task_scope',
+  'approve_protected_action',
+  'track_action',
+  'verify_claim',
+  'break_glass_emergency',
+]);
 const TTL_MS = 5 * 60 * 1000; // 5 minutes
 const SESSION_ACTION_TTL_MS = 60 * 60 * 1000; // 1 hour
 const PROTECTED_APPROVAL_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -479,8 +491,35 @@ function isTaskScopeExpired(taskScope, nowMs = Date.now()) {
   return nowMs >= deadline;
 }
 
+function currentScopeSessionId() {
+  const raw = String(
+    process.env.THUMBGATE_SESSION_AGENT
+    || process.env.THUMBGATE_SESSION_ID
+    || process.env.CLAUDE_SESSION_ID
+    || ''
+  ).trim();
+  return raw || null;
+}
+
+function sanitizeScopeSessionId(sessionId) {
+  return String(sessionId || '').replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 80);
+}
+
+// Sibling agents share ~/.thumbgate/governance-state.json today, so one
+// set_task_scope rebinds every other live session (#3522). When a session id
+// is present, persist a per-session file next to the legacy slot.
+function governanceStatePath() {
+  const base = module.exports.GOVERNANCE_STATE_PATH;
+  const sessionId = currentScopeSessionId();
+  if (!sessionId) return base;
+  const safe = sanitizeScopeSessionId(sessionId);
+  if (!safe) return base;
+  const parsed = path.parse(base);
+  return path.join(parsed.dir, `${parsed.name}.${safe}${parsed.ext}`);
+}
+
 function loadGovernanceState() {
-  const raw = loadJSON(module.exports.GOVERNANCE_STATE_PATH);
+  const raw = loadJSON(governanceStatePath());
   const state = {
     taskScope: raw && raw.taskScope && typeof raw.taskScope === 'object' ? raw.taskScope : null,
     protectedApprovals: Array.isArray(raw && raw.protectedApprovals) ? raw.protectedApprovals : [],
@@ -517,7 +556,7 @@ function saveGovernanceState(state) {
     branchGovernance: state && state.branchGovernance ? state.branchGovernance : null,
     workflowContract: state && state.workflowContract ? state.workflowContract : null,
   };
-  saveJSON(module.exports.GOVERNANCE_STATE_PATH, next);
+  saveJSON(governanceStatePath(), next);
 }
 
 function stableCanonicalStringify(value) {
@@ -661,6 +700,7 @@ function setTaskScope(scopeInput = {}) {
   const leaseMs = scopeInput.ttlMs == null ? null : clampTtlMs(scopeInput.ttlMs, TASK_SCOPE_LEASE_MS);
   const taskScope = {
     taskId: String(scopeInput.taskId || '').trim() || null,
+    sessionId: currentScopeSessionId(),
     summary: String(scopeInput.summary || '').trim() || null,
     allowedPaths,
     protectedPaths,
@@ -1050,14 +1090,55 @@ function safeExecFileLines(binary, args, cwd) {
   }
 }
 
+function extractGitMinusCPaths(command) {
+  const found = [];
+  const segments = String(command || '').split(/\r?\n|&&|\|\||[;|&]/);
+  for (const segment of segments) {
+    const tokens = tokenizeShellWords(segment);
+    const gitIdx = tokens.findIndex((token) => token === 'git' || /(?:^|\/)git$/.test(token));
+    if (gitIdx === -1) continue;
+    for (let i = gitIdx + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      if (token === '-C' && tokens[i + 1]) {
+        found.push(tokens[i + 1]);
+        i += 1;
+        continue;
+      }
+      if (token === '--work-tree' && tokens[i + 1]) {
+        found.push(tokens[i + 1]);
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--work-tree=')) {
+        found.push(token.slice('--work-tree='.length));
+        continue;
+      }
+      if (!token.startsWith('-')) break;
+    }
+  }
+  return found;
+}
+
 function resolveRepoRoot(toolInput = {}) {
-  const candidates = [
+  const command = String(toolInput.command || '');
+  const baseCwd = toolInput.cwd ? path.resolve(String(toolInput.cwd)) : process.cwd();
+  const minusC = extractGitMinusCPaths(command).map((entry) => path.resolve(baseCwd, entry));
+  const commandCwd = effectiveCommandCwd(command, toolInput);
+  const candidates = [];
+  const seen = new Set();
+  for (const value of [
+    ...minusC,
+    commandCwd,
     toolInput.repoPath,
     toolInput.cwd,
     process.cwd(),
-  ]
-    .filter(Boolean)
-    .map((value) => path.resolve(String(value)));
+  ]) {
+    if (!value) continue;
+    const resolved = path.resolve(String(value));
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    candidates.push(resolved);
+  }
 
   for (const cwd of candidates) {
     try {
@@ -1845,6 +1926,36 @@ function bareToolName(toolName) {
   return String(toolName || '').replace(/^mcp__.+?__/, '');
 }
 
+function isRemedyToolName(toolName) {
+  return REMEDY_TOOL_NAMES.has(bareToolName(toolName));
+}
+
+// permission-change-approval used to regex the entire command string, so
+// quoting `chmod 755` inside `gh issue create --body` was itself a deny (#3523).
+function isCommandPositionPermissionChange(toolName, toolInput = {}) {
+  if (toolName !== 'Bash') return false;
+  const command = String(toolInput.command || '');
+  if (!command) return false;
+  const segments = canonicalizeCommandForGates(command).split('; ');
+  for (const segment of segments) {
+    const tokens = tokenizeShellWords(segment);
+    if (tokens.length === 0) continue;
+    const bin = tokens[0].toLowerCase();
+    if (bin === 'chmod' || bin === 'chown' || bin === 'setfacl') return tokens.length >= 2;
+    if (bin === 'grant' || bin === 'revoke') return tokens.length >= 2;
+    const nextFew = tokens.slice(1, 6).map((token) => token.toLowerCase());
+    if ((bin === 'pm' || bin === 'adb') && nextFew.includes('grant')) return true;
+    if (
+      (bin === 'aws' || bin === 'gcloud' || bin === 'az')
+      && nextFew.some((token) => token === 'iam' || token === 'policy' || token === 'role'
+        || token === 'grant' || token === 'revoke')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isThreadResolutionEvidenceAction(toolName, toolInput = {}) {
   if (isGitCommitCommand(toolName, toolInput)) return true;
   if (['recall', 'search_lessons', 'verify_claim', 'satisfy_gate', 'track_action'].includes(bareToolName(toolName))) return true;
@@ -2559,17 +2670,23 @@ function matchGate(gate, toolName, toolInput = {}) {
 
   if (gate.pattern) {
     try {
-      const regex = new RegExp(gate.pattern);
-      // Match command text, tool name, and light payload surfaces. MCP tools
-      // (e.g. Gmail send_message) have no `command` field — without multi-surface
-      // matching, every pattern gate against them is permanently inert.
-      const surfaces = matchSurfaces.length > 0 ? matchSurfaces : [matchText];
-      const anySurfaceMatch = surfaces.some((surface) => patternMatchesCommand(regex, surface));
-      if (!anySurfaceMatch) {
-        return { matched: false, matchText, affectedFiles };
-      }
-      if (gate.id === 'permission-change-approval' && isSafeLocalCredentialHardeningCommand(toolName, toolInput)) {
-        return { matched: false, matchText, affectedFiles };
+      if (gate.id === 'permission-change-approval') {
+        if (isRemedyToolName(toolName) || !isCommandPositionPermissionChange(toolName, toolInput)) {
+          return { matched: false, matchText, affectedFiles };
+        }
+        if (isSafeLocalCredentialHardeningCommand(toolName, toolInput)) {
+          return { matched: false, matchText, affectedFiles };
+        }
+      } else {
+        const regex = new RegExp(gate.pattern);
+        // Match command text, tool name, and light payload surfaces. MCP tools
+        // (e.g. Gmail send_message) have no `command` field — without multi-surface
+        // matching, every pattern gate against them is permanently inert.
+        const surfaces = matchSurfaces.length > 0 ? matchSurfaces : [matchText];
+        const anySurfaceMatch = surfaces.some((surface) => patternMatchesCommand(regex, surface));
+        if (!anySurfaceMatch) {
+          return { matched: false, matchText, affectedFiles };
+        }
       }
       if (isBreakGlassSettingsBypass(gate, affectedFiles)) {
         return { matched: false, matchText, affectedFiles };
@@ -3713,6 +3830,7 @@ function evaluateUnconditionalHardFloor(input = {}, options = {}) {
 
 function evaluateFinancialHardFloor(input = {}, consumeReservation = false, options = {}) {
   const toolName = input.tool_name || input.toolName || 'unknown';
+  if (isRemedyToolName(toolName)) return null;
   const rawToolInput = input.tool_input ?? input.toolInput;
   const toolInput = rawToolInput && typeof rawToolInput === 'object'
     ? rawToolInput
@@ -4586,6 +4704,12 @@ module.exports = {
   actionApprovalDigest,
   buildMatchSurfaces,
   extractAffectedFiles,
+  extractGitMinusCPaths,
+  resolveRepoRoot,
+  governanceStatePath,
+  currentScopeSessionId,
+  isRemedyToolName,
+  isCommandPositionPermissionChange,
   parseGitPathspec,
   canonicalizeGitCommand,
   canonicalizeCommandForGates,

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -502,7 +502,10 @@ function currentScopeSessionId() {
 }
 
 function sanitizeScopeSessionId(sessionId) {
-  return String(sessionId || '').replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 80);
+  if (!sessionId) return '';
+  const hash = crypto.createHash('sha256').update(String(sessionId)).digest('hex').slice(0, 16);
+  const prefix = String(sessionId).replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 32);
+  return prefix ? `${prefix}-${hash}` : hash;
 }
 
 // Sibling agents share ~/.thumbgate/governance-state.json today, so one
@@ -1119,9 +1122,65 @@ function extractGitMinusCPaths(command) {
   return found;
 }
 
+function extractGitContextPair(command) {
+  const segments = String(command || '').split(/\r?\n|&&|\|\||[;|&]/);
+  for (const segment of segments) {
+    const tokens = tokenizeShellWords(segment);
+    const gitIdx = tokens.findIndex((token) => token === 'git' || /(?:^|\/)git$/.test(token));
+    if (gitIdx === -1) continue;
+    let gitDir = null;
+    let workTree = null;
+    for (let i = gitIdx + 1; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      if (token === '--git-dir' && tokens[i + 1]) {
+        gitDir = tokens[i + 1];
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--git-dir=')) {
+        gitDir = token.slice('--git-dir='.length);
+        continue;
+      }
+      if (token === '--work-tree' && tokens[i + 1]) {
+        workTree = tokens[i + 1];
+        i += 1;
+        continue;
+      }
+      if (token.startsWith('--work-tree=')) {
+        workTree = token.slice('--work-tree='.length);
+        continue;
+      }
+      if (token === '-C' && tokens[i + 1]) {
+        workTree = tokens[i + 1];
+        i += 1;
+        continue;
+      }
+      if (!token.startsWith('-')) break;
+    }
+    if (gitDir || workTree) return { gitDir, workTree };
+  }
+  return null;
+}
+
 function resolveRepoRoot(toolInput = {}) {
   const command = String(toolInput.command || '');
   const baseCwd = toolInput.cwd ? path.resolve(String(toolInput.cwd)) : process.cwd();
+  const paired = extractGitContextPair(command);
+  if (paired && paired.gitDir && paired.workTree) {
+    try {
+      const resolvedGitDir = path.resolve(baseCwd, paired.gitDir);
+      const resolvedWorkTree = path.resolve(baseCwd, paired.workTree);
+      const root = execFileSync('git', ['--git-dir', resolvedGitDir, '--work-tree', resolvedWorkTree, 'rev-parse', '--show-toplevel'], {
+        cwd: resolvedWorkTree,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (root) return root;
+    } catch {
+      // Fall through to standard candidate probing
+    }
+  }
+
   const minusC = extractGitMinusCPaths(command).map((entry) => path.resolve(baseCwd, entry));
   const commandCwd = effectiveCommandCwd(command, toolInput);
   const candidates = [];
@@ -1944,6 +2003,9 @@ function isCommandPositionPermissionChange(toolName, toolInput = {}) {
     if (tokens.length === 0) continue;
     const bin = tokens[0].toLowerCase();
     if (bin === 'chmod' || bin === 'chown' || bin === 'setfacl') return tokens.length >= 2;
+    if (bin === 'busybox' && tokens[1] && ['chmod', 'chown', 'setfacl'].includes(tokens[1].toLowerCase())) {
+      return tokens.length >= 3;
+    }
     if (bin === 'grant' || bin === 'revoke') return tokens.length >= 2;
     const nextFew = tokens.slice(1, 6).map((token) => token.toLowerCase());
     if ((bin === 'pm' || bin === 'adb') && nextFew.includes('grant')) return true;

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -1602,8 +1602,10 @@ function extractAffectedFiles(toolName, toolInput = {}) {
     }
 
     if (/\bgit\s+push\b/i.test(command) || /\bgh\s+pr\s+(?:create|merge)\b/i.test(command) || isGhApiPrCreateCommand(command)) {
-      for (const filePath of getBranchDiffFiles(repoRoot)) {
-        files.add(normalizePosix(filePath));
+      if (files.size === 0) {
+        for (const filePath of getBranchDiffFiles(repoRoot)) {
+          files.add(normalizePosix(filePath));
+        }
       }
     }
   }

--- a/scripts/sequence-guard.js
+++ b/scripts/sequence-guard.js
@@ -156,13 +156,23 @@ function evaluateSequenceState(toolName, toolInput) {
   // 1. Task Scope Verification
   let taskScope = null;
   try {
-    if (fs.existsSync(GOVERNANCE_STATE_PATH)) {
-      const gov = JSON.parse(fs.readFileSync(GOVERNANCE_STATE_PATH, 'utf8'));
+    const engine = require('./gates-engine');
+    if (typeof engine.loadGovernanceState === 'function') {
+      const gov = engine.loadGovernanceState();
       if (gov && gov.taskScope && typeof gov.taskScope === 'object') {
         taskScope = gov.taskScope;
       }
     }
-  } catch {}
+  } catch {
+    try {
+      if (fs.existsSync(GOVERNANCE_STATE_PATH)) {
+        const gov = JSON.parse(fs.readFileSync(GOVERNANCE_STATE_PATH, 'utf8'));
+        if (gov && gov.taskScope && typeof gov.taskScope === 'object') {
+          taskScope = gov.taskScope;
+        }
+      }
+    } catch { /* ignore unreadable governance state */ }
+  }
 
   if (taskScope && Array.isArray(taskScope.allowedPaths) && taskScope.allowedPaths.length > 0) {
     // Block file edits immediately if they touch files outside allowed paths

--- a/scripts/thumbgate-spend-guard.js
+++ b/scripts/thumbgate-spend-guard.js
@@ -63,6 +63,16 @@ const VENDOR_UPSELL =
 const PROTECTED_GUARD_PATH =
   /(?:^|[\s"'])(?:~\/|\$(?:HOME|\{HOME\})["']?\/|\/Users\/[^/\s"']+\/)?\.(?:thumbgate\/(?:bin\/thumbgate-spend-guard(?:\.HARDENED)?\.js|financial\/)|claude\/settings\.json)(?:$|[\s"'])/i;
 
+const REMEDY_TOOL_RE =
+  /(?:^|__)(?:satisfy_gate|capture_feedback|capture_memory_feedback|record_task_outcome|diagnose_failure|set_task_scope|approve_protected_action|track_action|verify_claim|break_glass_emergency)$/i;
+
+const PROSE_KEYS = new Set([
+  'description', 'evidence', 'body', 'title', 'message', 'content', 'prompt',
+  'summary', 'structuredReasoning', 'old_string', 'new_string', 'oldString',
+  'newString', 'context', 'whatWentWrong', 'whatToChange', 'whatWorked',
+  'what_went_wrong', 'what_to_change', 'what_worked',
+]);
+
 function flatten(value, depth = 0) {
   if (typeof erpFlatten === 'function') return erpFlatten(value, depth);
   if (depth > 5 || value == null) return '';
@@ -78,9 +88,51 @@ function flatten(value, depth = 0) {
   return '';
 }
 
+function flattenSkippingProse(value, depth = 0) {
+  if (depth > 5 || value == null) return '';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) return value.map((item) => flattenSkippingProse(item, depth + 1)).join(' ');
+  if (typeof value === 'object') {
+    return Object.entries(value)
+      .filter(([key]) => !PROSE_KEYS.has(key))
+      .map(([key, item]) => `${key} ${flattenSkippingProse(item, depth + 1)}`)
+      .join(' ');
+  }
+  return '';
+}
+
+// Drop --body/--message/-m payloads so filing an issue that QUOTES a trigger
+// word is not itself a commerce action (#3523).
+function stripFlaggedProse(command) {
+  return String(command || '').replace(
+    /\s(?:--(?:body|message|title|notes|field|reason|comment)|-[mF])(?:=|\s+)(?:"[^"]*"|'[^']*'|\S+)/g,
+    ' ',
+  );
+}
+
+function flattenSideEffect(toolName, toolInput) {
+  const name = String(toolName || '');
+  const input = toolInput && typeof toolInput === 'object' ? toolInput : {};
+  if (REMEDY_TOOL_RE.test(name)) {
+    return [input.url, input.uri, input.href, input.endpoint, input.command, input.cmd]
+      .filter(Boolean)
+      .map(String)
+      .join(' ');
+  }
+  if (/^bash$/i.test(name.trim())) {
+    return stripFlaggedProse(input.command || input.cmd || '');
+  }
+  if (/^(?:edit|write|multiedit)$/i.test(name.trim())) {
+    return [input.file_path, input.path, input.filePath].filter(Boolean).join(' ');
+  }
+  return flattenSkippingProse(input);
+}
+
 function evaluateSpend(toolName, toolInput) {
   const name = String(toolName || '');
-  const text = flatten(toolInput);
+  const text = flattenSideEffect(name, toolInput);
   const combined = `${name} ${text}`;
 
   // ERP plane first (journal + classification + auth + envelope)
@@ -226,6 +278,8 @@ module.exports = {
   DIRECT_TOOL_RULES,
   evaluateSpend,
   flatten,
+  flattenSideEffect,
+  stripFlaggedProse,
   safeToolName,
   toHookOutput,
 };

--- a/scripts/workflow-sentinel.js
+++ b/scripts/workflow-sentinel.js
@@ -66,6 +66,14 @@ function loadJson(filePath) {
 }
 
 function loadGovernanceState() {
+  try {
+    const engine = require('./gates-engine');
+    if (typeof engine.loadGovernanceState === 'function') {
+      return engine.loadGovernanceState();
+    }
+  } catch {
+    // Fall through to the local file if the engine cannot load.
+  }
   const raw = loadJson(GOVERNANCE_STATE_PATH);
   return {
     taskScope: raw?.taskScope && typeof raw.taskScope === 'object' ? raw.taskScope : null,
@@ -206,6 +214,19 @@ function getBranchDiffFiles(repoRoot) {
 }
 
 function collectAffectedFiles(toolName, toolInput = {}, repoRoot) {
+  try {
+    const { extractAffectedFiles } = require('./gates-engine');
+    if (typeof extractAffectedFiles === 'function') {
+      const extracted = extractAffectedFiles(toolName, {
+        ...toolInput,
+        cwd: toolInput.cwd || repoRoot,
+        repoPath: toolInput.repoPath || repoRoot,
+      });
+      if (extracted && Array.isArray(extracted.files)) return extracted.files;
+    }
+  } catch {
+    // Keep the local collector if the engine cannot load.
+  }
   const files = new Set(collectInlineAffectedFiles(toolInput, repoRoot));
   const command = String(toolInput.command || '');
   const hasExplicitAffectedFiles = files.size > 0;
@@ -1485,7 +1506,22 @@ function evaluateWorkflowSentinel(toolName, toolInput = {}, options = {}) {
   const workflowControl = buildWorkflowControl(normalizedAction, options.workflowPolicy || toolInput.workflowPolicy || options.budget || toolInput.budget || {});
   const governanceState = options.governanceState || loadGovernanceState();
   const repoPath = options.repoPath || normalizedToolInput.repoPath || normalizedToolInput.cwd || process.cwd();
-  const repoRoot = resolveRepoRoot(repoPath) || null;
+  let repoRoot = null;
+  try {
+    const engine = require('./gates-engine');
+    if (typeof engine.resolveRepoRoot === 'function') {
+      repoRoot = engine.resolveRepoRoot({
+        ...normalizedToolInput,
+        cwd: normalizedToolInput.cwd || repoPath,
+        repoPath: normalizedToolInput.repoPath || repoPath,
+      });
+    }
+  } catch {
+    repoRoot = null;
+  }
+  if (!repoRoot) {
+    repoRoot = resolveRepoRoot(repoPath) || null;
+  }
   const affectedFiles = Array.isArray(options.affectedFiles)
     ? options.affectedFiles.map((filePath) => normalizePosix(filePath)).filter(Boolean)
     : collectAffectedFiles(normalizedToolName, normalizedToolInput, repoRoot);

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -184,6 +184,9 @@ beforeEach(() => {
   process.env.THUMBGATE_FEEDBACK_LOG = sandboxPath('feedback-log.jsonl');
   process.env.THUMBGATE_ATTRIBUTED_FEEDBACK = sandboxPath('attributed-feedback.jsonl');
   process.env.THUMBGATE_GUARDS_PATH = sandboxPath('pretool-guards.json');
+  delete process.env.THUMBGATE_SESSION_AGENT;
+  delete process.env.THUMBGATE_SESSION_ID;
+  delete process.env.CLAUDE_SESSION_ID;
   fs.writeFileSync(process.env.THUMBGATE_FEEDBACK_LOG, '');
   fs.writeFileSync(process.env.THUMBGATE_ATTRIBUTED_FEEDBACK, '');
   cleanupStateFiles();
@@ -3720,4 +3723,32 @@ test('evaluateGates matches on-demand-freeze-mode when freeze_mode or env is set
     fs.rmSync(tmpConfig, { force: true });
     cleanupStateFiles();
   }
+});
+
+test('permission-change does not fire on quoted chmod in issue-body prose (#3523)', () => {
+  cleanupStateFiles();
+  const quoted = evaluateGates('Bash', {
+    command: 'gh issue create --title bug --body "the prior false trigger was chmod 755 on a script"',
+  });
+  assert.equal(quoted, null, 'quoting a permission command in prose must not require approval');
+
+  const real = evaluateGates('Bash', { command: 'chmod 777 /tmp/wide-open' });
+  assert.ok(real);
+  assert.equal(real.gate, 'permission-change-approval');
+  cleanupStateFiles();
+});
+
+test('satisfy_gate evidence mentioning checkout is not a financial hard floor (#3523)', () => {
+  cleanupStateFiles();
+  const result = evaluateGates('mcp__thumbgate__satisfy_gate', {
+    gate: 'pr_threads_checked',
+    evidence: 'false positive: git checkout of the working copy, not a paid checkout',
+    structuredReasoning: {
+      premise: 'unlock a false deny',
+      evidence: 'the matcher scanned checkout in remedy prose',
+      conclusion: 'allow',
+    },
+  });
+  assert.equal(result, null, 'remedy-tool evidence must not trip financial-control');
+  cleanupStateFiles();
 });

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -3725,6 +3725,47 @@ test('evaluateGates matches on-demand-freeze-mode when freeze_mode or env is set
   }
 });
 
+test('isCommandPositionPermissionChange recognizes busybox chmod/chown/setfacl', () => {
+  const { run } = require('../scripts/gates-engine');
+  withTempFeedbackDir(() => {
+    setTaskScope({ clear: true });
+    const output = JSON.parse(run({
+      tool_name: 'Bash',
+      tool_input: { command: 'busybox chmod 777 /tmp/target' },
+    }));
+    assert.ok(output.hookSpecificOutput);
+    assert.match(output.hookSpecificOutput.additionalContext, /permission/i);
+  });
+});
+
+test('governance state session IDs are collision-resistant via sha256', () => {
+  const { sanitizeScopeSessionId } = require('../scripts/gates-engine');
+  if (typeof sanitizeScopeSessionId === 'function') {
+    const id1 = sanitizeScopeSessionId('live:agent');
+    const id2 = sanitizeScopeSessionId('live?agent');
+    assert.notEqual(id1, id2);
+  }
+});
+
+test('resolveRepoRoot handles paired --git-dir and --work-tree options', () => {
+  const { resolveRepoRoot } = require('../scripts/gates-engine');
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'thumbgate-split-git-'));
+  try {
+    const gitDir = path.join(tempDir, 'custom.git');
+    const workTree = path.join(tempDir, 'tree');
+    fs.mkdirSync(workTree, { recursive: true });
+    execFileSync('git', ['init', '--bare', gitDir], { stdio: 'ignore' });
+    const resolved = resolveRepoRoot({
+      command: `git --git-dir=${gitDir} --work-tree=${workTree} commit -m "test"`,
+      cwd: tempDir,
+    });
+    assert.equal(fs.realpathSync(resolved), fs.realpathSync(workTree));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+
 test('permission-change does not fire on quoted chmod in issue-body prose (#3523)', () => {
   cleanupStateFiles();
   const quoted = evaluateGates('Bash', {

--- a/tests/git-pathspec-scope.test.js
+++ b/tests/git-pathspec-scope.test.js
@@ -297,3 +297,28 @@ test('cd parsing still handles its real forms', () => {
     ['src/a.js'],
   );
 });
+
+test('git -C a foreign worktree does not count the hook cwd dirty tree (#3522)', () => {
+  const hookCwd = makeDirtyRepo(40);
+  const target = makeDirtyRepo(0);
+  fs.mkdirSync(path.join(target, 'Handoffs'), { recursive: true });
+  fs.writeFileSync(path.join(target, 'Handoffs', 'note.md'), 'one file\n');
+  git(target, ['add', 'Handoffs/note.md']);
+
+  const previous = process.cwd();
+  process.chdir(hookCwd);
+  try {
+    const commit = extractAffectedFiles('Bash', {
+      command: `git -C ${target} commit -m vault-handoff`,
+    });
+    assert.deepEqual(commit.files, ['Handoffs/note.md']);
+    assert.equal(fs.realpathSync(commit.repoRoot), fs.realpathSync(target));
+
+    const viaCd = extractAffectedFiles('Bash', {
+      command: `cd ${target} && git commit -m vault-handoff`,
+    });
+    assert.deepEqual(viaCd.files, ['Handoffs/note.md']);
+  } finally {
+    process.chdir(previous);
+  }
+});

--- a/tests/spend-guard-hook-contract.test.js
+++ b/tests/spend-guard-hook-contract.test.js
@@ -152,3 +152,34 @@ test('the hook honours its stdout transport contract on every path', () => {
     assertTransportContract(runGuard(payload), `transport/${payload.tool_name}`);
   }
 });
+
+test('remedy-tool prose and quoted issue bodies are not commerce actions (#3523)', () => {
+  const payloads = [
+    {
+      tool_name: 'mcp__thumbgate__satisfy_gate',
+      tool_input: {
+        gate: 'pr_threads_checked',
+        evidence: 'blocked because evidence mentioned checkout of the working copy',
+      },
+    },
+    {
+      tool_name: 'capture_feedback',
+      tool_input: {
+        signal: 'down',
+        context: 'commerce matcher fired on checkout in a git sense',
+        whatWentWrong: 'create of a GitHub issue quoting checkout',
+      },
+    },
+    {
+      tool_name: 'Bash',
+      tool_input: {
+        command: 'gh issue create --title bug --body "matcher fired on checkout and chmod 755"',
+      },
+    },
+  ];
+  for (const payload of payloads) {
+    const out = runGuard(payload);
+    assert.equal(out.stdout, '', `allow/${payload.tool_name}: prose must be silent`);
+    assert.equal(out.code, 0, `${payload.tool_name} prose must not be a HARD BLOCK (stderr: ${out.stderr.slice(0, 160)})`);
+  }
+});

--- a/tests/task-scope-lease.test.js
+++ b/tests/task-scope-lease.test.js
@@ -34,6 +34,9 @@ test.beforeEach(() => {
   gatesEngine.GOVERNANCE_STATE_PATH = path.join(sandbox, 'governance-state.json');
   gatesEngine.STATE_PATH = path.join(sandbox, 'gate-state.json');
   gatesEngine.CONSTRAINTS_PATH = path.join(sandbox, 'session-constraints.json');
+  delete process.env.THUMBGATE_SESSION_AGENT;
+  delete process.env.THUMBGATE_SESSION_ID;
+  delete process.env.CLAUDE_SESSION_ID;
 });
 
 test.afterEach(() => {
@@ -318,4 +321,22 @@ test('e2e: a permanent scope still permits its own paths (no lease, no regressio
     const verdict = await editInScope(repo);
     assert.strictEqual(verdict, null, 'a permanent scope stopped permitting its own paths');
   });
+});
+
+test('sibling session ids keep separate task-scope slots (#3522)', () => {
+  process.env.THUMBGATE_SESSION_AGENT = 'agent-a';
+  setTaskScope({ allowedPaths: ['vault/**'], summary: 'vault handoff' });
+  assert.deepEqual(getScopeState().taskScope.allowedPaths, ['vault/**']);
+
+  process.env.THUMBGATE_SESSION_AGENT = 'agent-b';
+  setTaskScope({ allowedPaths: ['bin/**', 'package.json'], summary: 'thumbgate' });
+  assert.deepEqual(getScopeState().taskScope.allowedPaths, ['bin/**', 'package.json']);
+
+  process.env.THUMBGATE_SESSION_AGENT = 'agent-a';
+  assert.deepEqual(
+    getScopeState().taskScope.allowedPaths,
+    ['vault/**'],
+    'sibling set_task_scope must not rebind another session',
+  );
+  delete process.env.THUMBGATE_SESSION_AGENT;
 });


### PR DESCRIPTION
## Summary
Fixes the two open product bugs on `main` ([#3523](https://github.com/IgorGanapolsky/ThumbGate/issues/3523), [#3522](https://github.com/IgorGanapolsky/ThumbGate/issues/3522)).

These are **existing-surface false positives**, not new gates:

- **#3523** — Commerce/permission lexical matchers fired on `satisfy_gate` evidence, `capture_feedback`, and quoted command text (`gh issue create --body` quoting chmod/checkout). Filing the issue was itself blocked.
- **#3522** — workflow-sentinel / task-scope scored the hook cwd (primary dirty tree) instead of `git -C` / leading `cd` staged files, and one global governance slot was rebound by sibling sessions.

## Changes
- Permission-change matches **command-position** side effects only (`chmod` as argv0, `pm grant`, `aws iam`). Quoted body text is not a side-effect.
- Spend-guard + financial-control skip remedy-tool prose and `--body`/`-m` payloads. Real checkout URLs and `chmod 777` still deny.
- Repo root prefers `git -C` and leading `cd` over hook `process.cwd()`.
- Per-session `governance-state.<sessionId>.json` when `THUMBGATE_SESSION_AGENT` (or `THUMBGATE_SESSION_ID` / `CLAUDE_SESSION_ID`) is set. Sequence-guard reads the same store.

## Tests
`322/322` pass (`gates-engine`, `git-pathspec-scope`, `task-scope-lease`, `spend-guard-hook-contract`, `workflow-sentinel`, financial control + spend matrix).

Closes #3523
Closes #3522