### PR TITLE
feat(optimizer): stamp solver receipts as non-auto-apply decisions

### DIFF
--- a/.changeset/solver-no-auto-apply.md
+++ b/.changeset/solver-no-auto-apply.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Stamp solver receipts with decision-intelligence governance: autoApply false, human oversight required, capturedRevenueUsd 0. Heuristic remains plausible-only; MILP OPTIMAL is repeatable. PreToolUse does not load solver picks.

--- a/docs/GUROBI-SYSTEMWIDE-20260812.md
+++ b/docs/GUROBI-SYSTEMWIDE-20260812.md
@@ -54,3 +54,18 @@ Buyer narrative: *budget-aware enforcement* — we do not load every prevention 
 we select high-mitigation rules and affordable models under budgets. Solver is an
 implementation detail. **No Gurobi partnership / co-sell / logo claim.**
 `capturedRevenueUsd` is never invented from a solve.
+
+## Beyond LLMs process (not product)
+
+Podcast process steal — *provable/repeatable vs plausible*, plus **human oversight
+before action**. Gurobi-as-enterprise-AI-infrastructure does **not** transfer (ECI).
+
+| Layer | ThumbGate meaning |
+|-------|-------------------|
+| Understanding | Heuristic formulate (`plausibleOnly: true`) |
+| Computation | MILP OPTIMAL (`repeatable: true`) |
+| Action | `autoApply: false` — PreToolUse does not load solver picks |
+
+```bash
+npm run test:gurobi
+```

--- a/package.json
+++ b/package.json
@@ -1025,7 +1025,7 @@
     "test:openai-compatible-embed": "node --test tests/openai-compatible-embed.test.js",
     "archive:pre-eci": "node scripts/create-pre-eci-archive.js",
     "test:rag-embedding-identity": "node --test tests/rag-embedding-identity.test.js",
-    "test:gurobi": "node --test tests/gurobi-optimizer.test.js",
+    "test:gurobi": "node --test tests/gurobi-optimizer.test.js tests/solver-no-auto-apply.test.js",
     "gurobi:install": "bash scripts/gurobi-systemwide-install.sh",
     "gurobi:evaluate": "node scripts/gurobi-optimizer.js",
     "test:github-marketplace-action": "node --test tests/github-marketplace-action.test.js",

--- a/scripts/budget-aware-gates-proof.js
+++ b/scripts/budget-aware-gates-proof.js
@@ -189,6 +189,9 @@ function runBudgetAwareGatesProof(options = {}) {
   const report = {
     schema: 'thumbgate.budget_aware_gates_proof.v1',
     mode: 'simulation',
+    autoApply: false,
+    humanOversightRequired: true,
+    capturedRevenueUsd: 0,
     generatedAt: new Date().toISOString(),
     latencyMs: Date.now() - started,
     budgets,

--- a/scripts/gurobi-optimizer.js
+++ b/scripts/gurobi-optimizer.js
@@ -59,21 +59,46 @@ function runPythonMode(mode, payload, timeoutMs = 10000, pythonBin = resolvePyth
 }
 
 /**
+ * Decision-intelligence governance stamp (Beyond LLMs process, not Gurobi product).
+ * Understanding = heuristic (plausible). Computation = OPTIMAL MILP (repeatable).
+ * Action stays human-oversight — solver picks never auto-apply to PreToolUse.
+ */
+function isRepeatableSolve(result) {
+  const solver = String((result && result.solver) || '').toLowerCase();
+  return solver === 'gurobi' && String((result && result.status) || '') === 'OPTIMAL';
+}
+
+function stampDecisionGovernance(result) {
+  const body = result && typeof result === 'object' ? { ...result } : {};
+  const repeatable = isRepeatableSolve(body);
+  body.autoApply = false;
+  body.humanOversightRequired = true;
+  body.capturedRevenueUsd = 0;
+  body.repeatable = repeatable;
+  body.plausibleOnly = !repeatable;
+  return body;
+}
+
+/**
  * Optimizes model candidate routing via Gurobi MILP solver.
  * Falls back to deterministic heuristic if Gurobi is unavailable.
  */
 function optimizeModelRouting(candidates, { maxBudgetUsd = 1.0, maxLatencyMs = 5000.0 } = {}, opts = {}) {
   if (!Array.isArray(candidates) || candidates.length === 0) {
-    return { success: false, selected: null, error: 'Candidates must be a non-empty array' };
+    return stampDecisionGovernance({
+      success: false,
+      selected: null,
+      error: 'Candidates must be a non-empty array',
+    });
   }
 
   const pythonBin = opts.pythonBin || resolvePythonBin();
   try {
-    return runPythonMode('routing', {
+    return stampDecisionGovernance(runPythonMode('routing', {
       candidates,
       max_budget_usd: maxBudgetUsd,
       max_latency_ms: maxLatencyMs,
-    }, opts.timeoutMs || 10000, pythonBin);
+    }, opts.timeoutMs || 10000, pythonBin));
   } catch (err) {
     const valid = candidates.filter(
       (c) => (c.cost || 0) <= maxBudgetUsd && (c.latency_ms || 0) <= maxLatencyMs
@@ -83,14 +108,14 @@ function optimizeModelRouting(candidates, { maxBudgetUsd = 1.0, maxLatencyMs = 5
       (prev, curr) => ((curr.score || 0) > (prev.score || 0) ? curr : prev),
       pool[0]
     );
-    return {
+    return stampDecisionGovernance({
       success: true,
       selected: best.id,
       solver: 'node-fallback-heuristic',
       objective: best.score || 0,
       error: err.message,
       python: pythonBin,
-    };
+    });
   }
 }
 
@@ -99,16 +124,20 @@ function optimizeModelRouting(candidates, { maxBudgetUsd = 1.0, maxLatencyMs = 5
  */
 function optimizeRuleSelection(rules, { maxEvalTimeMs = 50.0, maxTokenFootprint = 1000 } = {}, opts = {}) {
   if (!Array.isArray(rules) || rules.length === 0) {
-    return { success: false, selected_rules: [], error: 'Rules must be a non-empty array' };
+    return stampDecisionGovernance({
+      success: false,
+      selected_rules: [],
+      error: 'Rules must be a non-empty array',
+    });
   }
 
   const pythonBin = opts.pythonBin || resolvePythonBin();
   try {
-    return runPythonMode('rules', {
+    return stampDecisionGovernance(runPythonMode('rules', {
       rules,
       max_eval_time_ms: maxEvalTimeMs,
       max_token_footprint: maxTokenFootprint,
-    }, opts.timeoutMs || 10000, pythonBin);
+    }, opts.timeoutMs || 10000, pythonBin));
   } catch (err) {
     const sorted = [...rules].sort(
       (a, b) =>
@@ -127,7 +156,7 @@ function optimizeRuleSelection(rules, { maxEvalTimeMs = 50.0, maxTokenFootprint 
         curTokens += tok;
       }
     }
-    return {
+    return stampDecisionGovernance({
       success: true,
       selected_rules: selected,
       solver: 'node-fallback-knapsack',
@@ -135,7 +164,7 @@ function optimizeRuleSelection(rules, { maxEvalTimeMs = 50.0, maxTokenFootprint 
       used_tokens: curTokens,
       error: err.message,
       python: pythonBin,
-    };
+    });
   }
 }
 
@@ -176,6 +205,8 @@ module.exports = {
   resolvePythonBin,
   probeGurobi,
   runPythonMode,
+  isRepeatableSolve,
+  stampDecisionGovernance,
   mainCli,
   get PYTHON_BIN() {
     return resolvePythonBin();

--- a/scripts/gurobi_optimizer.py
+++ b/scripts/gurobi_optimizer.py
@@ -237,20 +237,38 @@ def solve_rule_selection(
         return res
 
 
+def stamp_decision_governance(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Action layer stays human-oversight. A solve is not a PreToolUse apply."""
+    body = dict(result or {})
+    solver = str(body.get("solver") or "")
+    status = str(body.get("status") or "")
+    repeatable = solver == "gurobi" and status == "OPTIMAL"
+    body["autoApply"] = False
+    body["humanOversightRequired"] = True
+    body["capturedRevenueUsd"] = 0
+    body["repeatable"] = repeatable
+    body["plausibleOnly"] = not repeatable
+    return body
+
+
 def run_mode(mode: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     if mode == "routing":
-        return solve_model_routing(
-            candidates=payload.get("candidates", []),
-            max_budget_usd=float(payload.get("max_budget_usd", 1.0)),
-            max_latency_ms=float(payload.get("max_latency_ms", 5000.0)),
+        return stamp_decision_governance(
+            solve_model_routing(
+                candidates=payload.get("candidates", []),
+                max_budget_usd=float(payload.get("max_budget_usd", 1.0)),
+                max_latency_ms=float(payload.get("max_latency_ms", 5000.0)),
+            )
         )
     if mode == "rules":
-        return solve_rule_selection(
-            rules=payload.get("rules", []),
-            max_eval_time_ms=float(payload.get("max_eval_time_ms", 50.0)),
-            max_token_footprint=int(payload.get("max_token_footprint", 1000)),
+        return stamp_decision_governance(
+            solve_rule_selection(
+                rules=payload.get("rules", []),
+                max_eval_time_ms=float(payload.get("max_eval_time_ms", 50.0)),
+                max_token_footprint=int(payload.get("max_token_footprint", 1000)),
+            )
         )
-    return {"success": False, "error": f"Unknown mode: {mode}"}
+    return stamp_decision_governance({"success": False, "error": f"Unknown mode: {mode}"})
 
 
 def main(argv: List[str] | None = None) -> int:
@@ -267,7 +285,7 @@ def main(argv: List[str] | None = None) -> int:
         payload = load_input_payload(args.input)
         result = run_mode(args.mode, payload)
     except Exception as err:  # noqa: BLE001 — CLI always emits JSON
-        print(json.dumps({"success": False, "error": f"Failed to parse input: {err}"}))
+        print(json.dumps(stamp_decision_governance({"success": False, "error": f"Failed to parse input: {err}"})))
         return 1
 
     print(json.dumps(result, indent=2))

--- a/tests/budget-aware-gates-proof.test.js
+++ b/tests/budget-aware-gates-proof.test.js
@@ -39,6 +39,9 @@ test('buyer narrative includes disclaimers (no false Gurobi partnership)', () =>
   assert.match(text, /Budget-aware enforcement/);
   assert.match(text, /SIMULATION/);
   assert.equal(report.mode, 'simulation');
+  assert.equal(report.autoApply, false);
+  assert.equal(report.humanOversightRequired, true);
+  assert.equal(report.capturedRevenueUsd, 0);
   assert.ok(!/partner logo|official partner|powered exclusively by Gurobi/i.test(text));
 });
 

--- a/tests/solver-no-auto-apply.test.js
+++ b/tests/solver-no-auto-apply.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  optimizeModelRouting,
+  optimizeRuleSelection,
+  stampDecisionGovernance,
+  isRepeatableSolve,
+} = require('../scripts/gurobi-optimizer');
+const proof = require('../scripts/budget-aware-gates-proof');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function assertGovernance(result, { expectRepeatable } = {}) {
+  assert.equal(result.autoApply, false);
+  assert.equal(result.humanOversightRequired, true);
+  assert.equal(result.capturedRevenueUsd, 0);
+  if (typeof expectRepeatable === 'boolean') {
+    assert.equal(result.repeatable, expectRepeatable);
+    assert.equal(result.plausibleOnly, !expectRepeatable);
+  }
+}
+
+test('stampDecisionGovernance never auto-applies and never invents cash', () => {
+  const stamped = stampDecisionGovernance({
+    success: true,
+    selected: 'x',
+    solver: 'gurobi',
+    status: 'OPTIMAL',
+  });
+  assertGovernance(stamped, { expectRepeatable: true });
+  assert.equal(isRepeatableSolve(stamped), true);
+
+  const heuristic = stampDecisionGovernance({
+    success: true,
+    selected: 'y',
+    solver: 'node-fallback-heuristic',
+  });
+  assertGovernance(heuristic, { expectRepeatable: false });
+});
+
+test('routing and knapsack receipts carry governance on every path', () => {
+  const empty = optimizeModelRouting([]);
+  assert.equal(empty.success, false);
+  assertGovernance(empty, { expectRepeatable: false });
+
+  const emptyRules = optimizeRuleSelection([]);
+  assert.equal(emptyRules.success, false);
+  assertGovernance(emptyRules, { expectRepeatable: false });
+
+  const fallback = optimizeModelRouting(
+    [
+      { id: 'cheap', score: 8, cost: 0.001, latency_ms: 100 },
+      { id: 'pricey', score: 9, cost: 0.05, latency_ms: 900 },
+    ],
+    { maxBudgetUsd: 0.01, maxLatencyMs: 500 },
+    { pythonBin: '/no/such/gurobi-python' }
+  );
+  assert.equal(fallback.solver, 'node-fallback-heuristic');
+  assertGovernance(fallback, { expectRepeatable: false });
+
+  const live = optimizeModelRouting(
+    [{ id: 'only-local', score: 7.1, cost: 0, latency_ms: 90 }],
+    { maxBudgetUsd: 0.01, maxLatencyMs: 500 }
+  );
+  assert.equal(live.success, true);
+  assertGovernance(live);
+  if (live.solver === 'gurobi' && live.status === 'OPTIMAL') {
+    assert.equal(live.repeatable, true);
+    assert.equal(live.plausibleOnly, false);
+  } else {
+    assert.equal(live.repeatable, false);
+    assert.equal(live.plausibleOnly, true);
+  }
+});
+
+test('PreToolUse hook and gates-engine do not load solver selections', () => {
+  const hook = fs.readFileSync(path.join(ROOT, 'scripts', 'hook-pre-tool-use.js'), 'utf8');
+  const gates = fs.readFileSync(path.join(ROOT, 'scripts', 'gates-engine.js'), 'utf8');
+  assert.doesNotMatch(hook, /gurobi-optimizer|optimizeModelRouting|optimizeRuleSelection/);
+  assert.doesNotMatch(gates, /gurobi-optimizer|optimizeModelRouting|optimizeRuleSelection/);
+});
+
+test('budget-aware proof is simulation-only and does not auto-apply', () => {
+  const report = proof.runBudgetAwareGatesProof({ skipProbe: true });
+  assert.equal(report.autoApply, false);
+  assert.equal(report.humanOversightRequired, true);
+  assert.equal(report.capturedRevenueUsd, 0);
+  assert.equal(report.mode, 'simulation');
+  assert.match(JSON.stringify(report.buyerNarrative), /does not yet load selections/);
+});

--- a/tests/test_gurobi.py
+++ b/tests/test_gurobi.py
@@ -9,6 +9,7 @@ from scripts.gurobi_optimizer import (
     run_mode,
     solve_model_routing,
     solve_rule_selection,
+    stamp_decision_governance,
 )
 
 
@@ -137,3 +138,36 @@ def test_main_cli_rejects_path(capsys):
     assert code == 1
     assert body["success"] is False
     assert "filesystem paths are not accepted" in body["error"]
+    assert body["autoApply"] is False
+    assert body["humanOversightRequired"] is True
+    assert body["capturedRevenueUsd"] == 0
+
+
+def test_run_mode_stamps_decision_governance():
+    res = run_mode(
+        "routing",
+        {
+            "candidates": [{"id": "a", "score": 3, "cost": 0.0, "latency_ms": 1}],
+            "max_budget_usd": 1,
+            "max_latency_ms": 10,
+        },
+    )
+    assert res["autoApply"] is False
+    assert res["humanOversightRequired"] is True
+    assert res["capturedRevenueUsd"] == 0
+    if res.get("solver") == "gurobi" and res.get("status") == "OPTIMAL":
+        assert res["repeatable"] is True
+        assert res["plausibleOnly"] is False
+    else:
+        assert res["repeatable"] is False
+        assert res["plausibleOnly"] is True
+
+
+def test_stamp_decision_governance_heuristic_is_plausible_only():
+    stamped = stamp_decision_governance(
+        {"success": True, "selected": "x", "solver": "heuristic-fallback"}
+    )
+    assert stamped["autoApply"] is False
+    assert stamped["repeatable"] is False
+    assert stamped["plausibleOnly"] is True
+    assert stamped["capturedRevenueUsd"] == 0


### PR DESCRIPTION
## Summary

[Beyond LLMs](https://www.gurobi.com/resources/podcasts/beyond-llms) is a Gurobi podcast (Adam Dejans Jr. / David O'Keefe): generative AI is plausible; **certified optimization** is provable/repeatable; high-stakes Action needs **human oversight**.

Enterprise “Gurobi as foundational AI infrastructure” does **not** transfer (ECI). The process does:

| Layer | ThumbGate |
|-------|-----------|
| Understanding | Heuristic formulate (`plausibleOnly: true`) |
| Computation | MILP `status=OPTIMAL` (`repeatable: true`) |
| Action | `autoApply: false` + `humanOversightRequired: true` |

Every `optimizeModelRouting` / `optimizeRuleSelection` receipt (and the budget-aware proof) now carries that stamp. A regression test pins that `hook-pre-tool-use.js` and `gates-engine.js` do **not** `require` the optimizer. `capturedRevenueUsd` is always `0`. No Gurobi affiliation.

Does not dual-edit #3548 (IIS) or #3549 (parity).

## Proof

- `node --test tests/solver-no-auto-apply.test.js tests/gurobi-optimizer.test.js tests/budget-aware-gates-proof.test.js` — 23/23
- `python3 -m pytest tests/test_gurobi.py -q` — 11 passed