### PR TITLE
feat(gates): fail-closed DeepSeek harness grants and VPS-bound 24/7 schedules

### DIFF
--- a/.changeset/deepseek-ageless-fail-closed-gates.md
+++ b/.changeset/deepseek-ageless-fail-closed-gates.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fail-closed DeepSeek harness grants (allow-once, reconstructable receipts) and bind 24/7 schedules to always-on VPS with a human send/spend gate.

--- a/scripts/action-receipts.js
+++ b/scripts/action-receipts.js
@@ -414,6 +414,9 @@ function reconstructModelVisibleFacts(actionId, options = {}) {
   if (!receipt) {
     return { ok: false, failClosed: true, reason: 'missing_receipt' };
   }
+  if (!verifyReceiptSignature(receipt, options.signingKey)) {
+    return { ok: false, failClosed: true, reason: 'unauthenticated_receipt' };
+  }
   return {
     ok: true,
     facts: {

--- a/scripts/action-receipts.js
+++ b/scripts/action-receipts.js
@@ -405,6 +405,30 @@ function buildReceiptContextEntries(query, limit = 5, options = {}) {
   return ranked;
 }
 
+/**
+ * Reconstruct model-visible facts from the session/receipt log.
+ * A missing receipt fails closed so the model cannot invent world-state.
+ */
+function reconstructModelVisibleFacts(actionId, options = {}) {
+  const receipt = getReceiptForAction(actionId, options);
+  if (!receipt) {
+    return { ok: false, failClosed: true, reason: 'missing_receipt' };
+  }
+  return {
+    ok: true,
+    facts: {
+      actionId: receipt.actionId,
+      toolName: receipt.toolName,
+      toolInput: receipt.toolInput,
+      decision: receipt.decision,
+      principal: receipt.principal,
+      requestDigest: receipt.requestDigest,
+      recordedAt: receipt.recordedAt,
+      outcome: receipt.outcome,
+    },
+  };
+}
+
 module.exports = {
   RECEIPTS_FILE,
   getReceiptsPath,
@@ -414,6 +438,7 @@ module.exports = {
   getRecentReceipts,
   buildOutcomePairedLesson,
   pairFeedbackWithReceipt,
+  reconstructModelVisibleFacts,
   buildReceiptContextEntries,
   computeCanonicalRequestDigest,
   resolveReceiptSigningKey,

--- a/scripts/human-escalation.js
+++ b/scripts/human-escalation.js
@@ -588,6 +588,111 @@ function escalationError(message) {
   return error;
 }
 
+function createMemoryGrantStore() {
+  const consumed = new Set();
+  return {
+    consume(grantId) {
+      const id = String(grantId || '').trim();
+      if (!id) return { ok: false, reason: 'missing_grant_id' };
+      if (consumed.has(id)) return { ok: false, reason: 'grant_already_consumed' };
+      consumed.add(id);
+      return { ok: true };
+    },
+  };
+}
+
+const defaultHarnessGrantStore = createMemoryGrantStore();
+const ALLOW_ONCE_GRANT_MODES = new Set(['once', 'allow-once', 'allowed-once', 'allow_once']);
+const ALLOW_ALWAYS_GRANT_MODES = new Set(['always', 'allow-always', 'allow_always']);
+
+/**
+ * DeepSeek-style harness grant.
+ * Missing or throwing/failing approver fails closed (never silent-allow).
+ * Grants are allow-once only; allow-always is rejected.
+ */
+function evaluateHarnessGrant(input = {}, options = {}) {
+  const grantMode = String(input.grantMode || input.mode || 'once').trim().toLowerCase();
+  if (ALLOW_ALWAYS_GRANT_MODES.has(grantMode)) {
+    return { allowed: false, failClosed: true, reason: 'allow_always_forbidden' };
+  }
+  if (!ALLOW_ONCE_GRANT_MODES.has(grantMode)) {
+    return { allowed: false, failClosed: true, reason: 'unsupported_grant_mode' };
+  }
+  if (input.approver == null) {
+    return { allowed: false, failClosed: true, reason: 'missing_approver' };
+  }
+
+  let verdict;
+  try {
+    verdict = typeof input.approver === 'function' ? input.approver(input.action) : input.approver;
+  } catch (error) {
+    return {
+      allowed: false,
+      failClosed: true,
+      reason: 'approver_failed',
+      detail: String(error && error.message ? error.message : error),
+    };
+  }
+  if (verdict && typeof verdict.then === 'function') {
+    return {
+      allowed: false,
+      failClosed: true,
+      reason: 'approver_failed',
+      detail: 'async approver must be resolved by caller',
+    };
+  }
+  if (!verdict || verdict.allow !== true) {
+    return {
+      allowed: false,
+      failClosed: true,
+      reason: (verdict && verdict.reason) || 'approver_denied',
+    };
+  }
+
+  const grantStore = options.grantStore || defaultHarnessGrantStore;
+  const grantId = String(input.grantId || input.actionId || '').trim();
+  if (!grantId) {
+    return { allowed: false, failClosed: true, reason: 'missing_grant_id' };
+  }
+  const consumed = grantStore.consume(grantId);
+  if (!consumed.ok) {
+    return { allowed: false, failClosed: true, reason: consumed.reason || 'grant_already_consumed' };
+  }
+
+  const facts = {
+    actionId: grantId,
+    toolName: input.toolName || (input.action && input.action.toolName) || 'harness_action',
+    toolInput: (input.action && input.action.toolInput) || input.toolInput || {},
+    decision: 'allow',
+    grantMode: 'allow-once',
+    principal: input.principal || 'harness',
+  };
+
+  if (options.recordReceipt === false) {
+    return { allowed: true, failClosed: true, grantMode: 'allow-once', grantId, facts };
+  }
+
+  try {
+    const { recordReceipt } = require('./action-receipts');
+    const receipt = recordReceipt({
+      actionId: facts.actionId,
+      toolName: facts.toolName,
+      toolInput: facts.toolInput,
+      decision: facts.decision,
+      principal: facts.principal,
+      outcome: { testOutcome: 'approved-once' },
+    }, options);
+    return { allowed: true, failClosed: true, grantMode: 'allow-once', grantId, facts, receipt };
+  } catch (error) {
+    return {
+      allowed: false,
+      failClosed: true,
+      reason: 'receipt_record_failed',
+      detail: String(error && error.message ? error.message : error),
+    };
+  }
+}
+
 function isCliInvocation() {
   return Boolean(process.argv[1]) && path.resolve(process.argv[1]) === __filename;
 }
@@ -606,7 +711,9 @@ if (isCliInvocation()) {
 module.exports = {
   calculateEscalationMetrics,
   consumeVerifiedApproval,
+  createMemoryGrantStore,
   decideEscalation,
+  evaluateHarnessGrant,
   getEscalation,
   getEscalationsHeadPath,
   getEscalationsJournalPath,

--- a/scripts/human-escalation.js
+++ b/scripts/human-escalation.js
@@ -601,7 +601,46 @@ function createMemoryGrantStore() {
   };
 }
 
-const defaultHarnessGrantStore = createMemoryGrantStore();
+function createDurableGrantStore(options = {}) {
+  const storePath = options.grantStorePath || path.join(
+    getFeedbackPaths(options).FEEDBACK_DIR,
+    'harness-grants.jsonl'
+  );
+  return {
+    consume(grantId) {
+      const id = String(grantId || '').trim();
+      if (!id) return { ok: false, reason: 'missing_grant_id' };
+      return withFileLedgerLock(`${storePath}.lock`, () => {
+        let raw = '';
+        try {
+          raw = fs.readFileSync(storePath, 'utf8');
+        } catch (error) {
+          if (error.code !== 'ENOENT') throw error;
+        }
+        for (const line of raw.split('\n')) {
+          if (!line.trim()) continue;
+          try {
+            if (JSON.parse(line).grantId === id) {
+              return { ok: false, reason: 'grant_already_consumed' };
+            }
+          } catch {
+            return { ok: false, reason: 'grant_store_corrupt' };
+          }
+        }
+        fs.mkdirSync(path.dirname(storePath), { recursive: true });
+        fs.appendFileSync(storePath, `${JSON.stringify({
+          grantId: id,
+          consumedAt: (options.now || new Date()).toISOString(),
+        })}\n`);
+        return { ok: true };
+      }, {
+        now: options.now,
+        lockStaleMs: options.lockStaleMs,
+        errorFactory: (message) => escalationError(message),
+      });
+    },
+  };
+}
 const ALLOW_ONCE_GRANT_MODES = new Set(['once', 'allow-once', 'allowed-once', 'allow_once']);
 const ALLOW_ALWAYS_GRANT_MODES = new Set(['always', 'allow-always', 'allow_always']);
 
@@ -649,14 +688,24 @@ function evaluateHarnessGrant(input = {}, options = {}) {
     };
   }
 
-  const grantStore = options.grantStore || defaultHarnessGrantStore;
+  const grantStore = options.grantStore || createDurableGrantStore(options);
   const grantId = String(input.grantId || input.actionId || '').trim();
   if (!grantId) {
     return { allowed: false, failClosed: true, reason: 'missing_grant_id' };
   }
-  const consumed = grantStore.consume(grantId);
-  if (!consumed.ok) {
-    return { allowed: false, failClosed: true, reason: consumed.reason || 'grant_already_consumed' };
+  let consumed;
+  try {
+    consumed = grantStore.consume(grantId);
+  } catch (error) {
+    return {
+      allowed: false,
+      failClosed: true,
+      reason: 'grant_store_failed',
+      detail: String(error && error.message ? error.message : error),
+    };
+  }
+  if (!consumed || !consumed.ok) {
+    return { allowed: false, failClosed: true, reason: (consumed && consumed.reason) || 'grant_already_consumed' };
   }
 
   const facts = {
@@ -711,6 +760,7 @@ if (isCliInvocation()) {
 module.exports = {
   calculateEscalationMetrics,
   consumeVerifiedApproval,
+  createDurableGrantStore,
   createMemoryGrantStore,
   decideEscalation,
   evaluateHarnessGrant,

--- a/scripts/schedule-manager.js
+++ b/scripts/schedule-manager.js
@@ -61,6 +61,101 @@ function parseCronSpec(spec) {
   return null;
 }
 
+const LAPTOP_BOUND_RUNTIMES = new Set([
+  'laptop', 'macos', 'darwin', 'launchd', 'launchagent',
+  'lid-close', 'lid_close', 'continuity', 'mac-pair', 'phone-leash', 'local',
+]);
+const ALWAYS_ON_RUNTIMES = new Set([
+  'vps', 'hosted', 'always-on', 'always_on', 'railway', 'fenced-vps',
+]);
+
+function inferScheduleRuntime(params = {}) {
+  const explicit = String(params.runtime || '').trim().toLowerCase();
+  if (explicit) return explicit;
+  if (process.env.THUMBGATE_ALWAYS_ON_VPS === '1') return 'vps';
+  if (process.env.THUMBGATE_HOSTED === '1') return 'hosted';
+  if (process.platform === 'darwin') return 'launchd';
+  return 'laptop';
+}
+
+function isTwentyFourSevenSchedule(params = {}) {
+  if (params.alwaysOn === true || params.twentyFourSeven === true || params.claimLive === true) {
+    return true;
+  }
+  const spec = String(params.schedule || '').toLowerCase().trim();
+  return spec === 'hourly' || /^every\s+\d+\s*h/.test(spec);
+}
+
+function isSendSpendAction(params = {}) {
+  const text = [params.action, params.command, params.toolName, params.purpose]
+    .map((value) => String(value || ''))
+    .join(' ');
+  if (params.economicAction === true || params.autoBook === true) return true;
+  return /\b(?:send|spend|pay|purchase|transfer|wire|invoice|payout|book|auto-?book)\b/i.test(text);
+}
+
+function isConsumedHumanApproval(approval) {
+  return Boolean(
+    approval
+    && approval.consumed === true
+    && approval.actor
+    && approval.actor.kind === 'human'
+  );
+}
+
+function evaluateAlwaysOnSchedule(input = {}) {
+  const runtime = inferScheduleRuntime(input);
+  const alwaysOn = ALWAYS_ON_RUNTIMES.has(runtime);
+  const actionText = [input.action, input.command, input.toolName]
+    .map((value) => String(value || ''))
+    .join(' ');
+
+  if (input.autoBook === true || /\bauto-?book\b/i.test(actionText)) {
+    return {
+      allowed: false,
+      failClosed: true,
+      claimLive: false,
+      reason: 'auto_book_forbidden',
+      message: 'Auto-book is not stolen. Send/spend stays behind a human gate.',
+      runtime,
+    };
+  }
+
+  if (isTwentyFourSevenSchedule(input) && (LAPTOP_BOUND_RUNTIMES.has(runtime) || !alwaysOn)) {
+    return {
+      allowed: false,
+      failClosed: true,
+      claimLive: false,
+      reason: 'laptop_bound_schedule',
+      message: 'Scheduled/24-7 work must run on an always-on VPS. Laptop, launchd, and lid-close paths fail closed and must not claim live.',
+      runtime,
+    };
+  }
+
+  if (isSendSpendAction(input) && !isConsumedHumanApproval(input.humanApproval)) {
+    return {
+      allowed: false,
+      failClosed: true,
+      claimLive: alwaysOn,
+      reason: 'human_gate_required',
+      message: 'Send/spend requires a consumed human approval.',
+      runtime,
+    };
+  }
+
+  return {
+    allowed: true,
+    failClosed: true,
+    claimLive: alwaysOn,
+    runtime,
+    boundTo: alwaysOn ? 'always-on-vps' : null,
+  };
+}
+
+function shouldEnforceAlwaysOnGate(params = {}) {
+  return isTwentyFourSevenSchedule(params) || isSendSpendAction(params) || params.autoBook === true;
+}
+
 function generatePlist(schedule) {
   const label = escapePlistString(`${PLIST_PREFIX}.${schedule.id}`);
   const interval = schedule.calendarInterval;
@@ -151,6 +246,11 @@ function buildAgenticDataPipelineSchedule(params = {}) {
 }
 
 function createSchedule(params) {
+  const runtimeGate = evaluateAlwaysOnSchedule(params);
+  if (shouldEnforceAlwaysOnGate(params) && !runtimeGate.allowed) {
+    return { success: false, error: runtimeGate.message || runtimeGate.reason, gate: runtimeGate };
+  }
+
   ensureDir(SCHEDULES_DIR);
 
   const id = params.id || params.name || `sched_${Date.now()}`;
@@ -180,6 +280,8 @@ function createSchedule(params) {
     workingDirectory: params.workingDirectory || (jobFile ? path.dirname(jobFile) : process.cwd()),
     calendarInterval,
     createdAt: new Date().toISOString(),
+    runtimeGate,
+    claimLive: runtimeGate.claimLive === true,
   };
 
   // Save schedule metadata
@@ -246,4 +348,6 @@ module.exports = {
   parseCronSpec,
   buildManagedScheduleCommand,
   buildAgenticDataPipelineSchedule,
+  evaluateAlwaysOnSchedule,
+  inferScheduleRuntime,
 };

--- a/scripts/schedule-manager.js
+++ b/scripts/schedule-manager.js
@@ -79,11 +79,10 @@ function inferScheduleRuntime(params = {}) {
 }
 
 function isTwentyFourSevenSchedule(params = {}) {
-  if (params.alwaysOn === true || params.twentyFourSeven === true || params.claimLive === true) {
-    return true;
-  }
-  const spec = String(params.schedule || '').toLowerCase().trim();
-  return spec === 'hourly' || /^every\s+\d+\s*h/.test(spec);
+  // Interval alone is not a live claim. Existing hourly LaunchAgent/cron jobs
+  // (slow-loop, revenue-truth) stay installable; only explicit always-on/live
+  // claims fail closed when the path is laptop-bound.
+  return params.alwaysOn === true || params.twentyFourSeven === true || params.claimLive === true;
 }
 
 function isSendSpendAction(params = {}) {

--- a/scripts/schedule-manager.js
+++ b/scripts/schedule-manager.js
@@ -94,16 +94,58 @@ function isSendSpendAction(params = {}) {
   return /\b(?:send|spend|pay|purchase|transfer|wire|invoice|payout|book|auto-?book)\b/i.test(text);
 }
 
-function isConsumedHumanApproval(approval) {
-  return Boolean(
-    approval
-    && approval.consumed === true
-    && approval.actor
-    && approval.actor.kind === 'human'
-  );
+function resolveEscalationOptions(input = {}, options = {}) {
+  const approval = input.humanApproval || {};
+  return {
+    feedbackDir: options.feedbackDir || input.feedbackDir || approval.feedbackDir,
+    inputPath: options.inputPath || input.escalationPath || approval.escalationPath,
+    approvalVerificationKey: options.approvalVerificationKey || input.approvalVerificationKey,
+    approvalSigningKey: options.approvalSigningKey || input.approvalSigningKey,
+    now: options.now || input.now,
+  };
 }
 
-function evaluateAlwaysOnSchedule(input = {}) {
+function hasVerifiedHumanSendSpendApproval(input = {}, options = {}) {
+  const approval = input.humanApproval;
+  if (!approval || typeof approval !== 'object') return false;
+  const escalationId = String(approval.escalationId || approval.approval?.escalationId || '').trim();
+  if (!escalationId) return false;
+  try {
+    const { consumeVerifiedApproval, getVerifiedApproval } = require('./human-escalation');
+    const consumer = approval.consumer && typeof approval.consumer === 'object'
+      ? approval.consumer
+      : { id: 'schedule-manager', kind: 'system' };
+    const consumed = consumeVerifiedApproval(escalationId, { consumer }, resolveEscalationOptions(input, options));
+    if (consumed.consumed === true && consumed.approval?.actor?.kind === 'human') {
+      return true;
+    }
+    if (consumed.replayed === true) {
+      const verified = getVerifiedApproval(escalationId, {
+        ...resolveEscalationOptions(input, options),
+        allowConsumed: true,
+      });
+      return Boolean(verified && verified.actor?.kind === 'human');
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function resolveScheduleClaimLive(runtimeGate, platform = process.platform) {
+  if (!runtimeGate || runtimeGate.allowed !== true) {
+    return { claimLive: false, schedulerInstallation: 'blocked' };
+  }
+  if (platform === 'darwin') {
+    return { claimLive: false, schedulerInstallation: 'launchd' };
+  }
+  if (platform === 'linux') {
+    return { claimLive: false, schedulerInstallation: 'pending-crontab' };
+  }
+  return { claimLive: false, schedulerInstallation: 'unsupported' };
+}
+
+function evaluateAlwaysOnSchedule(input = {}, options = {}) {
   const runtime = inferScheduleRuntime(input);
   const alwaysOn = ALWAYS_ON_RUNTIMES.has(runtime);
   const actionText = [input.action, input.command, input.toolName]
@@ -132,13 +174,13 @@ function evaluateAlwaysOnSchedule(input = {}) {
     };
   }
 
-  if (isSendSpendAction(input) && !isConsumedHumanApproval(input.humanApproval)) {
+  if (isSendSpendAction(input) && !hasVerifiedHumanSendSpendApproval(input, options)) {
     return {
       allowed: false,
       failClosed: true,
-      claimLive: alwaysOn,
+      claimLive: false,
       reason: 'human_gate_required',
-      message: 'Send/spend requires a consumed human approval.',
+      message: 'Send/spend requires a consumed human approval from the escalation ledger.',
       runtime,
     };
   }
@@ -281,7 +323,7 @@ function createSchedule(params) {
     calendarInterval,
     createdAt: new Date().toISOString(),
     runtimeGate,
-    claimLive: runtimeGate.claimLive === true,
+    ...resolveScheduleClaimLive(runtimeGate),
   };
 
   // Save schedule metadata
@@ -350,4 +392,6 @@ module.exports = {
   buildAgenticDataPipelineSchedule,
   evaluateAlwaysOnSchedule,
   inferScheduleRuntime,
+  hasVerifiedHumanSendSpendApproval,
+  resolveScheduleClaimLive,
 };

--- a/tests/action-receipts.test.js
+++ b/tests/action-receipts.test.js
@@ -26,7 +26,7 @@ const {
   getReceiptsPath,
   verifyReceiptSignature,
 } = require('../scripts/action-receipts');
-const { createMemoryGrantStore, evaluateHarnessGrant } = require('../scripts/human-escalation');
+const { createDurableGrantStore, createMemoryGrantStore, evaluateHarnessGrant } = require('../scripts/human-escalation');
 
 test.after(() => {
   try {
@@ -255,4 +255,49 @@ test('grants are allow-once only and model-visible facts reconstruct from the re
   assert.equal(missing.ok, false);
   assert.equal(missing.failClosed, true);
   assert.equal(missing.reason, 'missing_receipt');
+});
+
+test('durable allow-once grants survive a new store instance', () => {
+  const firstStore = createDurableGrantStore();
+  const first = evaluateHarnessGrant({
+    grantId: 'g-durable-once',
+    grantMode: 'once',
+    approver: () => ({ allow: true }),
+  }, { grantStore: firstStore, recordReceipt: false });
+  assert.equal(first.allowed, true);
+
+  const restarted = createDurableGrantStore();
+  const second = evaluateHarnessGrant({
+    grantId: 'g-durable-once',
+    grantMode: 'once',
+    approver: () => ({ allow: true }),
+  }, { grantStore: restarted, recordReceipt: false });
+  assert.equal(second.allowed, false);
+  assert.equal(second.reason, 'grant_already_consumed');
+});
+
+test('reconstructModelVisibleFacts fails closed on tampered receipts', () => {
+  const receipt = recordReceipt({
+    actionId: 'act-reconstruct-tamper',
+    toolName: 'Bash',
+    toolInput: { command: 'echo ok' },
+    decision: 'allow',
+    principal: 'harness',
+  });
+  const receiptsPath = getReceiptsPath();
+  const lines = fs.readFileSync(receiptsPath, 'utf8').split('\n');
+  let rewritten = false;
+  const tampered = lines.map((line) => {
+    if (!line.includes('"act-reconstruct-tamper"')) return line;
+    const row = JSON.parse(line);
+    row.toolName = 'rm';
+    rewritten = true;
+    return JSON.stringify(row);
+  }).join('\n');
+  assert.equal(rewritten, true);
+  fs.writeFileSync(receiptsPath, tampered);
+  const reconstructed = reconstructModelVisibleFacts('act-reconstruct-tamper');
+  assert.equal(reconstructed.ok, false);
+  assert.equal(reconstructed.failClosed, true);
+  assert.equal(reconstructed.reason, 'unauthenticated_receipt');
 });

--- a/tests/action-receipts.test.js
+++ b/tests/action-receipts.test.js
@@ -21,10 +21,12 @@ const {
   getReceiptForAction,
   getRecentReceipts,
   pairFeedbackWithReceipt,
+  reconstructModelVisibleFacts,
   buildReceiptContextEntries,
   getReceiptsPath,
   verifyReceiptSignature,
 } = require('../scripts/action-receipts');
+const { createMemoryGrantStore, evaluateHarnessGrant } = require('../scripts/human-escalation');
 
 test.after(() => {
   try {
@@ -179,4 +181,78 @@ test('signReceiptDigest fails closed without signing key', () => {
   delete process.env.THUMBGATE_RECEIPT_SIGNING_KEY;
   assert.throws(() => signReceiptDigest('abc'), /THUMBGATE_RECEIPT_SIGNING_KEY/);
   process.env.THUMBGATE_RECEIPT_SIGNING_KEY = prev;
+});
+
+test('missing or failing approver fails closed and never silent-allows', () => {
+  const store = createMemoryGrantStore();
+  const missing = evaluateHarnessGrant(
+    { grantId: 'g-missing', grantMode: 'once' },
+    { grantStore: store, recordReceipt: false }
+  );
+  assert.equal(missing.allowed, false);
+  assert.equal(missing.failClosed, true);
+  assert.equal(missing.reason, 'missing_approver');
+
+  const failing = evaluateHarnessGrant({
+    grantId: 'g-fail',
+    grantMode: 'once',
+    approver: () => { throw new Error('approver down'); },
+  }, { grantStore: store, recordReceipt: false });
+  assert.equal(failing.allowed, false);
+  assert.equal(failing.failClosed, true);
+  assert.equal(failing.reason, 'approver_failed');
+
+  const denied = evaluateHarnessGrant({
+    grantId: 'g-deny',
+    grantMode: 'once',
+    approver: () => ({ allow: false, reason: 'no' }),
+  }, { grantStore: store, recordReceipt: false });
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.failClosed, true);
+  assert.equal(denied.reason, 'no');
+});
+
+test('grants are allow-once only and model-visible facts reconstruct from the receipt log', () => {
+  const store = createMemoryGrantStore();
+  const always = evaluateHarnessGrant({
+    grantId: 'g-always',
+    grantMode: 'allow-always',
+    approver: () => ({ allow: true }),
+  }, { grantStore: store, recordReceipt: false });
+  assert.equal(always.allowed, false);
+  assert.equal(always.reason, 'allow_always_forbidden');
+
+  const first = evaluateHarnessGrant({
+    grantId: 'g-once-receipt',
+    grantMode: 'allow-once',
+    toolName: 'Bash',
+    toolInput: { command: 'echo hi' },
+    approver: () => ({ allow: true }),
+    principal: 'harness',
+  }, { grantStore: store });
+  assert.equal(first.allowed, true);
+  assert.equal(first.grantMode, 'allow-once');
+  assert.equal(first.facts.toolName, 'Bash');
+
+  const second = evaluateHarnessGrant({
+    grantId: 'g-once-receipt',
+    grantMode: 'allow-once',
+    approver: () => ({ allow: true }),
+  }, { grantStore: store, recordReceipt: false });
+  assert.equal(second.allowed, false);
+  assert.equal(second.reason, 'grant_already_consumed');
+
+  const reconstructed = reconstructModelVisibleFacts('g-once-receipt');
+  assert.equal(reconstructed.ok, true);
+  assert.equal(reconstructed.facts.toolName, 'Bash');
+  assert.deepEqual(reconstructed.facts.toolInput, { command: 'echo hi' });
+  assert.equal(reconstructed.facts.decision, 'allow');
+  assert.equal(reconstructed.facts.principal, 'harness');
+  assert.ok(reconstructed.facts.requestDigest);
+  assert.ok(reconstructed.facts.recordedAt);
+
+  const missing = reconstructModelVisibleFacts('does-not-exist');
+  assert.equal(missing.ok, false);
+  assert.equal(missing.failClosed, true);
+  assert.equal(missing.reason, 'missing_receipt');
 });

--- a/tests/schedule-manager.test.js
+++ b/tests/schedule-manager.test.js
@@ -6,7 +6,9 @@ const assert = require('node:assert/strict');
 const {
   buildAgenticDataPipelineSchedule,
   buildManagedScheduleCommand,
+  createSchedule,
   escapePlistString,
+  evaluateAlwaysOnSchedule,
   generatePlist,
   parseCronSpec,
 } = require('../scripts/schedule-manager');
@@ -71,4 +73,75 @@ test('buildAgenticDataPipelineSchedule emits a managed job file contract for aut
   assert.equal(schedule.jobSpec.stages[0].name, 'materialize_pipeline');
   assert.match(schedule.jobSpec.stages[0].command, /agentic-data-pipeline\.js/);
   assert.match(schedule.command, /async-job-runner\.js/);
+});
+
+test('evaluateAlwaysOnSchedule fails closed for laptop-bound 24/7 work and refuses live claim', () => {
+  const denied = evaluateAlwaysOnSchedule({
+    runtime: 'laptop',
+    schedule: 'hourly',
+    alwaysOn: true,
+    claimLive: true,
+  });
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.failClosed, true);
+  assert.equal(denied.claimLive, false);
+  assert.equal(denied.reason, 'laptop_bound_schedule');
+
+  const launchd = evaluateAlwaysOnSchedule({
+    runtime: 'launchd',
+    schedule: 'every 6h',
+  });
+  assert.equal(launchd.allowed, false);
+  assert.equal(launchd.claimLive, false);
+  assert.equal(launchd.reason, 'laptop_bound_schedule');
+});
+
+test('evaluateAlwaysOnSchedule binds 24/7 work to an always-on VPS', () => {
+  const allowed = evaluateAlwaysOnSchedule({
+    runtime: 'vps',
+    schedule: 'hourly',
+    alwaysOn: true,
+  });
+  assert.equal(allowed.allowed, true);
+  assert.equal(allowed.claimLive, true);
+  assert.equal(allowed.boundTo, 'always-on-vps');
+});
+
+test('evaluateAlwaysOnSchedule requires a consumed human approval for send/spend and rejects auto-book', () => {
+  const spend = evaluateAlwaysOnSchedule({
+    runtime: 'vps',
+    schedule: 'daily 9:00',
+    action: 'send invoice to vendor',
+  });
+  assert.equal(spend.allowed, false);
+  assert.equal(spend.reason, 'human_gate_required');
+
+  const approved = evaluateAlwaysOnSchedule({
+    runtime: 'vps',
+    schedule: 'daily 9:00',
+    action: 'send invoice to vendor',
+    humanApproval: { consumed: true, actor: { kind: 'human', id: 'igor' } },
+  });
+  assert.equal(approved.allowed, true);
+
+  const autoBook = evaluateAlwaysOnSchedule({
+    runtime: 'vps',
+    autoBook: true,
+    action: 'auto-book clinic slot',
+  });
+  assert.equal(autoBook.allowed, false);
+  assert.equal(autoBook.reason, 'auto_book_forbidden');
+  assert.equal(autoBook.claimLive, false);
+});
+
+test('createSchedule fails closed for hourly laptop work', () => {
+  const result = createSchedule({
+    id: 'should-not-persist-hourly-laptop',
+    schedule: 'hourly',
+    command: 'console.log("no")',
+    runtime: 'laptop',
+  });
+  assert.equal(result.success, false);
+  assert.equal(result.gate.reason, 'laptop_bound_schedule');
+  assert.equal(result.gate.claimLive, false);
 });

--- a/tests/schedule-manager.test.js
+++ b/tests/schedule-manager.test.js
@@ -122,10 +122,18 @@ test('evaluateAlwaysOnSchedule fails closed for laptop-bound 24/7 work and refus
   const launchd = evaluateAlwaysOnSchedule({
     runtime: 'launchd',
     schedule: 'every 6h',
+    claimLive: true,
   });
   assert.equal(launchd.allowed, false);
   assert.equal(launchd.claimLive, false);
   assert.equal(launchd.reason, 'laptop_bound_schedule');
+
+  const hourlyNoClaim = evaluateAlwaysOnSchedule({
+    runtime: 'laptop',
+    schedule: 'hourly',
+  });
+  assert.equal(hourlyNoClaim.allowed, true);
+  assert.equal(hourlyNoClaim.claimLive, false);
 });
 
 test('evaluateAlwaysOnSchedule binds 24/7 work to an always-on VPS', () => {
@@ -196,12 +204,13 @@ test('resolveScheduleClaimLive stays false until a scheduler is installed', () =
   assert.equal(darwin.schedulerInstallation, 'launchd');
 });
 
-test('createSchedule fails closed for hourly laptop work', () => {
+test('createSchedule fails closed when laptop work claims live', () => {
   const result = createSchedule({
     id: 'should-not-persist-hourly-laptop',
     schedule: 'hourly',
     command: 'console.log("no")',
     runtime: 'laptop',
+    claimLive: true,
   });
   assert.equal(result.success, false);
   assert.equal(result.gate.reason, 'laptop_bound_schedule');

--- a/tests/schedule-manager.test.js
+++ b/tests/schedule-manager.test.js
@@ -3,6 +3,10 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
 const {
   buildAgenticDataPipelineSchedule,
   buildManagedScheduleCommand,
@@ -11,7 +15,35 @@ const {
   evaluateAlwaysOnSchedule,
   generatePlist,
   parseCronSpec,
+  resolveScheduleClaimLive,
 } = require('../scripts/schedule-manager');
+const {
+  decideEscalation,
+  requestEscalation,
+} = require('../scripts/human-escalation');
+
+function createSignedSendSpendApproval(taskId = `send-${Date.now()}`) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-esc-'));
+  const key = 'test-human-reviewer-key';
+  const options = { feedbackDir: dir, approvalSigningKey: key, approvalVerificationKey: key };
+  const requested = requestEscalation({
+    taskId,
+    reason: 'send vendor payment',
+    requester: { id: 'agent-1', kind: 'agent' },
+    evidence: ['invoice-42'],
+    idempotencyKey: taskId,
+  }, options);
+  decideEscalation({
+    escalationId: requested.escalation.escalationId,
+    decision: 'approved',
+    reason: 'human approved send',
+  }, { ...options, authenticatedActor: { id: 'igor', kind: 'human' } });
+  return {
+    escalationId: requested.escalation.escalationId,
+    options,
+    dir,
+  };
+}
 
 test('escapePlistString encodes XML metacharacters while preserving backslashes', () => {
   const input = String.raw`console.log("C:\temp\<tag>&'")`;
@@ -115,14 +147,29 @@ test('evaluateAlwaysOnSchedule requires a consumed human approval for send/spend
   });
   assert.equal(spend.allowed, false);
   assert.equal(spend.reason, 'human_gate_required');
+  assert.equal(spend.claimLive, false);
 
-  const approved = evaluateAlwaysOnSchedule({
+  const forged = evaluateAlwaysOnSchedule({
     runtime: 'vps',
     schedule: 'daily 9:00',
     action: 'send invoice to vendor',
     humanApproval: { consumed: true, actor: { kind: 'human', id: 'igor' } },
   });
+  assert.equal(forged.allowed, false);
+  assert.equal(forged.reason, 'human_gate_required');
+
+  const gate = createSignedSendSpendApproval();
+  const approved = evaluateAlwaysOnSchedule({
+    runtime: 'vps',
+    schedule: 'daily 9:00',
+    action: 'send invoice to vendor',
+    humanApproval: {
+      escalationId: gate.escalationId,
+      consumer: { id: 'schedule-manager', kind: 'system' },
+    },
+  }, gate.options);
   assert.equal(approved.allowed, true);
+  fs.rmSync(gate.dir, { recursive: true, force: true });
 
   const autoBook = evaluateAlwaysOnSchedule({
     runtime: 'vps',
@@ -132,6 +179,21 @@ test('evaluateAlwaysOnSchedule requires a consumed human approval for send/spend
   assert.equal(autoBook.allowed, false);
   assert.equal(autoBook.reason, 'auto_book_forbidden');
   assert.equal(autoBook.claimLive, false);
+});
+
+test('resolveScheduleClaimLive stays false until a scheduler is installed', () => {
+  const vps = evaluateAlwaysOnSchedule({
+    runtime: 'vps',
+    schedule: 'hourly',
+    alwaysOn: true,
+  });
+  assert.equal(vps.claimLive, true);
+  const linux = resolveScheduleClaimLive(vps, 'linux');
+  assert.equal(linux.claimLive, false);
+  assert.equal(linux.schedulerInstallation, 'pending-crontab');
+  const darwin = resolveScheduleClaimLive(vps, 'darwin');
+  assert.equal(darwin.claimLive, false);
+  assert.equal(darwin.schedulerInstallation, 'launchd');
 });
 
 test('createSchedule fails closed for hourly laptop work', () => {


### PR DESCRIPTION
## Summary
- DeepSeek harness steal (no vendor, no clone): missing or failing approver fails closed; grants are allow-once only; model-visible facts reconstruct from the session/receipt log.
- Ageless steal (no medspa/CRM/auto-book): scheduled/24-7 work must be bound to an always-on VPS; laptop/launchd/lid-close paths fail closed and cannot claim live; send/spend requires a consumed human approval.
- Smallest surface: gates added to existing `human-escalation`, `action-receipts`, and `schedule-manager` modules plus tests already on the `npm test` path.

## Test plan
- [x] `node --check` on patched modules and tests
- [ ] CI `test` job on this PR
- [ ] Confirm `npm run test:action-receipts` and `npm run test:ops` (includes `tests/schedule-manager.test.js`)
