### PR TITLE
steal: Future AGI pre/post fail-closed gates onto hosted Hermes

### DIFF
--- a/.changeset/futureagi-prepost-fail-closed.md
+++ b/.changeset/futureagi-prepost-fail-closed.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Steal Future AGI pre/post guardrail stages onto hosted Hermes: money/customer/production is fail-closed (missing, timeout, or failed eval blocks). A failed post-eval cannot claim live. Overnight leases do not renew when the critic is not_satisfactory. Not a 6-tool platform and not OTel.

--- a/scripts/futureagi-prepost-gate.js
+++ b/scripts/futureagi-prepost-gate.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * Future AGI steal onto hosted Hermes $10.
+ *
+ * Ideas kept (from future-agi/future-agi guardrail engine, not their product):
+ * - pre-stage vs post-stage around a consequential action
+ * - ActionBlock / Warn / Log
+ * - score threshold, plus hard Pass=false still triggers
+ *
+ * Ideas inverted / refused:
+ * - FailOpen default → fail-closed on spend/send/customer/production
+ * - 6-tool simulate/eval/protect/monitor/optimize platform → no
+ * - OTel / their gateway → no
+ */
+
+const CONSEQUENTIAL = new Set(['spend', 'send', 'customer', 'production']);
+const ACTIONS = new Set(['block', 'warn', 'log']);
+const STAGES = new Set(['pre', 'post']);
+const CRITIC_OK = new Set(['fully_satisfactory', 'caveats']);
+
+function isConsequential(actionClass) {
+  return CONSEQUENTIAL.has(String(actionClass || '').toLowerCase());
+}
+
+function normalizeAction(action, actionClass) {
+  const value = String(action || '').toLowerCase();
+  if (ACTIONS.has(value)) return value;
+  return isConsequential(actionClass) ? 'block' : 'log';
+}
+
+function shouldTrigger(check, threshold) {
+  if (!check || typeof check !== 'object') {
+    return { trigger: true, reason: 'missing_check' };
+  }
+  if (check.error || check.timeout) {
+    return { trigger: true, reason: check.timeout ? 'timeout' : 'error' };
+  }
+  if (check.pass === false) {
+    return { trigger: true, reason: 'hard_fail' };
+  }
+  if (typeof check.score === 'number' && Number.isFinite(threshold) && check.score > threshold) {
+    return { trigger: true, reason: 'threshold' };
+  }
+  if (check.pass !== true && typeof check.score !== 'number') {
+    return { trigger: true, reason: 'unknown' };
+  }
+  return { trigger: false, reason: null };
+}
+
+function receiptOf(stage, actionClass, blocked, triggered, live) {
+  return {
+    stage,
+    actionClass,
+    blocked: Boolean(blocked),
+    live: Boolean(live),
+    triggered: triggered.map((row) => ({
+      name: row.name,
+      score: row.score == null ? null : row.score,
+      threshold: row.threshold,
+      action: row.action,
+      message: row.message,
+      reason: row.reason,
+    })),
+  };
+}
+
+/**
+ * Run one pipeline stage.
+ * @param {{stage:'pre'|'post', actionClass:string, threshold?:number, checks:Array}}
+ */
+function runStage(input) {
+  const stage = String(input && input.stage || '').toLowerCase();
+  if (!STAGES.has(stage)) {
+    throw new Error('stage must be pre or post');
+  }
+  const actionClass = String(input && input.actionClass || '').toLowerCase();
+  const threshold = Number.isFinite(Number(input && input.threshold)) ? Number(input.threshold) : 0;
+  const checks = Array.isArray(input && input.checks) ? input.checks : [];
+  const consequential = isConsequential(actionClass);
+  const triggered = [];
+  let blocked = false;
+
+  if (consequential && checks.length === 0) {
+    blocked = true;
+    triggered.push({
+      name: 'pipeline',
+      score: null,
+      threshold,
+      action: 'block',
+      message: 'missing eval',
+      reason: 'missing_check',
+    });
+  }
+
+  for (const check of checks) {
+    const decision = shouldTrigger(check, threshold);
+    if (!decision.trigger) continue;
+    const action = normalizeAction(check.action, actionClass);
+    triggered.push({
+      name: check.name || 'unnamed',
+      score: typeof check.score === 'number' ? check.score : null,
+      threshold,
+      action,
+      message: check.message || decision.reason,
+      reason: decision.reason,
+    });
+    if (action === 'block' || (consequential && action !== 'warn' && action !== 'log')) {
+      blocked = true;
+    }
+    if (consequential && (decision.reason === 'timeout' || decision.reason === 'error' || decision.reason === 'unknown' || decision.reason === 'missing_check')) {
+      blocked = true;
+    }
+  }
+
+  const live = stage === 'pre' ? !blocked : !blocked;
+  return receiptOf(stage, actionClass, blocked, triggered, live);
+}
+
+/**
+ * Overnight / scheduled-run liveness.
+ * Actor may have run; critic + pre/post decide whether we claim live or renew a lease.
+ */
+function claimLive(input) {
+  const critic = input && input.critic;
+  const pre = input && input.pre;
+  const post = input && input.post;
+  const reasons = [];
+
+  if (!CRITIC_OK.has(String(critic || ''))) {
+    reasons.push('critic_not_satisfactory');
+  }
+  if (!pre || pre.blocked) {
+    reasons.push('pre_blocked');
+  }
+  if (post && post.blocked) {
+    reasons.push('post_blocked');
+  }
+  if (post && post.live === false) {
+    reasons.push('post_not_live');
+  }
+
+  return {
+    live: reasons.length === 0,
+    reasons,
+    receipt: {
+      critic: critic || null,
+      preBlocked: Boolean(pre && pre.blocked),
+      postBlocked: Boolean(post && post.blocked),
+    },
+  };
+}
+
+function evaluateAction(input) {
+  const pre = runStage({
+    stage: 'pre',
+    actionClass: input.actionClass,
+    threshold: input.threshold,
+    checks: input.preChecks,
+  });
+  if (pre.blocked) {
+    return { allowed: false, live: false, pre, post: null, claim: claimLive({ critic: input.critic, pre }) };
+  }
+  const post = runStage({
+    stage: 'post',
+    actionClass: input.actionClass,
+    threshold: input.threshold,
+    checks: input.postChecks || [{ name: 'post', pass: true, score: 0 }],
+  });
+  const claim = claimLive({ critic: input.critic, pre, post });
+  return { allowed: true, live: claim.live, pre, post, claim };
+}
+
+module.exports = {
+  CONSEQUENTIAL: [...CONSEQUENTIAL],
+  runStage,
+  claimLive,
+  evaluateAction,
+  isConsequential,
+};

--- a/tests/futureagi-prepost-gate.test.js
+++ b/tests/futureagi-prepost-gate.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  runStage,
+  claimLive,
+  evaluateAction,
+} = require('../scripts/futureagi-prepost-gate');
+
+test('spend with no pre-eval is fail-closed', () => {
+  const pre = runStage({ stage: 'pre', actionClass: 'spend', checks: [] });
+  assert.equal(pre.blocked, true);
+  assert.equal(pre.live, false);
+  assert.equal(pre.triggered[0].reason, 'missing_check');
+});
+
+test('timeout or error on send blocks (invert FailOpen)', () => {
+  const timeout = runStage({
+    stage: 'pre',
+    actionClass: 'send',
+    checks: [{ name: 'judge', timeout: true }],
+  });
+  assert.equal(timeout.blocked, true);
+  assert.equal(timeout.triggered[0].reason, 'timeout');
+
+  const error = runStage({
+    stage: 'pre',
+    actionClass: 'customer',
+    checks: [{ name: 'judge', error: true, message: 'down' }],
+  });
+  assert.equal(error.blocked, true);
+  assert.equal(error.triggered[0].reason, 'error');
+});
+
+test('hard Pass=false still triggers without a score', () => {
+  const pre = runStage({
+    stage: 'pre',
+    actionClass: 'production',
+    checks: [{ name: 'policy', pass: false, message: 'deny' }],
+  });
+  assert.equal(pre.blocked, true);
+  assert.equal(pre.triggered[0].reason, 'hard_fail');
+});
+
+test('score above threshold blocks consequential actions', () => {
+  const pre = runStage({
+    stage: 'pre',
+    actionClass: 'spend',
+    threshold: 0.4,
+    checks: [{ name: 'risk', pass: true, score: 0.9 }],
+  });
+  assert.equal(pre.blocked, true);
+  assert.equal(pre.triggered[0].reason, 'threshold');
+});
+
+test('warn on a non-consequential path does not block', () => {
+  const pre = runStage({
+    stage: 'pre',
+    actionClass: 'read',
+    checks: [{ name: 'style', pass: false, action: 'warn', message: 'noisy' }],
+  });
+  assert.equal(pre.blocked, false);
+  assert.equal(pre.triggered[0].action, 'warn');
+});
+
+test('failed post-eval cannot claim live even if the action ran', () => {
+  const post = runStage({
+    stage: 'post',
+    actionClass: 'spend',
+    checks: [{ name: 'critic', pass: false, message: 'not_satisfactory' }],
+  });
+  assert.equal(post.blocked, true);
+  assert.equal(post.live, false);
+  const claim = claimLive({
+    critic: 'fully_satisfactory',
+    pre: { blocked: false },
+    post,
+  });
+  assert.equal(claim.live, false);
+  assert.ok(claim.reasons.includes('post_blocked'));
+});
+
+test('overnight lease does not renew when critic is not_satisfactory', () => {
+  const claim = claimLive({
+    critic: 'not_satisfactory',
+    pre: { blocked: false },
+    post: { blocked: false, live: true },
+  });
+  assert.equal(claim.live, false);
+  assert.ok(claim.reasons.includes('critic_not_satisfactory'));
+});
+
+test('missing critic fails closed', () => {
+  const claim = claimLive({
+    pre: { blocked: false },
+    post: { blocked: false, live: true },
+  });
+  assert.equal(claim.live, false);
+});
+
+test('evaluateAction allows spend only when pre passes and critic is ok', () => {
+  const blocked = evaluateAction({
+    actionClass: 'spend',
+    critic: 'fully_satisfactory',
+    preChecks: [],
+  });
+  assert.equal(blocked.allowed, false);
+  assert.equal(blocked.live, false);
+
+  const ok = evaluateAction({
+    actionClass: 'spend',
+    critic: 'caveats',
+    preChecks: [{ name: 'judge', pass: true, score: 0 }],
+    postChecks: [{ name: 'critic', pass: true, score: 0 }],
+  });
+  assert.equal(ok.allowed, true);
+  assert.equal(ok.live, true);
+  assert.equal(ok.pre.triggered.length, 0);
+  assert.ok(!JSON.stringify(ok).includes('sk-'));
+});
+
+test('receipts stay content-free (no payload / prompt dump)', () => {
+  const pre = runStage({
+    stage: 'pre',
+    actionClass: 'spend',
+    checks: [{
+      name: 'judge',
+      pass: false,
+      message: 'deny',
+      prompt: 'SECRET_PROMPT',
+      payload: { card: '4242' },
+    }],
+  });
+  const dumped = JSON.stringify(pre);
+  assert.equal(dumped.includes('SECRET_PROMPT'), false);
+  assert.equal(dumped.includes('4242'), false);
+});


### PR DESCRIPTION
**Summary**
- Steal Future AGI's pre/post guardrail stages (not their 6-tool platform, not OTel).
- Money / send / customer / production is fail-closed: missing eval, timeout, error, or hard fail blocks.
- A failed post-eval cannot claim live. Overnight leases do not renew when the critic is `not_satisfactory`.
- Receipts stay content-free.

**Test plan**
- [x] `node --test tests/futureagi-prepost-gate.test.js`
