### PR TITLE
fix(sonar): satisfy S2871 and S6582 in the un-excluded Future AGI scripts

### DIFF
--- a/.changeset/sonar-future-agi-reliability.md
+++ b/.changeset/sonar-future-agi-reliability.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix the two SonarCloud findings that surfaced once the Future AGI scripts were removed from `sonar.exclusions`: give `extractTraceSignatures` an explicit code-unit comparator (S2871) and optional-chain the `post.live` guard in the pre/post gate (S6582). Both are behaviour-preserving.

--- a/scripts/future-agi-evaluator.js
+++ b/scripts/future-agi-evaluator.js
@@ -97,6 +97,16 @@ function evaluatePayload(payload, options = {}) {
 const NO_TRACE_FALLBACK_PATTERN = '(?:unverified_agent_mutation|unvetted_redteam_failure)';
 
 /**
+ * Explicit code-unit comparator (Sonar S2871). Every element reaching the sort
+ * is already a non-empty string, so this reproduces the default Array#sort
+ * ordering exactly — the gate pattern is unchanged, the intent is now stated.
+ */
+function compareSignatures(a, b) {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+/**
  * Pull the regex sources that actually produced the failures. Older traces
  * only carry prose issues, so fall back to the source embedded after ": ".
  */
@@ -111,7 +121,7 @@ function extractTraceSignatures(traces) {
     });
   });
   // Sorted + de-duped so the same failing traces always synthesize the same gate.
-  return [...new Set(raw.filter((s) => typeof s === 'string' && s.trim()))].sort();
+  return [...new Set(raw.filter((s) => typeof s === 'string' && s.trim()))].sort(compareSignatures);
 }
 
 function synthesizeSelfHealingGate(traces = []) {

--- a/scripts/futureagi-prepost-gate.js
+++ b/scripts/futureagi-prepost-gate.js
@@ -141,7 +141,7 @@ function claimLive(input = {}) {
   if (post?.blocked) {
     reasons.push('post_blocked');
   }
-  if (post && post.live === false) {
+  if (post?.live === false) {
     reasons.push('post_not_live');
   }
 


### PR DESCRIPTION
Follow-up to #3591, which merged before this landed.

## Why these two issues exist now

#3591 removed `scripts/future-agi-evaluator.js`, `scripts/futureagi-prepost-gate.js`, `scripts/index-leaf-context.js` and `scripts/session-attribution-summary.js` from **both** `sonar.exclusions` and `sonar.coverage.exclusions`. An earlier commit on that branch had added them speculatively, before the real quality-gate failure was diagnosed, which silently removed ~500 lines of governance logic from bug and security scanning.

Un-hiding them surfaced two genuine findings. They were never absent — only invisible.

SonarCloud on #3591 head `a923bef4`:

| condition | value | threshold |
|---|---|---|
| `new_reliability_rating` | **4** | 1 |
| `new_maintainability_rating` | 1 | 1 |
| `new_coverage` | 91.5% | 80% |
| `new_duplicated_lines_density` | 0.0% | 3% |
| `new_security_rating` | 1 | 1 |
| `new_security_hotspots_reviewed` | 100% | 100% |

Only the reliability rating was red, from exactly these two issues. SonarCloud is not a required status check, so the merge queue took #3591 on green required checks while the analysis was still finishing.

## The fixes

**`scripts/future-agi-evaluator.js:114` — `javascript:S2871`** ("Provide a compare function to avoid sorting elements alphabetically"). `extractTraceSignatures` ended in a bare `.sort()`. It now passes an explicit code-unit comparator. Every element reaching the sort has already been through `.filter((s) => typeof s === "string" && s.trim())`, so the default comparator's ToString step was a no-op and its ordering was already code-unit order — **the synthesized self-healing gate pattern is byte-identical before and after.**

**`scripts/futureagi-prepost-gate.js:144` — `javascript:S6582`** (prefer optional chaining). `post && post.live === false` becomes `post?.live === false`, matching the `post?.blocked` guard two lines above it. Strictly equivalent on every input: optional chaining short-circuits only on `null`/`undefined`, and `undefined === false` is `false` — the same result the `&&` guard produced. For a falsy-but-non-nullish `post` the property access still yields `undefined`.

## Verification

Neither edit can change behaviour; both were reviewed line-by-line against every reachable input class. The `post === undefined` path is already covered — `evaluateAction` calls `claimLive({ critic, pre })` with no `post` stage, and `tests/futureagi-prepost-gate.test.js` asserts `blocked.allowed === false` / `blocked.live === false` through it. The sort path is exercised by `tests/future-agi-review-regressions.test.js` (`synthesizeSelfHealingGate is deterministic for the same failing traces`).

Note: I could not execute `node --test` locally — a ThumbGate `workflow-sentinel` learned-deny latched onto this worktree cwd and hard-blocked every `node`/`npm` invocation for the rest of the session. CI is the execution evidence for this PR.
