### PR TITLE
fix(governance): path-based main check in simatree CLI (SonarCloud S3403)

### DIFF
--- a/.changeset/simatree-s3403-main-check.md
+++ b/.changeset/simatree-s3403-main-check.md
@@ -1,0 +1,11 @@
+---
+"thumbgate": patch
+---
+
+fix(governance): use the path-based main check in the Simatree governance CLI
+
+The Simatree governance CLI shipped its entry guard as the `require.main` strict-equality form, which SonarCloud flags as rule `javascript:S3403` (MAJOR) — an always-false comparison under strict type inference.
+
+Replaced with the path-resolve form this repo already standardises on (`process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)`), matching `scripts/agent-action-inventory.js`, `scripts/compact-memory-store.js`, and `scripts/budget-aware-gates-proof.js`.
+
+Behaviour is unchanged and now pinned by a test: `require()` returns the exports and prints nothing even when `process.argv` carries `--doctor`, while direct invocation still runs `--doctor`, `--eval`, and `--sql`.

--- a/.changeset/simatree-s3403-main-check.md
+++ b/.changeset/simatree-s3403-main-check.md
@@ -6,6 +6,8 @@ fix(governance): use the path-based main check in the Simatree governance CLI
 
 The Simatree governance CLI shipped its entry guard as the `require.main` strict-equality form, which SonarCloud flags as rule `javascript:S3403` (MAJOR) — an always-false comparison under strict type inference.
 
-Replaced with the path-resolve form this repo already standardises on (`process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)`), matching `scripts/agent-action-inventory.js`, `scripts/compact-memory-store.js`, and `scripts/budget-aware-gates-proof.js`.
+Replaced with the path-resolve form this repo already standardises on, wrapped in an `isDirectInvocation()` helper that canonicalises both sides with `fs.realpathSync` before comparing.
 
-Behaviour is unchanged and now pinned by a test: `require()` returns the exports and prints nothing even when `process.argv` carries `--doctor`, while direct invocation still runs `--doctor`, `--eval`, and `--sql`.
+The realpath step matters. When the CLI is launched through a symlink — an npm `bin` shim, a global install, `npx` — Node leaves `process.argv[1]` as the symlink path while `__filename` is already the realpath of the target. A bare resolve-and-compare is false in that case, and the process would exit 0 having printed nothing: no `--doctor` report, no `--eval` result, no `--sql` verdict. `require.main === module` did not have that hole because Node's module resolution canonicalises first, so the replacement must not open one. Each side falls back to its resolved path if `realpathSync` throws.
+
+Two regression tests pin the behaviour: `require()` returns the exports and prints nothing even when `process.argv` carries `--doctor`, and the CLI still emits its doctor report when invoked through a symlink. Direct `--doctor`, `--eval` and `--sql` invocation is unchanged.

--- a/scripts/simatree-data-governance.js
+++ b/scripts/simatree-data-governance.js
@@ -262,7 +262,8 @@ function checkDoctor() {
 }
 
 // CLI Interface
-if (require.main === module) {
+// Path-based main check: the `require.main === module` form trips SonarCloud S3403.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
   const args = process.argv.slice(2);
 
   if (args.includes('--doctor')) {

--- a/scripts/simatree-data-governance.js
+++ b/scripts/simatree-data-governance.js
@@ -261,9 +261,41 @@ function checkDoctor() {
   };
 }
 
+/**
+ * Path-based main check. The `require.main === module` form trips SonarCloud
+ * rule javascript:S3403 (always-false strict equality under strict type
+ * inference), so we compare paths instead.
+ *
+ * WHY realpath AND NOT A BARE `path.resolve` COMPARE: when this CLI is launched
+ * through a symlink — an npm `bin` shim, a global install, `npx` — Node leaves
+ * `process.argv[1]` as the symlink path while `__filename` is already the
+ * realpath of the target. A plain resolve-and-compare is then false, and the
+ * process would exit 0 having printed nothing: no `--doctor` report, no
+ * `--eval` result, no `--sql` verdict. `require.main === module` did not have
+ * that hole because Node's module resolution canonicalises first. Canonicalising
+ * both sides restores the original semantics.
+ *
+ * realpathSync throws on a path that no longer exists, so each side falls back
+ * to its resolved form; that keeps the check total rather than crashing on a
+ * deleted or exotic entry point.
+ */
+function canonicalPath(candidate) {
+  const resolved = path.resolve(candidate);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isDirectInvocation() {
+  const entryPoint = process.argv[1];
+  if (!entryPoint) return false;
+  return canonicalPath(entryPoint) === canonicalPath(__filename);
+}
+
 // CLI Interface
-// Path-based main check: the `require.main === module` form trips SonarCloud S3403.
-if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+if (isDirectInvocation()) {
   const args = process.argv.slice(2);
 
   if (args.includes('--doctor')) {

--- a/tests/simatree-data-governance.test.js
+++ b/tests/simatree-data-governance.test.js
@@ -237,6 +237,39 @@ test('simatree-data-governance: require() returns exports without running the CL
 });
 
 // ---------------------------------------------------------------------------
+// Regression: the CLI must still run when launched through a symlink.
+//
+// npm `bin` shims, global installs and npx all hand Node a symlink in
+// process.argv[1] while __filename is already the realpath of the target. A
+// main check that compares those two without canonicalising is false in that
+// case, and the CLI silently exits 0 having printed nothing. `require.main ===
+// module` did not have that hole, so replacing it must not open one.
+// ---------------------------------------------------------------------------
+
+test('simatree-data-governance: CLI runs when invoked through a symlink', () => {
+  const scriptPath = path.join(__dirname, '..', 'scripts', 'simatree-data-governance.js');
+  const linkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'simatree-symlink-'));
+  const linkPath = path.join(linkDir, 'simatree-cli.js');
+
+  try {
+    try {
+      fs.symlinkSync(scriptPath, linkPath);
+    } catch (err) {
+      // Windows without developer mode / restricted filesystems cannot symlink.
+      if (err.code === 'EPERM' || err.code === 'ENOSYS') return;
+      throw err;
+    }
+
+    const out = execFileSync(process.execPath, [linkPath, '--doctor'], { encoding: 'utf8' });
+    const report = JSON.parse(out);
+    assert.equal(report.ok, true);
+    assert.equal(report.name, 'simatree-data-governance');
+  } finally {
+    fs.rmSync(linkDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Regression: qualified and quoted table names
 //
 // The matcher used to be `DELETE\s+FROM\s+\w+...`. `\w+` matches only the

--- a/tests/simatree-data-governance.test.js
+++ b/tests/simatree-data-governance.test.js
@@ -3,8 +3,9 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
-const { execSync } = require('node:child_process');
+const { execSync, execFileSync } = require('node:child_process');
 
 const {
   evaluateDataLifecycleIntent,
@@ -191,6 +192,48 @@ test('simatree-data-governance: CLI execution handles --doctor and --sql flags',
   const sqlJson = JSON.parse(sqlOut);
   assert.equal(sqlJson.allowed, true);
   assert.equal(sqlJson.isDestructive, false);
+});
+
+// ---------------------------------------------------------------------------
+// Regression: the CLI must stay inert when the module is required.
+//
+// The entry guard used to be `require.main === module`, which SonarCloud flags
+// as rule javascript:S3403 — an always-false strict equality under strict type
+// inference. It is now the path-resolve form this repo standardised on. Either
+// way the contract is identical, and that contract is what this test pins:
+// `require()` hands back the exports and prints nothing, even when
+// `process.argv` carries flags the CLI would otherwise act on.
+// ---------------------------------------------------------------------------
+
+test('simatree-data-governance: require() returns exports without running the CLI', () => {
+  const scriptPath = path.join(__dirname, '..', 'scripts', 'simatree-data-governance.js');
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'simatree-require-probe-'));
+  const probePath = path.join(probeDir, 'probe.js');
+
+  fs.writeFileSync(
+    probePath,
+    [
+      "'use strict';",
+      'const mod = require(process.argv[2]);',
+      "const ok = typeof mod.checkDoctor === 'function'",
+      "  && typeof mod.evaluateDataLifecycleIntent === 'function';",
+      "process.stdout.write(ok ? 'REQUIRED_WITHOUT_CLI' : 'MISSING_EXPORTS');",
+      '',
+    ].join('\n')
+  );
+
+  try {
+    // `--doctor` is deliberately present in argv: an entry guard that keys off
+    // argv contents alone — or whose main check misfires — would emit the
+    // doctor report here and fail the exact-match assertion below.
+    // execFileSync (no shell) keeps the paths out of a command string.
+    const out = execFileSync(process.execPath, [probePath, scriptPath, '--doctor'], {
+      encoding: 'utf8',
+    });
+    assert.equal(out, 'REQUIRED_WITHOUT_CLI');
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`scripts/simatree-data-governance.js:265` shipped its CLI entry guard as the `require.main` strict-equality form. SonarCloud flags that as rule **`javascript:S3403` (MAJOR)** — an always-false strict equality under strict type inference.

It reached `main` via #3601 (merge commit `abfa1178`) because SonarCloud is **not** a required status check:

```
$ gh api repos/IgorGanapolsky/ThumbGate/branches/main/protection \
    --jq '.required_status_checks.contexts'
["test","Analyze JavaScript (javascript-typescript)","CodeQL",
 "Socket Security: Project Report","Verify changeset",
 "Socket Security: Pull Request Alerts","GitGuardian Security Checks"]
```

So it never blocked the merge. This PR fixes the one instance; it does not touch branch protection.

## The fix

Replaced with the path-resolve form this repo already standardises on:

```js
if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
```

Same idiom as `scripts/agent-action-inventory.js:866`, `scripts/compact-memory-store.js:117`, and `scripts/budget-aware-gates-proof.js:407`. `path` was already required at the top of the file (`const path = require('node:path')`), so no import change was needed.

## Scope: one instance, not a repo-wide sweep

`scripts/simatree-data-governance.js:265` is the **only** occurrence #3601 introduced. The other JS file that PR touched, `scripts/harness-selector.js`, has no main check at all — its diff only adds a harness entry and a detection pattern.

`git grep -c 'require.main === module' -- '*.js'` reports **174 further pre-existing occurrences** across the repo. Those are deliberately left alone: they are outside this changeset and sweeping them would turn a one-line fix into an unreviewable diff.

## Proof by execution, both directions

**Direct invocation still works:**

```
$ node scripts/simatree-data-governance.js --doctor
{ "ok": true, "name": "simatree-data-governance", "version": "1.35.0",
  "evaluator": "ONLINE", "bayesianModel": "ONLINE", "pmoGate": "ONLINE", ... }   exit=0

$ node scripts/simatree-data-governance.js --sql "SELECT 1 FROM dim_customers" \
    --why "Annual customer retention KPI reporting"
{ "allowed": true, "score": 100, "isDestructive": false, ... }

$ node scripts/simatree-data-governance.js
Usage: node scripts/simatree-data-governance.js [--doctor | --eval <json> | --sql <query> --why <intent>]   exit=0
```

**`require()` does not self-execute** — probe that requires the module with `--doctor --eval {}` deliberately in `process.argv`, with `console.log` and `process.exit` both instrumented:

```json
{
  "argvTail": ["--doctor", "--eval", "{}"],
  "stdoutDuringRequire": [],
  "processExitCalled": null,
  "requireError": null,
  "selfExecuted": false,
  "exports": ["evaluateDataLifecycleIntent", "estimateBayesianUncertainty",
              "auditPMOTransformationGate", "checkDoctor", "DESTRUCTIVE_SQL_PATTERNS"]
}
```

## Test

`tests/simatree-data-governance.test.js` gains `simatree-data-governance: require() returns exports without running the CLI`, which pins the require direction as a regression case. It spawns a probe via `execFileSync` (no shell) with `--doctor` in argv and asserts the child's stdout is exactly `REQUIRED_WITHOUT_CLI` — any entry guard that misfires would emit the doctor report instead.

```
$ node --test tests/simatree-data-governance.test.js
# tests 22
# pass 22
# fail 0
```

## Bundle ratchets: unchanged

Measured, not guessed. `npm pack --dry-run --json` reports `entryCount: 510`, which already equals all three ratchets (`tests/public-bundle-ratchet.test.js` `BASELINE_FILE_COUNT = 510`, `tests/package-boundary.test.js` `fileCount <= 510`, `tests/public-core-boundary.test.js` `CEILING = 510`). A pure in-file edit plus a test file (tests are not bundled) does not move the count, so no ratchet bump is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9N27VCGjZCNakAq7f6tXt


---

## Update (6094c15d): the path-resolve form had a symlink hole — fixed here

The Codex P2 review thread was correct. The bare path-resolve form this PR originally shipped in `22382e23` is **not** a safe drop-in for `require.main === module`: under a symlinked entry point (npm `bin` shim, global install, `npx`) Node leaves `process.argv[1]` as the symlink path while `__filename` is already the realpath of the target, so the compare is false and the CLI exits 0 having printed nothing.

Verified by execution, not by reading:

```
argv[1]             .../symrepro/link-probe.js
__filename          .../symrepro/probe.js
require.main===mod  true
BARE_RESOLVE_MATCH  false
REALPATH_MATCH      true
```

| Form, invoked through a symlink | stdout | exit |
|---|---|---|
| `require.main === module` | ran | 0 |
| bare `path.resolve` compare | *(nothing)* | 0 |
| realpath-canonicalised compare | ran | 0 |

And on the real file: `scripts/simatree-data-governance.js` at `22382e23` through a symlink with `--doctor` produced **no output, exit 0**; at `6094c15d` it produces the full doctor JSON.

Fix: an `isDirectInvocation()` helper canonicalising both sides with `fs.realpathSync`, each side falling back to its resolved path if `realpathSync` throws. No `require.main` reference remains in code, so SonarCloud S3403 stays satisfied. `tests/simatree-data-governance.test.js` gains a symlink regression case; 23/23 green.

### Proposed amendment to the CLAUDE.md "hard-won lessons" entry

`CLAUDE.md` is a protected path and is deliberately **not** edited by this PR. The current entry recommends the bare form, which trades a SonarCloud finding for a silent runtime no-op. Proposed replacement:

> **`require.main === module` is a lie in CommonJS — but so is a bare `path.resolve` compare.** SonarCloud rule S3403 flags `require.main === module` as an always-false strict equality, so use a path-based check — but canonicalise **both** sides with `fs.realpathSync` first:
>
> ```js
> function canonicalPath(candidate) {
>   const resolved = path.resolve(candidate);
>   try { return fs.realpathSync(resolved); } catch { return resolved; }
> }
> function isDirectInvocation() {
>   const entryPoint = process.argv[1];
>   if (!entryPoint) return false;
>   return canonicalPath(entryPoint) === canonicalPath(__filename);
> }
> ```
>
> `# WHY:` 2026-08-21 — under a symlink Node leaves `process.argv[1]` as the symlink path while `__filename` is already the realpath of the target, so a bare compare is false and the CLI exits 0 printing nothing. `require.main === module` never had that hole because Node's module resolution canonicalises first.

### Blast radius on shipped bin entries: currently zero

All four `package.json#bin` targets were checked: `bin/cli.js` and `bin/dashboard-cli.js` have no guard (top-level execution), `scripts/grafana-revenue-evidence.js` already canonicalises via `realpathSync`, and `bin/futureagi-bridge` is a wrapper calling `mainCli()` explicitly. **0 of 4 are broken today.**

The latent risk is real though: **47** files under `scripts/`, `bin/`, `src/`, `lib/` and `adapters/` use the bare form and would silently no-op if ever exposed as a `bin` entry. This repo already paid for this bug class once — `bin/futureagi-bridge` exists because of it. Migrating those files is a follow-up, not this PR.

### Follow-up noted, deliberately not included here

`tests/gates-engine.test.js` fails 5 tests whenever `THUMBGATE_STRICT_ENFORCEMENT=1` is exported in the developer's shell (tests 71-74 assert warn-by-default behaviour; test 199 asserts `additionalContext`, which strict mode replaces with `permissionDecisionReason` — verified by executing the gate directly). The durable fix is to clear that variable in the file's `beforeEach` so the suite is independent of the operator's environment. That touches an unrelated subsystem and is intentionally left out of this PR.
