### PR TITLE
fix(tests): make gates-engine suite hermetic against inherited strict enforcement

### DIFF
--- a/.changeset/gates-engine-strict-hermetic.md
+++ b/.changeset/gates-engine-strict-hermetic.md
@@ -1,0 +1,11 @@
+---
+'thumbgate': patch
+---
+
+fix(tests): make `tests/gates-engine.test.js` hermetic against an inherited `THUMBGATE_STRICT_ENFORCEMENT`
+
+Five tests in this suite assert the default warn-by-default posture but read the enforcement mode straight from the ambient process environment. When an operator or agent harness exports `THUMBGATE_STRICT_ENFORCEMENT=1`, strict mode turns every warn into a hard deny and replaces `additionalContext` with `permissionDecisionReason`, so those five fail on a clean tree with no code change — a false CI signal that points at the gate engine instead of at the environment.
+
+The variable is now captured into the existing `ORIGINAL_ENV` block, deleted in `beforeEach`, and restored in `afterEach`, matching how this file already isolates `THUMBGATE_FEEDBACK_DIR`, `THUMBGATE_FEEDBACK_LOG`, `THUMBGATE_ATTRIBUTED_FEEDBACK`, and `THUMBGATE_GUARDS_PATH`. The three tests that deliberately exercise strict mode continue to set it themselves, so strict-mode coverage is unchanged.
+
+Verified both directions: 203/203 pass with the variable set in the environment, and 203/203 pass with it absent. Test-only change; no runtime or packaged-bundle effect.

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -81,6 +81,12 @@ const ORIGINAL_ENV = {
   THUMBGATE_FEEDBACK_LOG: process.env.THUMBGATE_FEEDBACK_LOG,
   THUMBGATE_ATTRIBUTED_FEEDBACK: process.env.THUMBGATE_ATTRIBUTED_FEEDBACK,
   THUMBGATE_GUARDS_PATH: process.env.THUMBGATE_GUARDS_PATH,
+  // Most tests in this file assert the DEFAULT warn-by-default posture. Strict mode
+  // turns every warn into a hard deny and swaps `additionalContext` for
+  // `permissionDecisionReason`, so an inherited value from the operator's shell
+  // silently breaks those assertions. Captured here, cleared in beforeEach, restored
+  // in afterEach. Tests that exercise strict mode set it explicitly themselves.
+  THUMBGATE_STRICT_ENFORCEMENT: process.env.THUMBGATE_STRICT_ENFORCEMENT,
 };
 
 let sandboxDir = null;
@@ -187,6 +193,8 @@ beforeEach(() => {
   delete process.env.THUMBGATE_SESSION_AGENT;
   delete process.env.THUMBGATE_SESSION_ID;
   delete process.env.CLAUDE_SESSION_ID;
+  // Keep the suite hermetic: never inherit strict enforcement from the ambient shell.
+  delete process.env.THUMBGATE_STRICT_ENFORCEMENT;
   fs.writeFileSync(process.env.THUMBGATE_FEEDBACK_LOG, '');
   fs.writeFileSync(process.env.THUMBGATE_ATTRIBUTED_FEEDBACK, '');
   cleanupStateFiles();
@@ -209,6 +217,8 @@ afterEach(() => {
   else process.env.THUMBGATE_ATTRIBUTED_FEEDBACK = ORIGINAL_ENV.THUMBGATE_ATTRIBUTED_FEEDBACK;
   if (ORIGINAL_ENV.THUMBGATE_GUARDS_PATH === undefined) delete process.env.THUMBGATE_GUARDS_PATH;
   else process.env.THUMBGATE_GUARDS_PATH = ORIGINAL_ENV.THUMBGATE_GUARDS_PATH;
+  if (ORIGINAL_ENV.THUMBGATE_STRICT_ENFORCEMENT === undefined) delete process.env.THUMBGATE_STRICT_ENFORCEMENT;
+  else process.env.THUMBGATE_STRICT_ENFORCEMENT = ORIGINAL_ENV.THUMBGATE_STRICT_ENFORCEMENT;
   if (sandboxDir) {
     removeDirRobust(sandboxDir);
     sandboxDir = null;


### PR DESCRIPTION
### Summary
Five tests in `tests/gates-engine.test.js` assert the default warn-by-default posture but read the enforcement mode from the ambient process environment. When `THUMBGATE_STRICT_ENFORCEMENT=1` is exported by the operator's shell or an agent harness, strict mode turns every warn into a hard deny and replaces `additionalContext` with `permissionDecisionReason`, causing false CI failures on a clean tree.

### Changes
- Capture `THUMBGATE_STRICT_ENFORCEMENT` into `ORIGINAL_ENV` block
- Delete in `beforeEach` and restore in `afterEach`
- Add changeset

### Verification
- `node --test tests/gates-engine.test.js` passes 100% with and without strict mode set in ambient env