### PR TITLE
fix(sonar): narrow S3403 suppression to where the entry-point idiom lives

### DIFF
--- a/.changeset/sonar-s3403-false-positives.md
+++ b/.changeset/sonar-s3403-false-positives.md
@@ -29,12 +29,12 @@ Rewriting 169 entry points to satisfy the rule would change real startup
 behaviour across every CLI in order to improve a score. That is the wrong trade.
 Excluding the rule is the right one.
 
-**Accepted risk, stated rather than hidden:** this suppresses `S3403`
-everywhere, so a genuinely always-false `===` elsewhere would also go
-unreported. Judged acceptable because every sampled instance was the idiom, and
-because a rule at an 84% false-positive rate is already being ignored in
-practice — just silently, which is worse. The properties file carries the
-re-check command so the exclusion can be revisited rather than trusted forever.
+**Scope, narrowed after review:** the suppression covers only where the idiom
+actually lives — `scripts/**` (168 guard files by grep), `adapters/**` (2), and
+`src/api/server.js` (1). `S3403` stays active across the rest of `src/` (the
+product core), `bin/`, and `tests/`, so a genuinely always-false `===` there is
+still reported. The properties file carries the re-check command so the
+exclusion can be revisited rather than trusted forever.
 
 Note the shape of this problem is the same one `src/alert-noise-ledger.js`
 addresses on the gate surface: a high-volume, low-precision signal trains

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.exclusions=scripts/proof/**,**/node_modules/**,**/coverage/**,**/.claude/*
 sonar.coverage.exclusions=scripts/proof/**,scripts/install-spend-guard.js,scripts/enforcement-provenance-check.js,scripts/train_from_feedback.py,scripts/eval_gate_classifier.py,scripts/self-distill-agent.js,scripts/managed-lesson-agent.js,scripts/llm-client.js,scripts/reddit-dm-outreach.js,scripts/send-outreach-dms.js,scripts/security-scanner.js,scripts/social-analytics/**,scripts/commercial-offer.js,scripts/org-dashboard.js,scripts/lesson-inference.js,scripts/feedback-to-rules.js,adapters/**,scripts/prove-packaged-runtime.js,scripts/self-heal*.js,scripts/statusline*.js,scripts/sync-version.js,scripts/meta-agent-loop.js,scripts/harness-selector.js,scripts/decision-journal.js,scripts/content-engine/**,scripts/lesson-retrieval.js,scripts/semantic-dedup.js,bin/cli.js,scripts/gates-engine.js,scripts/billing-setup.js,scripts/render-demo-video/**,scripts/sonar-review-hotspots.js,scripts/social-reply-monitor.js,scripts/feedback_quality_eval.py,scripts/feedback-quality-eval.py,scripts/post-to-x.js,scripts/gtm-revenue-loop.js,scripts/stripe-bootstrap-saas-catalog.js,scripts/demo/**,public/**,.well-known/**,scripts/gurobi_optimizer.py,scripts/gurobi-systemwide-install.sh,scripts/mcp-writeguard.js,scripts/latency-budget.js,scripts/redteam-5-attacks.js
 sonar.test.inclusions=**/*.test.js
 sonar.sourceEncoding=UTF-8
-sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
 sonar.issue.ignore.multicriteria.e1.ruleKey=javascript:S2699
 sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*.test.js
 # e2) javascript:S3403 ("this === will always be false") fires on the canonical
@@ -27,19 +27,22 @@ sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*.test.js
 #     would change real startup behaviour to improve a score, which is the wrong
 #     trade.
 #
-#     ACCEPTED RISK, stated plainly: this suppresses S3403 everywhere, so a
-#     genuinely always-false === elsewhere in the codebase would also go
-#     unreported by Sonar. That was judged acceptable because every instance
-#     sampled was the idiom, and because a rule at 84% false-positive rate is
-#     already being ignored in practice — which is worse, since it is ignored
-#     silently.
+#     SCOPE (narrowed after review): the suppression covers only where the
+#     idiom actually lives, measured 2026-08-26 by grep on the tree —
+#     scripts/ (168 files), adapters/ (2), and src/api/server.js (1).
+#     S3403 stays ACTIVE across the rest of src/ (the product core), bin/,
+#     and tests/, so a genuinely always-false === there is still reported.
 #
 #     Re-check before assuming this is still correct:
 #       curl -s "https://sonarcloud.io/api/issues/search?componentKeys=IgorGanapolsky_ThumbGate&resolved=false&rules=javascript:S3403&ps=1"
 #     If the count is far above the `require.main === module` occurrence count,
 #     something other than the idiom is firing and this exclusion needs narrowing.
 sonar.issue.ignore.multicriteria.e2.ruleKey=javascript:S3403
-sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.js
+sonar.issue.ignore.multicriteria.e2.resourceKey=scripts/**/*.js
+sonar.issue.ignore.multicriteria.e3.ruleKey=javascript:S3403
+sonar.issue.ignore.multicriteria.e3.resourceKey=adapters/**/*.js
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S3403
+sonar.issue.ignore.multicriteria.e4.resourceKey=src/api/server.js
 # Copy-paste-detection exclusions.
 #
 # 1) Publisher CLI wrappers share an identical argparse + env-validation +


### PR DESCRIPTION
Follow-up to #3672 (merged with the blanket `**/*.js` suppression and one open Codex review thread). This keeps that PR's intent — the `require.main === module` idiom stays suppressed — while answering the reviewer's objection that a repo-wide ignore disables useful analysis across ~636 JS files to cover a much smaller false-positive surface.

Measured by grep on the tree (2026-08-26): the guard lives in `scripts/**` (**168 files**), `adapters/**` (**2**), and `src/api/server.js` (**1**). `bin/` has zero. So the ignore is now scoped to exactly those three surfaces, and `javascript:S3403` comes back ON across the rest of `src/` (the product core, where a genuinely always-false `===` matters most), `bin/`, and `tests/`.

Changes: `sonar-project.properties` e2 narrowed from `**/*.js` to `scripts/**/*.js`, new e3 (`adapters/**/*.js`) + e4 (`src/api/server.js`), comment block updated with the measured scope; the still-pending changeset from #3672 updated so the release note describes final reality. The embedded re-check command is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bzsj2cN9gwrwKQSNxAcBZe