### PR TITLE
feat(context): add bounded six-block envelopes

### DIFF
--- a/.changeset/bounded-context-envelopes.md
+++ b/.changeset/bounded-context-envelopes.md
@@ -1,0 +1,5 @@
+---
+'thumbgate': patch
+---
+
+Add budgeted six-block context envelopes, cache isolation for reusable examples and rubrics, and safe source-freshness provenance across ContextFS API and MCP packs.

--- a/adapters/chatgpt/openapi.yaml
+++ b/adapters/chatgpt/openapi.yaml
@@ -1958,7 +1958,9 @@ paths:
                 strategy: { type: string, enum: [summarize-then-expand] }
                 contextEnvelope:
                   type: object
-                  description: Six-block envelope; see context engineering docs.
+                  additionalProperties: false
+                  required: [goal, businessData, examples, procedures, constraints, rubric]
+                  properties: { goal: { type: string, minLength: 1 }, businessData: &contextList { type: array, minItems: 1, items: { type: string, minLength: 1 } }, examples: *contextList, procedures: *contextList, constraints: *contextList, rubric: *contextList }
       responses:
         '200':
           description: Context pack created

--- a/adapters/chatgpt/openapi.yaml
+++ b/adapters/chatgpt/openapi.yaml
@@ -1955,6 +1955,10 @@ paths:
                       - rules
                       - tools
                       - provenance
+                strategy: { type: string, enum: [summarize-then-expand] }
+                contextEnvelope:
+                  type: object
+                  description: Six-block envelope; see context engineering docs.
       responses:
         '200':
           description: Context pack created

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -647,9 +647,6 @@ function buildContextPackResponse(args = {}) {
     strategy: args.strategy || null,
     contextEnvelope: args.contextEnvelope || null,
   });
-  // Feed outcome-paired action receipts into the pack so an action->outcome
-  // history is available alongside lessons/rules. Additive + guarded: a
-  // receipt-store failure must never break context pack construction.
   try {
     const receiptEntries = buildReceiptContextEntries(args.query || '', Number(args.maxItems || 8));
     if (Array.isArray(receiptEntries) && receiptEntries.length && Array.isArray(pack.items)) {
@@ -663,10 +660,7 @@ function buildContextPackResponse(args = {}) {
           namespace: 'action-receipts',
           title: 'Action receipt outcome',
           structuredContext: { rawContent: receiptText },
-          provenance: {
-            source: 'action-receipts',
-            freshness: 'unknown',
-          },
+          provenance: { source: 'action-receipts', freshness: 'unknown' },
           tags: ['action-receipt', 'outcome-paired'],
           score: entry && typeof entry.score === 'number' ? entry.score : 0,
         });
@@ -680,9 +674,7 @@ function buildContextPackResponse(args = {}) {
         pack.visibility.visibleTitles = pack.items.slice(0, 5).map((item) => item.title);
       }
     }
-  } catch {
-    // ignore receipt enrichment failures
-  }
+  } catch { /* ignore */ }
   return toTextResult(pack);
 }
 

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -644,6 +644,8 @@ function buildContextPackResponse(args = {}) {
     maxItems: Number(args.maxItems || 8),
     maxChars: Number(args.maxChars || 6000),
     namespaces,
+    strategy: args.strategy || null,
+    contextEnvelope: args.contextEnvelope || null,
   });
   // Feed outcome-paired action receipts into the pack so an action->outcome
   // history is available alongside lessons/rules. Additive + guarded: a
@@ -652,17 +654,31 @@ function buildContextPackResponse(args = {}) {
     const receiptEntries = buildReceiptContextEntries(args.query || '', Number(args.maxItems || 8));
     if (Array.isArray(receiptEntries) && receiptEntries.length && Array.isArray(pack.items)) {
       for (const entry of receiptEntries) {
+        if (pack.items.length >= pack.maxItems) break;
+        const receiptText = entry && entry.text ? String(entry.text) : '';
+        const receiptChars = `Action receipt outcome\n${receiptText}`.length;
+        if (pack.usedChars + receiptChars > pack.maxChars) continue;
         pack.items.push({
           id: `action-receipt_${entry && entry.score != null ? entry.score : ''}_${pack.items.length}`,
           namespace: 'action-receipts',
           title: 'Action receipt outcome',
-          structuredContext: { rawContent: entry && entry.text ? String(entry.text) : '' },
+          structuredContext: { rawContent: receiptText },
+          provenance: {
+            source: 'action-receipts',
+            freshness: 'unknown',
+          },
           tags: ['action-receipt', 'outcome-paired'],
           score: entry && typeof entry.score === 'number' ? entry.score : 0,
         });
+        pack.usedChars += receiptChars;
       }
       if (!Array.isArray(pack.namespaces)) pack.namespaces = [];
       if (!pack.namespaces.includes('action-receipts')) pack.namespaces.push('action-receipts');
+      if (pack.visibility) {
+        pack.visibility.itemCount = pack.items.length;
+        pack.visibility.remainingCharBudget = Math.max(pack.maxChars - pack.usedChars, 0);
+        pack.visibility.visibleTitles = pack.items.slice(0, 5).map((item) => item.title);
+      }
     }
   } catch {
     // ignore receipt enrichment failures

--- a/docs/context-engineering/README.md
+++ b/docs/context-engineering/README.md
@@ -15,6 +15,40 @@ Maps [Hugging Face The Context Course](https://huggingface.co/learn/context-cour
 | 5 | Hooks | PreToolUse: gate-check, spend-guard, outbound-email-guard |
 | 6 | Nano harness | `gate-check` stdin contract, `bin/cli.js` |
 
+## Reusable six-block context
+
+`construct_context_pack` accepts a durable `contextEnvelope` that makes
+few-shot examples and rubric-first evaluation reusable across agents:
+
+```json
+{
+  "query": "Is this pull request ready?",
+  "maxChars": 6000,
+  "contextEnvelope": {
+    "goal": "Decide whether the exact pull request head is merge-ready.",
+    "businessData": ["Required checks and review threads are provider evidence."],
+    "examples": ["Good: cite the exact SHA and terminal check run."],
+    "procedures": ["Retrieve, compare with the rubric, then recommend."],
+    "constraints": ["Never approve or bypass branch protection."],
+    "rubric": ["Every readiness claim includes exact provider evidence."]
+  }
+}
+```
+
+The envelope is validated, counted against the same character budget as
+retrieved memory, and included in semantic-cache identity. A changed example or
+rubric cannot reuse a pack built for different instructions.
+
+Retrieved items include safe provenance fields:
+
+- `source` and optional `sourceUrl`;
+- `observedAt` and optional `maxAgeSeconds`;
+- `freshness`: `fresh`, `stale`, `future`, `invalid`, or `unknown`.
+
+This is the connector boundary: live business data is useful only when the
+source and freshness are carried with it. ContextFS does not turn an old
+connector result into current truth.
+
 ## GSD stages (Get Shit Done)
 
 Used for every multi-file context/coding task:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1958,7 +1958,9 @@ paths:
                 strategy: { type: string, enum: [summarize-then-expand] }
                 contextEnvelope:
                   type: object
-                  description: Six-block envelope; see context engineering docs.
+                  additionalProperties: false
+                  required: [goal, businessData, examples, procedures, constraints, rubric]
+                  properties: { goal: { type: string, minLength: 1 }, businessData: &contextList { type: array, minItems: 1, items: { type: string, minLength: 1 } }, examples: *contextList, procedures: *contextList, constraints: *contextList, rubric: *contextList }
       responses:
         '200':
           description: Context pack created

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1955,6 +1955,10 @@ paths:
                       - rules
                       - tools
                       - provenance
+                strategy: { type: string, enum: [summarize-then-expand] }
+                contextEnvelope:
+                  type: object
+                  description: Six-block envelope; see context engineering docs.
       responses:
         '200':
           description: Context pack created

--- a/scripts/contextfs.js
+++ b/scripts/contextfs.js
@@ -102,16 +102,8 @@ const PACK_TEMPLATES = {
 
 const CONTEXT_ENVELOPE_VERSION = 'six-block-v1';
 const CONTEXT_ENVELOPE_KEYS = [
-  'goal',
-  'businessData',
-  'examples',
-  'procedures',
-  'constraints',
-  'rubric',
+  'goal', 'businessData', 'examples', 'procedures', 'constraints', 'rubric',
 ];
-const CONTEXT_ENVELOPE_LIST_KEYS = CONTEXT_ENVELOPE_KEYS.filter((key) => key !== 'goal');
-
-
 function ensureContextFs() {
   Object.values(NAMESPACES).forEach((subPath) => {
     ensureDir(contextFsPath(subPath));
@@ -189,22 +181,15 @@ function querySimilarity(tokensA, tokensB) {
   return union === 0 ? 0 : intersection / union;
 }
 
-function buildSemanticCacheKey({
-  namespaces,
-  maxItems,
-  maxChars,
-  strategy = 'auto',
-  contextEnvelope = null,
-}) {
+function buildSemanticCacheKey({ namespaces, maxItems, maxChars, strategy = 'auto', contextEnvelope = null }) {
   return JSON.stringify({
     retrievalVersion: CONTEXTFS_RETRIEVAL_VERSION,
     namespaces: normalizeNamespaces(namespaces),
     maxItems,
     maxChars,
     strategy,
-    contextEnvelopeHash: contextEnvelope
-      ? crypto.createHash('sha256').update(JSON.stringify(contextEnvelope)).digest('hex')
-      : null,
+    contextEnvelopeHash: contextEnvelope ? crypto.createHash('sha256')
+      .update(JSON.stringify(contextEnvelope)).digest('hex') : null,
   });
 }
 
@@ -244,23 +229,14 @@ function getSourceHash(namespaces) {
         try {
           const stats = fs.statSync(filePath);
           hasher.update(`${file}:${stats.mtimeMs}:${stats.size}`);
-        } catch {
-          // Skip if file disappeared
-        }
+        } catch { /* ignore */ }
       }
     }
   }
   return hasher.digest('hex');
 }
 
-function findSemanticCacheHit({
-  query,
-  namespaces,
-  maxItems,
-  maxChars,
-  strategy = 'auto',
-  contextEnvelope = null,
-}) {
+function findSemanticCacheHit({ query, namespaces, maxItems, maxChars, strategy = 'auto', contextEnvelope = null }) {
   const { enabled, threshold, ttlSeconds } = getSemanticCacheConfig();
   if (!enabled) return null;
 
@@ -269,20 +245,13 @@ function findSemanticCacheHit({
 
   const now = Date.now();
   const queryTokens = tokenizeQuery(query);
-  const key = buildSemanticCacheKey({
-    namespaces,
-    maxItems,
-    maxChars,
-    strategy,
-    contextEnvelope,
-  });
+  const key = buildSemanticCacheKey({ namespaces, maxItems, maxChars, strategy, contextEnvelope });
   const currentSourceHash = getSourceHash(namespaces);
 
   for (let i = entries.length - 1; i >= 0; i -= 1) {
     const entry = entries[i];
     if (!entry || entry.key !== key || !entry.pack) continue;
 
-    // Zero-Waste Caching: validate source hash
     if (entry.sourceHash !== currentSourceHash) {
       continue;
     }
@@ -424,23 +393,21 @@ function measureContextEnvelopeChars(contextEnvelope) {
   return contextEnvelope ? JSON.stringify(contextEnvelope).length : 0;
 }
 
+function getFreshness(observedAt, maxAgeSeconds, currentTimeMs) {
+  if (!observedAt) return 'unknown';
+  const observedAtMs = new Date(observedAt).getTime();
+  if (!Number.isFinite(observedAtMs)) return 'invalid';
+  if (observedAtMs > currentTimeMs + 300_000) return 'future';
+  if (!(Number.isFinite(maxAgeSeconds) && maxAgeSeconds > 0)) return 'unknown';
+  return currentTimeMs - observedAtMs <= maxAgeSeconds * 1000 ? 'fresh' : 'stale';
+}
+
 function buildItemProvenance(doc, currentTimeMs = Date.now()) {
-  const metadata = doc && doc.metadata && typeof doc.metadata === 'object'
-    ? doc.metadata
-    : {};
+  const metadata = doc && typeof doc.metadata === 'object' ? doc.metadata : {};
   const observedAtRaw = metadata.sourceUpdatedAt || doc.createdAt || null;
   const observedAtMs = observedAtRaw ? new Date(observedAtRaw).getTime() : NaN;
   const parsedMaxAge = Number(metadata.maxAgeSeconds);
-  const maxAgeSeconds = Number.isFinite(parsedMaxAge) && parsedMaxAge > 0
-    ? parsedMaxAge
-    : null;
-  const freshness = observedAtRaw && !Number.isFinite(observedAtMs)
-    ? 'invalid'
-    : (Number.isFinite(observedAtMs) && observedAtMs > currentTimeMs + 300_000
-      ? 'future'
-      : (Number.isFinite(observedAtMs) && maxAgeSeconds
-        ? (currentTimeMs - observedAtMs <= maxAgeSeconds * 1000 ? 'fresh' : 'stale')
-        : 'unknown'));
+  const maxAgeSeconds = Number.isFinite(parsedMaxAge) && parsedMaxAge > 0 ? parsedMaxAge : null;
 
   return {
     source: doc.source || 'unknown',
@@ -449,8 +416,14 @@ function buildItemProvenance(doc, currentTimeMs = Date.now()) {
       : null,
     observedAt: Number.isFinite(observedAtMs) ? new Date(observedAtMs).toISOString() : null,
     maxAgeSeconds,
-    freshness,
+    freshness: getFreshness(observedAtRaw, maxAgeSeconds, currentTimeMs),
   };
+}
+
+function refreshItemProvenance(provenance, currentTimeMs = Date.now()) {
+  if (!provenance) return provenance;
+  const freshness = getFreshness(provenance.observedAt, Number(provenance.maxAgeSeconds), currentTimeMs);
+  return { ...provenance, freshness };
 }
 
 function findExistingContextObject({ namespace, title, content, tags = [], source }) {
@@ -475,9 +448,7 @@ function findExistingContextObject({ namespace, title, content, tags = [], sourc
         filePath,
         document: doc,
       };
-    } catch {
-      // Ignore malformed entries while searching for exact duplicates.
-    }
+    } catch { /* ignore */ }
   }
 
   return null;
@@ -612,9 +583,7 @@ function loadCandidates(namespaces) {
           ...payload,
           namespace,
         });
-      } catch {
-        // ignore malformed files
-      }
+      } catch { /* ignore */ }
     });
   });
 
@@ -1016,10 +985,6 @@ function constructContextPack({
   const tokens = tokenizeQuery(query);
   const sourceHash = getSourceHash(normalizedNamespaces);
 
-  // Resolve the effective strategy. Explicit `strategy` wins; otherwise
-  // `summarizeThenExpand: true` flips the flag. Default remains auto
-  // (flat | hierarchical) so callers that don't opt in keep their cached
-  // packs addressable.
   const effectiveStrategy = strategy
     || (summarizeThenExpand ? 'summarize-then-expand' : null);
   const hierarchicalRetrievalEnabled = shouldUseHierarchicalRetrieval(normalizedNamespaces);
@@ -1028,12 +993,8 @@ function constructContextPack({
     : (hierarchicalRetrievalEnabled ? 'hierarchical' : 'flat');
 
   const cacheHit = findSemanticCacheHit({
-    query,
-    namespaces: normalizedNamespaces,
-    maxItems,
-    maxChars,
-    strategy: retrievalStrategy,
-    contextEnvelope: normalizedContextEnvelope,
+    query, namespaces: normalizedNamespaces, maxItems, maxChars,
+    strategy: retrievalStrategy, contextEnvelope: normalizedContextEnvelope,
   });
 
   if (cacheHit) {
@@ -1044,6 +1005,12 @@ function constructContextPack({
       packId,
       query,
       createdAt: nowIso(),
+      items: Array.isArray(cachedPack.items)
+        ? cachedPack.items.map((item) => ({
+          ...item,
+          provenance: refreshItemProvenance(item.provenance),
+        }))
+        : cachedPack.items,
       cache: {
         hit: true,
         similarity: Number(cacheHit.score.toFixed(4)),
@@ -1071,10 +1038,6 @@ function constructContextPack({
 
   let selection;
   if (effectiveStrategy === 'summarize-then-expand') {
-    // Explicit opt-in: bypass the hierarchical path entirely. The
-    // summarize-then-expand selector assumes a flat ranked list where each
-    // item is a single episode, and mixing it with theme-based hierarchical
-    // retrieval would double-compress the top-of-list.
     selection = selectSummarizeThenExpand(candidates, maxItems, retrievalMaxChars);
   } else if (hierarchicalRetrievalEnabled) {
     selection = retrieveHierarchicalDocuments({
@@ -1089,10 +1052,6 @@ function constructContextPack({
     selection = selectFlatContextItems(candidates, maxItems, retrievalMaxChars);
   }
 
-  // The flat + hierarchical paths emit raw docs; summarize-then-expand emits
-  // fully-shaped items that already carry structuredContext and a `tier`
-  // marker. Detect the shape so we don't double-canonicalize STE items
-  // (which would re-expand every summary into full content).
   const selected = selection.items.map((item) => {
     if (item && item.structuredContext) {
       return {
@@ -1155,11 +1114,8 @@ function constructContextPack({
     id: `cache_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     timestamp: nowIso(),
     key: buildSemanticCacheKey({
-      namespaces: normalizedNamespaces,
-      maxItems,
-      maxChars,
-      strategy: retrievalStrategy,
-      contextEnvelope: normalizedContextEnvelope,
+      namespaces: normalizedNamespaces, maxItems, maxChars,
+      strategy: retrievalStrategy, contextEnvelope: normalizedContextEnvelope,
     }),
     query,
     tokens,

--- a/scripts/contextfs.js
+++ b/scripts/contextfs.js
@@ -100,6 +100,17 @@ const PACK_TEMPLATES = {
   },
 };
 
+const CONTEXT_ENVELOPE_VERSION = 'six-block-v1';
+const CONTEXT_ENVELOPE_KEYS = [
+  'goal',
+  'businessData',
+  'examples',
+  'procedures',
+  'constraints',
+  'rubric',
+];
+const CONTEXT_ENVELOPE_LIST_KEYS = CONTEXT_ENVELOPE_KEYS.filter((key) => key !== 'goal');
+
 
 function ensureContextFs() {
   Object.values(NAMESPACES).forEach((subPath) => {
@@ -178,12 +189,22 @@ function querySimilarity(tokensA, tokensB) {
   return union === 0 ? 0 : intersection / union;
 }
 
-function buildSemanticCacheKey({ namespaces, maxItems, maxChars }) {
+function buildSemanticCacheKey({
+  namespaces,
+  maxItems,
+  maxChars,
+  strategy = 'auto',
+  contextEnvelope = null,
+}) {
   return JSON.stringify({
     retrievalVersion: CONTEXTFS_RETRIEVAL_VERSION,
     namespaces: normalizeNamespaces(namespaces),
     maxItems,
     maxChars,
+    strategy,
+    contextEnvelopeHash: contextEnvelope
+      ? crypto.createHash('sha256').update(JSON.stringify(contextEnvelope)).digest('hex')
+      : null,
   });
 }
 
@@ -232,7 +253,14 @@ function getSourceHash(namespaces) {
   return hasher.digest('hex');
 }
 
-function findSemanticCacheHit({ query, namespaces, maxItems, maxChars }) {
+function findSemanticCacheHit({
+  query,
+  namespaces,
+  maxItems,
+  maxChars,
+  strategy = 'auto',
+  contextEnvelope = null,
+}) {
   const { enabled, threshold, ttlSeconds } = getSemanticCacheConfig();
   if (!enabled) return null;
 
@@ -241,7 +269,13 @@ function findSemanticCacheHit({ query, namespaces, maxItems, maxChars }) {
 
   const now = Date.now();
   const queryTokens = tokenizeQuery(query);
-  const key = buildSemanticCacheKey({ namespaces, maxItems, maxChars });
+  const key = buildSemanticCacheKey({
+    namespaces,
+    maxItems,
+    maxChars,
+    strategy,
+    contextEnvelope,
+  });
   const currentSourceHash = getSourceHash(namespaces);
 
   for (let i = entries.length - 1; i >= 0; i -= 1) {
@@ -341,6 +375,82 @@ function normalizeTagList(tags) {
     ? [...new Set(tags.map((tag) => String(tag)))]
       .sort()
     : [];
+}
+
+function invalidContextEnvelope(message) {
+  return Object.assign(new Error(message), { code: 'INVALID_CONTEXT_ENVELOPE' });
+}
+
+function normalizeContextEnvelope(value) {
+  if (value == null) return null;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw invalidContextEnvelope('contextEnvelope must be an object');
+  }
+
+  const unknownKeys = Object.keys(value).filter((key) => !CONTEXT_ENVELOPE_KEYS.includes(key));
+  if (unknownKeys.length > 0) {
+    throw invalidContextEnvelope(
+      `contextEnvelope contains unsupported blocks: ${unknownKeys.join(', ')}`,
+    );
+  }
+
+  const missingKeys = CONTEXT_ENVELOPE_KEYS.filter((key) => !Object.hasOwn(value, key));
+  if (missingKeys.length > 0) {
+    throw invalidContextEnvelope(
+      `contextEnvelope is missing required blocks: ${missingKeys.join(', ')}`,
+    );
+  }
+
+  const envelope = {
+    version: CONTEXT_ENVELOPE_VERSION,
+  };
+  for (const key of CONTEXT_ENVELOPE_KEYS) {
+    const items = key === 'goal' ? [value[key]] : value[key];
+    if (!Array.isArray(items)
+      || items.length === 0
+      || items.some((item) => (
+        typeof item !== 'string'
+        || !item.trim()
+      ))) {
+      throw invalidContextEnvelope(`contextEnvelope.${key} has invalid content`);
+    }
+    const normalized = items.map((item) => item.trim());
+    envelope[key] = key === 'goal' ? normalized[0] : normalized;
+  }
+  return envelope;
+}
+
+function measureContextEnvelopeChars(contextEnvelope) {
+  return contextEnvelope ? JSON.stringify(contextEnvelope).length : 0;
+}
+
+function buildItemProvenance(doc, currentTimeMs = Date.now()) {
+  const metadata = doc && doc.metadata && typeof doc.metadata === 'object'
+    ? doc.metadata
+    : {};
+  const observedAtRaw = metadata.sourceUpdatedAt || doc.createdAt || null;
+  const observedAtMs = observedAtRaw ? new Date(observedAtRaw).getTime() : NaN;
+  const parsedMaxAge = Number(metadata.maxAgeSeconds);
+  const maxAgeSeconds = Number.isFinite(parsedMaxAge) && parsedMaxAge > 0
+    ? parsedMaxAge
+    : null;
+  const freshness = observedAtRaw && !Number.isFinite(observedAtMs)
+    ? 'invalid'
+    : (Number.isFinite(observedAtMs) && observedAtMs > currentTimeMs + 300_000
+      ? 'future'
+      : (Number.isFinite(observedAtMs) && maxAgeSeconds
+        ? (currentTimeMs - observedAtMs <= maxAgeSeconds * 1000 ? 'fresh' : 'stale')
+        : 'unknown'));
+
+  return {
+    source: doc.source || 'unknown',
+    sourceUrl: typeof metadata.sourceUrl === 'string' && metadata.sourceUrl.trim()
+      ? metadata.sourceUrl.trim()
+      : null,
+    observedAt: Number.isFinite(observedAtMs) ? new Date(observedAtMs).toISOString() : null,
+    maxAgeSeconds,
+    freshness,
+  };
 }
 
 function findExistingContextObject({ namespace, title, content, tags = [], source }) {
@@ -580,6 +690,7 @@ function selectFlatContextItems(candidates, maxItems, maxChars) {
       namespace: item.doc.namespace,
       title: item.doc.title,
       structuredContext: buildStructuredContext(item.doc),
+      provenance: buildItemProvenance(item.doc),
       tags: item.doc.tags || [],
       score: item.score,
     });
@@ -687,6 +798,7 @@ function selectSummarizeThenExpand(candidates, maxItems, maxChars) {
       namespace: item.doc.namespace,
       title: item.doc.title,
       structuredContext: buildSummaryContext(item.doc),
+      provenance: buildItemProvenance(item.doc),
       tags: item.doc.tags || [],
       score: item.score,
       tier: 'summary',
@@ -888,8 +1000,19 @@ function constructContextPack({
   namespaces = [],
   strategy = null,
   summarizeThenExpand = false,
+  contextEnvelope = null,
 } = {}) {
   const normalizedNamespaces = normalizeNamespaces(namespaces);
+  const normalizedContextEnvelope = normalizeContextEnvelope(contextEnvelope);
+  const contextEnvelopeChars = measureContextEnvelopeChars(normalizedContextEnvelope);
+  if (contextEnvelopeChars >= maxChars) {
+    const error = new Error(
+      `contextEnvelope requires ${contextEnvelopeChars} characters but maxChars is ${maxChars}`,
+    );
+    error.code = 'CONTEXT_BUDGET_EXCEEDED';
+    throw error;
+  }
+  const retrievalMaxChars = maxChars - contextEnvelopeChars;
   const tokens = tokenizeQuery(query);
   const sourceHash = getSourceHash(normalizedNamespaces);
 
@@ -899,20 +1022,19 @@ function constructContextPack({
   // packs addressable.
   const effectiveStrategy = strategy
     || (summarizeThenExpand ? 'summarize-then-expand' : null);
+  const hierarchicalRetrievalEnabled = shouldUseHierarchicalRetrieval(normalizedNamespaces);
+  const retrievalStrategy = effectiveStrategy === 'summarize-then-expand'
+    ? 'summarize-then-expand'
+    : (hierarchicalRetrievalEnabled ? 'hierarchical' : 'flat');
 
-  // Skip the semantic cache for summarize-then-expand packs. The cache key
-  // is (namespaces, maxItems, maxChars) — it doesn't include the strategy,
-  // so a cached flat pack would be served to an STE caller (and vice versa)
-  // with the wrong shape. Cheaper to recompute than to extend the cache key
-  // and invalidate every entry on disk.
-  const cacheHit = effectiveStrategy === 'summarize-then-expand'
-    ? null
-    : findSemanticCacheHit({
-      query,
-      namespaces: normalizedNamespaces,
-      maxItems,
-      maxChars,
-    });
+  const cacheHit = findSemanticCacheHit({
+    query,
+    namespaces: normalizedNamespaces,
+    maxItems,
+    maxChars,
+    strategy: retrievalStrategy,
+    contextEnvelope: normalizedContextEnvelope,
+  });
 
   if (cacheHit) {
     const packId = `pack_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -947,25 +1069,24 @@ function constructContextPack({
     .map((doc) => ({ doc, score: scoreDocument(doc, tokens) }))
     .sort((a, b) => b.score - a.score);
 
-  const hierarchicalRetrievalEnabled = shouldUseHierarchicalRetrieval(normalizedNamespaces);
   let selection;
   if (effectiveStrategy === 'summarize-then-expand') {
     // Explicit opt-in: bypass the hierarchical path entirely. The
     // summarize-then-expand selector assumes a flat ranked list where each
     // item is a single episode, and mixing it with theme-based hierarchical
     // retrieval would double-compress the top-of-list.
-    selection = selectSummarizeThenExpand(candidates, maxItems, maxChars);
+    selection = selectSummarizeThenExpand(candidates, maxItems, retrievalMaxChars);
   } else if (hierarchicalRetrievalEnabled) {
     selection = retrieveHierarchicalDocuments({
       documents: candidates.map((candidate) => candidate.doc),
       query,
       maxItems,
-      maxChars,
+      maxChars: retrievalMaxChars,
       scorer: scoreDocument,
       measureDocument: measureDocumentChars,
     });
   } else {
-    selection = selectFlatContextItems(candidates, maxItems, maxChars);
+    selection = selectFlatContextItems(candidates, maxItems, retrievalMaxChars);
   }
 
   // The flat + hierarchical paths emit raw docs; summarize-then-expand emits
@@ -979,6 +1100,7 @@ function constructContextPack({
         namespace: item.namespace,
         title: item.title,
         structuredContext: item.structuredContext,
+        provenance: item.provenance || buildItemProvenance(item),
         tags: item.tags || [],
         score: typeof item.score === 'number' ? item.score : scoreDocument(item, tokens),
         ...(item.tier ? { tier: item.tier } : {}),
@@ -989,11 +1111,12 @@ function constructContextPack({
       namespace: item.namespace,
       title: item.title,
       structuredContext: buildStructuredContext(item),
+      provenance: buildItemProvenance(item),
       tags: item.tags || [],
       score: scoreDocument(item, tokens),
     };
   });
-  const usedChars = selection.usedChars;
+  const usedChars = selection.usedChars + contextEnvelopeChars;
   const skippedByMaxChars = selection.skippedByMaxChars;
 
   const visibility = {
@@ -1014,6 +1137,8 @@ function constructContextPack({
     maxItems,
     maxChars,
     usedChars,
+    contextEnvelope: normalizedContextEnvelope,
+    contextEnvelopeChars,
     namespaces: normalizedNamespaces,
     createdAt: nowIso(),
     items: selected,
@@ -1026,29 +1151,30 @@ function constructContextPack({
   };
 
   appendJsonl(contextFsPath(NAMESPACES.provenance, 'packs.jsonl'), pack);
-  // Symmetric with the cache read: don't persist STE packs into the shared
-  // semantic cache because the cache key is strategy-agnostic.
-  if (effectiveStrategy !== 'summarize-then-expand') {
-    appendSemanticCacheEntry({
-      id: `cache_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-      timestamp: nowIso(),
-      key: buildSemanticCacheKey({
-        namespaces: normalizedNamespaces,
-        maxItems,
-        maxChars,
-      }),
-      query,
-      tokens,
-      sourceHash,
-      pack,
-    });
-  }
+  appendSemanticCacheEntry({
+    id: `cache_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: nowIso(),
+    key: buildSemanticCacheKey({
+      namespaces: normalizedNamespaces,
+      maxItems,
+      maxChars,
+      strategy: retrievalStrategy,
+      contextEnvelope: normalizedContextEnvelope,
+    }),
+    query,
+    tokens,
+    sourceHash,
+    pack,
+  });
   recordProvenance({
     type: 'context_pack_constructed',
     packId,
     query,
     itemCount: selected.length,
     usedChars,
+    contextEnvelopeVersion: normalizedContextEnvelope
+      ? normalizedContextEnvelope.version
+      : null,
     sourceHash,
     retrievalStrategy: selection.retrieval.strategy,
   });

--- a/scripts/tool-registry.js
+++ b/scripts/tool-registry.js
@@ -913,6 +913,11 @@ const TOOLS = [
         maxItems: { type: 'number' },
         maxChars: { type: 'number' },
         namespaces: { type: 'array', items: { type: 'string' } },
+        strategy: { type: 'string', enum: ['summarize-then-expand'] },
+        contextEnvelope: {
+          type: 'object',
+          description: 'Six-block envelope; see context engineering docs.',
+        },
       },
     },
   }),

--- a/scripts/tool-registry.js
+++ b/scripts/tool-registry.js
@@ -104,6 +104,20 @@ const GOAL_CONTRACT_SCHEMA = {
   },
 };
 
+const CONTEXT_LIST_BLOCKS = ['businessData', 'examples', 'procedures', 'constraints', 'rubric'];
+const NON_EMPTY_STRING = { type: 'string', minLength: 1 };
+const CONTEXT_ENVELOPE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['goal', ...CONTEXT_LIST_BLOCKS],
+  properties: {
+    goal: NON_EMPTY_STRING,
+    ...Object.fromEntries(CONTEXT_LIST_BLOCKS.map((key) => [
+      key, { type: 'array', minItems: 1, items: NON_EMPTY_STRING },
+    ])),
+  },
+};
+
 const TASK_OUTCOME_INPUT_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -914,10 +928,7 @@ const TOOLS = [
         maxChars: { type: 'number' },
         namespaces: { type: 'array', items: { type: 'string' } },
         strategy: { type: 'string', enum: ['summarize-then-expand'] },
-        contextEnvelope: {
-          type: 'object',
-          description: 'Six-block envelope; see context engineering docs.',
-        },
+        contextEnvelope: CONTEXT_ENVELOPE_SCHEMA,
       },
     },
   }),

--- a/skills/context-engineering-checklist/SKILL.md
+++ b/skills/context-engineering-checklist/SKILL.md
@@ -52,6 +52,26 @@ Source: [The Context Course](https://huggingface.co/learn/context-course/unit0/i
 - [ ] Deny + allow + false-positive tests
 - [ ] Live probe before “protected”
 
+## Six-block context envelope
+
+Before generation, package reusable context into all six blocks:
+
+1. `goal`: one measurable outcome.
+2. `businessData`: current evidence with source and timestamp.
+3. `examples`: concrete good or bad few-shot cases.
+4. `procedures`: ordered actions and verification.
+5. `constraints`: safety, business, and SLA limits.
+6. `rubric`: grading criteria supplied before the answer is generated.
+
+Use `construct_context_pack.contextEnvelope` instead of repeating these blocks
+in chat. All blocks are required when the envelope is present, count against
+`maxChars`, and are part of semantic-cache identity.
+
+For connector evidence, set `metadata.sourceUpdatedAt`,
+`metadata.maxAgeSeconds`, and `metadata.sourceUrl` on the stored context
+object. Treat `stale`, `future`, `invalid`, and `unknown` freshness as
+explicit evidence states, not current truth.
+
 ## Scripts
 
 ```bash

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -10366,12 +10366,23 @@ footer{margin-top:40px;padding-top:20px;border-top:1px solid #e5e7eb;color:#6b72
         } catch (err) {
           throw createHttpError(400, err.message || 'Invalid namespaces');
         }
-        const pack = constructContextPack({
-          query: body.query || '',
-          maxItems: Number(body.maxItems || 8),
-          maxChars: Number(body.maxChars || 6000),
-          namespaces,
-        });
+        let pack;
+        try {
+          pack = constructContextPack({
+            query: body.query || '',
+            maxItems: Number(body.maxItems || 8),
+            maxChars: Number(body.maxChars || 6000),
+            namespaces,
+            strategy: body.strategy || null,
+            contextEnvelope: body.contextEnvelope || null,
+          });
+        } catch (err) {
+          if (err.code === 'INVALID_CONTEXT_ENVELOPE'
+            || err.code === 'CONTEXT_BUDGET_EXCEEDED') {
+            throw createHttpError(400, err.message);
+          }
+          throw err;
+        }
         sendJson(res, 200, pack);
         return;
       }

--- a/tests/api-server.test.js
+++ b/tests/api-server.test.js
@@ -2968,11 +2968,24 @@ test('context construct/evaluate/provenance endpoints work', async () => {
       query: 'verification',
       maxItems: 5,
       maxChars: 4000,
+      contextEnvelope: {
+        goal: 'Verify the exact outcome.',
+        businessData: ['The current PR head is the unit of CI truth.'],
+        examples: ['Good: cite the exact check run and commit.'],
+        procedures: ['Retrieve, compare, then recommend.'],
+        constraints: ['Do not approve or bypass branch protection.'],
+        rubric: ['Every completion claim includes provider evidence.'],
+      },
     }),
   });
   assert.equal(constructRes.status, 200);
   const constructBody = await constructRes.json();
   assert.ok(constructBody.packId);
+  assert.equal(constructBody.contextEnvelope.version, 'six-block-v1');
+  assert.deepEqual(constructBody.contextEnvelope.examples, [
+    'Good: cite the exact check run and commit.',
+  ]);
+  assert.ok(constructBody.usedChars <= constructBody.maxChars);
 
   const evalRes = await fetch(apiUrl('/v1/context/evaluate'), {
     method: 'POST',
@@ -3017,6 +3030,27 @@ test('context construct rejects invalid namespaces', async () => {
     }),
   });
   assert.equal(res.status, 400);
+});
+
+test('context construct rejects incomplete six-block envelopes', async () => {
+  const res = await fetch(apiUrl('/v1/context/construct'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...authHeader },
+    body: JSON.stringify({
+      query: 'verification',
+      contextEnvelope: {
+        goal: 'Verify the exact outcome.',
+        businessData: ['The current PR head is the unit of CI truth.'],
+        examples: ['Good: cite the exact check run and commit.'],
+        procedures: ['Retrieve, compare, then recommend.'],
+        constraints: ['Do not approve or bypass branch protection.'],
+      },
+    }),
+  });
+
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.match(JSON.stringify(body), /missing required blocks: rubric/);
 });
 
 test('unauthorized without bearer token', async () => {

--- a/tests/contextfs.test.js
+++ b/tests/contextfs.test.js
@@ -278,6 +278,38 @@ test('semantic cache isolates context envelopes and reuses exact envelopes', () 
   assert.equal(changed.cache.hit, false);
 });
 
+test('semantic cache recomputes connector freshness at response time', () => {
+  const actualNow = Date.now;
+  let clock = actualNow();
+  Date.now = () => clock;
+  try {
+    upsertContextObject({
+      namespace: NAMESPACES.research,
+      title: 'Cached freshness boundary',
+      content: 'cachedfreshness evidence',
+      source: 'test-connector',
+      metadata: {
+        sourceUpdatedAt: new Date(clock - 30_000).toISOString(),
+        maxAgeSeconds: 60,
+      },
+    });
+    const first = constructContextPack({
+      query: 'cachedfreshness', maxChars: 3000, namespaces: [NAMESPACES.research],
+    });
+    const firstItem = first.items.find((item) => item.title === 'Cached freshness boundary');
+    assert.equal(firstItem.provenance.freshness, 'fresh');
+    clock += 60_000;
+    const cached = constructContextPack({
+      query: 'cachedfreshness', maxChars: 3000, namespaces: [NAMESPACES.research],
+    });
+    assert.equal(cached.cache.hit, true);
+    const cachedItem = cached.items.find((item) => item.title === 'Cached freshness boundary');
+    assert.equal(cachedItem.provenance.freshness, 'stale');
+  } finally {
+    Date.now = actualNow;
+  }
+});
+
 test('context items expose safe fresh, stale, and unknown source provenance', () => {
   const now = Date.now();
   const fixtures = [

--- a/tests/contextfs.test.js
+++ b/tests/contextfs.test.js
@@ -33,6 +33,18 @@ const {
 } = require('../scripts/contextfs');
 const contextfs = require('../scripts/contextfs');
 
+function buildContextEnvelope(overrides = {}) {
+  return {
+    goal: 'Choose the safest verified next action.',
+    businessData: ['Customer impact is measured by blocked production tasks.'],
+    examples: ['Good: cite the exact check result before recommending merge.'],
+    procedures: ['Retrieve evidence, compare it with the rubric, then recommend.'],
+    constraints: ['Do not approve or bypass branch protection.'],
+    rubric: ['Every completion claim has exact provider evidence.'],
+    ...overrides,
+  };
+}
+
 test.after(() => {
   fs.rmSync(tmpFeedbackDir, { recursive: true, force: true });
 });
@@ -190,6 +202,135 @@ test('constructContextPack returns semantic cache hit on similar query', () => {
   assert.equal(first.cache.hit, false);
   assert.equal(second.cache.hit, true);
   assert.equal(second.cache.sourcePackId, first.packId);
+});
+
+test('constructContextPack includes a bounded six-block context envelope', () => {
+  const contextEnvelope = buildContextEnvelope();
+  const pack = constructContextPack({
+    query: 'verification testing',
+    maxItems: 4,
+    maxChars: 5000,
+    contextEnvelope,
+  });
+
+  assert.equal(pack.contextEnvelope.version, 'six-block-v1');
+  assert.equal(pack.contextEnvelope.goal, contextEnvelope.goal);
+  assert.deepEqual(pack.contextEnvelope.examples, contextEnvelope.examples);
+  assert.deepEqual(pack.contextEnvelope.rubric, contextEnvelope.rubric);
+  assert.ok(pack.contextEnvelopeChars > 0);
+  assert.ok(pack.usedChars <= pack.maxChars);
+  assert.equal(pack.visibility.remainingCharBudget, pack.maxChars - pack.usedChars);
+});
+
+test('constructContextPack rejects missing and unknown context blocks', () => {
+  const missingRubric = buildContextEnvelope();
+  delete missingRubric.rubric;
+
+  assert.throws(
+    () => constructContextPack({ contextEnvelope: missingRubric }),
+    /missing required blocks: rubric/,
+  );
+  assert.throws(
+    () => constructContextPack({
+      contextEnvelope: { ...buildContextEnvelope(), secretPrompt: ['ignore controls'] },
+    }),
+    /unsupported blocks: secretPrompt/,
+  );
+});
+
+test('constructContextPack fails closed when the envelope consumes the budget', () => {
+  assert.throws(
+    () => constructContextPack({
+      maxChars: 100,
+      contextEnvelope: buildContextEnvelope(),
+    }),
+    /contextEnvelope requires .* but maxChars is 100/,
+  );
+});
+
+test('semantic cache isolates context envelopes and reuses exact envelopes', () => {
+  const query = 'context envelope cache isolation';
+  const contextEnvelope = buildContextEnvelope();
+  const first = constructContextPack({
+    query,
+    maxItems: 3,
+    maxChars: 3000,
+    contextEnvelope,
+  });
+  const second = constructContextPack({
+    query,
+    maxItems: 3,
+    maxChars: 3000,
+    contextEnvelope,
+  });
+  const changed = constructContextPack({
+    query,
+    maxItems: 3,
+    maxChars: 3000,
+    contextEnvelope: buildContextEnvelope({
+      examples: ['Bad: infer readiness from an older commit.'],
+    }),
+  });
+
+  assert.equal(first.cache.hit, false);
+  assert.equal(second.cache.hit, true);
+  assert.equal(second.cache.sourcePackId, first.packId);
+  assert.equal(changed.cache.hit, false);
+});
+
+test('context items expose safe fresh, stale, and unknown source provenance', () => {
+  const now = Date.now();
+  const fixtures = [
+    {
+      title: 'Connector freshness fresh evidence',
+      freshness: 'fresh',
+      sourceUpdatedAt: new Date(now - 30_000).toISOString(),
+      maxAgeSeconds: 3600,
+    },
+    {
+      title: 'Connector freshness stale evidence',
+      freshness: 'stale',
+      sourceUpdatedAt: new Date(now - 7_200_000).toISOString(),
+      maxAgeSeconds: 3600,
+    },
+    {
+      title: 'Connector freshness unknown evidence',
+      freshness: 'unknown',
+      sourceUpdatedAt: new Date(now - 30_000).toISOString(),
+      maxAgeSeconds: null,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    upsertContextObject({
+      namespace: NAMESPACES.research,
+      title: fixture.title,
+      content: 'connectorfreshness evidence',
+      tags: ['connectorfreshness'],
+      source: 'test-connector',
+      metadata: {
+        sourceUrl: 'https://example.test/evidence',
+        sourceUpdatedAt: fixture.sourceUpdatedAt,
+        maxAgeSeconds: fixture.maxAgeSeconds,
+      },
+    });
+  }
+
+  const pack = constructContextPack({
+    query: 'connectorfreshness',
+    namespaces: [NAMESPACES.research],
+    maxItems: 10,
+    maxChars: 8000,
+  });
+
+  for (const fixture of fixtures) {
+    const item = pack.items.find((candidate) => candidate.title === fixture.title);
+    assert.ok(item, `missing ${fixture.title}`);
+    assert.equal(item.provenance.source, 'test-connector');
+    assert.equal(item.provenance.sourceUrl, 'https://example.test/evidence');
+    assert.equal(item.provenance.freshness, fixture.freshness);
+    assert.equal(Object.hasOwn(item, 'filePath'), false);
+  }
 });
 
 test('contextfs root follows feedback dir changes after module load', () => {
@@ -629,7 +770,7 @@ test('summarize-then-expand upgrades top-ranked items when budget allows', () =>
   assert.ok(expanded.structuredContext.rawContent.length > 0);
 });
 
-test('summarize-then-expand bypasses the semantic cache', () => {
+test('summarize-then-expand cache is isolated from flat packs', () => {
   // Warm the cache with a flat pack at the same key shape.
   constructContextPack({
     query: 'deployment incident',
@@ -646,4 +787,13 @@ test('summarize-then-expand bypasses the semantic cache', () => {
   });
   assert.equal(stePack.cache.hit, false);
   assert.equal(stePack.retrieval.strategy, 'summarize-then-expand');
+
+  const repeatedStePack = constructContextPack({
+    query: 'deployment incident',
+    maxItems: 5,
+    maxChars: 4000,
+    summarizeThenExpand: true,
+  });
+  assert.equal(repeatedStePack.cache.hit, true);
+  assert.equal(repeatedStePack.cache.sourcePackId, stePack.packId);
 });

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -1484,6 +1484,14 @@ test('construct/evaluate context pack tools work', async () => {
       arguments: {
         query: 'verification',
         maxItems: 5,
+        contextEnvelope: {
+          goal: 'Verify the exact outcome.',
+          businessData: ['The current PR head is the unit of CI truth.'],
+          examples: ['Good: cite the exact check run and commit.'],
+          procedures: ['Retrieve, compare, then recommend.'],
+          constraints: ['Do not approve or bypass branch protection.'],
+          rubric: ['Every completion claim includes provider evidence.'],
+        },
       },
     },
   });
@@ -1491,6 +1499,8 @@ test('construct/evaluate context pack tools work', async () => {
   assert.equal(Array.isArray(construct.content), true);
   const payload = JSON.parse(construct.content[0].text);
   assert.ok(payload.packId);
+  assert.equal(payload.contextEnvelope.version, 'six-block-v1');
+  assert.ok(payload.usedChars <= payload.maxChars);
 
   const evaluate = await handleRequest({
     jsonrpc: '2.0',

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -1475,6 +1475,16 @@ test('export_databricks_bundle defaults bundle path inside SAFE_DATA_DIR', async
 });
 
 test('construct/evaluate context pack tools work', async () => {
+  const listed = await handleRequest({ jsonrpc: '2.0', id: 3, method: 'tools/list' });
+  const contextTool = listed.tools.find((tool) => tool.name === 'construct_context_pack');
+  const envelopeSchema = contextTool.inputSchema.properties.contextEnvelope;
+  assert.equal(envelopeSchema.additionalProperties, false);
+  assert.deepEqual(envelopeSchema.required, [
+    'goal', 'businessData', 'examples', 'procedures', 'constraints', 'rubric',
+  ]);
+  assert.equal(envelopeSchema.properties.goal.type, 'string');
+  assert.equal(envelopeSchema.properties.examples.items.type, 'string');
+
   const construct = await handleRequest({
     jsonrpc: '2.0',
     id: 4,


### PR DESCRIPTION
## Summary
- add an optional validated six-block context envelope (`goal`, business data, examples, procedures, constraints, rubric)
- count reusable context against the same pack budget and isolate semantic cache entries by strategy and envelope hash
- attach safe source/freshness provenance to connector-backed context items
- expose the contract across the REST API, MCP tool registry, OpenAPI, docs, and the context-engineering skill
- keep action-receipt enrichment inside the advertised item and character limits

## ROI
This turns repeated prompt setup into a reusable, budgeted ContextFS contract. Few-shot examples and grading rubrics can be shared across agents without cross-contaminating cached packs, while connector data carries explicit freshness instead of being mistaken for current truth.

## Verification
- `npm run test:context-engineering` — 4/4 pass
- `npm run test:tool-registry` — 18/18 pass
- `node --test --test-concurrency=1 tests/contextfs.test.js tests/mcp-server.test.js tests/api-server.test.js tests/openapi-parity.test.js` — 267/267 pass
- `npm run test:deployment` — 170/170 pass, including the npm package-size boundary
- `npm run test:git-at-scale` — 21/21 pass on focused rerun
- full `npm test` reached `test:git-at-scale` and failed 1/21 once on the existing temp cleanup race: `ENOTEMPTY .../graphify-out`; the immediate focused rerun passed 21/21
- skill validator, OpenAPI YAML parse, `git diff --check`, pre-commit, and pre-push guards pass

Closes #3675
