### PR TITLE
fix(gates): left word boundary for the self-protect process rule

### DIFF
--- a/.changeset/gate-word-boundary-self-protect.md
+++ b/.changeset/gate-word-boundary-self-protect.md
@@ -1,0 +1,8 @@
+---
+"thumbgate": patch
+---
+
+self-protect process rule now requires a left word boundary, so prose containing
+words that merely end in the verb (e.g. "skill " followed later by a protected
+process name) no longer hard-blocks harmless commands; real kill/pkill/killall
+invocations still deny. Regression test added from the 2026-08-26 false positive.

--- a/config/gates/default.json
+++ b/config/gates/default.json
@@ -509,7 +509,7 @@
       "toolNames": [
         "Bash"
       ],
-      "pattern": "(?:kill|pkill|killall)\\s+.*(?:thumbgate|gates-engine|budget-enforcer)",
+      "pattern": "(?:^|[^A-Za-z0-9_])(?:kill|pkill|killall)\\s+.*(?:thumbgate|gates-engine|budget-enforcer)",
       "action": "block",
       "message": "Self-protection: agent cannot terminate ThumbGate processes.",
       "severity": "critical",

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -2880,6 +2880,23 @@ test('runHardFloor ignores ordinary block gates', () => {
   }), null);
 });
 
+test('self-protect process rule needs a word boundary: prose ending in the verb stays benign', () => {
+  // 2026-08-26 false positive: "new skill thumbgate-guard-regression is registered"
+  // matched because "skill" ends in the verb and no left boundary was required.
+  assert.equal(runHardFloor({
+    tool_name: 'Bash',
+    tool_input: { command: 'echo "new skill thumbgate-guard-regression is registered"' },
+  }), null);
+  // Real invocations must still hard-deny.
+  const output = runHardFloor({
+    tool_name: 'Bash',
+    tool_input: { command: 'kill -9 4242  # thumbgate serve pid' },
+  });
+  assert.ok(output, 'expected bare verb + pid + process name to stay denied');
+  assert.match(JSON.parse(output).hookSpecificOutput.permissionDecisionReason,
+    /\[GATE:self-protect-kill\]/);
+});
+
 test('runHardFloor denies described browser purchases for snake and camel hook payloads', () => {
   cleanupStateFiles();
   for (const input of [


### PR DESCRIPTION
## Problem

The self-protect process rule in the default gate policy-file has no left anchor, so any word that merely **ends** in the protected verb, followed by a space and (anywhere later) a protected process name, hard-blocks a harmless command. Observed 2026-08-26: a plain echo about a newly registered agent capability was denied five separate times across two sessions (receipts in the local gate history; it also bit the commit message of this very fix).

Related umbrella issues: #3684 (guard false positives), #3693 (gap map: routing before lexical gates).

## Fix

One-line pattern change — prepend a left-boundary group (start-of-string or non-word char) before the verb alternation:

- benign prose (word-suffix + later process name) no longer matches
- genuine terminations still deny: start-of-string (the existing hard-floor case) and mid-string after a non-word char are both covered

## Verification

- tests/gates-engine.test.js: **204 pass / 0 fail**, including a new regression test reproducing the 2026-08-26 false positive and asserting the real-invocation case still denies
- tests/gate-golden-set.test.js: 0 fail
- Standalone regex proof: 4/4 behavior checks (benign sentence, p-variant, bare verb, word-suffix)

Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2iHT9zUBjeDkrPUK5yS2a