### PR TITLE
fix(double-blind-eval-protocol): enforce seal integrity, reject incomplete scorer output, require caller attestation key

### DIFF
--- a/.changeset/fix-double-blind-eval-protocol-security-hardening.md
+++ b/.changeset/fix-double-blind-eval-protocol-security-hardening.md
@@ -1,0 +1,10 @@
+---
+"thumbgate": patch
+---
+
+fix(evals/security): harden double-blind evaluation protocol against seal substitution and incomplete scorer output
+
+- runEvaluation now validates that model and benchmark seals match the enclave commitment before scoring, preventing post-approval seal substitution attacks
+- scoreFn must return exactly one result per benchmark question, or runEvaluation throws before computing passRate
+- Remove hardcoded attestation key (CWE-321) — both attest() and verifyAttestation() now require a non-empty caller-provided attestationKey and throw on missing/empty/whitespace keys
+- Private content store — asset content stored in a private WeakMap instead of enumerable _content; seals expose only metadata via JSON.stringify

--- a/scripts/double-blind-eval-protocol.js
+++ b/scripts/double-blind-eval-protocol.js
@@ -34,6 +34,9 @@ const crypto = require('node:crypto');
 
 const ASSET_KINDS = Object.freeze(['model', 'benchmark']);
 
+// Private store for sealed asset content — never exposed in JSON serialization.
+const _contentStore = new WeakMap();
+
 /**
  * Seal one asset. The content goes into the sealed store; only metadata and
  * a sha256 commitment cross the boundary.
@@ -50,7 +53,7 @@ function sealAsset(kind, content, owner) {
     throw new Error('asset content must be a non-empty string');
   }
   const digest = crypto.createHash('sha256').update(content).digest('hex');
-  return {
+  const seal = {
     sealId: `seal_${digest.slice(0, 16)}`,
     kind,
     owner: String(owner || 'unknown'),
@@ -58,8 +61,16 @@ function sealAsset(kind, content, owner) {
     sealedAt: new Date().toISOString(),
     // token required to retrieve the content; holder != the other party
     accessToken: crypto.randomBytes(16).toString('hex'),
-    _content: content, // stays in the sealed store; never serialized out
   };
+  // Store content privately so it is never serialized by JSON.stringify.
+  Object.defineProperty(seal, '_content', {
+    value: content,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  _contentStore.set(seal, content);
+  return seal;
 }
 
 /**
@@ -92,10 +103,32 @@ function createEnclave(modelSeal, benchmarkSeal) {
  * @param {Function} scoreFn      ({ modelContent, questions }) => [{question, score}]
  */
 function runEvaluation(enclave, modelSeal, benchmarkSeal, scoreFn) {
+  // Validate seals against the enclave commitment before scoring.
+  // A caller cannot swap seals or tamper with content after enclave creation.
+  if (modelSeal.sealId !== enclave.modelSeal.sealId ||
+      modelSeal.sha256 !== enclave.modelSeal.sha256) {
+    throw new Error('model seal does not match the enclave commitment');
+  }
+  if (benchmarkSeal.sealId !== enclave.benchmarkSeal.sealId ||
+      benchmarkSeal.sha256 !== enclave.benchmarkSeal.sha256) {
+    throw new Error('benchmark seal does not match the enclave commitment');
+  }
+  const modelContent = _contentStore.get(modelSeal);
+  const benchmarkContent = _contentStore.get(benchmarkSeal);
+  if (typeof modelContent !== 'string') {
+    throw new Error('model content is not available in the private store');
+  }
+  const questions = JSON.parse(benchmarkContent);
   const results = scoreFn({
-    modelContent: modelSeal._content,
-    questions: JSON.parse(benchmarkSeal._content),
+    modelContent,
+    questions,
   });
+  // Require exactly one result per benchmark question.
+  if (!Array.isArray(results) || results.length !== questions.length) {
+    throw new Error(
+      `scoreFn must return exactly ${questions.length} results, got ${Array.isArray(results) ? results.length : 'non-array'}`,
+    );
+  }
   // Only scores cross the boundary. Questions and model content never do.
   const scores = results.map((r, i) => ({
     index: i,
@@ -133,7 +166,10 @@ function leakageGuard(output, benchmarkSeal) {
  * A third party can verify it without ever seeing either asset.
  */
 function attest(enclave, evaluationResult, attestationKey) {
-  const key = attestationKey || 'thumbgate-attestation-key';
+  if (typeof attestationKey !== 'string' || attestationKey.trim().length === 0) {
+    throw new Error('a non-empty attestationKey must be provided by the caller');
+  }
+  const key = attestationKey;
   const payload = JSON.stringify({
     enclaveId: enclave.enclaveId,
     modelSealSha: enclave.modelSeal.sha256,
@@ -158,7 +194,10 @@ function attest(enclave, evaluationResult, attestationKey) {
  * Verify an attestation receipt against the seals and scores.
  */
 function verifyAttestation(receipt, modelSeal, benchmarkSeal, scores, attestationKey) {
-  const key = attestationKey || 'thumbgate-attestation-key';
+  if (typeof attestationKey !== 'string' || attestationKey.trim().length === 0) {
+    throw new Error('a non-empty attestationKey must be provided by the caller');
+  }
+  const key = attestationKey;
   const payload = JSON.stringify({
     enclaveId: receipt.enclaveId,
     modelSealSha: modelSeal.sha256,

--- a/tests/double-blind-eval-protocol.test.js
+++ b/tests/double-blind-eval-protocol.test.js
@@ -32,6 +32,14 @@ test('seal refuses unknown kinds and empty content', () => {
   assert.throws(() => sealAsset('model', '', 'p'));
 });
 
+test('seal content is not enumerable and not leaked via JSON.stringify', () => {
+  const secret = 'super-secret-weights-never-leave';
+  const s = sealAsset('model', secret, 'provider');
+  const serialized = JSON.stringify(s);
+  assert.ok(!serialized.includes(secret), 'input content must not appear in JSON.stringify');
+  assert.ok(!serialized.includes('_content'), '_content must not appear as a key in JSON.stringify');
+});
+
 test('enclave requires one model seal and one benchmark seal', () => {
   const { modelSeal, benchmarkSeal } = standardPair();
   assert.throws(() => createEnclave(benchmarkSeal, benchmarkSeal));
@@ -70,7 +78,7 @@ test('attestation receipt binds both seal hashes to the scores', () => {
   const result = runEvaluation(enclave, modelSeal, benchmarkSeal, ({ questions }) =>
     questions.map((q, i) => ({ question: q, score: i === 0 ? 1 : 0.5 })),
   );
-  const receipt = attest(enclave, result);
+  const receipt = attest(enclave, result, 'test-attestation-key');
   assert.equal(receipt.modelSealSha, modelSeal.sha256);
   assert.equal(receipt.benchmarkSealSha, benchmarkSeal.sha256);
   assert.equal(receipt.scoreCount, 2);
@@ -82,11 +90,12 @@ test('verification passes on honest receipts, fails on tampered scores', () => {
   const result = runEvaluation(enclave, modelSeal, benchmarkSeal, ({ questions }) =>
     questions.map((q) => ({ question: q, score: 1 })),
   );
-  const receipt = attest(enclave, result);
-  const ok = verifyAttestation(receipt, modelSeal, benchmarkSeal, result.scores);
+  const KEY = 'test-attestation-key';
+  const receipt = attest(enclave, result, KEY);
+  const ok = verifyAttestation(receipt, modelSeal, benchmarkSeal, result.scores, KEY);
   assert.equal(ok.valid, true);
   const tampered = result.scores.map((s) => ({ ...s, score: 0 })); // score inflation attempt
-  const bad = verifyAttestation(receipt, modelSeal, benchmarkSeal, tampered);
+  const bad = verifyAttestation(receipt, modelSeal, benchmarkSeal, tampered, KEY);
   assert.equal(bad.valid, false);
   assert.deepEqual(bad.sealIntegrity, { model: true, benchmark: true });
 });
@@ -97,9 +106,10 @@ test('verification detects a swapped benchmark (seal integrity)', () => {
   const result = runEvaluation(enclave, modelSeal, benchmarkSeal, ({ questions }) =>
     questions.map((q) => ({ question: q, score: 1 })),
   );
-  const receipt = attest(enclave, result);
+  const KEY = 'test-attestation-key';
+  const receipt = attest(enclave, result, KEY);
   const swapped = sealAsset('benchmark', JSON.stringify(['easier question']), 'mlcommons');
-  const bad = verifyAttestation(receipt, modelSeal, swapped, result.scores);
+  const bad = verifyAttestation(receipt, modelSeal, swapped, result.scores, KEY);
   assert.equal(bad.valid, false);
   assert.equal(bad.sealIntegrity.benchmark, false);
 });


### PR DESCRIPTION

Address CodeRabbit review threads on PRs #3711/#3712:

1. **Seal integrity validation** — runEvaluation now validates that model and benchmark seals match the enclave commitment before scoring, preventing post-approval seal substitution.

2. **Complete scorer output validation** — scoreFn must return exactly one result per benchmark question, or runEvaluation throws before computing passRate.

3. **Remove hardcoded attestation key (CWE-321)** — Both attest() and verifyAttestation() now require a non-empty caller-provided attestationKey and throw on missing/empty/whitespace keys.

4. **Private content store** — Asset content is stored in a private WeakMap instead of an enumerable _content property. Seals now expose only metadata via JSON.stringify.

All 9 double-blind protocol tests pass, including a new test for private content serialization.
