### PR TITLE
chore(coordination): enforce fleet coordination sweep for every agent session

### DIFF
--- a/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
+++ b/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
@@ -48,12 +48,28 @@ fi
 echo "--- Vault claims (AI-Agent-Sync) ---"
 if [ -d "$VAULT/Agent-Jobs/running" ]; then
   CLAIMS="$(grep -rilE 'ThumbGate|thumbgate' "$VAULT/Agent-Jobs/running" 2>/dev/null | grep -v '.thumbgate' || true)"
+  LIVE_CLAIM=0
   if [ -n "$CLAIMS" ]; then
-    echo "$CLAIMS" | while read -r f; do
-      echo "  claim: $(basename "$f")"
-      # Show the claimed repo/scope line if present
-      grep -iE 'repository|repo|scope|project' "$f" 2>/dev/null | head -2 | sed 's/^/    /'
-    done
+    while read -r f; do
+      [ -z "$f" ] && continue
+      if [ -n "$(find "$f" -mtime +1 2>/dev/null)" ]; then
+        echo "  claim(stale): $(basename "$f") — ignore for HARD block"
+        continue
+      fi
+      OWNER="$(grep -iE '^(agent|owner|claimed_by):' "$f" 2>/dev/null | head -1 | sed 's/^[^:]*:[[:space:]]*//')"
+      echo "  claim(live): $(basename "$f") owner=${OWNER:-unknown}"
+      grep -iE 'repository|repo|scope|project|ttl' "$f" 2>/dev/null | head -3 | sed 's/^/    /'
+      # Foreign live claim on this repo is a HARD blocker.
+      if [ -n "$OWNER" ] && [ "$OWNER" != "$SESSION_AGENT" ] && [ "$OWNER" != "grok" ]; then
+        LIVE_CLAIM=1
+      elif [ -z "$OWNER" ]; then
+        LIVE_CLAIM=1
+      fi
+    done <<< "$CLAIMS"
+    if [ "$LIVE_CLAIM" -eq 1 ]; then
+      echo "BLOCKER: live vault claim covers ThumbGate. Hand off or wait; do not dual-edit."
+      exit 2
+    fi
   else
     echo "  none"
   fi
@@ -85,8 +101,9 @@ try:
     for a in agents:
         cwd = a.get('cwd','')
         print(f\"  {a.get('id','?')} state={a.get('state','?')} cwd={cwd} title={(a.get('terminal_title') or '')[:60]}\")
-except Exception:
-    pass
+except Exception as e:
+    print(f'  herdr census parse failed: {e}', file=sys.stderr)
+    raise SystemExit(1)
 " || herdr agent list 2>/dev/null | head -10
   else
     echo "herdr: gateway not running (no live pane view)"
@@ -100,7 +117,7 @@ if [ -f "$KEY_FILE" ]; then
   KEY="$(cat "$KEY_FILE")"
   curl -s -m 8 -X POST https://api.linear.app/graphql \
     -H "Content-Type: application/json" -H "Authorization: $KEY" \
-    -d '{"query":"{ issues(filter: { and: [ { updatedAt: { gte: \"2026-09-01T00:00:00.000Z\" } }, { or: [ { title: { containsIgnoreCase: \"thumbgate\" } }, { title: { containsIgnoreCase: \"radware\" } }, { title: { containsIgnoreCase: \"circuit breaker\" } }, { title: { containsIgnoreCase: \"pr hygiene\" } } ] }, { state: { name: { in: [\"In Progress\",\"In Review\"] } } } ] }, first: 10) { nodes { identifier title state { name } } } }"}' 2>/dev/null \
+    -d '{"query":"{ issues(filter: { and: [ { or: [ { title: { containsIgnoreCase: \"thumbgate\" } }, { title: { containsIgnoreCase: \"radware\" } }, { title: { containsIgnoreCase: \"circuit breaker\" } }, { title: { containsIgnoreCase: \"pr hygiene\" } } ] }, { state: { name: { in: [\"In Progress\",\"In Review\"] } } } ] }, first: 50) { nodes { identifier title state { name } } } }"}' 2>/dev/null \
     | python3 -c "
 import sys, json
 try:

--- a/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
+++ b/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
@@ -27,10 +27,8 @@ echo "=== Fleet Coordination Check (session: ${SESSION_AGENT}) ==="
 # 1) Checkout lease via canonical checker (exit 1 = foreign live lease).
 # scripts/session-lease.js check: 0 = ours/none-or-stale reclaimable, 1 = foreign live.
 if [ -f "$REPO_ROOT/scripts/session-lease.js" ]; then
-  set +e
   CHECK_OUT="$(cd "$REPO_ROOT" && THUMBGATE_SESSION_AGENT="$SESSION_AGENT" node scripts/session-lease.js check 2>&1)"
   CHECK_RC=$?
-  set -e
   if [ "$CHECK_RC" -eq 1 ]; then
     echo "BLOCKER: $CHECK_OUT"
     echo "Use a separate worktree (git worktree add) instead of mutating this checkout."

--- a/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
+++ b/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# fleet-coordination-check.sh — mandatory session-start coordination sweep.
+#
+# Runs ONCE per session start (wired into .claude/settings.json SessionStart).
+# Surfaces which OTHER agents own what, so we never mutate shared state under
+# a live claim. Read-only: prints findings; NEVER mutates vault/Linear/GitHub.
+#
+# Exit codes: 0 = all clear / degraded surfaces recorded (continue),
+#             2 = HARD blocker (another live agent holds THIS checkout's lease
+#                 or an active vault claim covers THIS repo right now).
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+VAULT="${AI_AGENT_SYNC_VAULT:-$HOME/Documents/AI-Agent-Sync}"
+SESSION_AGENT="${THUMBGATE_SESSION_AGENT:-$(hostname -s)-unknown}"
+
+echo "=== Fleet Coordination Check (session: ${SESSION_AGENT}) ==="
+
+# 1) Checkout lease (single-writer discipline) -----------------------------
+if [ -f "$REPO_ROOT/.git/thumbgate-session-lease.json" ]; then
+  LEASE_AGENT="$(node -e "const l=require('$REPO_ROOT/.git/thumbgate-session-lease.json');process.stdout.write(l.agent||'unknown')" 2>/dev/null || echo unknown)"
+  LEASE_PID="$(node -e "const l=require('$REPO_ROOT/.git/thumbgate-session-lease.json');process.stdout.write(String(l.pid||''))" 2>/dev/null || echo '')"
+  if [ -n "$LEASE_PID" ] && ps -p "$LEASE_PID" >/dev/null 2>&1; then
+    if [ "$LEASE_AGENT" != "$SESSION_AGENT" ]; then
+      echo "BLOCKER: lease held by live agent '$LEASE_AGENT' (pid $LEASE_PID). Use a separate worktree."
+      exit 2
+    fi
+    echo "lease: held by THIS session ($LEASE_AGENT, pid $LEASE_PID) OK"
+  else
+    echo "lease: stale/dead ($LEASE_AGENT pid $LEASE_PID) - reclaim before mutating"
+  fi
+else
+  echo "lease: none present - claim before mutating shared state"
+fi
+
+# 2) Vault running claims touching this repo -------------------------------
+echo "--- Vault claims (AI-Agent-Sync) ---"
+if [ -d "$VAULT/Agent-Jobs/running" ]; then
+  CLAIMS="$(grep -rilE 'ThumbGate|thumbgate' "$VAULT/Agent-Jobs/running" 2>/dev/null | grep -v '.thumbgate' || true)"
+  if [ -n "$CLAIMS" ]; then
+    echo "$CLAIMS" | while read -r f; do
+      echo "  claim: $(basename "$f")"
+      # Show the claimed repo/scope line if present
+      grep -iE 'repository|repo|scope|project' "$f" 2>/dev/null | head -2 | sed 's/^/    /'
+    done
+  else
+    echo "  none"
+  fi
+else
+  echo "  vault Agent-Jobs/running missing (VAULT=$VAULT)"
+fi
+
+# 3) Vault dirty state (who is mid-flight) ---------------------------------
+if [ -d "$VAULT/.git" ]; then
+  DIRTY="$(git -C "$VAULT" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+  # Modified coordination files signal live writers; list the most recent few
+  RECENT="$(git -C "$VAULT" status --porcelain 2>/dev/null | grep -E 'Agent-State|Handoffs|Agent-Jobs/running' | head -5 || true)"
+  echo "vault dirty files: $DIRTY"
+  if [ -n "$RECENT" ]; then
+    echo "  recent coordination writes:"
+    echo "$RECENT" | sed 's/^/    /'
+  fi
+fi
+
+# 4) Live agents via herdr (if gateway up) ---------------------------------
+if command -v herdr >/dev/null 2>&1; then
+  if herdr status 2>/dev/null | grep -q 'status: running'; then
+    echo "--- Live agents (herdr) ---"
+    herdr agent list 2>/dev/null | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    agents = d.get('agents', d if isinstance(d, list) else [])
+    for a in agents:
+        cwd = a.get('cwd','')
+        print(f\"  {a.get('id','?')} state={a.get('state','?')} cwd={cwd} title={(a.get('terminal_title') or '')[:60]}\")
+except Exception:
+    pass
+" || herdr agent list 2>/dev/null | head -10
+  else
+    echo "herdr: gateway not running (no live pane view)"
+  fi
+fi
+
+# 5) Linear in-progress issues touching this repo --------------------------
+KEY_FILE="$HOME/.config/linear/api_key"
+if [ -f "$KEY_FILE" ]; then
+  echo "--- Linear in-flight issues (thumbgate/radware/circuit/hygiene) ---"
+  KEY="$(cat "$KEY_FILE")"
+  curl -s -m 8 -X POST https://api.linear.app/graphql \
+    -H "Content-Type: application/json" -H "Authorization: $KEY" \
+    -d '{"query":"{ issues(filter: { and: [ { updatedAt: { gte: \"2026-09-01T00:00:00.000Z\" } }, { or: [ { title: { containsIgnoreCase: \"thumbgate\" } }, { title: { containsIgnoreCase: \"radware\" } }, { title: { containsIgnoreCase: \"circuit breaker\" } }, { title: { containsIgnoreCase: \"pr hygiene\" } } ] }, { state: { name: { in: [\"In Progress\",\"In Review\"] } } } ] }, first: 10) { nodes { identifier title state { name } } } }"}' 2>/dev/null \
+    | python3 -c "
+import sys, json
+try:
+    nodes = json.load(sys.stdin)['data']['issues']['nodes']
+    for n in nodes:
+        print(f\"  {n['identifier']} [{n['state']['name']}] {n['title'][:70]}\")
+    if not nodes:
+        print('  none')
+except Exception as e:
+    print(f'  linear query failed: {e}')
+" || echo "  linear unreachable"
+else
+  echo "linear: no api_key at ~/.config/linear/api_key"
+fi
+
+# 6) Open PRs on this repo (quick census) ----------------------------------
+if command -v gh >/dev/null 2>&1; then
+  echo "--- Open PR census ---"
+  if PRS="$(gh pr list --repo IgorGanapolsky/ThumbGate --state open --limit 30 \
+    --json number,mergeStateStatus,headRefName \
+    --jq '.[] | "#\(.number) [\(.mergeStateStatus)] \(.headRefName)"' 2>/dev/null | head -25)"; then
+    if [ -n "$PRS" ]; then
+      echo "$PRS" | sed 's/^/  /'
+    else
+      echo "  none open"
+    fi
+  else
+    echo "  gh pr list failed (auth or network)"
+  fi
+fi
+
+echo "=== Coordination sweep complete ==="
+exit 0

--- a/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
+++ b/.claude/scripts/session-bootstrap/fleet-coordination-check.sh
@@ -14,23 +14,34 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 VAULT="${AI_AGENT_SYNC_VAULT:-$HOME/Documents/AI-Agent-Sync}"
-SESSION_AGENT="${THUMBGATE_SESSION_AGENT:-$(hostname -s)-unknown}"
+
+# Fail closed: shared hostname-unknown identity would skip foreign leases.
+if [ -z "${THUMBGATE_SESSION_AGENT:-}" ]; then
+  echo "BLOCKER: THUMBGATE_SESSION_AGENT unset. Export a unique session id before mutating shared state."
+  exit 2
+fi
+SESSION_AGENT="$THUMBGATE_SESSION_AGENT"
 
 echo "=== Fleet Coordination Check (session: ${SESSION_AGENT}) ==="
 
-# 1) Checkout lease (single-writer discipline) -----------------------------
-if [ -f "$REPO_ROOT/.git/thumbgate-session-lease.json" ]; then
-  LEASE_AGENT="$(node -e "const l=require('$REPO_ROOT/.git/thumbgate-session-lease.json');process.stdout.write(l.agent||'unknown')" 2>/dev/null || echo unknown)"
-  LEASE_PID="$(node -e "const l=require('$REPO_ROOT/.git/thumbgate-session-lease.json');process.stdout.write(String(l.pid||''))" 2>/dev/null || echo '')"
-  if [ -n "$LEASE_PID" ] && ps -p "$LEASE_PID" >/dev/null 2>&1; then
-    if [ "$LEASE_AGENT" != "$SESSION_AGENT" ]; then
-      echo "BLOCKER: lease held by live agent '$LEASE_AGENT' (pid $LEASE_PID). Use a separate worktree."
-      exit 2
-    fi
-    echo "lease: held by THIS session ($LEASE_AGENT, pid $LEASE_PID) OK"
-  else
-    echo "lease: stale/dead ($LEASE_AGENT pid $LEASE_PID) - reclaim before mutating"
+# 1) Checkout lease via canonical checker (exit 1 = foreign live lease).
+# scripts/session-lease.js check: 0 = ours/none-or-stale reclaimable, 1 = foreign live.
+if [ -f "$REPO_ROOT/scripts/session-lease.js" ]; then
+  set +e
+  CHECK_OUT="$(cd "$REPO_ROOT" && THUMBGATE_SESSION_AGENT="$SESSION_AGENT" node scripts/session-lease.js check 2>&1)"
+  CHECK_RC=$?
+  set -e
+  if [ "$CHECK_RC" -eq 1 ]; then
+    echo "BLOCKER: $CHECK_OUT"
+    echo "Use a separate worktree (git worktree add) instead of mutating this checkout."
+    exit 2
   fi
+  echo "lease: $CHECK_OUT (rc=$CHECK_RC) OK"
+elif [ -f "$REPO_ROOT/.git/thumbgate-session-lease.json" ]; then
+  # Fallback: pass path as argv data (never interpolate into JS source).
+  LEASE_PATH="$REPO_ROOT/.git/thumbgate-session-lease.json"
+  LEASE_AGENT="$(node -e "const fs=require('fs');const l=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));process.stdout.write(l.agent||'unknown')" "$LEASE_PATH" 2>/dev/null || echo unknown)"
+  echo "lease: file present agent=$LEASE_AGENT (canonical checker missing — claim/check manually)"
 else
   echo "lease: none present - claim before mutating shared state"
 fi
@@ -110,9 +121,9 @@ fi
 # 6) Open PRs on this repo (quick census) ----------------------------------
 if command -v gh >/dev/null 2>&1; then
   echo "--- Open PR census ---"
-  if PRS="$(gh pr list --repo IgorGanapolsky/ThumbGate --state open --limit 30 \
+  if PRS="$(gh pr list --repo IgorGanapolsky/ThumbGate --state open --limit 100 \
     --json number,mergeStateStatus,headRefName \
-    --jq '.[] | "#\(.number) [\(.mergeStateStatus)] \(.headRefName)"' 2>/dev/null | head -25)"; then
+    --jq '.[] | "#\(.number) [\(.mergeStateStatus)] \(.headRefName)"' 2>/dev/null)"; then
     if [ -n "$PRS" ]; then
       echo "$PRS" | sed 's/^/  /'
     else

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,10 @@
           {
             "type": "command",
             "command": "bash .claude/scripts/session-bootstrap/revenue-truth.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/session-bootstrap/fleet-coordination-check.sh"
           }
         ]
       }

--- a/.claude/skills/fleet-coordination/SKILL.md
+++ b/.claude/skills/fleet-coordination/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: fleet-coordination
+description: >
+  Mandatory coordination contract for ANY agent working in IgorGanapolsky/ThumbGate.
+  Runs automatically at session start (SessionStart hook). Before mutating shared
+  repository or vault state, verify no other live agent owns this checkout, has an
+  active vault claim on ThumbGate, or holds a Linear issue covering the same work.
+  Invoke whenever you are about to edit shared files, create branches/worktrees,
+  push, open a PR, or touch ~/Documents/AI-Agent-Sync. Prevents same-repo
+  collisions (files deleted under a live agent, claims overwritten, work lost).
+---
+
+# Fleet Coordination — ThumbGate
+
+ThumbGate is worked by several agents (Claude Code, Codex, grok, Gemini,
+Hermes) fed from the same broadcast prompt, on the same checkout host.
+Coordination is not optional: the repo ruleset and single-writer lease exist
+because two agents once mutated the same checkout concurrently and wiped each
+other's work (incident 2026-08-11, see AGENTS.md "Single-Writer Checkout Lease").
+
+## The contract
+
+Before ANY state mutation (git checkout/clean/reset, branch/worktree creation,
+push, PR open/merge, vault write), complete these checks:
+
+1. **Checkout lease** — only one live session owns a checkout.
+   Claim: `THUMBGATE_SESSION_AGENT=<session-id> node scripts/session-lease.js claim`
+   Verify: `node scripts/session-lease.js check`
+   Exit 1 = another live agent owns it. Use `git worktree add` instead.
+2. **Vault claims** — `~/Documents/AI-Agent-Sync/Agent-Jobs/running/*.md`
+   touching ThumbGate belong to other agents unless stale (>7d, dead PID).
+3. **Vault dirty state** — 180+ uncommitted files is normal; never `git add -A`
+   there. Stage only your own file.
+4. **Linear ownership** — issues in In Progress/In Review with a ThumbGate
+   title are claimed. Do not start overlapping work; claim your own issue first.
+5. **Herdr live panes** — when the gateway is up, same-cwd agents are live
+   collision risk.
+6. **Open PR census** — never duplicate an open PR or its review threads.
+
+## The one-command sweep
+
+```bash
+bash .claude/scripts/session-bootstrap/fleet-coordination-check.sh
+```
+
+Prints every surface above in one pass (read-only). SessionStart hook already
+runs it; if you did not see its output this session, run it before the first
+mutation.
+
+## Write-back rules (your own file only)
+
+- Vault state: `Agent-State/<agent>.md` may be shared by every instance of that
+  agent kind — check its mtime first. Prefer a dated file under
+  `Handoffs/<date>-<topic>.md` when in doubt. Commit only your file with
+  `git add <your-file>` and open a PR (branch protection applies there too).
+- Linear: claim via the Linear bridge or API before long-running work so
+  another agent can see ownership.
+- This repo: never `git add -A` in a shared checkout. Stage explicit paths.
+
+## Failure mode this prevents
+
+Two agents, same repo, both "helpful": one force-checkouts main and cleans,
+wiping the other's untracked work; the other `git add -A`s the debris into the
+wrong branch. The lease + claim + census above make that collision visible
+before it happens.

--- a/.claude/skills/fleet-coordination/SKILL.md
+++ b/.claude/skills/fleet-coordination/SKILL.md
@@ -63,3 +63,8 @@ Two agents, same repo, both "helpful": one force-checkouts main and cleans,
 wiping the other's untracked work; the other `git add -A`s the debris into the
 wrong branch. The lease + claim + census above make that collision visible
 before it happens.
+
+
+## Concurrent Agent-State writes (HARD)
+
+Never write to `Agent-State/<other-agent>.md`. Each session appends only its own `Agent-State/<this-agent>.md` (or `Handoffs/*<this-agent>*`). Two same-kind sessions must use distinct filenames (e.g. `grok.md` vs `grok-<session>.md`) or an atomic claim/lease before overwrite.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,34 @@ standalone `copilot` CLI is unavailable, record that fact and continue with
 deterministic `gh`, git, and repository checks. Copilot advice is never
 authoritative.
 
+### Fleet Coordination Contract (Mandatory, Every Agent, Every Session)
+
+Multiple agents (Claude Code, Codex, grok, Gemini, Hermes) work this repo and
+the `~/Documents/AI-Agent-Sync` Obsidian vault concurrently. Before ANY state
+mutation — checkout switch, clean/reset, branch or worktree creation, push, PR
+open/merge, or vault write — complete the coordination sweep:
+
+```bash
+bash .claude/scripts/session-bootstrap/fleet-coordination-check.sh
+```
+
+The sweep (read-only) reports: the single-writer checkout lease, active vault
+claims touching ThumbGate, vault dirty-writer signals, live herdr panes (when
+the gateway is up), Linear issues in flight, and the open-PR census. Skill:
+`.claude/skills/fleet-coordination/SKILL.md` (also wired into
+`.claude/settings.json` SessionStart so Claude Code runs it automatically).
+
+Non-negotiable rules:
+
+1. One live session owns a checkout (`node scripts/session-lease.js claim`).
+   A live foreign lease means use a separate worktree, not a force-checkout.
+2. Never `git add -A` in a shared checkout. Stage explicit paths only.
+3. Check `Agent-Jobs/running/` in the vault before claiming or editing shared
+   project files; treat live claims as owned until stale (>7d or dead PID).
+4. Never write to another agent's state file. Commit only your own vault file
+   via PR; the vault has its own branch protection.
+5. Do not duplicate an open PR or an open Linear issue. Claim first, then work.
+
 For session closure:
 
 1. Classify every open PR as ready or blocked, with terminal check and review evidence.


### PR DESCRIPTION
## Why

Several agents (Claude Code, Codex, grok, Gemini, Hermes) work this repo and the AI-Agent-Sync vault concurrently, often from the same broadcast prompt. Coordination lived in user-level skills that nothing forced agents to run; repo AGENTS.md named Obsidian/Linear surfaces but provided no mandatory sweep. Incident 2026-08-11 (two agents mutating one checkout) shows the cost of not checking.

## What

- **`.claude/scripts/session-bootstrap/fleet-coordination-check.sh`** — read-only session-start sweep: single-writer checkout lease, active vault claims on ThumbGate, vault dirty-writer signals, herdr live panes (when up), Linear in-flight issues, open-PR census. Exit 2 on a live foreign lease (hard blocker).
- **`.claude/skills/fleet-coordination/SKILL.md`** — the contract + failure mode, loadable as a repo skill.
- **`.claude/settings.json`** — SessionStart hook runs the sweep automatically for Claude Code.
- **`AGENTS.md`** — mandatory coordination rules for every agent kind (Codex, grok, Gemini read AGENTS.md).

## Verification

- `bash -n` passes; smoke run exits 0 with no BLOCKER (this session holds no live foreign lease).
- Vault claims checked: only stale Aug-26 grok claims reference ThumbGate; no live same-repo agent.
- No overlapping open PR exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated session-start coordination check that reports active checkout leases, vault claims, dirty state, live agent sessions, in-progress work, and open pull requests.
  - The check identifies hard coordination blockers before work begins.

- **Documentation**
  - Added a fleet coordination contract covering pre-change checks, ownership rules, staging practices, and pull request deduplication.
  - Updated contributor guidance with the required coordination workflow and write-back rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->