### PR TITLE
feat(harness): JIT-Agent four-module compose doctor (FORMAT steal)

### DIFF
--- a/.agents/skills/jit-harness-compare-not-clone/SKILL.md
+++ b/.agents/skills/jit-harness-compare-not-clone/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: jit-harness-compare-not-clone
+description: >
+  JIT-Agent (arXiv:2608.25593) is a harness-intelligence model, not a ThumbGate
+  clone. Steal the four-module FORMAT (memory/planning/action/capability) onto
+  existing rails; never train or download JIT-Agent. Slash: /jit-harness-compare-not-clone.
+---
+
+# JIT-Agent — compare, do not clone
+
+## When
+JIT-Agent, arxiv 2608.25593, Rohan Paul harness intelligence, Model-as-a-Harness,
+just-in-time harness evolution, HarnessFactory, four-module agent harness.
+
+## Do
+```bash
+npx thumbgate jit-harness-compose --task="<what the agent should do>" --json
+npx thumbgate jit-harness-compose --map-only
+```
+
+Map modules to existing rails:
+- **memory** → lesson-retrieval / feedback / contextfs
+- **planning** → `bin/agent-loop` Plan + GSD
+- **action** → PreToolUse gates + `harness-selector` + `switchyard-router`
+- **capability** → `subagent-profiles` + MCP allowlists + skills + model pool
+
+## Never
+- Train, serve, or download JIT-Agent-27B / `huggingface.co/JIT-Agent`
+- Clone `bingreeky/JIT` HarnessFactory into ThumbGate
+- Emit free-form harness programs as a new SKU
+- Claim ThumbGate is JIT-Agent
+
+## Source
+https://arxiv.org/abs/2608.25593 · https://github.com/bingreeky/JIT — FORMAT only; not affiliated.

--- a/.changeset/jit-harness-compose-format.md
+++ b/.changeset/jit-harness-compose-format.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Steal JIT-Agent (arXiv:2608.25593) four-module harness FORMAT onto existing rails via `jit-harness-compose` doctor — memory / planning / action / capability — without training or downloading JIT-Agent.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2648,6 +2648,28 @@ function nvidiaSpecDecodeAlDoctor() {
   if (report.status === 'fail') process.exitCode = 1;
 }
 
+
+function jitHarnessCompose() {
+  const args = parseArgs(process.argv.slice(3));
+  const {
+    buildJitHarnessComposeReport,
+    formatJitHarnessComposeReport,
+  } = require(path.join(PKG_ROOT, 'scripts', 'jit-harness-compose'));
+  const report = buildJitHarnessComposeReport(args);
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    process.stdout.write(formatJitHarnessComposeReport(report));
+  }
+
+  if (args.strict && report.status !== 'ready') {
+    process.exitCode = 1;
+    return;
+  }
+  if (report.status === 'fail') process.exitCode = 1;
+}
+
 function packageManagerHonestyDoctor() {
   const args = parseArgs(process.argv.slice(3));
   const {
@@ -3489,6 +3511,7 @@ function help() {
   console.log('  npx thumbgate deepseek-v4-runtime-guardrails --context-tokens=900000 --hybrid-attention --speculative-decoding --accept-length=1.4 --precision-mode=fp8 --json');
   console.log('  npx thumbgate nvidia-specdecode-al-doctor --speculative-decoding --accept-length=1.4 --draft-length=7 --draft-depth-ratio=0.05 --claimed-speedup=3 --json');
   console.log('  npx thumbgate package-manager-honesty-doctor --propose-switch=pnpm --json');
+  console.log('  npx thumbgate jit-harness-compose --task="implement PreToolUse gate fix" --json');
   console.log('  npx thumbgate upstream-contributions --max-repos=10 --write');
   console.log('  npx thumbgate background-governance --json');
   console.log('  npx thumbgate background-governance --check --agent-id=builder --branch=main --files-changed=25 --json');
@@ -4128,6 +4151,12 @@ switch (COMMAND) {
   case 'pnpm12-honesty-doctor':
   case 'lockfile-ci-parity-doctor':
     packageManagerHonestyDoctor();
+    break;
+  case 'jit-harness-compose':
+  case 'jit-compose':
+  case 'jit-harness':
+  case 'harness-compose':
+    jitHarnessCompose();
     break;
   case 'long-running-agent-context-guardrails':
   case 'agent-context-guardrails':

--- a/docs/agents/jit-harness-compose.md
+++ b/docs/agents/jit-harness-compose.md
@@ -1,0 +1,28 @@
+# JIT harness compose (FORMAT steal)
+
+Doctor: `npx thumbgate jit-harness-compose --task="…" --json`
+
+Steals the **four-module harness protocol** from [JIT-Agent (arXiv:2608.25593)](https://arxiv.org/abs/2608.25593) — memory, planning, action, capability — and maps it onto **existing** ThumbGate rails. This is a compare-not-clone doctor. It does **not** train a harness model, download JIT-Agent-27B, or vendor [bingreeky/JIT](https://github.com/bingreeky/JIT). Not affiliated.
+
+## Module → rail map
+
+| Module | ThumbGate rails |
+|--------|-----------------|
+| memory | lesson-retrieval (BM25F / hybrid RRF), `.claude/memory/feedback`, contextfs, `capture-feedback.js` |
+| planning | `bin/agent-loop` Plan stage, GSD, harness-selector task class, implementation-notes |
+| action | PreToolUse / gates-engine, `config/gates/*.json`, switchyard-router step roles, session-lease |
+| capability | `config/subagent-profiles.json`, MCP allowlists, skills registry, switchyard / model-candidates |
+
+## Task classes
+
+`code_edit` · `review` · `deploy` · `research` · `secure` · `routine` · `db_write` · `default`
+
+Classifier uses `harness-selector` plus vocabulary heuristics. Override with `--class=` / `--harness=` / `--profile=`.
+
+## Fail closed
+
+Attempts to serve/download JIT-Agent, clone HarnessFactory, or emit free-form harness programs return `status=fail` with `jit_clone_refused`.
+
+## Skill
+
+`.agents/skills/jit-harness-compare-not-clone/SKILL.md` — `/jit-harness-compare-not-clone`

--- a/package.json
+++ b/package.json
@@ -432,7 +432,9 @@
     "skills/thumbgate/SKILL.md",
     "smithery.yaml",
     "src/",
-    "scripts/radware-threat-defense.js"
+    "scripts/radware-threat-defense.js",
+    ".agents/skills/jit-harness-compare-not-clone/",
+    "scripts/jit-harness-compose.js"
   ],
   "scripts": {
     "canary:snapshot": "node scripts/gate-decision-canary.js --snapshot",
@@ -930,7 +932,7 @@
     "test:agent-egress-policy": "node --test tests/agent-egress-policy.test.js",
     "test:budget-aware-gates-proof": "node --test tests/budget-aware-gates-proof.test.js",
     "test:business-function-agents": "node --test tests/business-function-agent-team.test.js",
-    "test:high-roi": "node --test tests/high-roi.test.js tests/gurobi-optimizer.test.js tests/model-candidates.test.js tests/autonomous-workflow.test.js tests/high-roi-agent-workflows.test.js tests/business-function-agent-team.test.js tests/radware-threat-defense.test.js tests/interaction-model.test.js tests/interaction-model-e2e.test.js tests/code-graph-guardrails.test.js tests/proxy-pointer-rag-guardrails.test.js tests/rag-precision-guardrails.test.js tests/ai-engineering-stack-guardrails.test.js tests/long-running-agent-context-guardrails.test.js tests/reasoning-efficiency-guardrails.test.js tests/deepseek-v4-runtime-guardrails.test.js tests/nvidia-specdecode-al-doctor.test.js tests/package-manager-honesty-doctor.test.js tests/upstream-contribution-engine.test.js tests/proactive-agent-eval-guardrails.test.js tests/reward-hacking-guardrails.test.js tests/chatgpt-ads-readiness-pack.test.js tests/oss-pr-opportunity-scout.test.js tests/agent-design-governance.test.js tests/gemini-embedding-policy.test.js tests/rag-embedding-identity.test.js tests/openclaw-agent-governance-kit.test.js tests/agent-operations-planner.test.js tests/aws-blocks-guardrails.test.js tests/vlt-proof.test.js tests/hf-context-course.test.js tests/proof-common.test.js tests/mcp-session-handles.test.js tests/agent-egress-policy.test.js tests/budget-aware-gates-proof.test.js tests/edotenv-rl-gateway.test.js tests/rsi-safety-hillclimb.test.js tests/research-agent-harness.test.js tests/rule-sprawl.test.js tests/solver-parity.test.js tests/six-function-agent-team.test.js",
+    "test:high-roi": "node --test tests/high-roi.test.js tests/gurobi-optimizer.test.js tests/model-candidates.test.js tests/autonomous-workflow.test.js tests/high-roi-agent-workflows.test.js tests/business-function-agent-team.test.js tests/radware-threat-defense.test.js tests/interaction-model.test.js tests/interaction-model-e2e.test.js tests/code-graph-guardrails.test.js tests/proxy-pointer-rag-guardrails.test.js tests/rag-precision-guardrails.test.js tests/ai-engineering-stack-guardrails.test.js tests/long-running-agent-context-guardrails.test.js tests/reasoning-efficiency-guardrails.test.js tests/deepseek-v4-runtime-guardrails.test.js tests/nvidia-specdecode-al-doctor.test.js tests/package-manager-honesty-doctor.test.js tests/upstream-contribution-engine.test.js tests/proactive-agent-eval-guardrails.test.js tests/reward-hacking-guardrails.test.js tests/chatgpt-ads-readiness-pack.test.js tests/oss-pr-opportunity-scout.test.js tests/agent-design-governance.test.js tests/gemini-embedding-policy.test.js tests/rag-embedding-identity.test.js tests/openclaw-agent-governance-kit.test.js tests/agent-operations-planner.test.js tests/aws-blocks-guardrails.test.js tests/vlt-proof.test.js tests/hf-context-course.test.js tests/proof-common.test.js tests/mcp-session-handles.test.js tests/agent-egress-policy.test.js tests/budget-aware-gates-proof.test.js tests/edotenv-rl-gateway.test.js tests/rsi-safety-hillclimb.test.js tests/research-agent-harness.test.js tests/rule-sprawl.test.js tests/solver-parity.test.js tests/six-function-agent-team.test.js && npm run test:jit-harness-compose",
     "test:public-static-assets": "node --test tests/public-static-assets.test.js tests/public-checkout-intent-gate.test.js tests/public-enterprise-capability-boundary.test.js tests/founders-conversion-page.test.js",
     "test:token-savings": "node --test tests/token-savings.test.js",
     "test:cost-cli": "node --test tests/cost-cli.test.js tests/conversion-receipt.test.js",
@@ -1130,7 +1132,8 @@
     "graphify:setup": "node scripts/graphify-setup.js",
     "graphify:ready": "node scripts/graphify-readiness.js",
     "graphify:stale": "node scripts/graphify-staleness-check.js",
-    "test:graphify": "node --test tests/graphify-readiness.test.js"
+    "test:graphify": "node --test tests/graphify-readiness.test.js",
+    "test:jit-harness-compose": "node --test tests/jit-harness-compose.test.js"
   },
   "keywords": [
     "mcp",

--- a/scripts/cli-schema.js
+++ b/scripts/cli-schema.js
@@ -457,6 +457,25 @@ const CLI_COMMANDS = [
       { name: 'allow-ignore-scripts-gaps', type: 'boolean', description: 'Do not warn when CI installs omit --ignore-scripts' },
     ],
   }),
+
+  discoveryCommand({
+    name: 'jit-harness-compose',
+    aliases: ['jit-compose', 'jit-harness', 'harness-compose'],
+    description: 'Compose JIT-Agent four-module harness FORMAT (memory/planning/action/capability) onto existing ThumbGate rails — does not train or download JIT-Agent',
+    flags: [
+      jsonFlag(),
+      { name: 'strict', type: 'boolean', description: 'Exit non-zero unless status=ready' },
+      { name: 'task', type: 'string', description: 'Task text to classify and compose' },
+      { name: 'query', type: 'string', description: 'Alias for --task' },
+      { name: 'class', type: 'string', description: 'Force task class (code_edit|review|deploy|research|secure|routine|db_write|default)' },
+      { name: 'harness', type: 'string', description: 'Force gate harness name' },
+      { name: 'profile', type: 'string', description: 'Force subagent profile' },
+      { name: 'roles', type: 'string', description: 'Comma-separated switchyard roles' },
+      { name: 'toolName', type: 'string', description: 'Tool-name hint for harness-selector' },
+      { name: 'map-only', type: 'boolean', description: 'Print four-module rail map only' },
+      { name: 'root', type: 'string', description: 'Repo root to probe' },
+    ],
+  }),
   discoveryCommand({
     name: 'nvidia-specdecode-al-doctor',
     aliases: ['specdecode-al-doctor', 'speculative-decoding-al-doctor', 'nvidia-speculative-decoding-doctor'],

--- a/scripts/jit-harness-compose.js
+++ b/scripts/jit-harness-compose.js
@@ -1,0 +1,628 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * JIT harness compose doctor — JIT-Agent FORMAT steal.
+ *
+ * Maps arXiv:2608.25593 four-module harness (memory, planning, action,
+ * capability) onto EXISTING ThumbGate rails:
+ *   memory     → lesson-retrieval / feedback / contextfs
+ *   planning   → bin/agent-loop Plan + GSD / harness-selector task class
+ *   action     → PreToolUse gates + selected gate harness + switchyard steps
+ *   capability → subagent-profiles + MCP profile + skills + model pool
+ *
+ * Does NOT train/download JIT-Agent-27B, emit free-form harness programs,
+ * or clone HarnessFactory / bingreeky/JIT.
+ *
+ * Source inspiration (not affiliated):
+ *   https://arxiv.org/abs/2608.25593
+ *   https://github.com/bingreeky/JIT
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  selectHarnessName,
+  listHarnesses,
+  HARNESSES,
+} = require('./harness-selector');
+const {
+  routeAgentSteps,
+  buildAlwaysOnAgentPlan,
+  DEFAULT_POOL,
+} = require('./switchyard-router');
+const {
+  listSubagentProfiles,
+  getSubagentProfile,
+  validateSubagentProfiles,
+} = require('./subagent-profiles');
+
+const SOURCE_URL = 'https://arxiv.org/abs/2608.25593';
+const SOURCE_REPO = 'https://github.com/bingreeky/JIT';
+const MODULES = Object.freeze(['memory', 'planning', 'action', 'capability']);
+
+const MODULE_RAILS = Object.freeze({
+  memory: {
+    label: 'memory management',
+    rails: [
+      'lesson-retrieval (BM25F / hybrid RRF)',
+      '.claude/memory/feedback',
+      'contextfs packs',
+      'capture-feedback.js',
+    ],
+    when: 'Prior mistakes, scoped lessons, and session context packs.',
+  },
+  planning: {
+    label: 'planning strategy',
+    rails: [
+      'bin/agent-loop Plan stage',
+      'GSD (Capture→Clarify→Organize→Execute→Review)',
+      'harness-selector task class',
+      'implementation-notes ledger',
+    ],
+    when: 'Multi-step work needs an explicit plan before tool calls.',
+  },
+  action: {
+    label: 'action protocol',
+    rails: [
+      'PreToolUse / gates-engine',
+      'config/gates/*.json harnesses',
+      'switchyard-router step roles',
+      'session-lease + worktree isolation',
+    ],
+    when: 'Every tool call must pass deterministic gates before execution.',
+  },
+  capability: {
+    label: 'tool / skill orchestration',
+    rails: [
+      'config/subagent-profiles.json',
+      'config/mcp-allowlists.json profiles',
+      '.agents/skills + skills/thumbgate',
+      'switchyard model pool / model-candidates',
+    ],
+    when: 'Bound which MCP profile, skills, and models this task may use.',
+  },
+});
+
+const TASK_CLASSES = Object.freeze({
+  code_edit: {
+    label: 'code edit',
+    memory: 'scoped_lessons',
+    planning: 'agent_loop_plan',
+    actionHarness: 'code-edit',
+    subagentProfile: 'pr_workflow',
+    switchyardRoles: ['code', 'gate'],
+  },
+  review: {
+    label: 'review / risk analysis',
+    memory: 'scoped_lessons',
+    planning: 'gsd_clarify',
+    actionHarness: null,
+    subagentProfile: 'review_workflow',
+    switchyardRoles: ['reason', 'summarize', 'gate'],
+  },
+  deploy: {
+    label: 'deploy / publish',
+    memory: 'deploy_lessons',
+    planning: 'agent_loop_plan',
+    actionHarness: 'deploy',
+    subagentProfile: 'secure_runtime',
+    switchyardRoles: ['gate', 'code'],
+  },
+  research: {
+    label: 'research / deep search',
+    memory: 'broad_hybrid',
+    planning: 'gsd_full',
+    actionHarness: null,
+    subagentProfile: 'review_workflow',
+    switchyardRoles: ['reason', 'summarize'],
+  },
+  secure: {
+    label: 'secure / constrained runtime',
+    memory: 'scoped_lessons',
+    planning: 'single_shot',
+    actionHarness: 'five-walls-governance',
+    subagentProfile: 'secure_runtime',
+    switchyardRoles: ['gate', 'private'],
+  },
+  routine: {
+    label: 'routine / scheduled agent',
+    memory: 'scoped_lessons',
+    planning: 'single_shot',
+    actionHarness: 'routine',
+    subagentProfile: 'pr_workflow',
+    switchyardRoles: ['intent', 'gate', 'bulk'],
+  },
+  db_write: {
+    label: 'database write',
+    memory: 'scoped_lessons',
+    planning: 'agent_loop_plan',
+    actionHarness: 'db-write',
+    subagentProfile: 'secure_runtime',
+    switchyardRoles: ['gate', 'code'],
+  },
+  default: {
+    label: 'general task',
+    memory: 'hybrid_default',
+    planning: 'agent_loop_plan',
+    actionHarness: null,
+    subagentProfile: 'pr_workflow',
+    switchyardRoles: ['intent', 'gate', 'code'],
+  },
+});
+
+const MEMORY_CHOICES = Object.freeze({
+  scoped_lessons: {
+    id: 'scoped_lessons',
+    rails: ['lesson-retrieval with entity/project/session scope', 'feedback promotion'],
+    why: 'Prefer matchable lessons over raw transcript dumps.',
+  },
+  deploy_lessons: {
+    id: 'deploy_lessons',
+    rails: ['lesson-retrieval tagged deploy/railway', 'prevention-rules.md'],
+    why: 'Deploy mistakes are high-cost; pull prior deploy denials first.',
+  },
+  broad_hybrid: {
+    id: 'broad_hybrid',
+    rails: ['pragmatic-hybrid-search RRF', 'graphify when architectural'],
+    why: 'Research tasks need lexical + optional dense + graph hops.',
+  },
+  hybrid_default: {
+    id: 'hybrid_default',
+    rails: ['lesson-retrieval reciprocalRankFusion', 'contextfs'],
+    why: 'Default: fuse lessons without shipping transcript blobs.',
+  },
+});
+
+const PLANNING_CHOICES = Object.freeze({
+  agent_loop_plan: {
+    id: 'agent_loop_plan',
+    rails: ['bin/agent-loop Plan→Observe→Act→Evaluate→Learn'],
+    why: 'Multi-step coding stays inside the Recollect→Plan loop.',
+  },
+  gsd_clarify: {
+    id: 'gsd_clarify',
+    rails: ['GSD Clarify + Organize before Execute'],
+    why: 'Review work needs acceptance criteria before patches.',
+  },
+  gsd_full: {
+    id: 'gsd_full',
+    rails: ['GSD Capture→Clarify→Organize→Execute→Review'],
+    why: 'Research / long-horizon tasks need the full GSD spine.',
+  },
+  single_shot: {
+    id: 'single_shot',
+    rails: ['single bounded plan + evidence receipt'],
+    why: 'Routine or locked profiles should not sprawl into multi-agent fan-out.',
+  },
+});
+
+function normalizeBoolean(value) {
+  if (value === true || value === 1) return true;
+  if (value === false || value === 0 || value == null) return false;
+  const s = String(value).trim().toLowerCase();
+  return s === '1' || s === 'true' || s === 'yes' || s === 'on';
+}
+
+function detectTrainOrCloneAttempt(text) {
+  const t = String(text || '');
+  const hits = [];
+  if (/\bjit-?agent-?27b\b/i.test(t) || /\bserve_meta_model\b/i.test(t)) {
+    hits.push('jit_model_serve');
+  }
+  if (/\bhuggingface\.co\/JIT-Agent\b/i.test(t) || /\bpip install.*\bjit\b/i.test(t)) {
+    hits.push('jit_model_download');
+  }
+  if (/\bHarnessFactory\b/.test(t) && /\bclone\b/i.test(t)) {
+    hits.push('harness_factory_clone');
+  }
+  if (/\bemit\b.*\bfree-?form\b.*\bharness\b/i.test(t) || /\bgenerate executable harness code\b/i.test(t)) {
+    hits.push('freeform_harness_emit');
+  }
+  return hits;
+}
+
+function classifyTask(taskText, options = {}) {
+  const q = String(taskText || '').trim();
+  const reasons = [];
+  if (options.taskClass && TASK_CLASSES[options.taskClass]) {
+    return {
+      taskClass: options.taskClass,
+      confidence: 1,
+      reasons: [`explicit taskClass=${options.taskClass}`],
+      gateHarness: TASK_CLASSES[options.taskClass].actionHarness,
+    };
+  }
+  if (!q) {
+    return {
+      taskClass: 'default',
+      confidence: 0.4,
+      reasons: ['empty task → default four-module compose'],
+      gateHarness: null,
+    };
+  }
+
+  const toolName = options.toolName || (/\b(edit|write|patch|refactor)\b/i.test(q) ? 'Edit' : 'Bash');
+  const gateHarness = selectHarnessName(toolName, { command: q, content: q });
+  if (gateHarness && HARNESSES[gateHarness]) {
+    reasons.push(`harness-selector → ${gateHarness}`);
+  }
+
+  if (gateHarness === 'deploy' || /\b(deploy|railway|npm publish|docker push)\b/i.test(q)) {
+    reasons.push('deploy / publish vocabulary');
+    return { taskClass: 'deploy', confidence: 0.9, reasons, gateHarness: gateHarness || 'deploy' };
+  }
+  if (gateHarness === 'db-write' || /\b(DROP TABLE|TRUNCATE|DELETE FROM|ALTER TABLE)\b/i.test(q)) {
+    reasons.push('database-write vocabulary');
+    return { taskClass: 'db_write', confidence: 0.9, reasons, gateHarness: 'db-write' };
+  }
+  if (gateHarness === 'routine' || /\b(nightly|scheduled|cron|routine agent)\b/i.test(q)) {
+    reasons.push('routine / scheduled vocabulary');
+    return { taskClass: 'routine', confidence: 0.85, reasons, gateHarness: 'routine' };
+  }
+  if (
+    gateHarness === 'five-walls-governance'
+    || /\b(secure_runtime|locked mcp|five.?walls|hard_deny|secret|pii)\b/i.test(q)
+  ) {
+    reasons.push('secure / constrained vocabulary');
+    return {
+      taskClass: 'secure',
+      confidence: 0.88,
+      reasons,
+      gateHarness: gateHarness || 'five-walls-governance',
+    };
+  }
+  if (/\b(review|code review|risk analysis|audit PR|read-only review)\b/i.test(q)) {
+    reasons.push('review vocabulary');
+    return { taskClass: 'review', confidence: 0.86, reasons, gateHarness };
+  }
+  if (/\b(research|deep search|investigate|survey|literature|arxiv)\b/i.test(q)) {
+    reasons.push('research vocabulary');
+    return { taskClass: 'research', confidence: 0.84, reasons, gateHarness };
+  }
+  if (gateHarness === 'code-edit' || /\b(implement|fix|refactor|patch|edit file|write code)\b/i.test(q)) {
+    reasons.push('code-edit vocabulary');
+    return { taskClass: 'code_edit', confidence: 0.87, reasons, gateHarness: gateHarness || 'code-edit' };
+  }
+
+  reasons.push('no strong class → default');
+  return { taskClass: 'default', confidence: 0.55, reasons, gateHarness };
+}
+
+function composeModules(classification, options = {}) {
+  const preset = TASK_CLASSES[classification.taskClass] || TASK_CLASSES.default;
+  const memory = MEMORY_CHOICES[preset.memory] || MEMORY_CHOICES.hybrid_default;
+  const planning = PLANNING_CHOICES[preset.planning] || PLANNING_CHOICES.agent_loop_plan;
+
+  let actionHarness = options.harness || classification.gateHarness || preset.actionHarness;
+  if (actionHarness && !HARNESSES[actionHarness]) {
+    actionHarness = preset.actionHarness;
+  }
+
+  const availableProfiles = listSubagentProfiles();
+  let subagentProfile = options.profile || preset.subagentProfile;
+  if (!availableProfiles.includes(subagentProfile)) {
+    subagentProfile = availableProfiles.includes('pr_workflow')
+      ? 'pr_workflow'
+      : availableProfiles[0] || null;
+  }
+
+  let profile = null;
+  if (subagentProfile) {
+    try {
+      profile = getSubagentProfile(subagentProfile);
+    } catch {
+      profile = null;
+    }
+  }
+
+  const roles = Array.isArray(options.roles) && options.roles.length
+    ? options.roles
+    : preset.switchyardRoles;
+  const plan = {
+    steps: roles.map((role, index) => ({
+      id: `m${index + 1}-${role}`,
+      type: role,
+      tags: [classification.taskClass, 'jit-compose'],
+      riskLevel: classification.taskClass === 'secure' || classification.taskClass === 'deploy'
+        ? 'high'
+        : 'medium',
+      sensitive: classification.taskClass === 'secure',
+    })),
+  };
+  const routed = routeAgentSteps(plan);
+
+  return {
+    memory: {
+      module: 'memory',
+      choice: memory.id,
+      rails: memory.rails,
+      why: memory.why,
+      catalog: MODULE_RAILS.memory,
+    },
+    planning: {
+      module: 'planning',
+      choice: planning.id,
+      rails: planning.rails,
+      why: planning.why,
+      catalog: MODULE_RAILS.planning,
+    },
+    action: {
+      module: 'action',
+      choice: actionHarness || 'default-gates-only',
+      gateHarness: actionHarness,
+      rails: [
+        ...(actionHarness ? [`config/gates/${actionHarness}.json`] : ['default.json + auto-promoted gates']),
+        'PreToolUse / gates-engine',
+        'switchyard step roles: ' + roles.join(', '),
+      ],
+      why: actionHarness
+        ? `Load specialized ${actionHarness} harness additively on top of default gates.`
+        : 'No specialized harness; default gates still apply.',
+      catalog: MODULE_RAILS.action,
+      switchyard: {
+        distinctModels: routed.distinctModels,
+        steps: routed.steps.map((s) => ({
+          id: s.id,
+          role: s.role,
+          modelId: s.modelId,
+          reason: s.reason,
+        })),
+      },
+    },
+    capability: {
+      module: 'capability',
+      choice: subagentProfile || 'none',
+      subagentProfile,
+      mcpProfile: profile?.mcpProfile || null,
+      skills: profile?.skills || [],
+      context: profile?.context || null,
+      rails: [
+        subagentProfile ? `subagent-profiles:${subagentProfile}` : 'no subagent profile',
+        profile?.mcpProfile ? `mcp-allowlists:${profile.mcpProfile}` : 'mcp default',
+        'skills registry + model pool',
+      ],
+      why: profile
+        ? `Bound tools/skills via ${subagentProfile} (mcp=${profile.mcpProfile}).`
+        : 'No matching subagent profile; keep MCP allowlist fail-closed.',
+      catalog: MODULE_RAILS.capability,
+      modelPoolSample: DEFAULT_POOL.slice(0, 3).map((m) => m.id),
+    },
+  };
+}
+
+function probeRails(rootDir) {
+  const root = rootDir || path.resolve(__dirname, '..');
+  const checks = [
+    { id: 'agent_loop', path: path.join(root, 'bin', 'agent-loop') },
+    { id: 'harness_selector', path: path.join(root, 'scripts', 'harness-selector.js') },
+    { id: 'switchyard_router', path: path.join(root, 'scripts', 'switchyard-router.js') },
+    { id: 'subagent_profiles', path: path.join(root, 'config', 'subagent-profiles.json') },
+    { id: 'mcp_allowlists', path: path.join(root, 'config', 'mcp-allowlists.json') },
+    { id: 'gates_dir', path: path.join(root, 'config', 'gates') },
+  ];
+  return checks.map((c) => ({
+    id: c.id,
+    path: c.path,
+    exists: fs.existsSync(c.path),
+  }));
+}
+
+function buildJitHarnessComposeReport(options = {}) {
+  const root = options.root
+    ? path.resolve(String(options.root))
+    : path.resolve(__dirname, '..');
+  const task = options.task || options.query || options._ || '';
+  const findings = [];
+  const cloneHits = detectTrainOrCloneAttempt(task);
+  for (const hit of options.argv || []) {
+    cloneHits.push(...detectTrainOrCloneAttempt(hit));
+  }
+  const uniqueCloneHits = [...new Set(cloneHits)];
+  if (uniqueCloneHits.length) {
+    findings.push({
+      severity: 'fail',
+      id: 'jit_clone_refused',
+      message: `Refusing JIT model/HarnessFactory clone path (${uniqueCloneHits.join(', ')}). Compose existing rails only.`,
+    });
+  }
+
+  const classification = classifyTask(task, {
+    taskClass: options.taskClass || options.class || null,
+    toolName: options.toolName || options.tool || null,
+  });
+  const modules = composeModules(classification, {
+    harness: options.harness || null,
+    profile: options.profile || null,
+    roles: options.roles
+      ? String(options.roles).split(',').map((s) => s.trim()).filter(Boolean)
+      : null,
+  });
+
+  const probes = probeRails(root);
+  const missing = probes.filter((p) => !p.exists);
+  for (const m of missing) {
+    findings.push({
+      severity: 'warn',
+      id: `missing_rail_${m.id}`,
+      message: `Expected rail missing: ${m.path}`,
+    });
+  }
+
+  let profileValidation = null;
+  try {
+    profileValidation = validateSubagentProfiles();
+    if (!profileValidation.valid) {
+      findings.push({
+        severity: 'warn',
+        id: 'subagent_profile_invalid',
+        message: profileValidation.issues.slice(0, 5).join('; '),
+      });
+    }
+  } catch (err) {
+    findings.push({
+      severity: 'warn',
+      id: 'subagent_profile_load_error',
+      message: err.message,
+    });
+  }
+
+  const alwaysOn = buildAlwaysOnAgentPlan({ includeBulk: false });
+  const mapOnly = normalizeBoolean(options.map || options['map-only']);
+
+  let status = 'ready';
+  if (findings.some((f) => f.severity === 'fail')) status = 'fail';
+  else if (findings.some((f) => f.severity === 'warn')) status = 'ready_with_warnings';
+
+  const report = {
+    name: 'thumbgate-jit-harness-compose',
+    status,
+    task: task || null,
+    taskClass: classification.taskClass,
+    taskLabel: (TASK_CLASSES[classification.taskClass] || TASK_CLASSES.default).label,
+    confidence: classification.confidence,
+    reasons: classification.reasons,
+    modules,
+    moduleOrder: MODULES,
+    availableGateHarnesses: listHarnesses(),
+    availableSubagentProfiles: listSubagentProfiles(),
+    railProbes: probes,
+    profileValidation,
+    alwaysOnPlanSteps: alwaysOn.steps?.length || 0,
+    compareNotClone: true,
+    never: [
+      'train or download JIT-Agent-27B',
+      'clone bingreeky/JIT HarnessFactory',
+      'emit free-form harness programs',
+      'claim ThumbGate is JIT-Agent',
+    ],
+    source: SOURCE_URL,
+    sourceRepo: SOURCE_REPO,
+    disclaimer: 'FORMAT steal only. Not affiliated with JIT-Agent / bingreeky/JIT. Composes existing ThumbGate rails; does not train a harness model.',
+    findings,
+  };
+
+  if (mapOnly) {
+    report.map = MODULES.map((id) => ({ id, ...MODULE_RAILS[id] }));
+    report.taskClasses = Object.keys(TASK_CLASSES);
+  }
+
+  return report;
+}
+
+function formatJitHarnessComposeReport(report) {
+  const lines = [
+    'ThumbGate JIT Harness Compose (JIT-Agent FORMAT steal)',
+    `Status   : ${report.status}`,
+    `Task     : ${report.task || '(none)'}`,
+    `Class    : ${report.taskClass} (${report.taskLabel}) confidence=${report.confidence}`,
+    `Reasons  : ${(report.reasons || []).join('; ')}`,
+    'Modules  :',
+  ];
+  for (const id of report.moduleOrder || MODULES) {
+    const m = report.modules?.[id];
+    if (!m) continue;
+    lines.push(`  [${id}] choice=${m.choice}`);
+    lines.push(`         rails=${(m.rails || []).join(' · ')}`);
+    lines.push(`         why=${m.why}`);
+  }
+  if (report.modules?.action?.switchyard?.distinctModels?.length) {
+    lines.push(`Models   : ${report.modules.action.switchyard.distinctModels.join(', ')}`);
+  }
+  if (report.modules?.capability?.subagentProfile) {
+    lines.push(
+      `Capability profile: ${report.modules.capability.subagentProfile}`
+      + ` mcp=${report.modules.capability.mcpProfile}`
+      + ` skills=${(report.modules.capability.skills || []).join(',') || '(none)'}`
+    );
+  }
+  if (report.findings?.length) {
+    lines.push('Findings:');
+    for (const f of report.findings) {
+      lines.push(`  [${f.severity}] ${f.id}: ${f.message}`);
+    }
+  }
+  lines.push(`Never    : ${(report.never || []).join('; ')}`);
+  lines.push(`Source   : ${report.source}`);
+  lines.push(report.disclaimer);
+  return `${lines.join('\n')}\n`;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/jit-harness-compose.js [options]
+
+JIT-Agent FORMAT steal — compose memory/planning/action/capability onto
+existing ThumbGate rails. Does not train or download JIT-Agent.
+
+Options:
+  --task=<text>              Task to classify / compose
+  --class=<taskClass>        Force task class (${Object.keys(TASK_CLASSES).join('|')})
+  --harness=<name>           Force gate harness
+  --profile=<name>           Force subagent profile
+  --roles=a,b,c              Switchyard roles override
+  --toolName=Bash|Edit       Hint for harness-selector
+  --map-only                 Print four-module rail map
+  --json
+  --strict                   Exit 1 unless status=ready
+  --root=<dir>
+`);
+}
+
+function main(argv = process.argv.slice(2)) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp();
+    return 0;
+  }
+  const options = { argv };
+  for (const arg of argv) {
+    if (arg === '--json') options.json = true;
+    else if (arg === '--strict') options.strict = true;
+    else if (arg === '--map' || arg === '--map-only') options.map = true;
+    else if (arg.startsWith('--task=')) options.task = arg.slice('--task='.length);
+    else if (arg.startsWith('--query=')) options.task = arg.slice('--query='.length);
+    else if (arg.startsWith('--class=')) options.taskClass = arg.slice('--class='.length);
+    else if (arg.startsWith('--taskClass=')) options.taskClass = arg.slice('--taskClass='.length);
+    else if (arg.startsWith('--harness=')) options.harness = arg.slice('--harness='.length);
+    else if (arg.startsWith('--profile=')) options.profile = arg.slice('--profile='.length);
+    else if (arg.startsWith('--roles=')) options.roles = arg.slice('--roles='.length);
+    else if (arg.startsWith('--toolName=')) options.toolName = arg.slice('--toolName='.length);
+    else if (arg.startsWith('--tool=')) options.toolName = arg.slice('--tool='.length);
+    else if (arg.startsWith('--root=')) options.root = arg.slice('--root='.length);
+    else if (!arg.startsWith('-') && !options.task) options.task = arg;
+  }
+
+  const report = buildJitHarnessComposeReport(options);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(formatJitHarnessComposeReport(report));
+  }
+  if (options.strict && report.status !== 'ready') return 1;
+  if (report.status === 'fail') return 1;
+  return 0;
+}
+
+if (require.main === module || (
+  process.argv[1]
+  && path.resolve(process.argv[1]) === path.resolve(__filename)
+)) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  MODULES,
+  MODULE_RAILS,
+  TASK_CLASSES,
+  MEMORY_CHOICES,
+  PLANNING_CHOICES,
+  classifyTask,
+  composeModules,
+  detectTrainOrCloneAttempt,
+  probeRails,
+  buildJitHarnessComposeReport,
+  formatJitHarnessComposeReport,
+  main,
+  SOURCE_URL,
+  SOURCE_REPO,
+};

--- a/tests/cli-schema.test.js
+++ b/tests/cli-schema.test.js
@@ -251,6 +251,17 @@ test('nvidia-specdecode-al-doctor exposes AL/D speedup flags', () => {
   assert.ok(flagNames.includes('attention-dominated'));
 });
 
+
+test('jit-harness-compose exposes four-module compose flags', () => {
+  const cmd = findCommand('jit-compose');
+  const flagNames = cmd.flags.map((f) => f.name);
+  assert.equal(cmd.name, 'jit-harness-compose');
+  assert.ok(cmd.aliases.includes('jit-compose'));
+  assert.ok(flagNames.includes('task'));
+  assert.ok(flagNames.includes('map-only'));
+  assert.ok(flagNames.includes('profile'));
+});
+
 test('package-manager-honesty-doctor exposes lockfile/CI parity flags', () => {
   const cmd = findCommand('pnpm12-honesty-doctor');
   const flagNames = cmd.flags.map((f) => f.name);

--- a/tests/jit-harness-compose.test.js
+++ b/tests/jit-harness-compose.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+  MODULES,
+  classifyTask,
+  detectTrainOrCloneAttempt,
+  buildJitHarnessComposeReport,
+  formatJitHarnessComposeReport,
+} = require('../scripts/jit-harness-compose');
+
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'jit-harness-compose.js');
+const CLI = path.resolve(__dirname, '..', 'bin', 'cli.js');
+
+test('MODULES is the JIT four-module protocol', () => {
+  assert.deepEqual([...MODULES], ['memory', 'planning', 'action', 'capability']);
+});
+
+test('classifyTask maps deploy vocabulary', () => {
+  const c = classifyTask('railway deploy production after npm publish');
+  assert.equal(c.taskClass, 'deploy');
+  assert.ok(c.confidence >= 0.8);
+});
+
+test('classifyTask maps review vocabulary', () => {
+  const c = classifyTask('read-only code review and risk analysis for this PR');
+  assert.equal(c.taskClass, 'review');
+});
+
+test('classifyTask maps research vocabulary', () => {
+  const c = classifyTask('deep search the arxiv literature on harness intelligence');
+  assert.equal(c.taskClass, 'research');
+});
+
+test('classifyTask maps code-edit vocabulary', () => {
+  const c = classifyTask('implement a fix and refactor the Edit patch in session-lease.js');
+  assert.equal(c.taskClass, 'code_edit');
+});
+
+test('detectTrainOrCloneAttempt refuses JIT model paths', () => {
+  const hits = detectTrainOrCloneAttempt('serve_meta_model.sh JIT-Agent-27B from huggingface.co/JIT-Agent');
+  assert.ok(hits.includes('jit_model_serve') || hits.includes('jit_model_download'));
+});
+
+test('report refuses clone attempts with status=fail', () => {
+  const report = buildJitHarnessComposeReport({
+    task: 'clone HarnessFactory and emit free-form harness code',
+  });
+  assert.equal(report.status, 'fail');
+  assert.ok(report.findings.some((f) => f.id === 'jit_clone_refused'));
+  assert.match(formatJitHarnessComposeReport(report), /Refusing JIT/);
+});
+
+test('compose report maps four modules onto existing rails', () => {
+  const report = buildJitHarnessComposeReport({
+    task: 'implement PreToolUse gate fix for session-lease path',
+  });
+  assert.equal(report.name, 'thumbgate-jit-harness-compose');
+  assert.ok(['ready', 'ready_with_warnings'].includes(report.status));
+  assert.equal(report.taskClass, 'code_edit');
+  assert.ok(report.modules.memory.rails.length >= 1);
+  assert.ok(report.modules.planning.rails.some((r) => /agent-loop|GSD/i.test(r)));
+  assert.ok(report.modules.action.rails.some((r) => /gates|PreToolUse/i.test(r)));
+  assert.ok(report.modules.capability.subagentProfile);
+  assert.equal(report.compareNotClone, true);
+  assert.match(report.disclaimer, /Not affiliated/);
+});
+
+test('explicit --class overrides classifier', () => {
+  const report = buildJitHarnessComposeReport({
+    task: 'implement a fix',
+    taskClass: 'secure',
+  });
+  assert.equal(report.taskClass, 'secure');
+  assert.equal(report.confidence, 1);
+  assert.equal(report.modules.capability.subagentProfile, 'secure_runtime');
+});
+
+test('map-only includes module catalog and task classes', () => {
+  const report = buildJitHarnessComposeReport({ map: true, task: '' });
+  assert.equal(report.map.length, 4);
+  assert.ok(report.taskClasses.includes('code_edit'));
+});
+
+test('script CLI --json exits 0 for code-edit compose', () => {
+  const result = spawnSync(process.execPath, [
+    SCRIPT,
+    '--task=implement a patch for gates-engine.js',
+    '--json',
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.taskClass, 'code_edit');
+  assert.ok(payload.modules.action);
+});
+
+test('thumbgate CLI jit-harness-compose is wired', () => {
+  const result = spawnSync(process.execPath, [
+    CLI,
+    'jit-harness-compose',
+    '--task=review this PR for risk',
+    '--json',
+  ], {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.name, 'thumbgate-jit-harness-compose');
+  assert.equal(payload.taskClass, 'review');
+});
+
+test('docs mention FORMAT steal without claiming a JIT SKU', () => {
+  const doc = fs.readFileSync(
+    path.join(__dirname, '..', 'docs', 'agents', 'jit-harness-compose.md'),
+    'utf8'
+  );
+  assert.match(doc, /jit-harness-compose|memory|planning|action|capability/i);
+  assert.match(doc, /not affiliated|compare-not-clone|do not train/i);
+  assert.doesNotMatch(doc, /npm install jit-agent|pip install jit-agent/i);
+});

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -485,8 +485,9 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // 519 -> 522 (2026-09-04): radware-threat-defense.js + learn page + config/gates/radware-threat-defense-2026.json.
   // 521 -> 522: scripts/nvidia-specdecode-al-doctor.js (AL/D doctor).
   // 522 -> 523: scripts/package-manager-honesty-doctor.js (pnpm 12 honesty).
-    manifest.fileCount <= 523,
-    `npm package should stay <= 523 files, got ${manifest.fileCount}`
+  // 523 -> 525: scripts/jit-harness-compose.js + skill (JIT-Agent FORMAT steal).
+    manifest.fileCount <= 525,
+    `npm package should stay <= 525 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing
@@ -695,8 +696,9 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // Bumped 8.21 MB -> 8.25 MB (2026-09-04): package-manager-honesty-doctor.js on top of AL/D.
   // 5,606 over the old cap. Narrow headroom retained.
   assert.ok(
-    manifest.unpackedSize <= 8_250_000,
-    `npm package should stay <= 8.25 MB unpacked, got ${manifest.unpackedSize}`
+  // Bumped 8.25 MB -> 8.30 MB (2026-09-04): jit-harness-compose.js FORMAT steal.
+    manifest.unpackedSize <= 8_300_000,
+    `npm package should stay <= 8.30 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -230,7 +230,9 @@ const path = require('node:path');
 //            speculative-decoding doctor (speedup ≤ AL/(1+ρD)).
 // 522 → 523: scripts/package-manager-honesty-doctor.js — InfoQ pnpm 12
 //            lockfile/CI parity + switch checkpoint (stay on npm).
-const BASELINE_FILE_COUNT = 523;
+// 523 → 525: scripts/jit-harness-compose.js + skill — JIT-Agent four-module
+//            FORMAT compose doctor (no JIT model / HarnessFactory clone).
+const BASELINE_FILE_COUNT = 525;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -281,7 +281,10 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // 522 -> 523: scripts/package-manager-honesty-doctor.js — InfoQ pnpm 12
   //   honesty steal without migrating off npm (public-shell CLI/doctor).
   //   Lockstep with package-boundary + public-bundle-ratchet.
-  const CEILING = 523;
+  // 523 -> 525: scripts/jit-harness-compose.js + skill — JIT four-module FORMAT
+  //   steal onto harness-selector/switchyard/subagent-profiles.
+  //   Lockstep with package-boundary + public-bundle-ratchet.
+  const CEILING = 525;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
## Summary
- Steal JIT-Agent (arXiv:2608.25593) **four-module harness FORMAT** (memory / planning / action / capability) onto existing rails via `jit-harness-compose` doctor.
- Maps onto `harness-selector`, `switchyard-router`, and `subagent-profiles` — does **not** train or download JIT-Agent-27B / HarnessFactory.
- Fail-closed on clone/train attempts (`jit_clone_refused`). Skill: `/jit-harness-compare-not-clone`.

## Evidence
- Focused tests: `node --test tests/jit-harness-compose.test.js tests/cli-schema.test.js` → 46 pass
- `npm pack` dry-run: **525 files**, unpacked **8,250,594** (ceilings 525 / 8.30 MB)
- Boundary ratchet tests green

## Compare-not-clone
Not affiliated with JIT-Agent / bingreeky/JIT. FORMAT only.

## Test plan
- [x] `npm run test:jit-harness-compose`
- [x] cli-schema discovery flags
- [x] package-boundary / public-bundle-ratchet / public-core-boundary