### PR TITLE
feat(governance): CyberStrike intent→governed-execution doctor (FORMAT steal)

### DIFF
--- a/.agents/skills/cyberstrike-compare-not-clone/SKILL.md
+++ b/.agents/skills/cyberstrike-compare-not-clone/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cyberstrike-compare-not-clone
+description: >
+  CyberStrikeAI (Ed1s0nZ) turns NL intent into governed cybersecurity actions
+  with HITL + RAG. Steal the FORMAT onto ThumbGate rails; never clone
+  CyberStrike, Eino, WebShell, or C2. Slash: /cyberstrike-compare-not-clone.
+---
+
+# CyberStrikeAI — compare, do not clone
+
+## When
+CyberStrikeAI, Ed1s0nZ, tom_doerr Eino agents, intent becomes governed execution,
+evidence becomes operational memory, human oversight pentest agent.
+
+## Do
+```bash
+npx thumbgate intent-governed-execution --intent="<what to do>" --json
+npx thumbgate intent-governed-execution --map-only
+```
+
+Map FORMAT onto existing rails:
+- **classify** → intent-router + harness-selector
+- **authorize** → session-lease / task-scope; offensive needs `THUMBGATE_ALLOW_OFFENSIVE=1`
+- **gate** → PreToolUse / gates-engine / harness JSON
+- **hitl** → admin-override / protectedApprovals (`--approved` only after a real human grant)
+- **execute** → subagent-profiles + maxChars result governance
+- **evidence** → capture-feedback → lessons → prevention rules
+
+## Never
+- Clone/vendor CyberStrikeAI or CloudWeGo Eino into ThumbGate
+- Ship WebShell / C2 / metasploit recipe packs
+- Invent automation ROI percentages
+- Run offensive tools without authorization grant + HITL
+
+## Source
+https://github.com/Ed1s0nZ/CyberStrikeAI · https://x.com/tom_doerr/status/2094509419929174170 — FORMAT only; not affiliated.

--- a/.changeset/intent-governed-execution-cyberstrike-format.md
+++ b/.changeset/intent-governed-execution-cyberstrike-format.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Steal CyberStrikeAI intent→governed-execution FORMAT onto existing rails via `intent-governed-execution` doctor — classify / authorize / gate / HITL / bounded execute / evidence memory — without cloning CyberStrike, Eino, WebShell, or C2.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2649,6 +2649,28 @@ function nvidiaSpecDecodeAlDoctor() {
 }
 
 
+
+function intentGovernedExecution() {
+  const args = parseArgs(process.argv.slice(3));
+  const {
+    buildIntentGovernedExecutionReport,
+    formatIntentGovernedExecutionReport,
+  } = require(path.join(PKG_ROOT, 'scripts', 'intent-governed-execution'));
+  const report = buildIntentGovernedExecutionReport(args);
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    process.stdout.write(formatIntentGovernedExecutionReport(report));
+  }
+
+  if (args.strict && report.status !== 'ready') {
+    process.exitCode = 1;
+    return;
+  }
+  if (report.status === 'fail') process.exitCode = 1;
+}
+
 function jitHarnessCompose() {
   const args = parseArgs(process.argv.slice(3));
   const {
@@ -3512,6 +3534,7 @@ function help() {
   console.log('  npx thumbgate nvidia-specdecode-al-doctor --speculative-decoding --accept-length=1.4 --draft-length=7 --draft-depth-ratio=0.05 --claimed-speedup=3 --json');
   console.log('  npx thumbgate package-manager-honesty-doctor --propose-switch=pnpm --json');
   console.log('  npx thumbgate jit-harness-compose --task="implement PreToolUse gate fix" --json');
+  console.log('  npx thumbgate intent-governed-execution --intent="railway deploy" --json');
   console.log('  npx thumbgate upstream-contributions --max-repos=10 --write');
   console.log('  npx thumbgate background-governance --json');
   console.log('  npx thumbgate background-governance --check --agent-id=builder --branch=main --files-changed=25 --json');
@@ -4157,6 +4180,12 @@ switch (COMMAND) {
   case 'jit-harness':
   case 'harness-compose':
     jitHarnessCompose();
+    break;
+  case 'intent-governed-execution':
+  case 'governed-intent':
+  case 'cyberstrike-governed':
+  case 'intent-govern':
+    intentGovernedExecution();
     break;
   case 'long-running-agent-context-guardrails':
   case 'agent-context-guardrails':

--- a/docs/agents/intent-governed-execution.md
+++ b/docs/agents/intent-governed-execution.md
@@ -1,0 +1,28 @@
+# Intent → governed execution (CyberStrike FORMAT steal)
+
+Doctor: `npx thumbgate intent-governed-execution --intent="…" --json`
+
+Steals the **process shape** from [CyberStrikeAI](https://github.com/Ed1s0nZ/CyberStrikeAI) (surfaced by [@tom_doerr](https://x.com/tom_doerr/status/2094509419929174170)): natural-language intent becomes **governed execution**, human oversight gates high risk, and evidence returns to operational memory.
+
+This is compare-not-clone. It does **not** install CyberStrikeAI, CloudWeGo Eino, WebShell, C2, or pentest recipe packs. Not affiliated.
+
+## Six-step spine → ThumbGate rails
+
+| Step | Rails |
+|------|--------|
+| classify | `intent-router` plan quality + `harness-selector` |
+| authorize | session-lease / task-scope; offensive needs `THUMBGATE_ALLOW_OFFENSIVE=1` |
+| gate | PreToolUse / `gates-engine` / `config/gates/*.json` |
+| hitl | `admin-override`, protectedApprovals (`--approved` only after a real human grant) |
+| execute | `subagent-profiles` + `context.maxChars` result governance |
+| evidence | `capture-feedback` → lesson-retrieval → prevention rules |
+
+## Fail closed
+
+- Offensive/cyber intents without `THUMBGATE_ALLOW_OFFENSIVE=1` → `status=fail`
+- High/critical without HITL → `checkpoint_required`
+- Clone/vendor CyberStrike or Eino wording → `cyberstrike_clone_refused`
+
+## Skill
+
+`.agents/skills/cyberstrike-compare-not-clone/SKILL.md` — `/cyberstrike-compare-not-clone`

--- a/package.json
+++ b/package.json
@@ -434,7 +434,9 @@
     "src/",
     "scripts/radware-threat-defense.js",
     ".agents/skills/jit-harness-compare-not-clone/",
-    "scripts/jit-harness-compose.js"
+    "scripts/jit-harness-compose.js",
+    ".agents/skills/cyberstrike-compare-not-clone/",
+    "scripts/intent-governed-execution.js"
   ],
   "scripts": {
     "canary:snapshot": "node scripts/gate-decision-canary.js --snapshot",
@@ -932,7 +934,7 @@
     "test:agent-egress-policy": "node --test tests/agent-egress-policy.test.js",
     "test:budget-aware-gates-proof": "node --test tests/budget-aware-gates-proof.test.js",
     "test:business-function-agents": "node --test tests/business-function-agent-team.test.js",
-    "test:high-roi": "node --test tests/high-roi.test.js tests/gurobi-optimizer.test.js tests/model-candidates.test.js tests/autonomous-workflow.test.js tests/high-roi-agent-workflows.test.js tests/business-function-agent-team.test.js tests/radware-threat-defense.test.js tests/interaction-model.test.js tests/interaction-model-e2e.test.js tests/code-graph-guardrails.test.js tests/proxy-pointer-rag-guardrails.test.js tests/rag-precision-guardrails.test.js tests/ai-engineering-stack-guardrails.test.js tests/long-running-agent-context-guardrails.test.js tests/reasoning-efficiency-guardrails.test.js tests/deepseek-v4-runtime-guardrails.test.js tests/nvidia-specdecode-al-doctor.test.js tests/package-manager-honesty-doctor.test.js tests/upstream-contribution-engine.test.js tests/proactive-agent-eval-guardrails.test.js tests/reward-hacking-guardrails.test.js tests/chatgpt-ads-readiness-pack.test.js tests/oss-pr-opportunity-scout.test.js tests/agent-design-governance.test.js tests/gemini-embedding-policy.test.js tests/rag-embedding-identity.test.js tests/openclaw-agent-governance-kit.test.js tests/agent-operations-planner.test.js tests/aws-blocks-guardrails.test.js tests/vlt-proof.test.js tests/hf-context-course.test.js tests/proof-common.test.js tests/mcp-session-handles.test.js tests/agent-egress-policy.test.js tests/budget-aware-gates-proof.test.js tests/edotenv-rl-gateway.test.js tests/rsi-safety-hillclimb.test.js tests/research-agent-harness.test.js tests/rule-sprawl.test.js tests/solver-parity.test.js tests/six-function-agent-team.test.js && npm run test:jit-harness-compose",
+    "test:high-roi": "node --test tests/high-roi.test.js tests/gurobi-optimizer.test.js tests/model-candidates.test.js tests/autonomous-workflow.test.js tests/high-roi-agent-workflows.test.js tests/business-function-agent-team.test.js tests/radware-threat-defense.test.js tests/interaction-model.test.js tests/interaction-model-e2e.test.js tests/code-graph-guardrails.test.js tests/proxy-pointer-rag-guardrails.test.js tests/rag-precision-guardrails.test.js tests/ai-engineering-stack-guardrails.test.js tests/long-running-agent-context-guardrails.test.js tests/reasoning-efficiency-guardrails.test.js tests/deepseek-v4-runtime-guardrails.test.js tests/nvidia-specdecode-al-doctor.test.js tests/package-manager-honesty-doctor.test.js tests/upstream-contribution-engine.test.js tests/proactive-agent-eval-guardrails.test.js tests/reward-hacking-guardrails.test.js tests/chatgpt-ads-readiness-pack.test.js tests/oss-pr-opportunity-scout.test.js tests/agent-design-governance.test.js tests/gemini-embedding-policy.test.js tests/rag-embedding-identity.test.js tests/openclaw-agent-governance-kit.test.js tests/agent-operations-planner.test.js tests/aws-blocks-guardrails.test.js tests/vlt-proof.test.js tests/hf-context-course.test.js tests/proof-common.test.js tests/mcp-session-handles.test.js tests/agent-egress-policy.test.js tests/budget-aware-gates-proof.test.js tests/edotenv-rl-gateway.test.js tests/rsi-safety-hillclimb.test.js tests/research-agent-harness.test.js tests/rule-sprawl.test.js tests/solver-parity.test.js tests/six-function-agent-team.test.js && npm run test:jit-harness-compose && npm run test:intent-governed-execution",
     "test:public-static-assets": "node --test tests/public-static-assets.test.js tests/public-checkout-intent-gate.test.js tests/public-enterprise-capability-boundary.test.js tests/founders-conversion-page.test.js",
     "test:token-savings": "node --test tests/token-savings.test.js",
     "test:cost-cli": "node --test tests/cost-cli.test.js tests/conversion-receipt.test.js",
@@ -1133,7 +1135,8 @@
     "graphify:ready": "node scripts/graphify-readiness.js",
     "graphify:stale": "node scripts/graphify-staleness-check.js",
     "test:graphify": "node --test tests/graphify-readiness.test.js",
-    "test:jit-harness-compose": "node --test tests/jit-harness-compose.test.js"
+    "test:jit-harness-compose": "node --test tests/jit-harness-compose.test.js",
+    "test:intent-governed-execution": "node --test tests/intent-governed-execution.test.js"
   },
   "keywords": [
     "mcp",

--- a/scripts/cli-schema.js
+++ b/scripts/cli-schema.js
@@ -458,6 +458,25 @@ const CLI_COMMANDS = [
     ],
   }),
 
+
+  discoveryCommand({
+    name: 'intent-governed-execution',
+    aliases: ['governed-intent', 'cyberstrike-governed', 'intent-govern'],
+    description: 'Compose CyberStrikeAI intent→governed-execution FORMAT onto existing rails (HITL + evidence memory; does not clone CyberStrike/Eino)',
+    flags: [
+      jsonFlag(),
+      { name: 'strict', type: 'boolean', description: 'Exit non-zero unless status=ready' },
+      { name: 'intent', type: 'string', description: 'Natural-language intent to govern' },
+      { name: 'task', type: 'string', description: 'Alias for --intent' },
+      { name: 'class', type: 'string', description: 'Force intent class' },
+      { name: 'risk', type: 'string', description: 'Force risk low|medium|high|critical' },
+      { name: 'harness', type: 'string', description: 'Force gate harness' },
+      { name: 'profile', type: 'string', description: 'Force subagent profile' },
+      { name: 'approved', type: 'boolean', description: 'HITL already satisfied (human grant only)' },
+      { name: 'map-only', type: 'boolean', description: 'Print six-step governance map' },
+      { name: 'root', type: 'string', description: 'Repo root to probe' },
+    ],
+  }),
   discoveryCommand({
     name: 'jit-harness-compose',
     aliases: ['jit-compose', 'jit-harness', 'harness-compose'],

--- a/scripts/intent-governed-execution.js
+++ b/scripts/intent-governed-execution.js
@@ -1,0 +1,602 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Intent → governed execution doctor — CyberStrikeAI FORMAT steal.
+ *
+ * Steals the process shape from Ed1s0nZ/CyberStrikeAI (via @tom_doerr):
+ *   natural-language intent → risk class → required governance rails
+ *   → HITL when high/critical → evidence back into memory
+ *
+ * Maps onto EXISTING ThumbGate rails:
+ *   intent-router, harness-selector, PreToolUse/gates-engine,
+ *   admin-override / protectedApprovals, subagent-profiles maxChars,
+ *   lesson-retrieval / capture-feedback
+ *
+ * Does NOT clone CyberStrikeAI, CloudWeGo Eino, WebShell, C2, or a pentest SKU.
+ * Offensive/cyber tooling stays fail-closed unless THUMBGATE_ALLOW_OFFENSIVE=1.
+ *
+ * Source inspiration (not affiliated):
+ *   https://github.com/Ed1s0nZ/CyberStrikeAI
+ *   https://x.com/tom_doerr/status/2094509419929174170
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  selectHarnessName,
+  HARNESSES,
+} = require('./harness-selector');
+const {
+  listSubagentProfiles,
+  getSubagentProfile,
+} = require('./subagent-profiles');
+const {
+  RISK_LEVELS,
+  evaluatePlanQuality,
+  getRequiredApprovalRisks,
+  loadPolicyBundle,
+} = require('./intent-router');
+
+const SOURCE_URL = 'https://github.com/Ed1s0nZ/CyberStrikeAI';
+const SOURCE_POST = 'https://x.com/tom_doerr/status/2094509419929174170';
+
+const RISK_ORDER = Object.freeze({
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+});
+
+const INTENT_CLASSES = Object.freeze({
+  code_edit: {
+    label: 'code edit',
+    risk: 'medium',
+    harness: 'code-edit',
+    profile: 'pr_workflow',
+    hitl: false,
+  },
+  review: {
+    label: 'review / read-only',
+    risk: 'low',
+    harness: null,
+    profile: 'review_workflow',
+    hitl: false,
+  },
+  deploy: {
+    label: 'deploy / publish',
+    risk: 'high',
+    harness: 'deploy',
+    profile: 'secure_runtime',
+    hitl: true,
+  },
+  db_write: {
+    label: 'database write',
+    risk: 'high',
+    harness: 'db-write',
+    profile: 'secure_runtime',
+    hitl: true,
+  },
+  secret_or_auth: {
+    label: 'secrets / auth change',
+    risk: 'critical',
+    harness: 'five-walls-governance',
+    profile: 'secure_runtime',
+    hitl: true,
+  },
+  offensive_cyber: {
+    label: 'offensive / pentest tooling',
+    risk: 'critical',
+    harness: 'radware-threat-defense',
+    profile: 'secure_runtime',
+    hitl: true,
+    requiresOffensiveGrant: true,
+  },
+  recon_readonly: {
+    label: 'authorized recon (read-only)',
+    risk: 'medium',
+    harness: null,
+    profile: 'review_workflow',
+    hitl: false,
+  },
+  default: {
+    label: 'general intent',
+    risk: 'medium',
+    harness: null,
+    profile: 'pr_workflow',
+    hitl: false,
+  },
+});
+
+const GOVERNANCE_STEPS = Object.freeze([
+  {
+    id: 'classify',
+    label: 'Classify intent risk',
+    rails: ['intent-router evaluatePlanQuality', 'harness-selector'],
+  },
+  {
+    id: 'authorize',
+    label: 'Authorization / scope',
+    rails: ['session-lease', 'task-scope', 'THUMBGATE_ALLOW_OFFENSIVE for offensive'],
+  },
+  {
+    id: 'gate',
+    label: 'PreToolUse gates',
+    rails: ['gates-engine', 'config/gates harness', 'MCP allowlist'],
+  },
+  {
+    id: 'hitl',
+    label: 'Human oversight when required',
+    rails: ['admin-override grants', 'protectedApprovals', 'approve_protected_action'],
+  },
+  {
+    id: 'execute',
+    label: 'Bounded tool execution',
+    rails: ['subagent-profiles', 'result maxChars / output caps'],
+  },
+  {
+    id: 'evidence',
+    label: 'Evidence → operational memory',
+    rails: ['capture-feedback', 'lesson-retrieval', 'prevention-rules'],
+  },
+]);
+
+function normalizeBoolean(value) {
+  if (value === true || value === 1) return true;
+  if (value === false || value === 0 || value == null) return false;
+  const s = String(value).trim().toLowerCase();
+  return s === '1' || s === 'true' || s === 'yes' || s === 'on';
+}
+
+function detectOffensiveGrant(env = process.env) {
+  return normalizeBoolean(env.THUMBGATE_ALLOW_OFFENSIVE);
+}
+
+function detectCloneAttempt(text) {
+  const t = String(text || '');
+  const hits = [];
+  if (/\b(clone|vendor|fork)\b/i.test(t) && /\b(CyberStrikeAI|cyberstrike)\b/i.test(t)) {
+    hits.push('cyberstrike_clone');
+  }
+  if (/\b(webshell|c2 beacon|metasploit|msfvenom)\b/i.test(t) && /\b(install|enable|ship)\b/i.test(t)) {
+    hits.push('offensive_sku_clone');
+  }
+  if (/\beino\b/i.test(t) && /\b(rebuild|vendor|cloudwego)\b/i.test(t)) {
+    hits.push('eino_framework_clone');
+  }
+  return [...new Set(hits)];
+}
+
+function classifyIntent(intentText, options = {}) {
+  const q = String(intentText || '').trim();
+  const reasons = [];
+  if (options.intentClass && INTENT_CLASSES[options.intentClass]) {
+    return {
+      intentClass: options.intentClass,
+      confidence: 1,
+      reasons: [`explicit intentClass=${options.intentClass}`],
+      gateHarness: INTENT_CLASSES[options.intentClass].harness,
+    };
+  }
+  if (!q) {
+    return {
+      intentClass: 'default',
+      confidence: 0.35,
+      reasons: ['empty intent → default'],
+      gateHarness: null,
+    };
+  }
+
+  const toolName = options.toolName || 'Bash';
+  const gateHarness = selectHarnessName(toolName, { command: q, content: q });
+  if (gateHarness && HARNESSES[gateHarness]) {
+    reasons.push(`harness-selector → ${gateHarness}`);
+  }
+
+  if (
+    /\b(nmap|nuclei|sqlmap|metasploit|msfvenom|hydra|hashcat|webshell|c2|bloodhound|mimikatz|exploit)\b/i.test(q)
+    || /\b(pentest|penetration test|red.?team|offensive security|attack chain)\b/i.test(q)
+  ) {
+    reasons.push('offensive / pentest vocabulary');
+    return {
+      intentClass: 'offensive_cyber',
+      confidence: 0.92,
+      reasons,
+      gateHarness: gateHarness || 'radware-threat-defense',
+    };
+  }
+  if (/\b(recon|enumerate subdomain|httpx|read-only scan|authorized inventory)\b/i.test(q)) {
+    reasons.push('authorized recon vocabulary');
+    return { intentClass: 'recon_readonly', confidence: 0.8, reasons, gateHarness };
+  }
+  if (gateHarness === 'deploy' || /\b(deploy|railway|npm publish|docker push)\b/i.test(q)) {
+    reasons.push('deploy vocabulary');
+    return { intentClass: 'deploy', confidence: 0.9, reasons, gateHarness: 'deploy' };
+  }
+  if (gateHarness === 'db-write' || /\b(DROP TABLE|TRUNCATE|DELETE FROM|ALTER TABLE)\b/i.test(q)) {
+    reasons.push('db-write vocabulary');
+    return { intentClass: 'db_write', confidence: 0.9, reasons, gateHarness: 'db-write' };
+  }
+  if (/\b(secret|api[_-]?key|credential|rotate.?pat|chmod 777|\.pem|\.env)\b/i.test(q)) {
+    reasons.push('secret / auth vocabulary');
+    return {
+      intentClass: 'secret_or_auth',
+      confidence: 0.9,
+      reasons,
+      gateHarness: gateHarness || 'five-walls-governance',
+    };
+  }
+  if (/\b(review|read-only|audit PR|risk analysis)\b/i.test(q)) {
+    reasons.push('review vocabulary');
+    return { intentClass: 'review', confidence: 0.85, reasons, gateHarness };
+  }
+  if (gateHarness === 'code-edit' || /\b(implement|fix|refactor|patch|edit file)\b/i.test(q)) {
+    reasons.push('code-edit vocabulary');
+    return {
+      intentClass: 'code_edit',
+      confidence: 0.86,
+      reasons,
+      gateHarness: gateHarness || 'code-edit',
+    };
+  }
+
+  reasons.push('no strong class → default');
+  return { intentClass: 'default', confidence: 0.5, reasons, gateHarness };
+}
+
+function composeGovernance(classification, options = {}) {
+  const preset = INTENT_CLASSES[classification.intentClass] || INTENT_CLASSES.default;
+  const risk = options.risk && RISK_LEVELS.includes(options.risk)
+    ? options.risk
+    : preset.risk;
+  const harness = options.harness || classification.gateHarness || preset.harness;
+  const profiles = listSubagentProfiles();
+  let profileName = options.profile || preset.profile;
+  if (!profiles.includes(profileName)) {
+    profileName = profiles.includes('pr_workflow') ? 'pr_workflow' : profiles[0] || null;
+  }
+  let profile = null;
+  if (profileName) {
+    try {
+      profile = getSubagentProfile(profileName);
+    } catch {
+      profile = null;
+    }
+  }
+
+  let requiredApprovalRisks = ['high', 'critical'];
+  try {
+    const bundle = loadPolicyBundle(options.bundleId);
+    requiredApprovalRisks = getRequiredApprovalRisks(
+      bundle,
+      profile?.mcpProfile || options.mcpProfile || 'default'
+    );
+  } catch {
+    // bundle optional for doctor map-only paths
+  }
+
+  const hitlRequired = Boolean(
+    preset.hitl
+    || requiredApprovalRisks.includes(risk)
+    || RISK_ORDER[risk] >= RISK_ORDER.high
+  );
+  const approved = normalizeBoolean(options.approved);
+  const offensiveGrant = detectOffensiveGrant(options.env || process.env);
+  const needsOffensiveGrant = Boolean(preset.requiresOffensiveGrant);
+
+  const planQuality = evaluatePlanQuality({
+    intentId: classification.intentClass,
+    intent: { id: classification.intentClass, risk, description: preset.label },
+    context: String(options.intent || options.task || ''),
+  });
+
+  const steps = GOVERNANCE_STEPS.map((step) => {
+    const copy = { ...step, status: 'pending' };
+    if (step.id === 'classify') copy.status = 'ready';
+    if (step.id === 'authorize') {
+      if (needsOffensiveGrant && !offensiveGrant) copy.status = 'blocked';
+      else copy.status = 'ready';
+    }
+    if (step.id === 'gate') {
+      copy.status = 'ready';
+      copy.harness = harness || 'default-gates-only';
+    }
+    if (step.id === 'hitl') {
+      copy.status = hitlRequired ? (approved ? 'satisfied' : 'required') : 'not_required';
+    }
+    if (step.id === 'execute') {
+      copy.status = (needsOffensiveGrant && !offensiveGrant) || (hitlRequired && !approved)
+        ? 'blocked'
+        : 'ready';
+      copy.maxChars = profile?.context?.maxChars || null;
+    }
+    if (step.id === 'evidence') copy.status = 'after_execute';
+    return copy;
+  });
+
+  return {
+    risk,
+    harness: harness || null,
+    subagentProfile: profileName,
+    mcpProfile: profile?.mcpProfile || null,
+    maxChars: profile?.context?.maxChars || null,
+    hitlRequired,
+    approved,
+    needsOffensiveGrant,
+    offensiveGrant,
+    requiredApprovalRisks,
+    planQuality,
+    steps,
+    nextActions: buildNextActions({
+      hitlRequired,
+      approved,
+      needsOffensiveGrant,
+      offensiveGrant,
+      harness,
+      profileName,
+    }),
+  };
+}
+
+function buildNextActions({
+  hitlRequired,
+  approved,
+  needsOffensiveGrant,
+  offensiveGrant,
+  harness,
+  profileName,
+}) {
+  const actions = [];
+  if (needsOffensiveGrant && !offensiveGrant) {
+    actions.push({
+      id: 'set_offensive_grant',
+      command: 'export THUMBGATE_ALLOW_OFFENSIVE=1  # only for authorized systems you own',
+      why: 'Offensive/cyber intents are fail-closed without an explicit grant.',
+    });
+  }
+  if (hitlRequired && !approved) {
+    actions.push({
+      id: 'obtain_hitl',
+      command: 'npx thumbgate protect  # or admin-override for a single gate id',
+      why: 'High/critical risk requires human oversight before tool execution.',
+    });
+  }
+  if (harness) {
+    actions.push({
+      id: 'load_harness',
+      command: `THUMBGATE_HARNESS=${harness}  # additive on default.json`,
+      why: 'Specialized gate harness for this intent class.',
+    });
+  }
+  actions.push({
+    id: 'bound_profile',
+    command: `use subagent profile ${profileName || 'pr_workflow'}`,
+    why: 'Bound MCP tools + context maxChars (result governance).',
+  });
+  actions.push({
+    id: 'capture_evidence',
+    command: 'node .claude/scripts/feedback/capture-feedback.js --feedback=up|down --context="..."',
+    why: 'Evidence becomes operational memory (lessons → prevention rules).',
+  });
+  return actions;
+}
+
+function buildIntentGovernedExecutionReport(options = {}) {
+  const root = options.root
+    ? path.resolve(String(options.root))
+    : path.resolve(__dirname, '..');
+  const intent = options.intent || options.task || options.query || '';
+  const findings = [];
+  const cloneHits = detectCloneAttempt(intent);
+  for (const arg of options.argv || []) {
+    cloneHits.push(...detectCloneAttempt(arg));
+  }
+  const uniqueCloneHits = [...new Set(cloneHits)];
+  if (uniqueCloneHits.length) {
+    findings.push({
+      severity: 'fail',
+      id: 'cyberstrike_clone_refused',
+      message: `Refusing CyberStrike/Eino/offensive SKU clone (${uniqueCloneHits.join(', ')}). Compose existing ThumbGate rails only.`,
+    });
+  }
+
+  const classification = classifyIntent(intent, {
+    intentClass: options.class || options.intentClass || null,
+    toolName: options.toolName || options.tool || null,
+  });
+  const governance = composeGovernance(classification, {
+    ...options,
+    intent,
+  });
+
+  if (governance.needsOffensiveGrant && !governance.offensiveGrant) {
+    findings.push({
+      severity: 'fail',
+      id: 'offensive_ungranted',
+      message: 'Offensive/cyber intent blocked: set THUMBGATE_ALLOW_OFFENSIVE=1 only for systems you own or are authorized to test.',
+    });
+  }
+  if (governance.hitlRequired && !governance.approved) {
+    findings.push({
+      severity: 'warn',
+      id: 'hitl_required',
+      message: 'Human oversight required before execute (high/critical). Pass --approved only after a real human grant.',
+    });
+  }
+  if (governance.planQuality?.gate === 'block') {
+    findings.push({
+      severity: 'warn',
+      id: 'plan_quality_block',
+      message: `Plan quality blocked: missing context [${(governance.planQuality.missingContext || []).join(', ')}]`,
+    });
+  }
+
+  const probes = [
+    { id: 'intent_router', path: path.join(root, 'scripts', 'intent-router.js') },
+    { id: 'harness_selector', path: path.join(root, 'scripts', 'harness-selector.js') },
+    { id: 'gates_engine', path: path.join(root, 'scripts', 'gates-engine.js') },
+    { id: 'admin_override', path: path.join(root, 'scripts', 'admin-override.js') },
+    { id: 'subagent_profiles', path: path.join(root, 'config', 'subagent-profiles.json') },
+  ].map((p) => ({ ...p, exists: fs.existsSync(p.path) }));
+
+  for (const p of probes.filter((x) => !x.exists)) {
+    findings.push({
+      severity: 'warn',
+      id: `missing_rail_${p.id}`,
+      message: `Expected rail missing: ${p.path}`,
+    });
+  }
+
+  let status = 'ready';
+  if (findings.some((f) => f.severity === 'fail')) status = 'fail';
+  else if (findings.some((f) => f.severity === 'warn')) status = 'checkpoint_required';
+  else if (governance.steps.some((s) => s.status === 'blocked' || s.status === 'required')) {
+    status = 'checkpoint_required';
+  }
+
+  const mapOnly = normalizeBoolean(options.map || options['map-only']);
+  const report = {
+    name: 'thumbgate-intent-governed-execution',
+    status,
+    intent: intent || null,
+    intentClass: classification.intentClass,
+    intentLabel: (INTENT_CLASSES[classification.intentClass] || INTENT_CLASSES.default).label,
+    confidence: classification.confidence,
+    reasons: classification.reasons,
+    governance,
+    railProbes: probes,
+    compareNotClone: true,
+    never: [
+      'clone CyberStrikeAI / Ed1s0nZ product',
+      'vendor CloudWeGo Eino as a ThumbGate SKU',
+      'ship WebShell / C2 / metasploit recipes',
+      'invent ROI percentages (70% automation theater)',
+      'execute offensive tools without authorization grant',
+    ],
+    source: SOURCE_URL,
+    sourcePost: SOURCE_POST,
+    disclaimer:
+      'FORMAT steal from CyberStrikeAI (intent→governed execution + HITL + evidence memory). Not affiliated. Does not install CyberStrikeAI or Eino.',
+    findings,
+  };
+
+  if (mapOnly) {
+    report.map = GOVERNANCE_STEPS;
+    report.intentClasses = Object.keys(INTENT_CLASSES);
+  }
+
+  return report;
+}
+
+function formatIntentGovernedExecutionReport(report) {
+  const g = report.governance || {};
+  const lines = [
+    'ThumbGate Intent → Governed Execution (CyberStrike FORMAT steal)',
+    `Status   : ${report.status}`,
+    `Intent   : ${report.intent || '(none)'}`,
+    `Class    : ${report.intentClass} (${report.intentLabel}) confidence=${report.confidence}`,
+    `Risk     : ${g.risk}  HITL=${g.hitlRequired ? (g.approved ? 'approved' : 'REQUIRED') : 'not required'}`,
+    `Harness  : ${g.harness || 'default-gates-only'}`,
+    `Profile  : ${g.subagentProfile || 'none'} mcp=${g.mcpProfile || 'n/a'} maxChars=${g.maxChars || 'n/a'}`,
+    `Offensive grant: ${g.offensiveGrant ? 'yes' : 'no'}${g.needsOffensiveGrant ? ' (required)' : ''}`,
+    'Steps    :',
+  ];
+  for (const step of g.steps || []) {
+    lines.push(`  [${step.status}] ${step.id}: ${step.label}`);
+    lines.push(`         rails=${(step.rails || []).join(' · ')}`);
+  }
+  if (g.nextActions?.length) {
+    lines.push('Next     :');
+    for (const a of g.nextActions) {
+      lines.push(`  - ${a.id}: ${a.command}`);
+      lines.push(`    why: ${a.why}`);
+    }
+  }
+  if (report.findings?.length) {
+    lines.push('Findings:');
+    for (const f of report.findings) {
+      lines.push(`  [${f.severity}] ${f.id}: ${f.message}`);
+    }
+  }
+  lines.push(`Never    : ${(report.never || []).join('; ')}`);
+  lines.push(`Source   : ${report.source}`);
+  lines.push(report.disclaimer);
+  return `${lines.join('\n')}\n`;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/intent-governed-execution.js [options]
+
+CyberStrikeAI FORMAT steal — NL intent → governed execution on existing rails.
+Does not clone CyberStrikeAI / Eino / WebShell / C2.
+
+Options:
+  --intent=<text>            Natural-language intent
+  --class=<intentClass>      Force class (${Object.keys(INTENT_CLASSES).join('|')})
+  --risk=low|medium|high|critical
+  --harness=<name>           Force gate harness
+  --profile=<name>           Force subagent profile
+  --approved                 Mark HITL already satisfied (human grant only)
+  --map-only                 Print governance step map
+  --json
+  --strict                   Exit 1 unless status=ready
+  --root=<dir>
+`);
+}
+
+function main(argv = process.argv.slice(2)) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp();
+    return 0;
+  }
+  const options = { argv };
+  for (const arg of argv) {
+    if (arg === '--json') options.json = true;
+    else if (arg === '--strict') options.strict = true;
+    else if (arg === '--map' || arg === '--map-only') options.map = true;
+    else if (arg === '--approved') options.approved = true;
+    else if (arg.startsWith('--intent=')) options.intent = arg.slice('--intent='.length);
+    else if (arg.startsWith('--task=')) options.intent = arg.slice('--task='.length);
+    else if (arg.startsWith('--query=')) options.intent = arg.slice('--query='.length);
+    else if (arg.startsWith('--class=')) options.intentClass = arg.slice('--class='.length);
+    else if (arg.startsWith('--risk=')) options.risk = arg.slice('--risk='.length);
+    else if (arg.startsWith('--harness=')) options.harness = arg.slice('--harness='.length);
+    else if (arg.startsWith('--profile=')) options.profile = arg.slice('--profile='.length);
+    else if (arg.startsWith('--toolName=')) options.toolName = arg.slice('--toolName='.length);
+    else if (arg.startsWith('--root=')) options.root = arg.slice('--root='.length);
+    else if (!arg.startsWith('-') && !options.intent) options.intent = arg;
+  }
+
+  const report = buildIntentGovernedExecutionReport(options);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(formatIntentGovernedExecutionReport(report));
+  }
+  if (options.strict && report.status !== 'ready') return 1;
+  if (report.status === 'fail') return 1;
+  return 0;
+}
+
+if (require.main === module || (
+  process.argv[1]
+  && path.resolve(process.argv[1]) === path.resolve(__filename)
+)) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  INTENT_CLASSES,
+  GOVERNANCE_STEPS,
+  RISK_ORDER,
+  classifyIntent,
+  composeGovernance,
+  detectOffensiveGrant,
+  detectCloneAttempt,
+  buildIntentGovernedExecutionReport,
+  formatIntentGovernedExecutionReport,
+  main,
+  SOURCE_URL,
+  SOURCE_POST,
+};

--- a/tests/cli-schema.test.js
+++ b/tests/cli-schema.test.js
@@ -252,6 +252,17 @@ test('nvidia-specdecode-al-doctor exposes AL/D speedup flags', () => {
 });
 
 
+
+test('intent-governed-execution exposes HITL and intent flags', () => {
+  const cmd = findCommand('governed-intent');
+  const flagNames = cmd.flags.map((f) => f.name);
+  assert.equal(cmd.name, 'intent-governed-execution');
+  assert.ok(cmd.aliases.includes('cyberstrike-governed'));
+  assert.ok(flagNames.includes('intent'));
+  assert.ok(flagNames.includes('approved'));
+  assert.ok(flagNames.includes('map-only'));
+});
+
 test('jit-harness-compose exposes four-module compose flags', () => {
   const cmd = findCommand('jit-compose');
   const flagNames = cmd.flags.map((f) => f.name);

--- a/tests/intent-governed-execution.test.js
+++ b/tests/intent-governed-execution.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+  GOVERNANCE_STEPS,
+  classifyIntent,
+  detectOffensiveGrant,
+  detectCloneAttempt,
+  buildIntentGovernedExecutionReport,
+  formatIntentGovernedExecutionReport,
+} = require('../scripts/intent-governed-execution');
+
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'intent-governed-execution.js');
+const CLI = path.resolve(__dirname, '..', 'bin', 'cli.js');
+
+test('GOVERNANCE_STEPS is the six-step CyberStrike FORMAT spine', () => {
+  assert.deepEqual(
+    GOVERNANCE_STEPS.map((s) => s.id),
+    ['classify', 'authorize', 'gate', 'hitl', 'execute', 'evidence']
+  );
+});
+
+test('classifyIntent maps offensive tooling to offensive_cyber', () => {
+  const c = classifyIntent('run nuclei and sqlmap against the target');
+  assert.equal(c.intentClass, 'offensive_cyber');
+  assert.ok(c.confidence >= 0.85);
+});
+
+test('classifyIntent maps deploy vocabulary', () => {
+  const c = classifyIntent('railway deploy production after npm publish');
+  assert.equal(c.intentClass, 'deploy');
+});
+
+test('classifyIntent maps review vocabulary', () => {
+  const c = classifyIntent('read-only code review and risk analysis');
+  assert.equal(c.intentClass, 'review');
+});
+
+test('offensive grant is fail-closed by default', () => {
+  assert.equal(detectOffensiveGrant({}), false);
+  assert.equal(detectOffensiveGrant({ THUMBGATE_ALLOW_OFFENSIVE: '1' }), true);
+});
+
+test('detectCloneAttempt refuses CyberStrike / Eino SKU paths', () => {
+  const hits = detectCloneAttempt('clone CyberStrikeAI and vendor cloudwego eino');
+  assert.ok(hits.includes('cyberstrike_clone') || hits.includes('eino_framework_clone'));
+});
+
+test('offensive intent without grant fails closed', () => {
+  const report = buildIntentGovernedExecutionReport({
+    intent: 'run nmap and metasploit against the host',
+    env: {},
+  });
+  assert.equal(report.status, 'fail');
+  assert.ok(report.findings.some((f) => f.id === 'offensive_ungranted'));
+  assert.match(formatIntentGovernedExecutionReport(report), /Offensive grant: no/);
+});
+
+test('offensive intent with grant still requires HITL until --approved', () => {
+  const report = buildIntentGovernedExecutionReport({
+    intent: 'authorized nuclei scan on systems we own',
+    env: { THUMBGATE_ALLOW_OFFENSIVE: '1' },
+  });
+  assert.equal(report.governance.offensiveGrant, true);
+  assert.equal(report.governance.hitlRequired, true);
+  assert.ok(['checkpoint_required', 'ready'].includes(report.status));
+  assert.ok(report.findings.some((f) => f.id === 'hitl_required') || report.status === 'checkpoint_required');
+});
+
+test('deploy intent with --approved clears HITL warn path to ready when rails present', () => {
+  const report = buildIntentGovernedExecutionReport({
+    intent: 'railway deploy production',
+    approved: true,
+  });
+  assert.equal(report.intentClass, 'deploy');
+  assert.equal(report.governance.approved, true);
+  assert.ok(['ready', 'checkpoint_required'].includes(report.status));
+  assert.ok(report.governance.steps.some((s) => s.id === 'hitl' && s.status === 'satisfied'));
+});
+
+test('clone attempt fails', () => {
+  const report = buildIntentGovernedExecutionReport({
+    intent: 'clone CyberStrikeAI into ThumbGate',
+  });
+  assert.equal(report.status, 'fail');
+  assert.ok(report.findings.some((f) => f.id === 'cyberstrike_clone_refused'));
+});
+
+test('map-only includes step catalog', () => {
+  const report = buildIntentGovernedExecutionReport({ map: true });
+  assert.equal(report.map.length, 6);
+  assert.ok(report.intentClasses.includes('offensive_cyber'));
+  assert.equal(report.compareNotClone, true);
+});
+
+test('result governance exposes maxChars from subagent profile', () => {
+  const report = buildIntentGovernedExecutionReport({
+    intent: 'implement a patch in gates-engine.js',
+  });
+  assert.ok(report.governance.maxChars > 0);
+  assert.ok(report.governance.subagentProfile);
+});
+
+test('script CLI --json exits 0 for review intent', () => {
+  const result = spawnSync(process.execPath, [
+    SCRIPT,
+    '--intent=read-only risk analysis of this PR',
+    '--json',
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.intentClass, 'review');
+});
+
+test('thumbgate CLI intent-governed-execution is wired', () => {
+  const result = spawnSync(process.execPath, [
+    CLI,
+    'intent-governed-execution',
+    '--intent=implement PreToolUse gate fix',
+    '--json',
+  ], {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.name, 'thumbgate-intent-governed-execution');
+});
+
+test('docs refuse CyberStrike SKU clone language', () => {
+  const doc = fs.readFileSync(
+    path.join(__dirname, '..', 'docs', 'agents', 'intent-governed-execution.md'),
+    'utf8'
+  );
+  assert.match(doc, /intent-governed-execution|human oversight|evidence/i);
+  assert.match(doc, /not affiliated|compare-not-clone|do not clone/i);
+  assert.doesNotMatch(doc, /npm install cyberstrike|go install.*CyberStrikeAI/i);
+});

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -486,8 +486,9 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // 521 -> 522: scripts/nvidia-specdecode-al-doctor.js (AL/D doctor).
   // 522 -> 523: scripts/package-manager-honesty-doctor.js (pnpm 12 honesty).
   // 523 -> 525: scripts/jit-harness-compose.js + skill (JIT-Agent FORMAT steal).
-    manifest.fileCount <= 525,
-    `npm package should stay <= 525 files, got ${manifest.fileCount}`
+  // 525 -> 527: scripts/intent-governed-execution.js + skill (CyberStrike FORMAT).
+    manifest.fileCount <= 527,
+    `npm package should stay <= 527 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing
@@ -697,8 +698,9 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // 5,606 over the old cap. Narrow headroom retained.
   assert.ok(
   // Bumped 8.25 MB -> 8.30 MB (2026-09-04): jit-harness-compose.js FORMAT steal.
-    manifest.unpackedSize <= 8_300_000,
-    `npm package should stay <= 8.30 MB unpacked, got ${manifest.unpackedSize}`
+  // Bumped 8.30 MB -> 8.35 MB (2026-09-04): intent-governed-execution CyberStrike FORMAT.
+    manifest.unpackedSize <= 8_350_000,
+    `npm package should stay <= 8.35 MB unpacked, got ${manifest.unpackedSize}`
   );
 
   for (const file of requiredRuntimeFiles) {

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -232,7 +232,9 @@ const path = require('node:path');
 //            lockfile/CI parity + switch checkpoint (stay on npm).
 // 523 → 525: scripts/jit-harness-compose.js + skill — JIT-Agent four-module
 //            FORMAT compose doctor (no JIT model / HarnessFactory clone).
-const BASELINE_FILE_COUNT = 525;
+// 525 → 527: scripts/intent-governed-execution.js + skill — CyberStrike FORMAT
+//            intent→governed execution (no CyberStrike/Eino clone).
+const BASELINE_FILE_COUNT = 527;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -284,7 +284,9 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   // 523 -> 525: scripts/jit-harness-compose.js + skill — JIT four-module FORMAT
   //   steal onto harness-selector/switchyard/subagent-profiles.
   //   Lockstep with package-boundary + public-bundle-ratchet.
-  const CEILING = 525;
+  // 525 -> 527: intent-governed-execution.js + skill — CyberStrike FORMAT steal.
+  //   Lockstep with package-boundary + public-bundle-ratchet.
+  const CEILING = 527;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
## Summary
Steal FORMAT from [CyberStrikeAI](https://github.com/Ed1s0nZ/CyberStrikeAI) (via [@tom_doerr](https://x.com/tom_doerr/status/2094509419929174170)): **intent → governed execution**, human oversight, evidence → memory.

Doctor: `npx thumbgate intent-governed-execution --intent="…" --json`

Maps onto existing rails (`intent-router`, `harness-selector`, PreToolUse, `admin-override`, subagent-profiles maxChars, capture-feedback).

## Never (compare-not-clone)
- CyberStrikeAI / CloudWeGo Eino product clone
- WebShell / C2 / metasploit recipe packs
- Invented ROI % theater (also refused the local untracked `eino-agent-llama-integration.js` theater script)

## Evidence
- Focused + cli-schema tests green
- `npm pack`: ceilings **527 / 8.35 MB**

## Note vs #3770
Both bump ceilings 525→527; whichever lands second rebases to 529.

## Test plan
- [x] `npm run test:intent-governed-execution`
- [x] package-boundary / public-bundle-ratchet / public-core-boundary