### PR TITLE
feat(memory): steal Supermemory Memory-vs-RAG into local lesson scope (rebased)

### DIFF
--- a/.changeset/supermemory-memory-vs-rag.md
+++ b/.changeset/supermemory-memory-vs-rag.md
@@ -1,0 +1,9 @@
+---
+"thumbgate": patch
+---
+
+feat(memory): steal Supermemory Memory-vs-RAG routing into local lesson scope
+
+Add containerTag encode/decode, fail-closed memory-vs-RAG routing, static/dynamic
+lesson profiles, and dreaming promotion modes. Process steal only — not a
+Supermemory SaaS clone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ RAG = graphify/docs (stateless). Memory = lesson store with complete four-field 
 
 ```bash
 npm run memory:vs-rag -- --query "how does PreToolUse work?"
-npm run memory:vs-rag -- --query "what did we decide?" --entity <e> --project <p> --process <a> --session <s> --json
+npm run memory:vs-rag -- --query "what did we decide?" --entity entity-id --project project-id --process process-id --session session-id --json
 ```
 
 Details: [`docs/agents/memory-vs-rag.md`](./docs/agents/memory-vs-rag.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,17 @@ npm run explainx:trending -- --fetch --top 10 --json
 
 Visual answers: `.agents/skills/show-me/SKILL.md` (`/show-me`). Details: `docs/agents/explainx-trending.md`.
 
+## Memory vs RAG (Supermemory steal)
+
+RAG = graphify/docs (stateless). Memory = lesson store with complete four-field scope (stateful). Profile = always-on static+dynamic facts. Do not clone Supermemory SaaS.
+
+```bash
+npm run memory:vs-rag -- --query "how does PreToolUse work?"
+npm run memory:vs-rag -- --query "what did we decide?" --entity <e> --project <p> --process <a> --session <s> --json
+```
+
+Details: [`docs/agents/memory-vs-rag.md`](./docs/agents/memory-vs-rag.md).
+
 ## Canonical Product Scope
 
 - The only active product, repository, npm package, and launch surface is **ThumbGate**:

--- a/docs/agents/memory-vs-rag.md
+++ b/docs/agents/memory-vs-rag.md
@@ -1,0 +1,42 @@
+# Memory vs RAG (Supermemory process steal)
+
+Source format: [Supermemory — Memory vs RAG](https://supermemory.ai/docs/concepts/memory-vs-rag)  
+Logged console: `console.supermemory.ai` (Igor Google SSO). **We do not clone Supermemory as a ThumbGate SKU.**
+
+## Contract
+
+| Rail | Answers | ThumbGate surface |
+|------|---------|-------------------|
+| **RAG** | “What do I know?” — stateless knowledge | Graphify AST graph, grepai, `docs/`, public HTML |
+| **Memory** | “What do I remember about you?” — scoped + temporal | Lesson store + four-field scope + temporal decay |
+| **Profile** | Always-on facts (not query-similar) | `buildLessonProfile` static + dynamic |
+
+## Isolation
+
+Supermemory `containerTag` ≈ ThumbGate four-field scope encoded as:
+
+`entity:<id>:project:<id>:process:<id>:session:<id>`
+
+Field values must not contain `:`. Incomplete scope → memory rail **fails closed**.
+
+## Dreaming (promotion)
+
+| Mode | Behavior |
+|------|----------|
+| `dynamic` (default) | Batch related feedback before promotion |
+| `instant` | Promote this signal alone immediately |
+
+## CLI
+
+```bash
+node scripts/memory-vs-rag-route.js --query "how does PreToolUse work?"
+node scripts/memory-vs-rag-route.js --query "what did we decide last time?" \
+  --entity alice --project thumbgate --process coder --session s1 --json
+npm run memory:vs-rag -- --dreaming dynamic --json
+```
+
+## Never
+
+- Treat lesson-store vector hits as a substitute for scoped memory
+- Call memory rail without `entityId`/`projectId`/`processId`/`sessionId`
+- Vendor Supermemory SaaS as ThumbGate product memory without counsel clearance

--- a/package.json
+++ b/package.json
@@ -1139,7 +1139,8 @@
     "test:graphify": "node --test tests/graphify-readiness.test.js",
     "test:jit-harness-compose": "node --test tests/jit-harness-compose.test.js",
     "test:workspace-search-route": "node --test tests/workspace-search-route.test.js",
-    "test:intent-governed-execution": "node --test tests/intent-governed-execution.test.js"
+    "test:intent-governed-execution": "node --test tests/intent-governed-execution.test.js",
+    "memory:vs-rag": "node scripts/memory-vs-rag-route.js"
   },
   "keywords": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "scripts/mcp-wiring-doctor.js",
     "scripts/memory-firewall.js",
     "scripts/memory-scope-readiness.js",
+    "scripts/memory-vs-rag-route.js",
     "scripts/meta-agent-loop.js",
     "scripts/model-access-eligibility.js",
     "scripts/model-eval.js",

--- a/scripts/memory-scope-readiness.js
+++ b/scripts/memory-scope-readiness.js
@@ -525,7 +525,7 @@ function encodeContainerTag(scopeInput = {}) {
  */
 function decodeContainerTag(tag) {
   const text = normalizeId(tag);
-  if (!text) return null;
+  if (!text || !CONTAINER_TAG_PATTERN.test(text) || text.length > 100) return null;
   const parts = text.split(':');
   if (parts.length !== 8) return null;
   const scope = {};
@@ -568,8 +568,24 @@ function routeMemoryVsRag(query = '', options = {}) {
   let memoryHits = memoryCues.filter((c) => lower.includes(c)).length;
   let ragHits = ragCues.filter((c) => lower.includes(c)).length;
 
-  // Explicit override
-  if (options.forceRail === 'memory' || options.forceRail === 'rag' || options.forceRail === 'hybrid') {
+  // Explicit override — reject typos instead of falling through to heuristics.
+  if (options.forceRail != null && options.forceRail !== '') {
+    if (options.forceRail !== 'memory' && options.forceRail !== 'rag' && options.forceRail !== 'hybrid') {
+      return {
+        ok: false,
+        rail: null,
+        query: text,
+        scope,
+        missingFields: missing,
+        containerTag: null,
+        rails: {},
+        recommended: [],
+        reason: 'invalid forceRail (expected rag|memory|hybrid)',
+        error: 'invalid_force_rail',
+        memoryHits,
+        ragHits,
+      };
+    }
     return finalizeRoute(options.forceRail, text, scope, missing, {
       memoryHits,
       ragHits,
@@ -594,8 +610,11 @@ function routeMemoryVsRag(query = '', options = {}) {
 }
 
 function finalizeRoute(rail, text, scope, missing, meta) {
-  const ok = rail !== 'memory' || missing.length === 0;
   const container = encodeContainerTag(scope);
+  // Memory rail requires a complete, encodable scope (fail closed on bad tags).
+  const ok = rail !== 'memory'
+    ? true
+    : (missing.length === 0 && container.ok);
   return {
     ok,
     rail,
@@ -629,7 +648,11 @@ function finalizeRoute(rail, text, scope, missing, meta) {
     reason: meta.reason,
     memoryHits: meta.memoryHits,
     ragHits: meta.ragHits,
-    error: ok ? null : `memory rail requires complete scope; missing: ${missing.join(', ')}`,
+    error: ok
+      ? null
+      : (!container.ok
+        ? (container.reason || 'memory rail requires encodable containerTag')
+        : `memory rail requires complete scope; missing: ${missing.join(', ')}`),
   };
 }
 

--- a/scripts/memory-scope-readiness.js
+++ b/scripts/memory-scope-readiness.js
@@ -133,6 +133,16 @@ function normalizeId(value) {
 }
 
 function normalizeScope(input = {}) {
+  // Supermemory-style containerTag is an opaque namespace. If present and
+  // parseable as our four-field encoding, prefer it; otherwise fall through
+  // to field aliases. (Steal: https://supermemory.ai/docs/concepts/container-tags)
+  const fromTag = decodeContainerTag(
+    input.containerTag || input.container_tag || input.metadata?.containerTag
+  );
+  if (fromTag && missingScopeFields(fromTag).length === 0) {
+    return fromTag;
+  }
+
   const scope = {};
   for (const field of REQUIRED_SCOPE_FIELDS) {
     let resolved = null;
@@ -460,15 +470,281 @@ function buildMemoriStyleBenchmarkRecords() {
   ];
 }
 
+
+// ---------------------------------------------------------------------------
+// Supermemory process steal (NOT a product clone)
+// Docs: Memory vs RAG, container tags, profiles, dreaming modes.
+// ---------------------------------------------------------------------------
+
+const CONTAINER_TAG_PATTERN = /^[a-zA-Z0-9_:-]+$/;
+const DREAMING_MODES = Object.freeze(['dynamic', 'instant']);
+
+/**
+ * Encode four-field ThumbGate scope as a Supermemory-valid containerTag.
+ * Format: entity:<id>:project:<id>:process:<id>:session:<id>
+ */
+function encodeContainerTag(scopeInput = {}) {
+  const scope = normalizeScope(scopeInput);
+  const missing = missingScopeFields(scope);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      containerTag: null,
+      missingFields: missing,
+      reason: `incomplete scope: ${missing.join(', ')}`,
+    };
+  }
+  const values = [scope.entityId, scope.projectId, scope.processId, scope.sessionId];
+  if (values.some((value) => String(value).includes(':'))) {
+    return {
+      ok: false,
+      containerTag: null,
+      missingFields: [],
+      reason: 'scope field values must not contain ":" (reserved for containerTag encoding)',
+    };
+  }
+  const tag = [
+    `entity:${scope.entityId}`,
+    `project:${scope.projectId}`,
+    `process:${scope.processId}`,
+    `session:${scope.sessionId}`,
+  ].join(':');
+  if (!CONTAINER_TAG_PATTERN.test(tag) || tag.length > 100) {
+    return {
+      ok: false,
+      containerTag: null,
+      missingFields: [],
+      reason: 'encoded tag fails supermemory charset/length rules',
+    };
+  }
+  return { ok: true, containerTag: tag, missingFields: [], scope };
+}
+
+/**
+ * Decode containerTag produced by encodeContainerTag (or null if opaque).
+ */
+function decodeContainerTag(tag) {
+  const text = normalizeId(tag);
+  if (!text) return null;
+  const parts = text.split(':');
+  if (parts.length !== 8) return null;
+  const scope = {};
+  for (let i = 0; i < 8; i += 2) {
+    const key = parts[i];
+    const value = parts[i + 1];
+    if (key === 'entity') scope.entityId = value;
+    else if (key === 'project') scope.projectId = value;
+    else if (key === 'process') scope.processId = value;
+    else if (key === 'session') scope.sessionId = value;
+    else return null;
+  }
+  if (missingScopeFields(scope).length > 0) return null;
+  return scope;
+}
+
+/**
+ * Route a question to RAG (stateless knowledge) vs MEMORY (scoped temporal).
+ * Steal: https://supermemory.ai/docs/concepts/memory-vs-rag
+ * RAG answers "what do I know?"; Memory answers "what do I remember about you?"
+ */
+function routeMemoryVsRag(query = '', options = {}) {
+  const text = String(query || '').trim();
+  const scope = normalizeScope(options.scope || options);
+  const missing = missingScopeFields(scope);
+  const lower = text.toLowerCase();
+
+  const memoryCues = [
+    'i prefer', 'my preference', 'last time', 'we decided', 'remember that',
+    'what did we', 'what do i usually', 'my usual', 'for this user', 'for this project',
+    'previous mistake', 'lesson about', 'prevention rule', 'thumbs down', 'what went wrong',
+    'session', 'our agent', 'ceo said', 'standing order',
+  ];
+  const ragCues = [
+    'how does', 'where is', 'which file', 'architecture', 'implements',
+    'api endpoint', 'readme', 'documentation', 'source of', 'call graph',
+    'pretooluse', 'gate-check', 'package.json', 'what connects',
+  ];
+
+  let memoryHits = memoryCues.filter((c) => lower.includes(c)).length;
+  let ragHits = ragCues.filter((c) => lower.includes(c)).length;
+
+  // Explicit override
+  if (options.forceRail === 'memory' || options.forceRail === 'rag' || options.forceRail === 'hybrid') {
+    return finalizeRoute(options.forceRail, text, scope, missing, {
+      memoryHits,
+      ragHits,
+      reason: `forced:${options.forceRail}`,
+    });
+  }
+
+  let rail = 'hybrid';
+  let reason = 'default hybrid: prefer graphify/docs for code, lesson-store only with complete scope';
+  if (memoryHits > ragHits && memoryHits > 0) {
+    rail = 'memory';
+    reason = 'memory cues dominate (preferences, prior decisions, lessons)';
+  } else if (ragHits > memoryHits && ragHits > 0) {
+    rail = 'rag';
+    reason = 'rag cues dominate (code/docs/architecture)';
+  } else if (!text) {
+    rail = 'rag';
+    reason = 'empty query defaults to rag/code-map';
+  }
+
+  return finalizeRoute(rail, text, scope, missing, { memoryHits, ragHits, reason });
+}
+
+function finalizeRoute(rail, text, scope, missing, meta) {
+  const ok = rail !== 'memory' || missing.length === 0;
+  const container = encodeContainerTag(scope);
+  return {
+    ok,
+    rail,
+    query: text,
+    scope,
+    missingFields: missing,
+    containerTag: container.ok ? container.containerTag : null,
+    rails: {
+      rag: {
+        tools: [
+          'graphify query/path/explain (when graphify-out/graph.json exists)',
+          'grepai / codebase search',
+          'docs/ and public/ HTML',
+        ],
+        note: 'Stateless knowledge — same answer for every user',
+      },
+      memory: {
+        tools: [
+          'lesson-retrieval.js (requires complete four-field scope)',
+          'memory-scope-readiness.selectRecordsForScope',
+          'temporal-decay-weighting.js',
+        ],
+        note: 'Stateful scoped memory — fails closed without entity/project/process/session',
+      },
+    },
+    recommended: rail === 'rag'
+      ? ['graphify', 'docs']
+      : rail === 'memory'
+        ? ['lesson-retrieval', 'profile']
+        : ['graphify', 'lesson-retrieval+scope', 'profile'],
+    reason: meta.reason,
+    memoryHits: meta.memoryHits,
+    ragHits: meta.ragHits,
+    error: ok ? null : `memory rail requires complete scope; missing: ${missing.join(', ')}`,
+  };
+}
+
+/**
+ * Dreaming mode for feedback→memory promotion (Supermemory process steal).
+ * dynamic = batch related feedback into coherent units (default, cheaper/higher quality)
+ * instant = promote this signal alone immediately (demo / crisis)
+ */
+function resolveDreamingMode(input = {}) {
+  const raw = String(input.dreaming || input.mode || 'dynamic').toLowerCase().trim();
+  const mode = DREAMING_MODES.includes(raw) ? raw : 'dynamic';
+  return {
+    mode,
+    promoteImmediately: mode === 'instant',
+    batchRelated: mode === 'dynamic',
+    reason: mode === 'instant'
+      ? 'instant dreaming: promote this document/feedback alone now'
+      : 'dynamic dreaming: group related feedback before promotion (default)',
+  };
+}
+
+/**
+ * Build a static+dynamic profile from lesson-like records for one container/scope.
+ * Steal: https://supermemory.ai/docs/concepts/user-profiles
+ * Profile rides along every turn; search stays for query-specific recall.
+ */
+function buildLessonProfile(records = [], scopeInput = {}, options = {}) {
+  const scope = normalizeScope(scopeInput);
+  const missing = missingScopeFields(scope);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      missingFields: missing,
+      profile: { static: [], dynamic: [] },
+      reason: `incomplete scope: ${missing.join(', ')}`,
+    };
+  }
+
+  const selected = selectRecordsForScope(records, scope, options);
+  const now = options.now ? new Date(options.now).getTime() : Date.now();
+  const dynamicWindowMs = Number.isFinite(options.dynamicWindowMs)
+    ? options.dynamicWindowMs
+    : 14 * 24 * 60 * 60 * 1000;
+
+  const staticFacts = [];
+  const dynamicFacts = [];
+
+  for (const record of selected.allowed) {
+    const content = String(
+      record.content || record.title || record.whatWorked || record.whatToChange || ''
+    ).trim();
+    if (!content) continue;
+
+    const ts = Date.parse(record.updatedAt || record.createdAt || record.timestamp || '');
+    const ageOk = Number.isFinite(ts) ? (now - ts) <= dynamicWindowMs : false;
+    const isPreference = /prefer|always|never|standing|ceo|mandate|policy/i.test(content)
+      || record.type === 'fact'
+      || record.visibility === 'shared'
+      || record.importance === 'high';
+
+    const entry = {
+      id: record.id || null,
+      content: content.slice(0, 280),
+      type: record.type || null,
+    };
+
+    if (isPreference && !ageOk) {
+      staticFacts.push(entry);
+    } else if (ageOk) {
+      dynamicFacts.push(entry);
+    } else if (isPreference) {
+      staticFacts.push(entry);
+    } else {
+      // Older non-preference lessons stay out of always-on profile
+      // (search/lesson-retrieval still covers them).
+    }
+  }
+
+  const encoded = encodeContainerTag(scope);
+  return {
+    ok: true,
+    missingFields: [],
+    containerTag: encoded.containerTag,
+    scope,
+    profile: {
+      static: staticFacts.slice(0, options.staticLimit || 12),
+      dynamic: dynamicFacts.slice(0, options.dynamicLimit || 12),
+    },
+    counts: {
+      allowed: selected.allowed.length,
+      blocked: selected.blocked.length,
+      static: Math.min(staticFacts.length, options.staticLimit || 12),
+      dynamic: Math.min(dynamicFacts.length, options.dynamicLimit || 12),
+    },
+    reason: 'profile synthesizes always-on facts; use search/lesson-retrieval for query-specific recall',
+  };
+}
+
+
 module.exports = {
   MEMORY_OS_LAYERS,
   REQUIRED_SCOPE_FIELDS,
+  DREAMING_MODES,
+  CONTAINER_TAG_PATTERN,
+  buildLessonProfile,
   buildMemoriStyleBenchmarkRecords,
   buildMemoryOsLayerReport,
   buildMemoryScopeReadinessReport,
+  decodeContainerTag,
+  encodeContainerTag,
   isSharedMemory,
   memoryScopeKey,
   missingScopeFields,
   normalizeScope,
+  resolveDreamingMode,
+  routeMemoryVsRag,
   selectRecordsForScope,
 };

--- a/scripts/memory-vs-rag-route.js
+++ b/scripts/memory-vs-rag-route.js
@@ -24,6 +24,13 @@ const {
   routeMemoryVsRag,
 } = require('./memory-scope-readiness');
 
+function takeValue(flag, next) {
+  if (next == null || next.startsWith('-')) {
+    throw new Error(`Incomplete argument: ${flag} requires a value`);
+  }
+  return next;
+}
+
 function parseArgs(argv) {
   const out = {
     query: '',
@@ -44,25 +51,31 @@ function parseArgs(argv) {
     if (arg === '--help' || arg === '-h') out.help = true;
     else if (arg === '--json') out.json = true;
     else if (arg === '--profile') out.profile = true;
-    else if (arg === '--query' && next) { out.query = next; i += 1; }
-    else if (arg === '--dreaming' && next) { out.dreaming = next; i += 1; }
-    else if (arg === '--force-rail' && next) { out.forceRail = next; i += 1; }
-    else if (arg === '--entity' && next) { out.entityId = next; i += 1; }
-    else if (arg === '--project' && next) { out.projectId = next; i += 1; }
-    else if (arg === '--process' && next) { out.processId = next; i += 1; }
-    else if (arg === '--session' && next) { out.sessionId = next; i += 1; }
-    else if (arg === '--container-tag' && next) { out.containerTag = next; i += 1; }
+    else if (arg === '--query') { out.query = takeValue(arg, next); i += 1; }
+    else if (arg === '--dreaming') { out.dreaming = takeValue(arg, next); i += 1; }
+    else if (arg === '--force-rail') { out.forceRail = takeValue(arg, next); i += 1; }
+    else if (arg === '--entity') { out.entityId = takeValue(arg, next); i += 1; }
+    else if (arg === '--project') { out.projectId = takeValue(arg, next); i += 1; }
+    else if (arg === '--process') { out.processId = takeValue(arg, next); i += 1; }
+    else if (arg === '--session') { out.sessionId = takeValue(arg, next); i += 1; }
+    else if (arg === '--container-tag') { out.containerTag = takeValue(arg, next); i += 1; }
     else if (!arg.startsWith('-') && !out.query) out.query = arg;
     else throw new Error(`Unknown or incomplete argument: ${arg}`);
   }
   return out;
 }
 
+const MAX_STDIN_BYTES = 2 * 1024 * 1024;
+
 function readStdinJson() {
   if (process.stdin.isTTY) return null;
-  const raw = fs.readFileSync(0, 'utf8').trim();
-  if (!raw) return null;
-  return JSON.parse(raw);
+  const raw = fs.readFileSync(0, 'utf8');
+  if (Buffer.byteLength(raw, 'utf8') > MAX_STDIN_BYTES) {
+    throw new Error(`stdin exceeds ${MAX_STDIN_BYTES} bytes`);
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return JSON.parse(trimmed);
 }
 
 function printHelp() {

--- a/scripts/memory-vs-rag-route.js
+++ b/scripts/memory-vs-rag-route.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * memory-vs-rag-route.js — Supermemory process steal (NOT a product clone).
+ *
+ * RAG answers "what do I know?" (graphify/docs/code).
+ * Memory answers "what do I remember about you?" (scoped lesson store).
+ *
+ * Usage:
+ *   node scripts/memory-vs-rag-route.js --query "how does PreToolUse work?"
+ *   node scripts/memory-vs-rag-route.js --query "what did we decide about checkout?" \
+ *     --entity alice --project thumbgate --process coder --session s1 --json
+ *   node scripts/memory-vs-rag-route.js --profile --entity ... --json < records.json
+ *   node scripts/memory-vs-rag-route.js --dreaming instant --json
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {
+  buildLessonProfile,
+  encodeContainerTag,
+  resolveDreamingMode,
+  routeMemoryVsRag,
+} = require('./memory-scope-readiness');
+
+function parseArgs(argv) {
+  const out = {
+    query: '',
+    json: false,
+    profile: false,
+    dreaming: null,
+    forceRail: null,
+    help: false,
+    entityId: null,
+    projectId: null,
+    processId: null,
+    sessionId: null,
+    containerTag: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--help' || arg === '-h') out.help = true;
+    else if (arg === '--json') out.json = true;
+    else if (arg === '--profile') out.profile = true;
+    else if (arg === '--query' && next) { out.query = next; i += 1; }
+    else if (arg === '--dreaming' && next) { out.dreaming = next; i += 1; }
+    else if (arg === '--force-rail' && next) { out.forceRail = next; i += 1; }
+    else if (arg === '--entity' && next) { out.entityId = next; i += 1; }
+    else if (arg === '--project' && next) { out.projectId = next; i += 1; }
+    else if (arg === '--process' && next) { out.processId = next; i += 1; }
+    else if (arg === '--session' && next) { out.sessionId = next; i += 1; }
+    else if (arg === '--container-tag' && next) { out.containerTag = next; i += 1; }
+    else if (!arg.startsWith('-') && !out.query) out.query = arg;
+    else throw new Error(`Unknown or incomplete argument: ${arg}`);
+  }
+  return out;
+}
+
+function readStdinJson() {
+  if (process.stdin.isTTY) return null;
+  const raw = fs.readFileSync(0, 'utf8').trim();
+  if (!raw) return null;
+  return JSON.parse(raw);
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/memory-vs-rag-route.js [options]
+
+Options:
+  --query <text>         Question to route (rag | memory | hybrid)
+  --entity/--project/--process/--session
+  --container-tag <tag>  Four-field encoded tag from encodeContainerTag
+  --force-rail rag|memory|hybrid
+  --dreaming dynamic|instant
+  --profile              Build static+dynamic lesson profile (stdin JSON array)
+  --json
+  --help
+`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const scope = {
+    entityId: args.entityId,
+    projectId: args.projectId,
+    processId: args.processId,
+    sessionId: args.sessionId,
+    containerTag: args.containerTag,
+  };
+
+  if (args.dreaming && !args.query && !args.profile) {
+    const result = resolveDreamingMode({ dreaming: args.dreaming });
+    if (args.json) console.log(JSON.stringify(result, null, 2));
+    else console.log(`dreaming=${result.mode} immediate=${result.promoteImmediately}`);
+    process.exitCode = 0;
+    return;
+  }
+
+  if (args.profile) {
+    const stdin = readStdinJson();
+    const records = Array.isArray(stdin) ? stdin : (stdin?.records || []);
+    const result = buildLessonProfile(records, scope);
+    if (args.json) console.log(JSON.stringify(result, null, 2));
+    else {
+      console.log(result.ok ? 'profile: OK' : `profile: FAIL ${result.reason}`);
+      console.log(`static=${result.profile.static.length} dynamic=${result.profile.dynamic.length}`);
+    }
+    process.exitCode = result.ok ? 0 : 1;
+    return;
+  }
+
+  const route = routeMemoryVsRag(args.query, { ...scope, forceRail: args.forceRail });
+  const dreaming = resolveDreamingMode({ dreaming: args.dreaming || 'dynamic' });
+  const encoded = encodeContainerTag(scope);
+  const result = { ...route, dreaming, encodedContainerTag: encoded };
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`rail=${result.rail} ok=${result.ok}`);
+    console.log(`reason=${result.reason}`);
+    if (result.error) console.log(`error=${result.error}`);
+    console.log(`recommended=${result.recommended.join(', ')}`);
+    if (result.containerTag) console.log(`containerTag=${result.containerTag}`);
+  }
+  process.exitCode = result.ok ? 0 : 2;
+}
+
+if (path.resolve(process.argv[1] || '') === path.resolve(__filename)) {
+  try {
+    main();
+  } catch (err) {
+    console.error(String(err && err.message ? err.message : err));
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  parseArgs,
+  main,
+};

--- a/tests/memory-scope-readiness.test.js
+++ b/tests/memory-scope-readiness.test.js
@@ -251,6 +251,31 @@ test('routeMemoryVsRag memory rail succeeds with complete scope', () => {
   assert.ok(route.containerTag);
 });
 
+test('routeMemoryVsRag rejects invalid forceRail instead of falling through', () => {
+  const route = routeMemoryVsRag('how does PreToolUse work?', { forceRail: 'memroy' });
+  assert.equal(route.ok, false);
+  assert.equal(route.error, 'invalid_force_rail');
+  assert.equal(route.rail, null);
+});
+
+test('routeMemoryVsRag memory rail fails closed when encodeContainerTag rejects scope', () => {
+  const route = routeMemoryVsRag('what did we decide last time?', {
+    forceRail: 'memory',
+    entityId: 'alice:admin',
+    projectId: 'thumbgate',
+    processId: 'coder',
+    sessionId: 's1',
+  });
+  assert.equal(route.rail, 'memory');
+  assert.equal(route.ok, false);
+  assert.equal(route.containerTag, null);
+});
+
+test('decodeContainerTag rejects forbidden charset and overlength tags', () => {
+  assert.equal(decodeContainerTag('entity:alice:project:tg:process:p:session:s!'), null);
+  assert.equal(decodeContainerTag(`entity:${'a'.repeat(120)}:project:p:process:x:session:s`), null);
+});
+
 test('resolveDreamingMode defaults to dynamic', () => {
   assert.deepEqual(resolveDreamingMode({}), {
     mode: 'dynamic',

--- a/tests/memory-scope-readiness.test.js
+++ b/tests/memory-scope-readiness.test.js
@@ -189,3 +189,113 @@ test('buildMemoryOsLayerReport flags missing curation, structured facts, and int
   assert.ok(report.recommendations.some((item) => /typed records/.test(item)));
   assert.ok(report.recommendations.some((item) => /dedupe/.test(item)));
 });
+
+const {
+  buildLessonProfile,
+  decodeContainerTag,
+  encodeContainerTag,
+  resolveDreamingMode,
+  routeMemoryVsRag,
+} = require('../scripts/memory-scope-readiness');
+
+test('encode/decode containerTag round-trips four-field scope', () => {
+  const scope = {
+    entityId: 'alice',
+    projectId: 'thumbgate',
+    processId: 'coder',
+    sessionId: 'session-7',
+  };
+  const encoded = encodeContainerTag(scope);
+  assert.equal(encoded.ok, true);
+  assert.match(encoded.containerTag, /^entity:alice:project:thumbgate:process:coder:session:session-7$/);
+  assert.deepEqual(decodeContainerTag(encoded.containerTag), scope);
+  assert.deepEqual(normalizeScope({ containerTag: encoded.containerTag }), scope);
+});
+
+test('encodeContainerTag rejects colon-bearing ids', () => {
+  const bad = encodeContainerTag({
+    entityId: 'org:acme',
+    projectId: 'thumbgate',
+    processId: 'coder',
+    sessionId: 's1',
+  });
+  assert.equal(bad.ok, false);
+});
+
+test('routeMemoryVsRag sends architecture questions to rag', () => {
+  const route = routeMemoryVsRag('how does PreToolUse gate-check work?');
+  assert.equal(route.rail, 'rag');
+  assert.equal(route.ok, true);
+  assert.ok(route.recommended.includes('graphify'));
+});
+
+test('routeMemoryVsRag fails closed for memory rail without complete scope', () => {
+  const route = routeMemoryVsRag('what did we decide about checkout last time?', {
+    entityId: 'alice',
+    projectId: 'thumbgate',
+  });
+  assert.equal(route.rail, 'memory');
+  assert.equal(route.ok, false);
+  assert.deepEqual(route.missingFields, ['processId', 'sessionId']);
+});
+
+test('routeMemoryVsRag memory rail succeeds with complete scope', () => {
+  const route = routeMemoryVsRag('what did we decide about checkout last time?', {
+    entityId: 'alice',
+    projectId: 'thumbgate',
+    processId: 'coder',
+    sessionId: 's1',
+  });
+  assert.equal(route.rail, 'memory');
+  assert.equal(route.ok, true);
+  assert.ok(route.containerTag);
+});
+
+test('resolveDreamingMode defaults to dynamic', () => {
+  assert.deepEqual(resolveDreamingMode({}), {
+    mode: 'dynamic',
+    promoteImmediately: false,
+    batchRelated: true,
+    reason: 'dynamic dreaming: group related feedback before promotion (default)',
+  });
+  assert.equal(resolveDreamingMode({ dreaming: 'instant' }).promoteImmediately, true);
+});
+
+test('buildLessonProfile separates static preferences from recent dynamic facts', () => {
+  const scope = {
+    entityId: 'alice',
+    projectId: 'thumbgate',
+    processId: 'agent-a',
+    sessionId: 'session-1',
+  };
+  const now = '2026-09-04T12:00:00.000Z';
+  const records = [
+    {
+      id: 'pref',
+      ...scope,
+      importance: 'high',
+      content: 'CEO standing order: never approve PRs as the agent.',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+    {
+      id: 'recent',
+      ...scope,
+      content: 'Debugging Railway rebuild lag this week.',
+      updatedAt: '2026-09-01T00:00:00.000Z',
+    },
+    {
+      id: 'other-user',
+      entityId: 'bob',
+      projectId: 'thumbgate',
+      processId: 'agent-a',
+      sessionId: 'session-1',
+      content: 'Bob private note',
+      updatedAt: '2026-09-01T00:00:00.000Z',
+    },
+  ];
+  const profile = buildLessonProfile(records, scope, { now });
+  assert.equal(profile.ok, true);
+  assert.equal(profile.profile.static.some((f) => f.id === 'pref'), true);
+  assert.equal(profile.profile.dynamic.some((f) => f.id === 'recent'), true);
+  assert.equal(profile.profile.dynamic.some((f) => f.id === 'other-user'), false);
+});

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -487,8 +487,9 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // 522 -> 523: scripts/package-manager-honesty-doctor.js (pnpm 12 honesty).
   // 525 -> 527: workspace-search-route (#3770)
   // 527 -> 529: intent-governed-execution (#3771 CyberStrike FORMAT).
-    manifest.fileCount <= 529,
-    `npm package should stay <= 529 files, got ${manifest.fileCount}`
+  // 529 -> 530: memory-vs-rag-route.js (Supermemory FORMAT steal).
+    manifest.fileCount <= 530,
+    `npm package should stay <= 530 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -233,7 +233,7 @@ const path = require('node:path');
 // 523 → 525: jit-harness-compose (#3768)
 // 525 → 527: workspace-search-route (#3770)
 // 527 → 529: intent-governed-execution CyberStrike FORMAT (#3771)
-const BASELINE_FILE_COUNT = 529;
+const BASELINE_FILE_COUNT = 530;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -288,7 +288,7 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   //   Lockstep with package-boundary + public-bundle-ratchet.
   // 527 -> 529: intent-governed-execution after zg #3770.
   //   Lockstep with package-boundary + public-bundle-ratchet.
-  const CEILING = 529;
+  const CEILING = 530;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
## Summary
- Rebase of #3756 onto tip `main` (`35d1ca28`) after CyberStrike/zg/JIT lands made it CONFLICTING.
- Keeps ExplainX AGENTS section from tip + Memory-vs-RAG steal section.
- Packages `scripts/memory-vs-rag-route.js` and locksteps bundle ceilings at measured **530** files / **8,311,691** B unpacked (under 8.40 MB).

## Supersedes
Closes the DIRTY queue for #3756 (`feat/supermemory-memory-vs-rag-20260904`).

## Test plan
- [x] `node --test tests/memory-scope-readiness.test.js` (16 pass)
- [x] `node --test tests/public-bundle-ratchet.test.js tests/public-core-boundary.test.js tests/package-boundary.test.js`
- [x] `npm run memory:vs-rag -- --query "how does PreToolUse work?"` → `rail=rag`
- [ ] CI required checks green on this head

## Compare-not-clone
Process steal from Supermemory Memory-vs-RAG FORMAT only — not a SaaS clone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory-versus-RAG query routing with safe handling for incomplete memory scopes.
  * Added scoped container tags using entity, project, process, and session context.
  * Added static and dynamic lesson profiles, including dynamic and immediate promotion modes.
  * Added a command-line tool for routing queries, building profiles, and generating structured output.

* **Documentation**
  * Added guidance explaining memory and RAG behavior, scope isolation, routing, and command-line usage.

* **Tests**
  * Added coverage for routing, scope encoding, lesson profiles, promotion modes, and package boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->