### PR TITLE
fix(gates): sequence-guard task-scope works with THUMBGATE_SESSION_AGENT (#3682)

### DIFF
--- a/.changeset/sequence-guard-session-scope.md
+++ b/.changeset/sequence-guard-session-scope.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Fix sequence-guard task-scope tests to use session-scoped governance via setTaskScope (#3682).

--- a/scripts/sequence-guard.js
+++ b/scripts/sequence-guard.js
@@ -154,6 +154,9 @@ function evaluateSequenceState(toolName, toolInput) {
   const entry = state.repos[repoKey] || { dirty: false, lastEditAt: 0 };
 
   // 1. Task Scope Verification
+  // Prefer gates-engine (session-scoped when THUMBGATE_SESSION_AGENT is set).
+  // Fall back to the base governance-state.json when the engine returns no
+  // taskScope — keeps agents that write the base path enforceable.
   let taskScope = null;
   try {
     const engine = require('./gates-engine');
@@ -163,7 +166,8 @@ function evaluateSequenceState(toolName, toolInput) {
         taskScope = gov.taskScope;
       }
     }
-  } catch {
+  } catch { /* fall through to base file */ }
+  if (!taskScope) {
     try {
       if (fs.existsSync(GOVERNANCE_STATE_PATH)) {
         const gov = JSON.parse(fs.readFileSync(GOVERNANCE_STATE_PATH, 'utf8'));

--- a/tests/sequence-guard.test.js
+++ b/tests/sequence-guard.test.js
@@ -6,15 +6,15 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { evaluateSequenceState } = require('../scripts/sequence-guard');
+const { setTaskScope } = require('../scripts/gates-engine');
 
-const STATE_DIR = process.env.THUMBGATE_STATE_DIR || 
+const STATE_DIR = process.env.THUMBGATE_STATE_DIR ||
                   (process.env.XDG_STATE_HOME ? path.join(process.env.XDG_STATE_HOME, 'thumbgate') : null) ||
                   (process.env.CODEX_SANDBOX ? path.join(os.tmpdir(), 'thumbgate') : null) ||
                   path.join(process.env.HOME || '/tmp', '.thumbgate');
 
 const SEQUENCE_STATE_PATH = path.join(STATE_DIR, 'sequence-state.json');
 const SESSION_ACTIONS_PATH = path.join(STATE_DIR, 'session-actions.json');
-const GOVERNANCE_STATE_PATH = path.join(STATE_DIR, 'governance-state.json');
 
 function resetSequenceState() {
   try { fs.rmSync(SEQUENCE_STATE_PATH, { force: true }); } catch { /* ignore */ }
@@ -31,7 +31,9 @@ function clearTestsPassed() {
 }
 
 function resetGovernanceState() {
-  try { fs.rmSync(GOVERNANCE_STATE_PATH, { force: true }); } catch { /* ignore */ }
+  // Clear via setTaskScope so session-scoped governance files
+  // (governance-state.<THUMBGATE_SESSION_AGENT>.json) are cleared too.
+  try { setTaskScope({ clear: true }); } catch { /* ignore */ }
 }
 
 const REPO = process.cwd();
@@ -85,15 +87,11 @@ test('sequence-guard - edit in one repo does NOT block a commit in another (per-
 test('sequence-guard - task scope active - edit outside allowedPaths is blocked', () => {
   resetSequenceState();
   clearTestsPassed();
+  resetGovernanceState();
 
-  // Set up active task scope allowing only files under src/api
-  fs.mkdirSync(STATE_DIR, { recursive: true });
-  fs.writeFileSync(GOVERNANCE_STATE_PATH, JSON.stringify({
-    taskScope: {
-      allowedPaths: ['src/api/**'],
-      repoPath: REPO
-    }
-  }));
+  // Use setTaskScope so the write lands on the same session-scoped
+  // governance path loadGovernanceState / sequence-guard read.
+  setTaskScope({ allowedPaths: ['src/api/**'], repoPath: REPO });
 
   // Editing a file inside allowedPaths -> should be allowed (returns null)
   const allowedEdit = evaluateSequenceState('Edit', { file_path: path.join(REPO, 'src/api/server.js') });
@@ -112,20 +110,14 @@ test('sequence-guard - task scope active - edit outside allowedPaths is blocked'
 test('sequence-guard - task scope active - commit/complete with modified files outside allowedPaths is blocked', () => {
   resetSequenceState();
   clearTestsPassed();
+  resetGovernanceState();
 
   // Write a temporary untracked file to ensure there is a modified file outside allowedPaths
   const tempFile = path.join(REPO, 'tests/temp-test-file.txt');
   fs.writeFileSync(tempFile, 'temp content', 'utf8');
 
   try {
-    // Mock task scope allowing files under 'dummy'
-    fs.mkdirSync(STATE_DIR, { recursive: true });
-    fs.writeFileSync(GOVERNANCE_STATE_PATH, JSON.stringify({
-      taskScope: {
-        allowedPaths: ['dummy/**'],
-        repoPath: REPO
-      }
-    }));
+    setTaskScope({ allowedPaths: ['dummy/**'], repoPath: REPO });
 
     // Commit attempt should fail since we have a modified file that doesn't match 'dummy/**'
     const commit = evaluateSequenceState('Bash', { command: 'git commit -m "wip"', repoPath: REPO });
@@ -133,7 +125,7 @@ test('sequence-guard - task scope active - commit/complete with modified files o
     assert.equal(commit.decision, 'deny');
     assert.equal(commit.gate, 'task-scope-violation');
   } finally {
-    try { fs.unlinkSync(tempFile); } catch {}
+    try { fs.unlinkSync(tempFile); } catch { /* ignore */ }
   }
 
   resetSequenceState();


### PR DESCRIPTION
**Summary**
- Closes the red AC on #3682: task-scope edit/commit denials now pass **5/5** with and without `THUMBGATE_SESSION_AGENT`.
- Root cause: tests wrote `~/.thumbgate/governance-state.json` while `gates-engine.loadGovernanceState()` reads `governance-state.<session>.json` when a session agent is set.
- Fix: drive scope through `setTaskScope` / `setTaskScope({ clear: true })`; sequence-guard also falls back to the base governance file when the engine returns null `taskScope`.

**Test plan**
- [x] `env -u THUMBGATE_SESSION_AGENT node --test tests/sequence-guard.test.js` → 5/5
- [x] `THUMBGATE_SESSION_AGENT=grok-test-session node --test tests/sequence-guard.test.js` → 5/5
- [ ] CI required checks

Closes #3682 when merged.