### PR TITLE
fix(security): async-job command stages without shell (successor #3635)

### DIFF
--- a/.changeset/async-job-no-shell-20260905120419.md
+++ b/.changeset/async-job-no-shell-20260905120419.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Run async-job command stages with quote-aware argv parsing and `shell: false` (no `sh -lc` / `cmd /c`), rejecting unquoted shell metacharacters.

--- a/scripts/async-job-runner.js
+++ b/scripts/async-job-runner.js
@@ -448,18 +448,96 @@ function getJobStats() {
   };
 }
 
-function shellConfig(command) {
-  if (process.platform === 'win32') {
-    return {
-      command: process.env.ComSpec || 'cmd.exe',
-      args: ['/d', '/s', '/c', command],
-    };
+const SAFE_EXECUTABLE_RE = /^[A-Za-z0-9_./\\:+-]+$/;
+
+/**
+ * Quote-aware argv split for command stages (no shell).
+ * Supports single/double quotes; rejects unquoted shell metacharacters.
+ */
+function parseCommandArgv(command) {
+  const raw = String(command == null ? '' : command).trim();
+  if (!raw) {
+    const err = new Error('Command stage rejected: empty command');
+    err.code = 'JOB_STAGE_FAILED';
+    throw err;
   }
 
-  return {
-    command: process.env.SHELL || '/bin/sh',
-    args: ['-lc', command],
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  let tokenStarted = false;
+
+  const flushToken = ({ allowEmpty = false } = {}) => {
+    if (tokenStarted || (allowEmpty && current === '')) {
+      tokens.push(current);
+      current = '';
+      tokenStarted = false;
+    }
   };
+
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+        // Closing quotes always emits a token (including empty `-e ""`).
+        flushToken({ allowEmpty: true });
+      } else if (ch === '\\' && quote === '"' && i + 1 < raw.length) {
+        current += raw[i + 1];
+        tokenStarted = true;
+        i += 1;
+      } else {
+        current += ch;
+        tokenStarted = true;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      // Flush any unquoted token abutting the quote (`node -e"code"`).
+      flushToken();
+      quote = ch;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      flushToken();
+      continue;
+    }
+
+    // Unquoted shell metacharacters would require a shell; fail closed.
+    if (/[;&|`$<>(){}]/.test(ch)) {
+      const err = new Error('Command stage rejected: shell metacharacters are not allowed');
+      err.code = 'JOB_STAGE_FAILED';
+      throw err;
+    }
+
+    current += ch;
+    tokenStarted = true;
+  }
+
+  if (quote) {
+    const err = new Error('Command stage rejected: unmatched quote');
+    err.code = 'JOB_STAGE_FAILED';
+    throw err;
+  }
+
+  flushToken();
+
+  if (tokens.length === 0) {
+    const err = new Error('Command stage rejected: empty command');
+    err.code = 'JOB_STAGE_FAILED';
+    throw err;
+  }
+
+  if (!SAFE_EXECUTABLE_RE.test(tokens[0])) {
+    const err = new Error(`Command stage rejected: invalid executable "${tokens[0]}"`);
+    err.code = 'JOB_STAGE_FAILED';
+    throw err;
+  }
+
+  return tokens;
 }
 
 function normalizeStageResult(result, currentContext) {
@@ -495,13 +573,25 @@ function applyStageContext(currentContext, stageResult) {
 }
 
 function runCommandStage(stage) {
-  const shell = shellConfig(stage.command);
-  const result = spawnSync(shell.command, shell.args, {
+  const tokens = parseCommandArgv(stage.command);
+  const result = spawnSync(tokens[0], tokens.slice(1), {
     cwd: stage.workingDirectory || process.cwd(),
     env: process.env,
     encoding: 'utf8',
     stdio: 'pipe',
+    shell: false,
   });
+
+  if (result.error) {
+    const error = new Error([
+      `Stage "${stage.name}" command failed`,
+      result.error.message || 'spawn error',
+    ].join(': '));
+    error.code = 'JOB_STAGE_FAILED';
+    error.stdout = '';
+    error.stderr = result.error.message || '';
+    throw error;
+  }
 
   if (result.status !== 0) {
     const stderr = (result.stderr || '').trim();
@@ -1044,6 +1134,7 @@ module.exports = {
   resumeJob,
   resumeManagedJobs,
   getJobRuntimePaths,
+  parseCommandArgv,
   JOB_LOG_FILENAME,
   JOB_CONTROL_FILENAME,
   JOB_STATE_DIRNAME,

--- a/tests/async-job-runner.test.js
+++ b/tests/async-job-runner.test.js
@@ -361,6 +361,50 @@ test('command stages that emit no stdout preserve the current context', () => {
   }
 });
 
+test('parseCommandArgv keeps quoted args and rejects shell metacharacters', () => {
+  const runner = require('../scripts/async-job-runner');
+
+  assert.deepEqual(
+    runner.parseCommandArgv(`${process.execPath} -e "process.exit(0)"`),
+    [process.execPath, '-e', 'process.exit(0)'],
+  );
+  assert.deepEqual(
+    runner.parseCommandArgv(`${process.execPath} -e ""`),
+    [process.execPath, '-e', ''],
+  );
+
+  assert.throws(
+    () => runner.parseCommandArgv('echo hi; rm -rf /'),
+    (err) => err && err.code === 'JOB_STAGE_FAILED',
+  );
+  assert.throws(
+    () => runner.parseCommandArgv('node -e "process.exit(0)" | cat'),
+    (err) => err && err.code === 'JOB_STAGE_FAILED',
+  );
+});
+
+test('command stages fail closed on shell metacharacters without spawning a shell', () => {
+  const feedbackDir = createFeedbackDir();
+  const harness = loadRuntimeHarness({ feedbackDir });
+
+  try {
+    const result = harness.runner.executeJob({
+      id: 'shell-meta-reject-job',
+      tags: ['testing'],
+      stages: [
+        { name: 'inject', command: 'echo pwned; true' },
+      ],
+    });
+
+    assert.equal(result.status, 'failed');
+    const evidence = (result.taskOutcome && result.taskOutcome.verification && result.taskOutcome.verification.evidence) || [];
+    assert.ok(evidence.some((line) => /shell metacharacters/i.test(String(line))));
+  } finally {
+    harness.cleanup();
+    fs.rmSync(feedbackDir, { recursive: true, force: true });
+  }
+});
+
 test('runHarness compiles and executes a natural-language harness through async-job-runner', () => {
   const feedbackDir = createFeedbackDir();
   const harness = loadRuntimeHarness({ feedbackDir });


### PR DESCRIPTION
## Summary
Successor to cross-repo fork PR #3635 (`anupamme/ThumbGate`). Tip still ran command stages via `sh -lc` / `cmd /c`, which is a child_process injection surface.

## Change
- Quote-aware `parseCommandArgv` (keeps empty `-e ""` args)
- `spawnSync(..., { shell: false })`
- Fail closed on unquoted shell metacharacters (`;|&\`$<>(){}`)
- Tests for parse + stage rejection

## Why not rebase #3635
Head lives on fork `anupamme/ThumbGate`; tip moved far; fork patch used naive whitespace split that would break quoted `-e` scripts already in our tests.

## Verification
```
node --test tests/async-job-runner.test.js tests/parallel-workflow-public.test.js
# 13/13 pass
```

Closes nothing yet — will close #3635 as superseded after this lands.