### PR TITLE
fix(deploy): stop Vercel hobby rate-limits; unblock Railway ownership gate

### DIFF
--- a/.changeset/vercel-disable-git-deploys-20260905.md
+++ b/.changeset/vercel-disable-git-deploys-20260905.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Disable Vercel Git auto-deploys (hobby rate-limit noise) and allow unpublished npm ownership on Railway post-deploy checks between releases.

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -322,6 +322,10 @@ jobs:
             --max-attempts=6 \
             --retry-delay-ms=10000 \
             --json
+      # Between releases npm correctly has no package for this SHA (tag may
+      # already exist on an older commit). Fail-closed on foreign ownership;
+      # allow unpublished so content-only main deploys stay green. The earlier
+      # pre-deploy ownership step already uses --allow-unpublished.
       - name: Verify deployed package ownership after publication
         if: steps.railway-config.outputs.enabled == 'true'
         timeout-minutes: 12
@@ -329,6 +333,7 @@ jobs:
           node scripts/verify-npm-githead.js \
             --version="$(node -p "require('./package.json').version")" \
             --expected-sha="$GITHUB_SHA" \
+            --allow-unpublished \
             --max-attempts=60 \
             --retry-delay-ms=10000 \
             --json

--- a/docs/agents/vercel-hobby-not-prod.md
+++ b/docs/agents/vercel-hobby-not-prod.md
@@ -1,0 +1,13 @@
+# Vercel on ThumbGate (hobby) — not production
+
+**Production is Railway** (`https://thumbgate-production.up.railway.app` / `thumbgate.ai`).
+
+The Vercel project `thumbgate` under the hobby team `igorganapolskys-projects` used to auto-build every GitHub PR/push. On the free plan that hit **build rate limits** (`upgradeToPro=build-rate-limit`) and painted optional `Vercel` checks red/pending on PRs even when required CI was green.
+
+## Durable posture (2026-09-05)
+
+1. Repo `vercel.json` sets `"git": { "deploymentEnabled": false }` so Git pushes never start Vercel builds.
+2. Project Ignored Build Step is also set to `exit 0` (skip all builds) as a belt-and-suspenders control.
+3. `config/merge-quality-checks.json` already lists `Vercel` / `Vercel Preview Comments` as **optional** — Trunk must not wait on them.
+
+Do **not** re-enable Git deployments without upgrading the Vercel plan **and** an explicit product decision that Vercel previews are worth the quota.

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -431,7 +431,6 @@ test('Deploy to Railway hard-gates build health and keeps revenue readiness advi
   assert.match(ownershipStep, /--expected-sha="\$GITHUB_SHA"/);
   assert.match(ownershipStep, /--max-attempts=(?:[3-9][0-9]|[1-9][0-9]{2,})/);
   assert.match(ownershipStep, /--allow-unpublished/, 'content merges between npm releases must not red the Railway Deploy workflow');
-  assert.match(ownershipStep, /--max-attempts=(?:[3-9][0-9]|[1-9][0-9]{2,})/);
   assert.ok(revenueIndex > healthIndex, 'revenue readiness must inspect the promoted build after SHA verification');
   assert.ok(revenueIndex > behaviorIndex, 'revenue readiness follows the hard authenticated behavior gate');
   assert.ok(evidenceIndex > revenueIndex, 'revenue evidence upload must follow the advisory probe');

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -430,7 +430,8 @@ test('Deploy to Railway hard-gates build health and keeps revenue readiness advi
   assert.match(ownershipStep, /node scripts\/verify-npm-githead\.js/);
   assert.match(ownershipStep, /--expected-sha="\$GITHUB_SHA"/);
   assert.match(ownershipStep, /--max-attempts=(?:[3-9][0-9]|[1-9][0-9]{2,})/);
-  assert.doesNotMatch(ownershipStep, /--allow-unpublished/);
+  assert.match(ownershipStep, /--allow-unpublished/, 'content merges between npm releases must not red the Railway Deploy workflow');
+  assert.match(ownershipStep, /--max-attempts=(?:[3-9][0-9]|[1-9][0-9]{2,})/);
   assert.ok(revenueIndex > healthIndex, 'revenue readiness must inspect the promoted build after SHA verification');
   assert.ok(revenueIndex > behaviorIndex, 'revenue readiness follows the hard authenticated behavior gate');
   assert.ok(evidenceIndex > revenueIndex, 'revenue evidence upload must follow the advisory probe');

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## What was wrong

Two different reds were getting confused as “Vercel”:

1. **Vercel hobby build rate limit** — open PRs linked to `upgradeToPro=build-rate-limit` because the hobby project auto-built every GitHub push/PR. Optional check, but noisy and looked like a product outage.
2. **Railway Deploy false-red** (screenshot of “Verify deployed package ownership after publication”) — between npm releases `verify-npm-githead` correctly saw `unpublished` and burned 60 retries after Railway had already shipped the SHA (prod `/health.buildSha` matched tip).

Production remains **Railway**, not Vercel.

## Fix

- Tracked `vercel.json` with `"git": { "deploymentEnabled": false }`
- Vercel project Ignored Build Step already set live to `exit 0` via API
- Railway post-deploy ownership step now uses `--allow-unpublished` (still fails closed on foreign `gitHead`)
- Doc: `docs/agents/vercel-hobby-not-prod.md`
- Deleted mistaken local `scripts/vercel-deploy.js` attempt to host the API on Vercel

## Test plan
- [x] `node --test tests/deployment.test.js` (63/63)
- [ ] Required CI green → Trunk
- [ ] After merge: Railway Deploy no longer fails ownership between releases; new PRs do not start Vercel builds