### PR TITLE
docs(agents): record Vercel Git disconnect (stale PR checks caveat)

### DIFF
--- a/.changeset/vercel-git-disconnected-20260906.md
+++ b/.changeset/vercel-git-disconnected-20260906.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Record that the Vercel thumbgate project is Git-disconnected so hobby rate-limit statuses stop on new pushes.

--- a/docs/agents/vercel-hobby-not-prod.md
+++ b/docs/agents/vercel-hobby-not-prod.md
@@ -11,3 +11,16 @@ The Vercel project `thumbgate` under the hobby team `igorganapolskys-projects` u
 3. `config/merge-quality-checks.json` already lists `Vercel` / `Vercel Preview Comments` as **optional** — Trunk must not wait on them.
 
 Do **not** re-enable Git deployments without upgrading the Vercel plan **and** an explicit product decision that Vercel previews are worth the quota.
+
+
+## Git disconnect (2026-09-06)
+
+The Vercel project `thumbgate` is **no longer linked** to `IgorGanapolsky/ThumbGate`
+(`vercel git disconnect`). Combined with `vercel.json` `git.deploymentEnabled: false`
+and Ignored Build Step `exit 0`, pushes and PRs must not create new Vercel deployments
+or fresh Vercel commit statuses.
+
+**Stale UI caveat:** open PRs that already received a Vercel status before disconnect
+can still show that historical check (including old `upgradeToPro=build-rate-limit`
+links). Those rows are non-required and do not clear until the PR head moves or the
+PR closes. Do not treat them as a live outage.


### PR DESCRIPTION
## Why
After #3784, live controls were: `ignoreCommand=exit 0` + `vercel.json` `git.deploymentEnabled:false`.
CEO pushback: old CONFLICTING PRs still showed stale Vercel rate-limit rows.

## What changed
- Ran `vercel git disconnect` on project `thumbgate` — API now reports `link=null`.
- Documented disconnect + **stale-UI caveat** in `docs/agents/vercel-hobby-not-prod.md`.

## Honesty
Historical Vercel statuses on open DIRTY PRs are not deleted by disconnect; they stay until those heads move or PRs close. New pushes should not get new Vercel statuses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that the Vercel project is disconnected from the repository.
  * Clarified that pushes and pull requests no longer create Vercel deployments or new commit statuses.
  * Noted that historical Vercel checks may remain visible on existing pull requests and do not indicate active outages.

* **Chores**
  * Added a patch release entry for the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->