### PR TITLE
chore(deps): bump @anthropic-ai/sdk to ^0.122.0 (successor of #3800)

### DIFF
--- a/.changeset/dependabot-pr-3800-succ.md
+++ b/.changeset/dependabot-pr-3800-succ.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Dependabot successor for #3800: bump @anthropic-ai/sdk to ^0.122.0 on current main.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.117.1",
+        "@anthropic-ai/sdk": "^0.122.0",
         "@google/genai": "2.19.0",
         "@lancedb/lancedb": "^0.37.1",
         "apache-arrow": "^18.1.0",
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.117.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
-      "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.122.0.tgz",
+      "integrity": "sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1232,7 +1232,7 @@
     "node": ">=18.18.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "0.117.1",
+    "@anthropic-ai/sdk": "^0.122.0",
     "@google/genai": "2.19.0",
     "@lancedb/lancedb": "^0.37.1",
     "apache-arrow": "^18.1.0",


### PR DESCRIPTION
**Summary**
- Successor to CONFLICTING Dependabot #3800 after tip moved.
- Regenerated `package-lock.json` from current `main` and applied `@anthropic-ai/sdk@^0.122.0`.

**Test plan**
- [x] `npm install --package-lock-only --ignore-scripts`
- [ ] required CI green
- [ ] `npm run pr:manage`

Supersedes #3800.

<!-- This is an auto-generated comment: release notes by [coderabbit.ai](http://coderabbit.ai) -->

**Summary by CodeRabbit**

- **Chores**
  * Updated the underlying AI integration to a newer supported version.
  * Included a patch release for this maintenance update.

<!-- end of auto-generated comment: release notes by [coderabbit.ai](http://coderabbit.ai) -->