### PR TITLE
chore(deps): bump @lancedb/lancedb to ^0.38.0 (successor of #3799)

### DIFF
--- a/.changeset/dependabot-pr-3799-succ.md
+++ b/.changeset/dependabot-pr-3799-succ.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Dependabot successor for #3799: bump @lancedb/lancedb to ^0.38.0 on current main.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "0.117.1",
         "@google/genai": "2.19.0",
-        "@lancedb/lancedb": "^0.37.1",
+        "@lancedb/lancedb": "^0.38.0",
         "apache-arrow": "^18.1.0",
         "better-sqlite3": "^12.9.0",
         "dotenv": "^17.4.2",
@@ -1021,9 +1021,9 @@
       }
     },
     "node_modules/@lancedb/lancedb": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.37.1.tgz",
-      "integrity": "sha512-l+si3t+bQ1JNxrnEfbbfKt9gWk2HcWYWx0dzoEBTVAs8B0BP79OrAv+mKTJ0EwG5wRDS3MwEChEg0g0Wh8I3tQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.38.0.tgz",
+      "integrity": "sha512-10+Cy0P8GyGg7d6l6AmuruEfFt6sxdCZNFCmhcJyUofvopxCb1yIiFNXsfzjO8Iyh2hijTEuyKTzIi4LGlH6Kw==",
       "cpu": [
         "x64",
         "arm64"
@@ -1039,21 +1039,21 @@
         "reflect-metadata": "^0.2.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
       },
       "optionalDependencies": {
         "@huggingface/transformers": "3.0.2",
-        "@lancedb/lancedb-darwin-arm64": "0.37.1",
-        "@lancedb/lancedb-linux-arm64-gnu": "0.37.1",
-        "@lancedb/lancedb-linux-arm64-musl": "0.37.1",
-        "@lancedb/lancedb-linux-x64-gnu": "0.37.1",
-        "@lancedb/lancedb-linux-x64-musl": "0.37.1",
-        "@lancedb/lancedb-win32-arm64-msvc": "0.37.1",
-        "@lancedb/lancedb-win32-x64-msvc": "0.37.1",
+        "@lancedb/lancedb-darwin-arm64": "0.38.0",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.38.0",
+        "@lancedb/lancedb-linux-arm64-musl": "0.38.0",
+        "@lancedb/lancedb-linux-x64-gnu": "0.38.0",
+        "@lancedb/lancedb-linux-x64-musl": "0.38.0",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.38.0",
+        "@lancedb/lancedb-win32-x64-msvc": "0.38.0",
         "openai": "4.29.2"
       },
       "peerDependencies": {
-        "@types/node": ">=18",
+        "@types/node": ">=22",
         "apache-arrow": ">=15.0.0 <=18.1.0"
       },
       "peerDependenciesMeta": {
@@ -1063,9 +1063,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-darwin-arm64": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.37.1.tgz",
-      "integrity": "sha512-t/SRU1no2rf7bdgCAIhhAdm8oI/l5ne1Xuq50BEAKxSfJjZq7RSd8Khg0cLy1Pwrfr8v78VpJVluPTbQSn97kQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.38.0.tgz",
+      "integrity": "sha512-AOSqmezmLGjv7SjZfDdzYznebdihApjPklhIJJ8cFfMsqYqc1pJtRAM8zWKotbiwLOg31ttIcGIoWbv/0dUJSQ==",
       "cpu": [
         "arm64"
       ],
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.37.1.tgz",
-      "integrity": "sha512-YvyxTbjsysvrR4kXRzIspDvg+wGH/Xq1yiXEEg0I+gYO7NFq2I+2bYtjOhUcUM+EDVVFP2Y6n7sKZvqqP5dZ/A==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.38.0.tgz",
+      "integrity": "sha512-Lgw64fSC5+jRpEpYtPnOOOIq7ODc+uXnAbdzAoofqmzjizfT2s8MoFVq1I/oXHxgKbEQLyeM3IrRqp7ur2+ivA==",
       "cpu": [
         "arm64"
       ],
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-arm64-musl": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.37.1.tgz",
-      "integrity": "sha512-/c8M97zgnpRveB7XBkQb8xtaCgS/h+sZ/txKPE8uNyEKrJK78s8x94hjlnciCZ8cnv90WGzqK0Nf9BA3Up2OGg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.38.0.tgz",
+      "integrity": "sha512-g1TWe8QxCTU2YwSTs8LqJVnK+kmws6cSxq04xo8ap6RefybUq67ik9DUNR6H0oqkPuM5HBfPNoYvZvCIWeuFAg==",
       "cpu": [
         "arm64"
       ],
@@ -1111,9 +1111,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-gnu": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.37.1.tgz",
-      "integrity": "sha512-PAmTlvNJBE+0t27bBS3PVLt1pSULhnDRSlNSOXkB1roK8g5ay1X6djifkIAkkebM/PCkaJc2aEf3l9lXm2NoAQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.38.0.tgz",
+      "integrity": "sha512-RdlMdP4JjMvK1Ro7esrhtLsSwdO0jrZnD+XNEZswQz00apvPF/F3+nLcY94IVH44Tho8jBP9qgVc4y+GimIHKQ==",
       "cpu": [
         "x64"
       ],
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-linux-x64-musl": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.37.1.tgz",
-      "integrity": "sha512-ZgpyeNJlzChghoME4P+FwOiuwhNQcVAtab+yiwe4eG87JtSqkS5VjIu40vKWV4XT5lCc5y/yWfpwTuaY496W9g==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.38.0.tgz",
+      "integrity": "sha512-5lbuUJijTuypzRrNHNGEa7iYe2T22sgTZBRmf3S/zis0sFiT3pxPvEEOu8nhF3GstPbJElBweFPW6Yzfpa4o3Q==",
       "cpu": [
         "x64"
       ],
@@ -1143,9 +1143,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.37.1.tgz",
-      "integrity": "sha512-fzZWKbZfhA7CJ9axZ7ZyOLJRtgItEudkwWHxzvdS1ta+fhvfoLGP0QTozvJkNVJzG95zXsuQ9uHyzA/7MPlGcA==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.38.0.tgz",
+      "integrity": "sha512-ObG2yXxZxo3mEJp7whFh1A4rspJW8DxMGRnLvjPs9EvCoyqjOXaIgrsqL+FnsZ4g3HAGYYOmUhusTYcD0Nu54g==",
       "cpu": [
         "arm64"
       ],
@@ -1159,9 +1159,9 @@
       }
     },
     "node_modules/@lancedb/lancedb-win32-x64-msvc": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.37.1.tgz",
-      "integrity": "sha512-3pfkTlCHPVXn9s7adRbf6mbwUYQxsabzUzCywQnXv+kR46tE1znHjkP44ZganrzH0tVWGL6eOD0Lvsw8tIXYNQ==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.38.0.tgz",
+      "integrity": "sha512-DrzY0/XSyf7z8+xiSXQWhwREaNXLsxvRqbrdWLr4cisOoZe80PoEWQiwqKNIgHRyHY9alXPoyXj9BV60pkvanw==",
       "cpu": [
         "x64"
       ],
@@ -1346,12 +1346,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -1431,6 +1431,21 @@
       "bin": {
         "arrow2csv": "bin/arrow2csv.js"
       }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3822,9 +3837,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "license": "MIT"
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -1234,7 +1234,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "0.117.1",
     "@google/genai": "2.19.0",
-    "@lancedb/lancedb": "^0.37.1",
+    "@lancedb/lancedb": "^0.38.0",
     "apache-arrow": "^18.1.0",
     "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary
- Successor to CONFLICTING Dependabot #3799 after tip moved.
- Regenerated `package-lock.json` from current `main` and applied `@lancedb/lancedb@^0.38.0`.

## Test plan
- [x] `npm install --package-lock-only --ignore-scripts`
- [ ] required CI green
- [ ] `npm run pr:manage`

Supersedes #3799.