### PR TITLE
fix(ci): treat Gitar as optional merge-quality check

### DIFF
--- a/.changeset/gitar-optional-check.md
+++ b/.changeset/gitar-optional-check.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Treat Gitar status as optional in merge-quality checks so pending Gitar no longer blocks pr:manage.

--- a/config/merge-quality-checks.json
+++ b/config/merge-quality-checks.json
@@ -27,6 +27,8 @@
   ],
   "optionalChecks": [
     "Vercel",
-    "Vercel Preview Comments"
+    "Vercel Preview Comments",
+    "Gitar",
+    "Gitar AI"
   ]
 }


### PR DESCRIPTION
## Summary
- Pending **Gitar** was blocking `npm run pr:manage` even when every required protection context was SUCCESS.
- Add `Gitar` / `Gitar AI` to `optionalChecks` in `config/merge-quality-checks.json` (same class as Vercel).

## Test plan
- [x] Config JSON valid
- [ ] required CI green
- [ ] `npm run pr:manage` no longer blocks solely on pending Gitar