### PR TITLE
feat(honesty): OpenUI catalog-compose FORMAT steal

### DIFF
--- a/.agents/skills/openui-catalog-compose-honesty/SKILL.md
+++ b/.agents/skills/openui-catalog-compose-honesty/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: openui-catalog-compose-honesty
+description: >
+  OpenUI FORMAT steal: catalog-compose-only, root-first streaming, repair-before-claim.
+  Audit agent-composed UI against an allowlisted component catalog; never clone OpenUI,
+  Thesys Gateway, or a generative-UI SKU. Slash: /openui-catalog-compose-honesty.
+---
+
+# OpenUI Catalog-Compose Honesty
+
+## Goal
+Keep agent-composed UI honest: only allowlisted components, root-first streams, repair before any ready/done claim. Steal OpenUI FORMAT — do not clone the product.
+
+## Constraints
+- Never install `@openuidev/cli`, OpenUI Gateway, or Thesys Observability as ThumbGate
+- Never invent components outside the catalog or `eval` / `new Function` generated UI
+- Never claim UI/compose ready without `--repair --claim-ready` evidence
+- Never dual-edit a sibling OpenUI/generative-UI WIP PR
+- ECI: no net-new generative-UI SKU
+
+## Reference
+- https://www.openui.com/ (source FORMAT)
+- Gates: `require-catalog-compose-only`, `require-repair-before-compose-claim`
+- Script: `scripts/openui-catalog-compose-honesty.js`
+- Docs: `docs/agents/openui-catalog-compose-honesty.md`
+
+## Examples
+```bash
+# Clean catalog stream → ready
+npx thumbgate openui-catalog-compose-honesty \
+  --catalog=catalog.json \
+  --stream=compose.txt \
+  --repair --claim-ready --json
+
+# Unknown component / missing root → fail
+npx thumbgate openui-catalog-compose-honesty \
+  --catalog='{"components":["Stack"]}' \
+  --stream=$'header = Ghost()\n' \
+  --json
+```
+
+Catalog:
+```json
+{ "components": ["Stack", "Card", "Table"] }
+```
+
+Stream (root first):
+```
+root = Stack([header, body])
+header = Card()
+body = Table([row])
+```
+
+## Procedures
+1. Check sibling WIP for OpenUI/generative-UI PRs — do not duplicate.
+2. Write or load a component catalog JSON.
+3. Run doctor with `--catalog` + `--stream` (+ `--repair`).
+4. Before any UI/compose done claim, re-run with `--claim-ready --strict`.
+5. Wire gates from `config/gate-templates.json` Agent Honesty pair.
+
+## Rubric
+- ok=true when doctor status is `ready` with `repairClean=true` on the claimed stream
+- ok=false on unknown components, missing root, arbitrary-code markers, or OpenUI SKU clone signals
+- evidence: `--json` report in the same turn

--- a/.changeset/openui-catalog-compose-honesty.md
+++ b/.changeset/openui-catalog-compose-honesty.md
@@ -1,0 +1,7 @@
+---
+"thumbgate": patch
+---
+
+Steal OpenUI's catalog-compose-only / root-first / repair-before-claim FORMAT onto ThumbGate honesty rails.
+
+Adds `openui-catalog-compose-honesty` doctor + CLI, Agent Honesty gate templates (`require-catalog-compose-only`, `require-repair-before-compose-claim`), and skill. Does not install `@openuidev/cli`, OpenUI Gateway, or Thesys Observability, and does not ship a generative-UI SKU.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2734,6 +2734,27 @@ function packageManagerHonestyDoctor() {
   if (report.status === 'fail') process.exitCode = 1;
 }
 
+function openuiCatalogComposeHonestyDoctor() {
+  const args = parseArgs(process.argv.slice(3));
+  const {
+    buildOpenuiCatalogComposeHonestyReport,
+    formatOpenuiCatalogComposeHonestyReport,
+  } = require(path.join(PKG_ROOT, 'scripts', 'openui-catalog-compose-honesty'));
+  const report = buildOpenuiCatalogComposeHonestyReport(args);
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    process.stdout.write(formatOpenuiCatalogComposeHonestyReport(report));
+  }
+
+  if (args.strict && report.status !== 'ready') {
+    process.exitCode = 1;
+    return;
+  }
+  if (report.status === 'fail') process.exitCode = 1;
+}
+
 
 async function workspaceSearchRoute() {
   const args = parseArgs(process.argv.slice(3));
@@ -3538,6 +3559,7 @@ function help() {
   console.log('  deepseek-v4-runtime-guardrails Map sparse-attention runtime signals to safety gates');
   console.log('  nvidia-specdecode-al-doctor Check speculative AL/D evidence vs AL/(1+ρD) speedup math');
   console.log('  package-manager-honesty-doctor Audit lockfile/CI parity; fail-closed manager switches');
+  console.log('  openui-catalog-compose-honesty Catalog-compose-only + repair-before-claim (OpenUI FORMAT)');
   console.log('  allowlist-bridge-honesty Audit allowlisted registries/proxies as hops, not trust boundaries');
   console.log('  jit-harness-compose   Compose memory/planning/action/capability onto existing rails (JIT FORMAT)');
   console.log('  workspace-search-route     Route query to rg/fts/vector/hybrid/graph (zg FORMAT)');
@@ -3580,6 +3602,7 @@ function help() {
   console.log('  npx thumbgate deepseek-v4-runtime-guardrails --context-tokens=900000 --hybrid-attention --speculative-decoding --accept-length=1.4 --precision-mode=fp8 --json');
   console.log('  npx thumbgate nvidia-specdecode-al-doctor --speculative-decoding --accept-length=1.4 --draft-length=7 --draft-depth-ratio=0.05 --claimed-speedup=3 --json');
   console.log('  npx thumbgate package-manager-honesty-doctor --propose-switch=pnpm --json');
+  console.log('  npx thumbgate openui-catalog-compose-honesty --catalog=catalog.json --stream=compose.txt --repair --json');
   console.log('  npx thumbgate allowlist-bridge-honesty --json');
   console.log('  npx thumbgate jit-harness-compose --task="implement PreToolUse gate fix" --json');
   console.log('  npx thumbgate workspace-search-route --query="how does X connect" --json');
@@ -4223,6 +4246,12 @@ switch (COMMAND) {
   case 'pnpm12-honesty-doctor':
   case 'lockfile-ci-parity-doctor':
     packageManagerHonestyDoctor();
+    break;
+  case 'openui-catalog-compose-honesty':
+  case 'openui-honesty-doctor':
+  case 'catalog-compose-honesty':
+  case 'repair-before-compose-claim':
+    openuiCatalogComposeHonestyDoctor();
     break;
   case 'allowlist-bridge-honesty':
   case 'gitlab-sandbox-allowlist':

--- a/config/gate-templates.json
+++ b/config/gate-templates.json
@@ -38,6 +38,30 @@
       "rollout": "Use for every workflow where proof matters more than speed."
     },
     {
+      "id": "require-catalog-compose-only",
+      "name": "Require catalog-compose-only agent UI",
+      "category": "Agent Honesty",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "high",
+      "pattern": "(generative\\s*ui|compose\\s*ui|openui|@openuidev).*(invent|arbitrary|eval|new Function|dangerouslySetInnerHTML|install\\s+@openuidev|clone\\s+openui)|component\\s+not\\s+in\\s+catalog|unknown\\s+component",
+      "problem": "Blocks agents from inventing UI components outside an allowlisted catalog or running generated code. OpenUI's safe-by-default FORMAT: compose only from your components.",
+      "roi": "Stops generative-UI theater and arbitrary-code compose paths. Keeps agent dashboards/widgets inside a known catalog without cloning OpenUI/Thesys.",
+      "rollout": "Enable for any agent-composed UI, dashboard widget, or tool-result card. Pair with openui-catalog-compose-honesty --catalog --stream --json."
+    },
+    {
+      "id": "require-repair-before-compose-claim",
+      "name": "Require repair-before-claim on composed UI",
+      "category": "Agent Honesty",
+      "signal": "👎",
+      "defaultAction": "block",
+      "severity": "high",
+      "pattern": "(ui|compose|generative\\s*ui|dashboard\\s*widget).*(ready|done|shipped|fixed|live)|claim.*compose.*(ready|done)",
+      "problem": "Blocks claiming composed UI is ready before a line-level validate+repair pass (root present, unknown components dropped, zero arbitrary-code lines).",
+      "roi": "Mirrors OpenUI Gateway's repair-before-users-see-it FORMAT on ThumbGate rails: invalid compose never becomes a completion claim.",
+      "rollout": "Require openui-catalog-compose-honesty --repair --claim-ready evidence before any compose/UI done claim. Does not install OpenUI Gateway."
+    },
+    {
       "id": "require-broker-signed-execution-receipt",
       "name": "Require broker-signed execution receipts",
       "category": "Provider Side-Effect Governance",

--- a/docs/agents/openui-catalog-compose-honesty.md
+++ b/docs/agents/openui-catalog-compose-honesty.md
@@ -1,0 +1,26 @@
+# OpenUI catalog-compose honesty (FORMAT steal)
+
+Source: https://www.openui.com/
+
+## How this helps ThumbGate
+
+OpenUI is a generative-UI framework (OpenUI Lang + optional Thesys Gateway). We do **not** clone that product. Three process tactics transfer onto existing PreToolUse / claim-honesty rails:
+
+| OpenUI FORMAT | ThumbGate mapping |
+|---------------|-------------------|
+| Model only composes allowlisted components | `require-catalog-compose-only` + doctor catalog check |
+| Line-oriented root-first streaming | Doctor requires `root = ...` before children |
+| Gateway repairs invalid output before users see it | `--repair` + `require-repair-before-compose-claim` |
+
+## Commands
+
+```bash
+npm run openui-catalog-compose-honesty -- --catalog=catalog.json --stream=compose.txt --repair --json
+npm run test:openui-catalog-compose-honesty
+```
+
+## Out of scope
+
+- Installing `@openuidev/cli` or OpenUI Lang
+- Thesys Gateway / Observability as a ThumbGate SKU
+- Net-new generative-UI R&D (ECI wall)

--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "scripts/deepseek-v4-runtime-guardrails.js",
     "scripts/nvidia-specdecode-al-doctor.js",
     "scripts/package-manager-honesty-doctor.js",
+    "scripts/openui-catalog-compose-honesty.js",
     "scripts/docker-sandbox-planner.js",
     "scripts/document-intake.js",
     "scripts/document-workflow-governance.js",
@@ -443,7 +444,8 @@
     "scripts/workspace-search-route.js",
     ".agents/skills/jit-harness-compare-not-clone/",
     "scripts/jit-harness-compose.js",
-    ".agents/skills/gitlab-sandbox-allowlist-not-trust/"
+    ".agents/skills/gitlab-sandbox-allowlist-not-trust/",
+    ".agents/skills/openui-catalog-compose-honesty/"
   ],
   "scripts": {
     "canary:snapshot": "node scripts/gate-decision-canary.js --snapshot",
@@ -963,9 +965,11 @@
     "test:agent-egress-policy": "node --test tests/agent-egress-policy.test.js",
     "test:allowlist-bridge-honesty": "node --test tests/allowlist-bridge-honesty.test.js",
     "allowlist-bridge-honesty": "node scripts/allowlist-bridge-honesty.js",
+    "test:openui-catalog-compose-honesty": "node --test tests/openui-catalog-compose-honesty.test.js",
+    "openui-catalog-compose-honesty": "node scripts/openui-catalog-compose-honesty.js",
     "test:budget-aware-gates-proof": "node --test tests/budget-aware-gates-proof.test.js",
     "test:business-function-agents": "node --test tests/business-function-agent-team.test.js",
-    "test:high-roi": "node --test tests/high-roi.test.js tests/gurobi-optimizer.test.js tests/model-candidates.test.js tests/autonomous-workflow.test.js tests/high-roi-agent-workflows.test.js tests/business-function-agent-team.test.js tests/radware-threat-defense.test.js tests/interaction-model.test.js tests/interaction-model-e2e.test.js tests/code-graph-guardrails.test.js tests/proxy-pointer-rag-guardrails.test.js tests/rag-precision-guardrails.test.js tests/ai-engineering-stack-guardrails.test.js tests/long-running-agent-context-guardrails.test.js tests/reasoning-efficiency-guardrails.test.js tests/deepseek-v4-runtime-guardrails.test.js tests/nvidia-specdecode-al-doctor.test.js tests/package-manager-honesty-doctor.test.js tests/gist-prompt-budget.test.js tests/workload-identity-honesty.test.js tests/config-strict-parse.test.js tests/upstream-contribution-engine.test.js tests/proactive-agent-eval-guardrails.test.js tests/reward-hacking-guardrails.test.js tests/chatgpt-ads-readiness-pack.test.js tests/oss-pr-opportunity-scout.test.js tests/agent-design-governance.test.js tests/gemini-embedding-policy.test.js tests/rag-embedding-identity.test.js tests/openclaw-agent-governance-kit.test.js tests/agent-operations-planner.test.js tests/aws-blocks-guardrails.test.js tests/vlt-proof.test.js tests/hf-context-course.test.js tests/proof-common.test.js tests/mcp-session-handles.test.js tests/agent-egress-policy.test.js tests/allowlist-bridge-honesty.test.js tests/budget-aware-gates-proof.test.js tests/edotenv-rl-gateway.test.js tests/rsi-safety-hillclimb.test.js tests/research-agent-harness.test.js tests/rule-sprawl.test.js tests/solver-parity.test.js tests/six-function-agent-team.test.js && npm run test:jit-harness-compose && npm run test:workspace-search-route && npm run test:intent-governed-execution",
+    "test:high-roi": "node --test tests/high-roi.test.js tests/gurobi-optimizer.test.js tests/model-candidates.test.js tests/autonomous-workflow.test.js tests/high-roi-agent-workflows.test.js tests/business-function-agent-team.test.js tests/radware-threat-defense.test.js tests/interaction-model.test.js tests/interaction-model-e2e.test.js tests/code-graph-guardrails.test.js tests/proxy-pointer-rag-guardrails.test.js tests/rag-precision-guardrails.test.js tests/ai-engineering-stack-guardrails.test.js tests/long-running-agent-context-guardrails.test.js tests/reasoning-efficiency-guardrails.test.js tests/deepseek-v4-runtime-guardrails.test.js tests/nvidia-specdecode-al-doctor.test.js tests/package-manager-honesty-doctor.test.js tests/openui-catalog-compose-honesty.test.js tests/gist-prompt-budget.test.js tests/workload-identity-honesty.test.js tests/config-strict-parse.test.js tests/upstream-contribution-engine.test.js tests/proactive-agent-eval-guardrails.test.js tests/reward-hacking-guardrails.test.js tests/chatgpt-ads-readiness-pack.test.js tests/oss-pr-opportunity-scout.test.js tests/agent-design-governance.test.js tests/gemini-embedding-policy.test.js tests/rag-embedding-identity.test.js tests/openclaw-agent-governance-kit.test.js tests/agent-operations-planner.test.js tests/aws-blocks-guardrails.test.js tests/vlt-proof.test.js tests/hf-context-course.test.js tests/proof-common.test.js tests/mcp-session-handles.test.js tests/agent-egress-policy.test.js tests/allowlist-bridge-honesty.test.js tests/budget-aware-gates-proof.test.js tests/edotenv-rl-gateway.test.js tests/rsi-safety-hillclimb.test.js tests/research-agent-harness.test.js tests/rule-sprawl.test.js tests/solver-parity.test.js tests/six-function-agent-team.test.js && npm run test:jit-harness-compose && npm run test:workspace-search-route && npm run test:intent-governed-execution",
     "test:public-static-assets": "node --test tests/public-static-assets.test.js tests/public-checkout-intent-gate.test.js tests/public-enterprise-capability-boundary.test.js tests/founders-conversion-page.test.js",
     "test:token-savings": "node --test tests/token-savings.test.js",
     "test:cost-cli": "node --test tests/cost-cli.test.js tests/conversion-receipt.test.js",

--- a/scripts/cli-schema.js
+++ b/scripts/cli-schema.js
@@ -475,6 +475,22 @@ const CLI_COMMANDS = [
     ],
   }),
 
+  discoveryCommand({
+    name: 'openui-catalog-compose-honesty',
+    aliases: ['openui-honesty-doctor', 'catalog-compose-honesty', 'repair-before-compose-claim'],
+    description: 'OpenUI FORMAT steal: catalog-compose-only, root-first streaming, repair-before-claim (does not install @openuidev or clone Thesys Gateway)',
+    flags: [
+      jsonFlag(),
+      { name: 'strict', type: 'boolean', description: 'Exit non-zero on fail or actionable findings' },
+      { name: 'root', type: 'string', description: 'Repo root for relative paths (default cwd)' },
+      { name: 'catalog', type: 'string', description: 'Path to JSON component catalog' },
+      { name: 'stream', type: 'string', description: 'Path to line-oriented compose stream' },
+      { name: 'compose', type: 'string', description: 'Alias for --stream' },
+      { name: 'repair', type: 'boolean', description: 'Include dropped lines and repaired stream text' },
+      { name: 'claim-ready', type: 'boolean', description: 'Fail unless repair is clean (root + zero drops)' },
+    ],
+  }),
+
 
   discoveryCommand({
     name: 'intent-governed-execution',

--- a/scripts/openui-catalog-compose-honesty.js
+++ b/scripts/openui-catalog-compose-honesty.js
@@ -1,0 +1,593 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * OpenUI catalog-compose honesty doctor (FORMAT steal, not a product clone).
+ *
+ * Source: https://www.openui.com/
+ *
+ * Transfers (process only):
+ *   1. Catalog-compose-only — model may compose from an allowlisted component
+ *      catalog; never invent arbitrary components or run generated code.
+ *   2. Root-first streaming — structure assigns `root` before children fill in.
+ *   3. Repair-before-claim — validate line-by-line, drop/repair invalid lines,
+ *      and refuse "UI ready / compose done" claims without a clean repair pass.
+ *
+ * Does NOT install @openuidev/cli, OpenUI Lang, Thesys Gateway, or Observability.
+ * Does NOT ship a generative-UI SKU. ECI: no net-new agent-governance product.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SOURCE_URL = 'https://www.openui.com/';
+
+const ARBITRARY_CODE_RE =
+  /\b(eval\s*\(|new\s+Function\s*\(|dangerouslySetInnerHTML|innerHTML\s*=|document\.write\s*\(|<script\b|Function\s*\(\s*['"`])/i;
+
+const OPENUI_SKU_CLONE_RE =
+  /@openuidev\/cli|openui\s+gateway|thesys\.dev|pnpx\s+@openuidev|clone\s+openui|install\s+openui\s+lang/i;
+
+const COMPOSE_LINE_RE =
+  /^\s*([A-Za-z_][\w.-]*)\s*=\s*([A-Za-z_][\w.-]*)\s*(?:\((.*)\))?\s*$/;
+
+function normalizeBoolean(value) {
+  if (value === true) return true;
+  if (value === false || value === undefined || value === null) return false;
+  return /^(1|true|yes|on)$/i.test(String(value).trim());
+}
+
+function readText(filePath) {
+  if (!filePath) return null;
+  if (!fs.existsSync(filePath)) {
+    const err = new Error(`file not found: ${filePath}`);
+    err.code = 'ENOENT';
+    throw err;
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+/**
+ * Accepts:
+ *   { "components": ["Stack","Card"] }
+ *   { "components": [{ "id": "Stack" }, { "id": "Card", "props": ["title"] }] }
+ *   ["Stack","Card"]
+ */
+function parseCatalog(raw) {
+  if (raw == null || raw === '') {
+    return { ok: false, error: 'empty_catalog', ids: new Set(), entries: [] };
+  }
+  let data;
+  try {
+    data = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch {
+    return { ok: false, error: 'catalog_parse_error', ids: new Set(), entries: [] };
+  }
+
+  let list = [];
+  if (Array.isArray(data)) list = data;
+  else if (data && Array.isArray(data.components)) list = data.components;
+  else {
+    return { ok: false, error: 'catalog_shape_error', ids: new Set(), entries: [] };
+  }
+
+  const entries = [];
+  const ids = new Set();
+  for (const item of list) {
+    if (typeof item === 'string' && item.trim()) {
+      const id = item.trim();
+      ids.add(id);
+      entries.push({ id, props: null });
+      continue;
+    }
+    if (item && typeof item === 'object' && item.id) {
+      const id = String(item.id).trim();
+      if (!id) continue;
+      ids.add(id);
+      entries.push({
+        id,
+        props: Array.isArray(item.props) ? item.props.map(String) : null,
+      });
+    }
+  }
+  if (ids.size === 0) {
+    return { ok: false, error: 'empty_catalog_ids', ids, entries };
+  }
+  return { ok: true, error: null, ids, entries };
+}
+
+/**
+ * Line-oriented compose stream inspired by OpenUI Lang's streaming shape,
+ * not a clone of OpenUI Lang syntax. Form:
+ *   root = Stack([header, body])
+ *   header = Card()
+ *   body = Table([row])
+ */
+function parseComposeStream(raw) {
+  const text = String(raw == null ? '' : raw);
+  const lines = text.split(/\r?\n/);
+  const parsed = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const original = lines[i];
+    const trimmed = original.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      parsed.push({
+        line: i + 1,
+        original,
+        kind: 'skip',
+        binding: null,
+        component: null,
+        refs: [],
+        validSyntax: true,
+      });
+      continue;
+    }
+    if (ARBITRARY_CODE_RE.test(trimmed) || OPENUI_SKU_CLONE_RE.test(trimmed)) {
+      parsed.push({
+        line: i + 1,
+        original,
+        kind: 'dangerous',
+        binding: null,
+        component: null,
+        refs: [],
+        validSyntax: false,
+        danger: ARBITRARY_CODE_RE.test(trimmed) ? 'arbitrary_code' : 'openui_sku_clone',
+      });
+      continue;
+    }
+    const m = COMPOSE_LINE_RE.exec(trimmed);
+    if (!m) {
+      parsed.push({
+        line: i + 1,
+        original,
+        kind: 'invalid',
+        binding: null,
+        component: null,
+        refs: [],
+        validSyntax: false,
+      });
+      continue;
+    }
+    const binding = m[1];
+    const component = m[2];
+    const args = m[3] == null ? '' : m[3];
+    const refs = [];
+    const refRe = /\b([A-Za-z_][\w.-]*)\b/g;
+    let rm;
+    while ((rm = refRe.exec(args)) !== null) {
+      const token = rm[1];
+      // Skip obvious literals / keywords
+      if (/^(true|false|null|undefined)$/i.test(token)) continue;
+      if (/^\d/.test(token)) continue;
+      refs.push(token);
+    }
+    parsed.push({
+      line: i + 1,
+      original,
+      kind: binding === 'root' ? 'root' : 'node',
+      binding,
+      component,
+      refs,
+      validSyntax: true,
+    });
+  }
+  return parsed;
+}
+
+function collectComponentRefs(parsedLines) {
+  const refs = [];
+  for (const row of parsedLines) {
+    if (!row.validSyntax || !row.component) continue;
+    refs.push({ line: row.line, binding: row.binding, component: row.component });
+  }
+  return refs;
+}
+
+function repairComposeStream(parsedLines, catalogIds) {
+  const kept = [];
+  const dropped = [];
+  for (const row of parsedLines) {
+    if (row.kind === 'skip') {
+      kept.push(row);
+      continue;
+    }
+    if (!row.validSyntax || row.kind === 'dangerous' || row.kind === 'invalid') {
+      dropped.push({ line: row.line, reason: row.danger || row.kind, text: row.original });
+      continue;
+    }
+    if (!catalogIds.has(row.component)) {
+      dropped.push({
+        line: row.line,
+        reason: 'unknown_component',
+        component: row.component,
+        text: row.original,
+      });
+      continue;
+    }
+    kept.push(row);
+  }
+  const repairedText = kept
+    .filter((r) => r.kind !== 'skip' || String(r.original).trim() === '')
+    .map((r) => r.original)
+    .join('\n')
+    .replace(/\n+$/, '');
+  const hasRoot = kept.some((r) => r.kind === 'root');
+  return {
+    kept,
+    dropped,
+    repairedText: repairedText.length ? `${repairedText}\n` : '',
+    hasRoot,
+    clean: dropped.length === 0 && hasRoot,
+  };
+}
+
+function buildFindings({
+  catalog,
+  parsed,
+  repair,
+  claimReady,
+  cloneSignal,
+}) {
+  const findings = [];
+
+  if (!catalog.ok) {
+    findings.push({
+      id: catalog.error || 'missing_catalog',
+      severity: 'fail',
+      gateId: 'require-catalog-compose-only',
+      message: 'Catalog missing or unparseable. Provide --catalog=path with a non-empty components list.',
+    });
+  } else if (catalog.ids.size === 0) {
+    findings.push({
+      id: 'empty_catalog_ids',
+      severity: 'fail',
+      gateId: 'require-catalog-compose-only',
+      message: 'Catalog has zero component ids.',
+    });
+  }
+
+  const structural = parsed.filter((p) => p.kind !== 'skip');
+  if (structural.length === 0) {
+    findings.push({
+      id: 'empty_compose_stream',
+      severity: 'fail',
+      gateId: 'require-catalog-compose-only',
+      message: 'Compose stream is empty. Provide --stream=path with root-first catalog lines.',
+    });
+  }
+
+  for (const row of parsed) {
+    if (row.kind === 'dangerous' && row.danger === 'arbitrary_code') {
+      findings.push({
+        id: 'arbitrary_code_in_compose',
+        severity: 'fail',
+        gateId: 'require-catalog-compose-only',
+        line: row.line,
+        message: `Line ${row.line}: arbitrary code marker — catalog compose must never eval/run generated code.`,
+      });
+    }
+    if (row.kind === 'dangerous' && row.danger === 'openui_sku_clone') {
+      findings.push({
+        id: 'openui_sku_clone',
+        severity: 'fail',
+        gateId: 'require-catalog-compose-only',
+        line: row.line,
+        message: `Line ${row.line}: OpenUI/Thesys SKU clone signal — steal FORMAT only; do not install @openuidev or Gateway.`,
+      });
+    }
+    if (row.kind === 'invalid') {
+      findings.push({
+        id: 'invalid_compose_syntax',
+        severity: 'fail',
+        gateId: 'require-repair-before-compose-claim',
+        line: row.line,
+        message: `Line ${row.line}: invalid compose syntax (expected binding = Component(...)).`,
+      });
+    }
+  }
+
+  if (catalog.ok) {
+    for (const ref of collectComponentRefs(parsed)) {
+      if (!catalog.ids.has(ref.component)) {
+        findings.push({
+          id: 'unknown_component',
+          severity: 'fail',
+          gateId: 'require-catalog-compose-only',
+          line: ref.line,
+          component: ref.component,
+          message: `Line ${ref.line}: component "${ref.component}" is not in the allowlisted catalog.`,
+        });
+      }
+    }
+  }
+
+  const rootLines = parsed.filter((p) => p.kind === 'root');
+  if (structural.length > 0 && rootLines.length === 0) {
+    findings.push({
+      id: 'missing_root',
+      severity: 'fail',
+      gateId: 'require-catalog-compose-only',
+      message: 'Compose stream has no root = ... assignment (root-first streaming honesty).',
+    });
+  }
+
+  const firstStructural = structural[0];
+  if (firstStructural && firstStructural.kind !== 'root' && rootLines.length > 0) {
+    findings.push({
+      id: 'root_not_first',
+      severity: 'warn',
+      gateId: 'require-catalog-compose-only',
+      message: `Root appears after other nodes (first structural line ${firstStructural.line}). Prefer root-first streaming.`,
+    });
+  }
+
+  if (cloneSignal) {
+    findings.push({
+      id: 'openui_sku_clone',
+      severity: 'fail',
+      gateId: 'require-catalog-compose-only',
+      message: 'Input requests cloning OpenUI/Thesys product surface. Refuse SKU clone; keep FORMAT steal only.',
+    });
+  }
+
+  if (claimReady) {
+    if (!repair || !repair.clean) {
+      findings.push({
+        id: 'claim_without_repair',
+        severity: 'fail',
+        gateId: 'require-repair-before-compose-claim',
+        message:
+          'Claimed compose/UI ready without a clean validate+repair pass. Run with --repair and zero drops + root present before claiming.',
+      });
+    }
+  }
+
+  return findings;
+}
+
+function normalizeOptions(raw = {}) {
+  const rootDir = path.resolve(
+    String(raw.root || raw.rootDir || process.cwd())
+  );
+  const catalogPath = raw.catalog
+    ? path.resolve(rootDir, String(raw.catalog))
+    : raw.catalogPath
+      ? path.resolve(rootDir, String(raw.catalogPath))
+      : null;
+  const streamPath = raw.stream || raw.compose
+    ? path.resolve(rootDir, String(raw.stream || raw.compose))
+    : raw.streamPath
+      ? path.resolve(rootDir, String(raw.streamPath))
+      : null;
+
+  return {
+    rootDir,
+    catalogPath,
+    streamPath,
+    catalogText: raw.catalogText != null ? String(raw.catalogText) : null,
+    streamText: raw.streamText != null ? String(raw.streamText) : null,
+    repair: normalizeBoolean(raw.repair),
+    claimReady: normalizeBoolean(raw['claim-ready'] || raw.claimReady),
+    strict: normalizeBoolean(raw.strict),
+    json: normalizeBoolean(raw.json),
+  };
+}
+
+function buildOpenuiCatalogComposeHonestyReport(rawOptions = {}) {
+  const options = normalizeOptions(rawOptions);
+  let catalogRaw = options.catalogText;
+  let streamRaw = options.streamText;
+  const ioErrors = [];
+
+  if (catalogRaw == null && options.catalogPath) {
+    try {
+      catalogRaw = readText(options.catalogPath);
+    } catch (err) {
+      ioErrors.push({ id: 'catalog_read_error', message: err.message });
+      catalogRaw = '';
+    }
+  }
+  if (streamRaw == null && options.streamPath) {
+    try {
+      streamRaw = readText(options.streamPath);
+    } catch (err) {
+      ioErrors.push({ id: 'stream_read_error', message: err.message });
+      streamRaw = '';
+    }
+  }
+
+  // Fixture mode when nothing provided: demonstrate fail-closed empty state.
+  if (catalogRaw == null && streamRaw == null) {
+    catalogRaw = '';
+    streamRaw = '';
+  }
+
+  const catalog = parseCatalog(catalogRaw || '');
+  const parsed = parseComposeStream(streamRaw || '');
+  const cloneSignal = OPENUI_SKU_CLONE_RE.test(String(catalogRaw || ''))
+    || OPENUI_SKU_CLONE_RE.test(String(streamRaw || ''));
+
+  const repair = repairComposeStream(parsed, catalog.ids);
+  const findings = [
+    ...ioErrors.map((e) => ({
+      id: e.id,
+      severity: 'fail',
+      gateId: 'require-catalog-compose-only',
+      message: e.message,
+    })),
+    ...buildFindings({
+      catalog,
+      parsed,
+      repair,
+      claimReady: options.claimReady,
+      cloneSignal,
+    }),
+  ];
+
+  // Deduplicate finding ids+line
+  const seen = new Set();
+  const deduped = [];
+  for (const f of findings) {
+    const key = `${f.id}:${f.line || ''}:${f.component || ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(f);
+  }
+
+  const failCount = deduped.filter((f) => f.severity === 'fail').length;
+  const warnCount = deduped.filter((f) => f.severity === 'warn').length;
+  let status = 'ready';
+  if (failCount > 0) status = 'fail';
+  else if (warnCount > 0) status = 'actionable';
+
+  return {
+    name: 'thumbgate-openui-catalog-compose-honesty',
+    status,
+    source: SOURCE_URL,
+    disclaimer:
+      'FORMAT steal from OpenUI (catalog-compose-only, root-first streaming, repair-before-claim). Not affiliated with OpenUI/Thesys. Does not install @openuidev or ship a generative-UI SKU.',
+    rootDir: options.rootDir,
+    metrics: {
+      catalogPath: options.catalogPath,
+      streamPath: options.streamPath,
+      catalogOk: catalog.ok,
+      catalogSize: catalog.ids.size,
+      streamLines: parsed.length,
+      structuralLines: parsed.filter((p) => p.kind !== 'skip').length,
+      rootPresent: parsed.some((p) => p.kind === 'root'),
+      repairRequested: options.repair,
+      claimReady: options.claimReady,
+      droppedLineCount: repair.dropped.length,
+      keptLineCount: repair.kept.filter((k) => k.kind !== 'skip').length,
+      repairClean: repair.clean,
+    },
+    repair: options.repair
+      ? {
+          clean: repair.clean,
+          dropped: repair.dropped,
+          repairedText: repair.repairedText,
+        }
+      : {
+          clean: repair.clean,
+          droppedCount: repair.dropped.length,
+          note: 'Pass --repair to include dropped lines and repaired stream text.',
+        },
+    findings: deduped,
+    summary: {
+      failCount,
+      warnCount,
+      findingCount: deduped.length,
+      recommendedGateCount: [...new Set(deduped.map((f) => f.gateId).filter(Boolean))].length,
+    },
+    recommendedGates: [...new Set(deduped.map((f) => f.gateId).filter(Boolean))],
+    nextActions: [
+      'Compose only from an allowlisted component catalog — never invent components or eval generated code.',
+      'Emit root = ... first, then fill child bindings (root-first streaming).',
+      'Validate + repair invalid lines before claiming UI/compose ready.',
+      'Do not install @openuidev/cli, OpenUI Gateway, or Thesys Observability as a ThumbGate SKU.',
+      'Pair with gates require-catalog-compose-only and require-repair-before-compose-claim.',
+    ],
+    exampleCommand:
+      'npx thumbgate openui-catalog-compose-honesty --catalog=catalog.json --stream=compose.txt --repair --json',
+  };
+}
+
+function formatOpenuiCatalogComposeHonestyReport(report) {
+  const lines = [
+    '',
+    'ThumbGate OpenUI Catalog-Compose Honesty Doctor',
+    '-'.repeat(48),
+    `Status   : ${report.status}`,
+    `Root     : ${report.rootDir}`,
+    `Catalog  : ${report.metrics.catalogPath || '(inline/empty)'} (${report.metrics.catalogSize} ids, ok=${report.metrics.catalogOk})`,
+    `Stream   : ${report.metrics.streamPath || '(inline/empty)'} (${report.metrics.structuralLines} structural)`,
+    `Root line: ${report.metrics.rootPresent}`,
+    `Repair   : clean=${report.metrics.repairClean} dropped=${report.metrics.droppedLineCount}`,
+    `Findings : ${report.summary.findingCount} (fail=${report.summary.failCount}, warn=${report.summary.warnCount})`,
+    `Source   : ${report.source}`,
+  ];
+  if (report.findings.length) {
+    lines.push('', 'Findings:');
+    for (const f of report.findings) {
+      const gate = f.gateId ? ` [${f.gateId}]` : '';
+      const loc = f.line ? ` L${f.line}` : '';
+      lines.push(`  - [${f.severity}] ${f.id}${loc}${gate}`);
+      lines.push(`    ${f.message}`);
+    }
+  }
+  if (report.repair && report.repair.dropped && report.repair.dropped.length) {
+    lines.push('', 'Repaired drops:');
+    for (const d of report.repair.dropped) {
+      lines.push(`  - L${d.line} ${d.reason}${d.component ? ` (${d.component})` : ''}`);
+    }
+  }
+  lines.push('', 'Next actions:');
+  for (const a of report.nextActions) lines.push(`  - ${a}`);
+  lines.push('', `Example: ${report.exampleCommand}`);
+  lines.push(`Note: ${report.disclaimer}`, '');
+  return `${lines.join('\n')}\n`;
+}
+
+function parseCliArgs(argv) {
+  const options = {};
+  for (const arg of argv) {
+    if (arg === '--json') { options.json = true; continue; }
+    if (arg === '--strict') { options.strict = true; continue; }
+    if (arg === '--repair') { options.repair = true; continue; }
+    if (arg === '--claim-ready') { options['claim-ready'] = true; continue; }
+    if (arg === '--help' || arg === '-h') { options.help = true; continue; }
+    const m = /^--([^=]+)(?:=(.*))?$/.exec(arg);
+    if (!m) continue;
+    options[m[1]] = m[2] === undefined ? true : m[2];
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/openui-catalog-compose-honesty.js [flags]
+
+Flags:
+  --catalog=PATH     JSON catalog ({"components":["Stack","Card"]})
+  --stream=PATH      Line-oriented compose stream (root = Stack([...]))
+  --compose=PATH     Alias for --stream
+  --repair           Include dropped lines + repaired stream text
+  --claim-ready      Fail unless repair is clean (root + zero drops)
+  --root=DIR         Repo root for relative paths (default: cwd)
+  --strict           Exit 1 on fail/actionable
+  --json
+
+Source: ${SOURCE_URL}
+`);
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  const args = parseCliArgs(argv);
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+  const report = buildOpenuiCatalogComposeHonestyReport(args);
+  if (args.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  else process.stdout.write(formatOpenuiCatalogComposeHonestyReport(report));
+  if (args.strict && report.status !== 'ready') return 1;
+  if (report.status === 'fail') return 1;
+  return 0;
+}
+
+module.exports = {
+  SOURCE_URL,
+  ARBITRARY_CODE_RE,
+  OPENUI_SKU_CLONE_RE,
+  parseCatalog,
+  parseComposeStream,
+  repairComposeStream,
+  collectComponentRefs,
+  buildOpenuiCatalogComposeHonestyReport,
+  formatOpenuiCatalogComposeHonestyReport,
+  runCli,
+};
+
+if (require.main === module
+  || (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename))) {
+  process.exitCode = runCli(process.argv.slice(2));
+}

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -600,7 +600,7 @@ describe('bin/cli.js', () => {
       'oss-pr-opportunity-scout', 'chatgpt-ads-readiness-pack',
       'model-candidates', 'upstream-contributions',
       'deepseek-v4-runtime-guardrails', 'nvidia-specdecode-al-doctor',
-      'package-manager-honesty-doctor', 'allowlist-bridge-honesty', 'risk', 'export-dpo',
+      'package-manager-honesty-doctor', 'openui-catalog-compose-honesty', 'allowlist-bridge-honesty', 'risk', 'export-dpo',
       'export-databricks', 'lessons', 'stats', 'north-star', 'eval',
       'rules', 'self-heal', 'prove', 'doctor', 'compass', 'dispatch',
       'background-governance', 'analytics', 'gate-check', 'statusline-render',

--- a/tests/openui-catalog-compose-honesty.test.js
+++ b/tests/openui-catalog-compose-honesty.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const {
+  parseCatalog,
+  parseComposeStream,
+  repairComposeStream,
+  buildOpenuiCatalogComposeHonestyReport,
+  formatOpenuiCatalogComposeHonestyReport,
+} = require('../scripts/openui-catalog-compose-honesty');
+
+const CLI = path.resolve(__dirname, '..', 'bin', 'cli.js');
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'openui-catalog-compose-honesty.js');
+
+function makeFixture({ catalog, stream }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openui-honesty-'));
+  if (catalog != null) {
+    fs.writeFileSync(
+      path.join(root, 'catalog.json'),
+      typeof catalog === 'string' ? catalog : `${JSON.stringify(catalog, null, 2)}\n`
+    );
+  }
+  if (stream != null) {
+    fs.writeFileSync(path.join(root, 'compose.txt'), String(stream));
+  }
+  return root;
+}
+
+test('parseCatalog accepts string ids and object entries', () => {
+  const a = parseCatalog(JSON.stringify({ components: ['Stack', 'Card'] }));
+  assert.equal(a.ok, true);
+  assert.ok(a.ids.has('Stack'));
+  const b = parseCatalog({ components: [{ id: 'Table', props: ['rows'] }] });
+  assert.equal(b.ok, true);
+  assert.ok(b.ids.has('Table'));
+});
+
+test('parseCatalog fails closed on empty or bad JSON', () => {
+  assert.equal(parseCatalog('').ok, false);
+  assert.equal(parseCatalog('{nope').ok, false);
+  assert.equal(parseCatalog(JSON.stringify({ components: [] })).ok, false);
+});
+
+test('parseComposeStream marks root, nodes, and dangerous lines', () => {
+  const parsed = parseComposeStream(`
+# comment
+root = Stack([header])
+header = Card()
+evil = eval("x")
+`);
+  assert.ok(parsed.some((p) => p.kind === 'root' && p.component === 'Stack'));
+  assert.ok(parsed.some((p) => p.kind === 'node' && p.binding === 'header'));
+  assert.ok(parsed.some((p) => p.kind === 'dangerous' && p.danger === 'arbitrary_code'));
+});
+
+test('repairComposeStream drops unknown components and keeps catalog hits', () => {
+  const catalog = parseCatalog({ components: ['Stack', 'Card'] });
+  const parsed = parseComposeStream('root = Stack([x])\nx = Ghost()\ny = Card()\n');
+  const repair = repairComposeStream(parsed, catalog.ids);
+  assert.equal(repair.dropped.some((d) => d.component === 'Ghost'), true);
+  assert.equal(repair.kept.some((k) => k.component === 'Card'), true);
+  assert.equal(repair.kept.some((k) => k.component === 'Stack'), true);
+});
+
+test('doctor fails on unknown component and missing root', () => {
+  const report = buildOpenuiCatalogComposeHonestyReport({
+    catalogText: JSON.stringify({ components: ['Stack'] }),
+    streamText: 'header = Card()\n',
+  });
+  assert.equal(report.status, 'fail');
+  assert.ok(report.findings.some((f) => f.id === 'unknown_component'));
+  assert.ok(report.findings.some((f) => f.id === 'missing_root'));
+});
+
+test('doctor fails on arbitrary code and OpenUI SKU clone signals', () => {
+  const report = buildOpenuiCatalogComposeHonestyReport({
+    catalogText: JSON.stringify({ components: ['Stack'] }),
+    streamText: 'root = Stack([])\nbad = eval(1)\nnote = install @openuidev/cli\n',
+  });
+  assert.equal(report.status, 'fail');
+  assert.ok(report.findings.some((f) => f.id === 'arbitrary_code_in_compose'));
+  assert.ok(report.findings.some((f) => f.id === 'openui_sku_clone'));
+});
+
+test('claim-ready fails without clean repair; passes after clean catalog stream', () => {
+  const dirty = buildOpenuiCatalogComposeHonestyReport({
+    catalogText: JSON.stringify({ components: ['Stack'] }),
+    streamText: 'root = Stack([x])\nx = Ghost()\n',
+    claimReady: true,
+    repair: true,
+  });
+  assert.equal(dirty.status, 'fail');
+  assert.ok(dirty.findings.some((f) => f.id === 'claim_without_repair' || f.id === 'unknown_component'));
+
+  const clean = buildOpenuiCatalogComposeHonestyReport({
+    catalogText: JSON.stringify({ components: ['Stack', 'Card'] }),
+    streamText: 'root = Stack([header])\nheader = Card()\n',
+    claimReady: true,
+    repair: true,
+  });
+  assert.equal(clean.status, 'ready');
+  assert.equal(clean.metrics.repairClean, true);
+});
+
+test('root-not-first is a warn when root exists later', () => {
+  const report = buildOpenuiCatalogComposeHonestyReport({
+    catalogText: JSON.stringify({ components: ['Stack', 'Card'] }),
+    streamText: 'header = Card()\nroot = Stack([header])\n',
+  });
+  assert.ok(['actionable', 'ready'].includes(report.status));
+  assert.ok(report.findings.some((f) => f.id === 'root_not_first'));
+});
+
+test('format report includes status and disclaimer', () => {
+  const report = buildOpenuiCatalogComposeHonestyReport({
+    catalogText: JSON.stringify({ components: ['Stack'] }),
+    streamText: 'root = Stack([])\n',
+  });
+  const text = formatOpenuiCatalogComposeHonestyReport(report);
+  assert.match(text, /Catalog-Compose Honesty Doctor/);
+  assert.match(text, /not affiliated with OpenUI\/Thesys/i);
+});
+
+test('CLI script --json exits 0 on clean stream', () => {
+  const root = makeFixture({
+    catalog: { components: ['Stack', 'Card'] },
+    stream: 'root = Stack([header])\nheader = Card()\n',
+  });
+  const result = spawnSync(process.execPath, [
+    SCRIPT,
+    `--root=${root}`,
+    '--catalog=catalog.json',
+    '--stream=compose.txt',
+    '--repair',
+    '--json',
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.status, 'ready');
+  assert.equal(report.metrics.repairClean, true);
+});
+
+test('bin/cli.js openui-catalog-compose-honesty is wired', () => {
+  const root = makeFixture({
+    catalog: { components: ['Stack'] },
+    stream: 'root = Stack([])\n',
+  });
+  const result = spawnSync(process.execPath, [
+    CLI,
+    'openui-catalog-compose-honesty',
+    `--root=${root}`,
+    '--catalog=catalog.json',
+    '--stream=compose.txt',
+    '--json',
+  ], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.name, 'thumbgate-openui-catalog-compose-honesty');
+});
+
+test('gate templates include catalog-compose honesty pair', () => {
+  const config = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'config', 'gate-templates.json'), 'utf8')
+  );
+  const ids = config.templates.map((t) => t.id);
+  assert.ok(ids.includes('require-catalog-compose-only'));
+  assert.ok(ids.includes('require-repair-before-compose-claim'));
+  const catalogGate = config.templates.find((t) => t.id === 'require-catalog-compose-only');
+  assert.equal(catalogGate.category, 'Agent Honesty');
+  assert.match(catalogGate.rollout, /openui-catalog-compose-honesty/);
+});

--- a/tests/package-boundary.test.js
+++ b/tests/package-boundary.test.js
@@ -490,8 +490,9 @@ test('npm package ships a slim runtime boundary instead of repo/dev surfaces', (
   // 529 -> 530: memory-vs-rag-route.js (Supermemory FORMAT steal).
   // 530 -> 532: test-all.js + find-dormant-requires.js (aggregate runner, #3703 successor).
   // 532 -> 534: allowlist-bridge-honesty.js + gitlab-sandbox-allowlist-not-trust skill.
-    manifest.fileCount <= 534,
-    `npm package should stay <= 534 files, got ${manifest.fileCount}`
+  // 534 -> 536: openui-catalog-compose-honesty.js + skill — OpenUI FORMAT steal.
+    manifest.fileCount <= 536,
+    `npm package should stay <= 536 files, got ${manifest.fileCount}`
   );
   // Ceiling bumped from 2.75 MB → 2.85 MB (2026-04-16) to accommodate the
   // incremental review-delta demo content in public/dashboard.html landing

--- a/tests/public-bundle-ratchet.test.js
+++ b/tests/public-bundle-ratchet.test.js
@@ -236,7 +236,9 @@ const path = require('node:path');
 // 530 → 532: test-all.js + find-dormant-requires.js (#3703 successor)
 // 532 → 534: allowlist-bridge-honesty.js + gitlab-sandbox-allowlist-not-trust skill
 //            (GitLab 2026-09 allowlist-as-bridge FORMAT steal).
-const BASELINE_FILE_COUNT = 534;
+// 534 → 536: openui-catalog-compose-honesty.js + skill — OpenUI FORMAT steal
+//            (catalog-compose-only, root-first, repair-before-claim; not @openuidev).
+const BASELINE_FILE_COUNT = 536;
 
 function readBundleSnapshot() {
   const repoRoot = path.resolve(__dirname, '..');

--- a/tests/public-core-boundary.test.js
+++ b/tests/public-core-boundary.test.js
@@ -290,7 +290,9 @@ test('public-core-boundary: npm bundle stays thin (file count ceiling)', () => {
   //   Lockstep with package-boundary + public-bundle-ratchet.
   // 530 -> 532: test-all.js + find-dormant-requires.js (#3703 successor).
   // 532 -> 534: allowlist-bridge-honesty.js + gitlab-sandbox-allowlist-not-trust skill.
-  const CEILING = 534;
+  // 534 -> 536: openui-catalog-compose-honesty.js + skill — OpenUI FORMAT steal
+  //   (catalog-compose-only / repair-before-claim; not a generative-UI SKU).
+  const CEILING = 536;
   assert.ok(
     files.length <= CEILING,
     `public npm bundle should stay <= ${CEILING} files, got ${files.length}. ` +


### PR DESCRIPTION
## Summary
- Steal OpenUI (https://www.openui.com/) **FORMAT** only: catalog-compose-only, root-first streaming, repair-before-claim.
- Add `openui-catalog-compose-honesty` doctor + CLI, Agent Honesty gates (`require-catalog-compose-only`, `require-repair-before-compose-claim`), skill, docs, changeset.
- Bump public bundle ceiling 534 → 536 (script + skill). **Not** an OpenUI/Thesys product clone (ECI).

## How this helps
OpenUI’s generative-UI product does not transfer as a ThumbGate SKU. Its process does: agents must compose from an allowlisted catalog, emit `root` first, and validate+repair before claiming UI ready — the same honesty class as evidence-before-done.

## Test plan
- [x] `node --test tests/openui-catalog-compose-honesty.test.js` (12/12 pass)
- [x] `node --test tests/public-bundle-ratchet.test.js tests/public-core-boundary.test.js tests/package-boundary.test.js`
- [ ] CI required checks green
- [ ] Trunk merge via `npm run pr:manage`

## Source
https://www.openui.com/ — FORMAT steal, not affiliated.