### PR TITLE
fix(ci): OIDC-first npm publish (heal E404 classic token)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -146,9 +146,27 @@ jobs:
           git push origin "v${VERSION}"
       - name: Publish npm package
         if: ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.publish_npm == 'true') || (github.event_name == 'release' && steps.npm.outputs.published == 'false')
-        run: npm publish --tag "${{ steps.plan.outputs.npm_tag || 'latest' }}" --provenance
+        # OIDC-first (id-token: write above). A stale classic NPM_TOKEN returns
+        # E404 "Not found" and masks trusted publishing. Only inject NODE_AUTH_TOKEN
+        # when THUMBGATE_NPM_TOKEN_FALLBACK=1 is set on the workflow_dispatch input
+        # or repo variable — default is OIDC-only.
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN_FALLBACK: ${{ vars.THUMBGATE_NPM_TOKEN_FALLBACK }}
+          NPM_TAG: ${{ steps.plan.outputs.npm_tag || 'latest' }}
+        run: |
+          set -euo pipefail
+          if [ "${NPM_TOKEN_FALLBACK:-}" = "1" ] && [ -n "${NPM_TOKEN:-}" ]; then
+            export NODE_AUTH_TOKEN="${NPM_TOKEN}"
+            echo "Using NPM_TOKEN fallback (THUMBGATE_NPM_TOKEN_FALLBACK=1)."
+          else
+            unset NODE_AUTH_TOKEN || true
+            echo "Publishing via GitHub Actions OIDC trusted publisher (no NODE_AUTH_TOKEN)."
+          fi
+          if ! npm publish --tag "${NPM_TAG}" --provenance; then
+            echo "::error::npm publish failed. Configure Trusted Publisher on npmjs.com for package thumbgate → GitHub Actions → IgorGanapolsky/ThumbGate / publish-npm.yml (WebAuthn once), then re-run. Do not pin unpublished versions in customer emails (see thumbgate-npm-pin-honesty)."
+            exit 1
+          fi
       - name: Verify published npm runtime smoke
         if: ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.publish_npm == 'true') || (github.event_name == 'release' && steps.npm.outputs.published == 'false')
         env:

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -745,6 +745,8 @@ test('Publish to NPM workflow uses the tested publish-decision guardrail', () =>
   assert.match(workflow, /group:\s*publish-npm-\$\{\{\s*github\.workflow\s*\}\}-\$\{\{\s*github\.ref\s*\}\}/);
   assert.match(workflow, /cancel-in-progress:\s*false/);
   assert.match(workflow, /permissions:\s+contents:\s+write\s+id-token:\s+write/s);
+  assert.match(workflow, /Publishing via GitHub Actions OIDC trusted publisher/);
+  assert.match(workflow, /THUMBGATE_NPM_TOKEN_FALLBACK/);
   assert.match(workflow, /node-version:\s*'24\.x'/);
   assert.match(workflow, /timeout-minutes:\s*25/);
   assert.match(workflow, /cache:\s*'npm'/);

--- a/tests/deployment.test.js
+++ b/tests/deployment.test.js
@@ -782,7 +782,9 @@ test('Publish to NPM workflow uses the tested publish-decision guardrail', () =>
     /Treating this no-op as release-audited until the next versioned publish lands\./,
     'the unbounded exemption must not return',
   );
-  assert.match(workflow, /npm publish --tag "\$\{\{\s*steps\.plan\.outputs\.npm_tag \|\| 'latest'\s*\}\}" --provenance/);
+  assert.match(workflow, /NPM_TAG:\s*\$\{\{\s*steps\.plan\.outputs\.npm_tag \|\| 'latest'\s*\}\}/);
+  assert.match(workflow, /npm publish --tag "\$\{NPM_TAG\}" --provenance/);
+  assert.match(workflow, /unset NODE_AUTH_TOKEN/);
   assert.match(workflow, /--install-attempts 12 --install-delay-ms 10000/);
 });
 


### PR DESCRIPTION
## Summary
- Root cause of unpublished `1.37.0`: classic `NPM_TOKEN` gets `E404` on `PUT` (2FA-bypass token deprecation). Prod/tag tip are already `1.37.0` / `da9a8e69`; npm latest remains `1.35.0`.
- Default publish path is now GitHub Actions OIDC trusted publisher (`id-token: write`); do not inject dead `NODE_AUTH_TOKEN`.
- Optional fallback only when repo var `THUMBGATE_NPM_TOKEN_FALLBACK=1`.
- Pins workflow contract in `tests/deployment.test.js`.

## After merge (one WebAuthn)
1. On npmjs.com package `thumbgate` → Trusted Publisher → GitHub Actions → `IgorGanapolsky` / `ThumbGate` / `publish-npm.yml` (allow direct publish).
2. Re-run `publish-npm.yml` on tip; confirm `npm view thumbgate version` → `1.37.0`.
3. Then update Vignesh Hermes draft pin from `@1.35.0` → `@1.37.0` (still drafts-only).

## Test plan
- [x] `node --test tests/publish-decision.test.js`
- [x] `tests/deployment.test.js` Publish to NPM assertions updated
- [ ] CI green on this PR
- [ ] Trusted Publisher configured + publish succeeds (WebAuthn)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NPM publishing now uses OIDC trusted publishing by default.
  * Optional token-based publishing remains available through a repository setting.
  * Publishing supports the configured release tag, defaulting to `latest`.
  * Clear guidance is provided when trusted-publisher configuration is missing.

* **Tests**
  * Added coverage for trusted publishing, fallback authentication, dynamic release tags, and authentication cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->