### PR TITLE
chore(release): 1.37.1 — unstick unpublished 1.37.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate-marketplace",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "owner": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com"
@@ -14,7 +14,7 @@
         "source": "npm",
         "package": "thumbgate"
       },
-      "version": "1.37.0",
+      "version": "1.37.1",
       "author": {
         "name": "Igor Ganapolsky",
         "email": "ig5973700@gmail.com",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thumbgate",
   "description": "One 👎 becomes a hard rule the agent cannot bypass. Captures thumbs-down feedback, distills it into PreToolUse Pre-Action Checks, enforced across every future Claude Code session.",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "author": {
     "name": "Igor Ganapolsky",
     "email": "ig5973700@gmail.com",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-    "version": "1.37.0"
+    "version": "1.37.1"
   },
   "plugins": [
     {

--- a/.well-known/mcp/server-card.json
+++ b/.well-known/mcp/server-card.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "ThumbGate — 👍👎 feedback that teaches your AI agent. Thumbs down a mistake, it never happens again.",
   "homepage": "https://thumbgate.ai",
   "transport": "stdio",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.37.1
+
+### Patch Changes
+
+- Unstick unpublished 1.37.0: tip moved past tag v1.37.0@da9a8e69 after OIDC publish workflow landed; bump so publish-decision can tag+publish a matching commit via trusted publisher OIDC.
+
 ## 1.37.0
 
 ### Minor Changes

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -4,7 +4,7 @@
 - `chatgpt/openapi.yaml`: import into GPT Actions.
 - `gemini/function-declarations.json`: Gemini function-calling definitions.
 - `mcp/server-stdio.js`: underlying local MCP stdio server implementation.
-- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.37.0 thumbgate serve`.
+- `claude/.mcp.json`: example Claude Code MCP config using `npx --yes --package thumbgate@1.37.1 thumbgate serve`.
 - `codex/config.toml`: example Codex MCP profile section using the same version-pinned portable launcher.
 - `amp/skills/thumbgate-feedback/SKILL.md`: Amp skill template.
 - `opencode/opencode.json`: portable OpenCode MCP profile using the same version-pinned portable launcher.

--- a/adapters/claude/.mcp.json
+++ b/adapters/claude/.mcp.json
@@ -2,13 +2,13 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
     "preToolUse": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
     }
   }
 }

--- a/adapters/claw/.mcp.json
+++ b/adapters/claw/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     }
   },
   "notes": "For claw-style agents (Automation Anywhere EnterpriseClaw, Nvidia OpenShell): enable ThumbGate gates for dynamic tool creation, screen/UI interaction, file system access, agent identity. See adapters/claw/CLAW.md. Combine with adapters/perplexity/HYBRID.md for hybrid local-cloud claw agents. Use new model candidates (automation-anywhere/enterprise-claw, nvidia/openshell-claw) and gate templates in 'Claw-Style Enterprise Agent Governance' category."

--- a/adapters/claw/config.toml
+++ b/adapters/claw/config.toml
@@ -2,7 +2,7 @@
 # Copy into ~/.codex/config.toml or merge. See CLAW.md and adapters/perplexity/HYBRID.md for hybrid+claw synergy.
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
 
 # Example for claw/orchestration awareness (extend MCP server or use sidecar when available)
 # [mcp_servers.claw]
@@ -12,7 +12,7 @@ args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
 # Hard PreToolUse hook for Codex - includes claw gates
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
 
 # For hybrid claw: combine with Perplexity hybrid MCP for inference routing.
 # Use new gate templates: block-dynamic-tool-creation-without-approval, require-review-for-screen-ui-interaction, etc.

--- a/adapters/claw/opencode.json
+++ b/adapters/claw/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "serve"
       ],

--- a/adapters/forge/forge.yaml
+++ b/adapters/forge/forge.yaml
@@ -9,12 +9,12 @@ version: "1"
 skills:
   thumbgate-gate-check:
     description: "ThumbGate PreToolUse gate — blocks known-bad tool calls"
-    command: "npx --yes --package thumbgate@1.37.0 thumbgate gate-check"
+    command: "npx --yes --package thumbgate@1.37.1 thumbgate gate-check"
     trigger: pre_tool_use
 
   thumbgate-feedback:
     description: "ThumbGate feedback capture — logs user prompt context"
-    command: "npx --yes --package thumbgate@1.37.0 thumbgate hook-auto-capture"
+    command: "npx --yes --package thumbgate@1.37.1 thumbgate hook-auto-capture"
     trigger: user_prompt
 
 mcp:
@@ -23,6 +23,6 @@ mcp:
     args:
       - "--yes"
       - "--package"
-      - "thumbgate@1.37.0"
+      - "thumbgate@1.37.1"
       - "thumbgate"
       - "serve"

--- a/adapters/future-agi/.mcp.json
+++ b/adapters/future-agi/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     }
   }
 }

--- a/adapters/future-agi/config.toml
+++ b/adapters/future-agi/config.toml
@@ -1,3 +1,3 @@
 [mcp.servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]

--- a/adapters/future-agi/opencode.json
+++ b/adapters/future-agi/opencode.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     }
   }
 }

--- a/adapters/herdr/herdr-plugin.toml
+++ b/adapters/herdr/herdr-plugin.toml
@@ -1,7 +1,7 @@
 [plugin]
 id = "thumbgate-approvals"
 name = "ThumbGate Approvals"
-version = "1.37.0"
+version = "1.37.1"
 minHerdrVersion = "0.7.0"
 description = "Pre-action governance, spend guard, and safety approval gates for multi-agent terminal sessions in Herdr."
 platforms = ["linux", "macos", "windows"]
@@ -12,7 +12,7 @@ category = "Security & Governance"
 
 [mcp_server]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
 
 [mcp_server.env]
 THUMBGATE_ENFORCE_ENTITLEMENTS = "1"

--- a/adapters/hermes/.mcp.json
+++ b/adapters/hermes/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
@@ -11,7 +11,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "gate-check"
       ]

--- a/adapters/hermes/config.toml
+++ b/adapters/hermes/config.toml
@@ -2,12 +2,12 @@
 # Copy into ~/.codex/config.toml or merge. See HERMES.md for skill-synthesis + channel-posting safety.
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
 
 # Hard PreToolUse hook for Codex - includes Hermes safety gates
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
 
 # For Hermes Agent: enable templates like block-unauthorized-multi-channel-posts, prevent-infinite-skill-synthesis-loops, validate-synthesized-skills-against-rules.
 # See config/gate-templates.json for "Nous Research Hermes Agent Governance" category.

--- a/adapters/hermes/opencode.json
+++ b/adapters/hermes/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "serve"
       ],

--- a/adapters/huggingface-context-course/.mcp.json
+++ b/adapters/huggingface-context-course/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
@@ -11,11 +11,11 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "gate-check"
       ]
     }
   },
-  "notes": "Claude Code MCP config with ThumbGate gates for Hugging Face Context Course exercises. PreToolUse hook gates all tool calls. All configs pin thumbgate@1.37.0. See HF_CONTEXT.md for unit-by-unit integration guide."
+  "notes": "Claude Code MCP config with ThumbGate gates for Hugging Face Context Course exercises. PreToolUse hook gates all tool calls. All configs pin thumbgate@1.37.1. See HF_CONTEXT.md for unit-by-unit integration guide."
 }

--- a/adapters/huggingface-context-course/HF_CONTEXT.md
+++ b/adapters/huggingface-context-course/HF_CONTEXT.md
@@ -25,7 +25,7 @@ npx thumbgate serve
 # Codex — add to ~/.codex/config.toml
 # [hooks.pre_tool_use]
 # command = "npx"
-# args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+# args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
 
 # OpenCode — add MCP server to ~/.config/opencode.json
 ```
@@ -96,7 +96,7 @@ npx thumbgate capture \
 - `opencode.json`: For OpenCode (copy into ~/.config/opencode.json)
 - `.mcp.json`: For Claude Code (copy into project .mcp.json)
 
-All configs pin `thumbgate@1.37.0`.
+All configs pin `thumbgate@1.37.1`.
 
 ## Model Candidates
 

--- a/adapters/huggingface-context-course/config.toml
+++ b/adapters/huggingface-context-course/config.toml
@@ -4,12 +4,12 @@
 
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
 
 # Hard PreToolUse hook for Codex — gates all tool calls before execution
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
 
 # Context-engineering gates to enable for HF Context Course exercises:
 # - require-agent-context-freshness: Ensure AGENTS.md is fresh before code edits

--- a/adapters/huggingface-context-course/opencode.json
+++ b/adapters/huggingface-context-course/opencode.json
@@ -7,12 +7,12 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "serve"
       ],
       "enabled": true
     }
   },
-  "notes": "For Hugging Face Context Course exercises (https://huggingface.co/learn/context-course): enable ThumbGate gates for context freshness, skill validation, MCP tool safety, and agent identity separation. See adapters/huggingface-context-course/HF_CONTEXT.md and docs/guides/huggingface-context-course-governance.md. Uses vlt/gate templates for supply-chain safety on npm/vlt installs. Pin thumbgate@1.37.0."
+  "notes": "For Hugging Face Context Course exercises (https://huggingface.co/learn/context-course): enable ThumbGate gates for context freshness, skill validation, MCP tool safety, and agent identity separation. See adapters/huggingface-context-course/HF_CONTEXT.md and docs/guides/huggingface-context-course-governance.md. Uses vlt/gate templates for supply-chain safety on npm/vlt installs. Pin thumbgate@1.37.1."
 }

--- a/adapters/mcp/server-stdio.js
+++ b/adapters/mcp/server-stdio.js
@@ -334,7 +334,7 @@ const {
   finalizeSession: finalizeFeedbackSession,
 } = require('../../scripts/feedback-session');
 
-const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.37.0' };
+const SERVER_INFO = { name: 'thumbgate-mcp', version: '1.37.1' };
 const COMMERCE_CATEGORIES = [
   'product_recommendation',
   'brand_compliance',

--- a/adapters/opencode/opencode.json
+++ b/adapters/opencode/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "serve"
       ],

--- a/adapters/perplexity/.mcp.json
+++ b/adapters/perplexity/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     },
     "perplexity": {
       "command": "npx",
@@ -18,7 +18,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "gate-check"
       ]

--- a/adapters/perplexity/config.toml
+++ b/adapters/perplexity/config.toml
@@ -2,7 +2,7 @@
 # Includes support for Perplexity hybrid local-cloud inference (see HYBRID.md for Personal Computer / Computex 2026 orchestrator integration).
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
 
 [mcp_servers.perplexity]
 command = "npx"
@@ -14,7 +14,7 @@ PERPLEXITY_API_KEY = "${PERPLEXITY_API_KEY}"
 # Hard PreToolUse hook for Codex
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
 
 # For hybrid: when using Perplexity Personal Computer, add hybrid-routing gates
 # via custom rules in ThumbGate config/gates/ for "cloud-escalation" on sensitive paths.

--- a/adapters/perplexity/opencode.json
+++ b/adapters/perplexity/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "serve"
       ],

--- a/adapters/poolside/README.md
+++ b/adapters/poolside/README.md
@@ -11,7 +11,7 @@ Merge [`settings.yaml`](./settings.yaml) into
 `~/.config/poolside/settings.yaml`, or run:
 
 ```bash
-pool mcp add thumbgate -- npx --yes --package thumbgate@1.37.0 thumbgate serve
+pool mcp add thumbgate -- npx --yes --package thumbgate@1.37.1 thumbgate serve
 pool mcp get thumbgate
 ```
 

--- a/adapters/poolside/settings.yaml
+++ b/adapters/poolside/settings.yaml
@@ -7,6 +7,6 @@ mcp_servers:
         args:
             - --yes
             - --package
-            - thumbgate@1.37.0
+            - thumbgate@1.37.1
             - thumbgate
             - serve

--- a/adapters/vlt/.mcp.json
+++ b/adapters/vlt/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+      "args": ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
     }
   },
   "hooks": {
@@ -11,11 +11,11 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "gate-check"
       ]
     }
   },
-  "notes": "Claude Code MCP config with vlt registry governance. PreToolUse hook gates vlt install/add/publish, registry config overrides, and dependency version pinning. See adapters/vlt/VLT.md for gate templates and feedback capture patterns. All configs pin thumbgate@1.37.0."
+  "notes": "Claude Code MCP config with vlt registry governance. PreToolUse hook gates vlt install/add/publish, registry config overrides, and dependency version pinning. See adapters/vlt/VLT.md for gate templates and feedback capture patterns. All configs pin thumbgate@1.37.1."
 }

--- a/adapters/vlt/VLT.md
+++ b/adapters/vlt/VLT.md
@@ -44,18 +44,18 @@ Enable any of these via `npx thumbgate gate-templates` or by adding them to your
 ```toml
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
 
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
 ```
 
 **`adapters/vlt/opencode.json`** — OpenCode profile (see file).
 
 **`adapters/vlt/.mcp.json`** — Claude Code profile with `preToolUse` hook.
 
-All configs pin `thumbgate@1.37.0` (the current shipped version).
+All configs pin `thumbgate@1.37.1` (the current shipped version).
 
 ### 2. Custom Gate Rules (Optional)
 

--- a/adapters/vlt/config.toml
+++ b/adapters/vlt/config.toml
@@ -5,12 +5,12 @@
 
 [mcp_servers.thumbgate]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"]
 
 # Hard PreToolUse hook for Codex — gates vlt package management and registry changes
 [hooks.pre_tool_use]
 command = "npx"
-args = ["--yes", "--package", "thumbgate@1.37.0", "thumbgate", "gate-check"]
+args = ["--yes", "--package", "thumbgate@1.37.1", "thumbgate", "gate-check"]
 
 # For hybrid vlt agents: combine with Perplexity hybrid MCP for inference routing.
 # Use new gate templates: block-vlt-install-vulnerable-deps, gate-vlt-package-publishing, etc.

--- a/adapters/vlt/opencode.json
+++ b/adapters/vlt/opencode.json
@@ -7,7 +7,7 @@
         "npx",
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "serve"
       ],

--- a/docs/guides/opencode-integration.md
+++ b/docs/guides/opencode-integration.md
@@ -26,7 +26,7 @@ That gives OpenCode a repo-native permission surface instead of bolting on a sec
 
 If you want the same MCP server in a different OpenCode project, copy `adapters/opencode/opencode.json` into your OpenCode config and merge the `mcp.thumbgate` block.
 
-The portable profile stays version-pinned to `thumbgate@1.37.0`, and `scripts/sync-version.js` now checks it for drift.
+The portable profile stays version-pinned to `thumbgate@1.37.1`, and `scripts/sync-version.js` now checks it for drift.
 
 ## Why This Is High ROI
 

--- a/docs/mcp-hub-submission.md
+++ b/docs/mcp-hub-submission.md
@@ -51,7 +51,7 @@ Works in local mode (zero config, no API key) or connected to the Context Gatewa
 ### Option A: Local mode (OSS, no API key needed)
 
 ```bash
-claude mcp add thumbgate -- npx -y thumbgate@1.37.0 serve
+claude mcp add thumbgate -- npx -y thumbgate@1.37.1 serve
 ```
 
 Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/settings.json`):
@@ -61,7 +61,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.37.0", "serve"],
+      "args": ["-y", "thumbgate@1.37.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "http://localhost:8787"
       }
@@ -77,7 +77,7 @@ Optional manual config (`~/.claude/claude_desktop_config.json` or `.claude/setti
   "mcpServers": {
     "thumbgate": {
       "command": "npx",
-      "args": ["-y", "thumbgate@1.37.0", "serve"],
+      "args": ["-y", "thumbgate@1.37.1", "serve"],
       "env": {
         "THUMBGATE_BASE_URL": "https://thumbgate-production.up.railway.app",
         "THUMBGATE_API_KEY": "tg_YOUR_KEY_HERE"
@@ -125,7 +125,7 @@ Verification evidence: https://github.com/IgorGanapolsky/ThumbGate/blob/main/doc
 
 ## Transport
 
-- **stdio** (primary): `npx -y thumbgate@1.37.0 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
+- **stdio** (primary): `npx -y thumbgate@1.37.1 serve` — version-pinned portable MCP launcher for Claude Code desktop and CLI
 - **HTTP** (secondary): `src/api/server.js` — REST API (`POST /v1/feedback/capture`, `GET /v1/feedback/summary`, `POST /v1/dpo/export`)
 
 ---
@@ -172,7 +172,7 @@ MIT
 
 ## Version
 
-1.37.0
+1.37.1
 
 ---
 

--- a/mcpize.yaml
+++ b/mcpize.yaml
@@ -1,6 +1,6 @@
 # mcpize configuration for ThumbGate
 project: "thumbgate"
-version: "1.37.0"
+version: "1.37.1"
 start_command: "npx -y thumbgate serve"
 mcp_profile: "default"
 description: "Agent quality feedback loop with Pre-Action Gates engine — blocks dangerous tool calls before execution, generates prevention rules from failures, and captures ThumbGate signals."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thumbgate",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thumbgate",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "ThumbGate Pre-Action Checks self-improve from ranked lessons and repeated failures, hard-block detected secret leaks, and block matches in strict mode.",
   "homepage": "https://thumbgate.ai",
   "repository": {

--- a/plugins/claude-codex-bridge/.claude-plugin/plugin.json
+++ b/plugins/claude-codex-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-bridge",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "Run Codex review, adversarial review, and second-pass handoffs from Claude Code while keeping ThumbGate reliability memory in the loop.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/claude-codex-bridge/.mcp.json
+++ b/plugins/claude-codex-bridge/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "--yes",
         "--package",
-        "thumbgate@1.37.0",
+        "thumbgate@1.37.1",
         "thumbgate",
         "serve"
       ]

--- a/plugins/codex-profile/.codex-plugin/plugin.json
+++ b/plugins/codex-profile/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "ThumbGate for Codex turns one thumbs-down into a repeat-blocking pre-action check, backed by local MCP memory.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/cursor-marketplace/.cursor-plugin/plugin.json
+++ b/plugins/cursor-marketplace/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "author": {
     "name": "Igor Ganapolsky",
     "url": "https://github.com/IgorGanapolsky"

--- a/plugins/cursor-marketplace/plugin.json
+++ b/plugins/cursor-marketplace/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbgate",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "👍👎 Thumbs down a mistake — your AI agent won't repeat it. Thumbs up good work — it remembers the pattern.",
   "author": {
     "name": "Igor Ganapolsky",

--- a/plugins/opencode-profile/INSTALL.md
+++ b/plugins/opencode-profile/INSTALL.md
@@ -25,7 +25,7 @@ The portable profile adds this MCP server entry:
   "mcp": {
     "thumbgate": {
       "type": "local",
-      "command": ["npx", "--yes", "--package", "thumbgate@1.37.0", "thumbgate", "serve"],
+      "command": ["npx", "--yes", "--package", "thumbgate@1.37.1", "thumbgate", "serve"],
       "enabled": true
     }
   }

--- a/plugins/vscode-extension/package.json
+++ b/plugins/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "thumbgate",
   "displayName": "ThumbGate",
   "description": "Deterministic pre-action checks, feedback capture, and MCP guardrails for AI coding agents in VS Code-compatible IDEs.",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "publisher": "igorganapolsky",
   "license": "MIT",
   "icon": "assets/logo-400x400.png",

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="ThumbGate">
   <meta name="author" content="Igor Ganapolsky">
-  <meta name="thumbgate-version" content="1.37.0">
+  <meta name="thumbgate-version" content="1.37.1">
   __GOOGLE_SITE_VERIFICATION_META__
   <link rel="icon" type="image/png" href="/thumbgate-icon.png">
   <link rel="canonical" href="__APP_ORIGIN__/">
@@ -948,7 +948,7 @@ next      decision recorded before execution</pre>
 
   <footer>
     <div class="shell footer-inner">
-      <span>ThumbGate · MIT License · npm v1.37.0</span>
+      <span>ThumbGate · MIT License · npm v1.37.1</span>
       <div class="footer-links">
         <a href="https://github.com/IgorGanapolsky/ThumbGate" target="_blank" rel="noopener">GitHub</a>
         <a href="/guide">Technical setup</a>

--- a/public/install.html
+++ b/public/install.html
@@ -154,7 +154,7 @@ __GA_BOOTSTRAP__
     <div class="grid">
       <article class="card"><h3>CLI and MCP-compatible agents</h3><p>Fastest path for Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, and local MCP-compatible agents.</p><pre><code>npx -y thumbgate@1.37.1 doctor
 npx -y thumbgate@1.37.1 doctor --fix</code></pre></article>
-      <article class="card"><h3>Claude Desktop</h3><p>Use the npm-backed MCP server today. The Claude Desktop `.mcpb` directory submission packet is prepared separately.</p><pre><code>claude mcp add thumbgate -- npx --yes --package thumbgate thumbgate serve</code></pre></article>
+      <article class="card"><h3>Claude Desktop</h3><p>Use the npm-backed MCP server today. The Claude Desktop `.mcpb` directory submission packet is prepared separately.</p><pre><code>claude mcp add thumbgate -- npx --yes --package thumbgate@1.37.1 thumbgate serve</code></pre></article>
       <article class="card"><h3>Cursor</h3><p>The public Cursor Marketplace listing is not live yet. Use the CLI wiring while the dashboard submission is resolved.</p><pre><code>npx -y thumbgate@1.37.1 init --agent cursor</code></pre></article>
       <article class="card"><h3>Codex</h3><p>Use the local adapter now. Public Codex self-serve plugin publishing is not open yet, so the GitHub Release asset is the distribution proof.</p><pre><code>npx -y thumbgate@1.37.1 init --agent codex</code></pre></article>
     </div>

--- a/public/install.html
+++ b/public/install.html
@@ -139,7 +139,7 @@ __GA_BOOTSTRAP__
       <a class="btn-secondary" href="/diagnostic?utm_source=install_page&utm_medium=owned_page&utm_campaign=marketplace_distribution">Harden one workflow</a>
     </div>
     <div class="proof-strip" aria-label="Verified live distribution surfaces">
-      <div class="proof"><strong>npm</strong><span>thumbgate@1.37.0</span></div>
+      <div class="proof"><strong>npm</strong><span>thumbgate@1.37.1</span></div>
       <div class="proof"><strong>VS Code</strong><span>Marketplace version live</span></div>
       <div class="proof"><strong>Open VSX</strong><span>Antigravity-compatible path</span></div>
       <div class="proof"><strong>MCP Registry</strong><span>1.27.20 is latest</span></div>
@@ -152,11 +152,11 @@ __GA_BOOTSTRAP__
     <h2>Choose the install path that matches your agent.</h2>
     <p class="section-lede">Use the local CLI path for immediate enforcement. Use marketplace installs where your editor supports them. Use the diagnostic path when you need a human-reviewed gate map for one risky workflow. New install: <a href="/guides/progressive-wiring">prove the pipe first</a> (doctor green, empty dashboard OK) before expecting a gate to fire.</p>
     <div class="grid">
-      <article class="card"><h3>CLI and MCP-compatible agents</h3><p>Fastest path for Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, and local MCP-compatible agents.</p><pre><code>npx -y thumbgate@1.37.0 doctor
-npx -y thumbgate@1.37.0 doctor --fix</code></pre></article>
+      <article class="card"><h3>CLI and MCP-compatible agents</h3><p>Fastest path for Claude Code, Cursor, Codex, Gemini CLI, Amp, Cline, OpenCode, and local MCP-compatible agents.</p><pre><code>npx -y thumbgate@1.37.1 doctor
+npx -y thumbgate@1.37.1 doctor --fix</code></pre></article>
       <article class="card"><h3>Claude Desktop</h3><p>Use the npm-backed MCP server today. The Claude Desktop `.mcpb` directory submission packet is prepared separately.</p><pre><code>claude mcp add thumbgate -- npx --yes --package thumbgate thumbgate serve</code></pre></article>
-      <article class="card"><h3>Cursor</h3><p>The public Cursor Marketplace listing is not live yet. Use the CLI wiring while the dashboard submission is resolved.</p><pre><code>npx -y thumbgate@1.37.0 init --agent cursor</code></pre></article>
-      <article class="card"><h3>Codex</h3><p>Use the local adapter now. Public Codex self-serve plugin publishing is not open yet, so the GitHub Release asset is the distribution proof.</p><pre><code>npx -y thumbgate@1.37.0 init --agent codex</code></pre></article>
+      <article class="card"><h3>Cursor</h3><p>The public Cursor Marketplace listing is not live yet. Use the CLI wiring while the dashboard submission is resolved.</p><pre><code>npx -y thumbgate@1.37.1 init --agent cursor</code></pre></article>
+      <article class="card"><h3>Codex</h3><p>Use the local adapter now. Public Codex self-serve plugin publishing is not open yet, so the GitHub Release asset is the distribution proof.</p><pre><code>npx -y thumbgate@1.37.1 init --agent codex</code></pre></article>
     </div>
   </div>
 </section>
@@ -165,7 +165,7 @@ npx -y thumbgate@1.37.0 doctor --fix</code></pre></article>
     <h2>Verified public surfaces.</h2>
     <p class="section-lede">These are the surfaces safe to claim in public copy right now. Pending surfaces are listed so buyers do not get sent to dead marketplace pages.</p>
     <div class="status-list">
-      <div class="status"><span class="badge live">LIVE</span><div><strong><a href="https://www.npmjs.com/package/thumbgate">npm package</a></strong><span>`thumbgate@1.37.0` is the canonical runtime install.</span></div></div>
+      <div class="status"><span class="badge live">LIVE</span><div><strong><a href="https://www.npmjs.com/package/thumbgate">npm package</a></strong><span>`thumbgate@1.37.1` is the canonical runtime install.</span></div></div>
       <div class="status"><span class="badge live">LIVE</span><div><strong><a href="https://marketplace.visualstudio.com/items?itemName=igorganapolsky.thumbgate">VS Code Marketplace</a></strong><span>Marketplace version-list API includes `1.27.20`.</span></div></div>
       <div class="status"><span class="badge live">LIVE</span><div><strong><a href="https://open-vsx.org/extension/igorganapolsky/thumbgate">Open VSX</a></strong><span>Public registry latest version is `1.27.20`; use this path for VS Code-compatible IDEs that consume Open VSX.</span></div></div>
       <div class="status"><span class="badge live">LIVE</span><div><strong><a href="https://registry.modelcontextprotocol.io/v0/servers?search=thumbgate">MCP Registry</a></strong><span>Public search returns `io.github.IgorGanapolsky/thumbgate` version `1.27.20` as latest.</span></div></div>

--- a/public/numbers.html
+++ b/public/numbers.html
@@ -25,7 +25,7 @@
   "alternateName": "thumbgate",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform, Node.js >=18.18.0",
-  "softwareVersion": "1.37.0",
+  "softwareVersion": "1.37.1",
   "url": "https://thumbgate-production.up.railway.app/numbers",
   "dateModified": "2026-08-03",
   "creator": {
@@ -202,7 +202,7 @@
 <main class="container">
   <h1>The Numbers</h1>
   <p class="subtitle">Generated first-party operational snapshot from the ThumbGate runtime. This is not customer traction, install volume, revenue, or proof that a configured gate has fired.</p>
-  <div class="freshness">Updated: 2026-08-03 · Version 1.37.0</div>
+  <div class="freshness">Updated: 2026-08-03 · Version 1.37.1</div>
   <div class="truth-note"><strong>Read this first:</strong> configured checks are inventory. Recorded blocks and warnings are usage evidence. This snapshot currently reports 0 recorded hard-block event(s) and 0 recorded warning event(s).</div>
 
   <h2>Gate enforcement</h2>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "url": "https://github.com/IgorGanapolsky/ThumbGate"
   },
-  "version": "1.37.0",
+  "version": "1.37.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "thumbgate",
-      "version": "1.37.0",
+      "version": "1.37.1",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Summary
- `v1.37.0` is tagged at `da9a8e69` but never reached npm (`E404` classic token).
- Main tip moved to `e5f27443` (OIDC publish workflow #3857) with the same package version → `publish-decision` refuses tip publish (tag/tip SHA mismatch).
- Patch bump to **1.37.1** so tip can create a matching tag and publish via OIDC trusted publisher.

## After merge
1. Configure npm Trusted Publisher (WebAuthn once): `thumbgate` → GitHub Actions → `IgorGanapolsky/ThumbGate` / `publish-npm.yml`.
2. Confirm `npm view thumbgate version` → `1.37.1`.
3. Update Vignesh draft pin from `@1.35.0` → `@1.37.1` (drafts-only).

## Test plan
- [ ] CI green
- [ ] publish-npm creates `v1.37.1` and publishes (after Trusted Publisher)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated ThumbGate to version **1.37.1** across plugin manifests, integrations, installation commands, and server metadata.
  * Added the 1.37.1 patch release entry to the changelog.
  * Standardized package version pins across supported integrations for consistent installations.

* **Documentation**
  * Updated setup guides, adapter examples, and website version references to use ThumbGate 1.37.1.
  * Installation instructions now reference the explicitly pinned 1.37.1 package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->