### PR TITLE
fix(gates): relevance-gate lesson injection (#3689)

### DIFF
--- a/.changeset/lesson-relevance-gate-3689.md
+++ b/.changeset/lesson-relevance-gate-3689.md
@@ -1,0 +1,5 @@
+---
+"thumbgate": patch
+---
+
+Relevance-gate PreToolUse lesson injection (#3689): suppress high-entropy conflict disclaimers and skip low-relevance negatives instead of polluting every tool call.

--- a/scripts/gates-engine.js
+++ b/scripts/gates-engine.js
@@ -146,6 +146,10 @@ const BOOSTED_RISK_MIN_EXAMPLES = 3;
 const PR_THREAD_RESOLUTION_ACTION = 'pr_thread_resolution_verified_after_commit';
 const HELPER_BYPASS_ACTION = 'helper_script_modified';
 const KNOWLEDGE_ENTROPY_THRESHOLD = 0.7;
+// Issue #3689: do not inject lessons that only barely matched. Retrieval already
+// filters >0.1 for ranking; injection requires a higher bar so low-relevance
+// memories cannot ride along with an entropy disclaimer.
+const MIN_LESSON_INJECTION_RELEVANCE = 0.75;
 // Generous character bound: keeps every affected file for realistic actions while still
 // preventing an unbounded haystack. Chosen over a file-count cap, which dropped targets.
 const MEMORY_GUARD_MAX_SERIALIZED_CHARS = 200000;
@@ -4452,7 +4456,11 @@ async function buildRelevantLessonContextAsync(toolName, toolInput) {
  * negative lesson present is relevant enough to surface.
  */
 function formatNegativeLessonContext(lessons) {
-  const negative = (lessons || []).filter((l) => l.signal === 'negative');
+  const negative = (lessons || []).filter((l) => {
+    if (l.signal !== 'negative') return false;
+    const score = Number(l.rerankedScore ?? l.relevanceScore ?? 0);
+    return score >= MIN_LESSON_INJECTION_RELEVANCE;
+  });
   if (negative.length === 0) return null;
 
   const formatted = negative.map((l) => {
@@ -4477,8 +4485,10 @@ function isKnowledgeConflictHardBlockAction(toolName, toolInput = {}) {
 }
 
 function buildKnowledgeConflictContext(toolName, toolInput, lessons, entropy) {
-  const lessonContext = formatNegativeLessonContext(lessons);
-  const message = `Knowledge conflict warning: retrieved lessons disagree for this action (entropy ${entropy}). Treat the reminders below as cautionary context, but do not stop unrelated work solely because memory is noisy.`;
+  // Issue #3689: high entropy means the scorer disagrees with itself. Do NOT
+  // inject a disclaimer + noisy lessons into unrelated tool calls — suppress.
+  // Strict mode may still hard-block destructive/external side effects.
+  const message = `Knowledge conflict: retrieved lessons disagree for this action (entropy ${entropy}).`;
 
   if (isKnowledgeConflictHardBlockAction(toolName, toolInput)) {
     recordStat('retrieval_entropy_high', 'block', null, { toolName, toolInput });
@@ -4490,8 +4500,9 @@ function buildKnowledgeConflictContext(toolName, toolInput, lessons, entropy) {
     };
   }
 
-  recordStat('retrieval_entropy_high', 'warn', null, { toolName, toolInput });
-  return mergeContextStrings(`[ThumbGate] ${message}`, lessonContext);
+  // Count as log (not warn): we intentionally did not inject context.
+  recordStat('retrieval_entropy_high', 'log', null, { toolName, toolInput });
+  return null;
 }
 
 function extractActionContext(toolName, toolInput) {

--- a/tests/gates-engine.test.js
+++ b/tests/gates-engine.test.js
@@ -1056,31 +1056,62 @@ async function withConflictingLessonRetrieval(fn) {
   }
 }
 
-test('knowledge conflict warns instead of hard-blocking safe credential chmod', async () => {
+test('knowledge conflict suppresses lesson injection on safe credential chmod (#3689)', async () => {
   cleanupStateFiles();
   await withConflictingLessonRetrieval(() => {
     const output = JSON.parse(run({
       tool_name: 'Bash',
       tool_input: { command: 'chmod 600 ~/.config/gemini/key.json' },
     }));
-    assert.notEqual(output.hookSpecificOutput.permissionDecision, 'deny');
-    assert.match(output.hookSpecificOutput.additionalContext, /Knowledge conflict warning/);
-    assert.match(output.hookSpecificOutput.additionalContext, /do not stop unrelated work solely because memory is noisy/);
+    assert.notEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+    const ctx = output.hookSpecificOutput?.additionalContext || '';
+    assert.doesNotMatch(ctx, /Knowledge conflict warning/);
+    assert.doesNotMatch(ctx, /Past mistakes relevant to this action/);
   });
   cleanupStateFiles();
 });
 
-test('knowledge conflict warns instead of hard-blocking package setup', async () => {
+test('knowledge conflict suppresses lesson injection on package setup (#3689)', async () => {
   cleanupStateFiles();
   await withConflictingLessonRetrieval(async () => {
     const output = JSON.parse(await runAsync({
       tool_name: 'Bash',
       tool_input: { command: 'pip install paperbanana' },
     }));
-    assert.notEqual(output.hookSpecificOutput.permissionDecision, 'deny');
-    assert.match(output.hookSpecificOutput.additionalContext, /Knowledge conflict warning/);
+    assert.notEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+    const ctx = output.hookSpecificOutput?.additionalContext || '';
+    assert.doesNotMatch(ctx, /Knowledge conflict warning/);
   });
   cleanupStateFiles();
+});
+
+
+test('low-relevance negative lessons are not injected (#3689)', async () => {
+  cleanupStateFiles();
+  const retrieval = require('../scripts/lesson-retrieval');
+  const originalRetrieve = retrieval.retrieveRelevantLessons;
+  const originalEntropy = retrieval.calculateRetrievalEntropy;
+  retrieval.retrieveRelevantLessons = () => ([{
+    id: 'weak',
+    title: 'MISTAKE: weakly related',
+    content: 'How to avoid: ignore me',
+    signal: 'negative',
+    relevanceScore: 0.2,
+  }]);
+  retrieval.calculateRetrievalEntropy = () => 0.1;
+  try {
+    const output = JSON.parse(run({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+    }));
+    const ctx = output.hookSpecificOutput?.additionalContext || '';
+    assert.doesNotMatch(ctx, /Past mistakes relevant to this action/);
+    assert.doesNotMatch(ctx, /weakly related/);
+  } finally {
+    retrieval.retrieveRelevantLessons = originalRetrieve;
+    retrieval.calculateRetrievalEntropy = originalEntropy;
+    cleanupStateFiles();
+  }
 });
 
 test('strict knowledge conflict mode can still block external destructive side effects', async () => {


### PR DESCRIPTION
## Summary
Closes #3689. PreToolUse lesson injection was wrapping high-entropy retrieval disagreements in a `Knowledge conflict warning` disclaimer and still injecting lessons into unrelated tool calls. That is context pollution, not a gate.

## What Changed
- High-entropy retrieval on the non-strict path: **suppress** (return null) and `recordStat(..., 'log')` instead of disclaimer injection
- Negative lessons must meet `MIN_LESSON_INJECTION_RELEVANCE` (0.75) before injection
- Strict knowledge-conflict hard-block for destructive/external side effects unchanged

## Why
Issue #3689 AC: relevance-gate retrieved lessons instead of injecting with entropy disclaimers.

## Verification
- `node --test --test-name-pattern='3689|strict knowledge conflict' tests/gates-engine.test.js` → 4/4 pass
- Pre-existing `approve_protected_action` failure exists on unmodified `origin/main` tip (not this diff)

## Evidence
- Issue: #3689
- Base: `27b3bf9d`

## Risks
- Agents that relied on the noisy disclaimer as a soft signal will see silence instead (intended). Strict-mode destructive hard-block retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call guidance by filtering out low-relevance negative lessons.
  * Suppressed noisy conflict disclaimers when relevance is too uncertain.
  * Preserved safe credential and package setup actions without incorrectly denying them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->